### PR TITLE
fix: stop hardcoding 'typescript' parser

### DIFF
--- a/src/formatting/runPrettier.ts
+++ b/src/formatting/runPrettier.ts
@@ -32,7 +32,6 @@ export async function runPrettier(
 
 			const updatedFileContent = await prettier.format(originalFileContent, {
 				filepath: filePath,
-				parser: "typescript",
 				...(await prettier.resolveConfig(filePath)),
 			});
 


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #84
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/flint/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/flint/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Removes the erroneous line.

❤️‍🔥