### PR TITLE
fix: allow config 'use' objects without 'rules'

### DIFF
--- a/src/running/runConfig.ts
+++ b/src/running/runConfig.ts
@@ -38,7 +38,7 @@ export async function runConfig(
 					}),
 				),
 			),
-			rules: use.rules.flat() as ConfigRuleDefinition[],
+			rules: (use.rules?.flat() ?? []) as ConfigRuleDefinition[],
 		})),
 	);
 

--- a/src/types/configs.ts
+++ b/src/types/configs.ts
@@ -24,7 +24,7 @@ export interface ConfigRuleDefinitionObject {
 export interface ConfigUseDefinition {
 	exclude?: string;
 	glob: AnyLevelArray<string> | string;
-	rules: AnyLevelArray<ConfigRuleDefinition>;
+	rules?: AnyLevelArray<ConfigRuleDefinition>;
 }
 
 export interface NormalizedConfigUseDefinition extends ConfigUseDefinition {


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #86
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/flint/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/flint/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Changes the non-normalized type to an optional, and adds `?? []` defaulting logic in `runConfig`.

❤️‍🔥