### PR TITLE
feat(linter/ts): add explicitModuleBoundaryTypes rule

### DIFF
--- a/packages/core/src/types/rules.ts
+++ b/packages/core/src/types/rules.ts
@@ -1,5 +1,5 @@
 import { RuleContext } from "./context.js";
-import { Language } from "./languages.js";
+import { AnyLanguage, Language } from "./languages.js";
 import { PromiseOrSync } from "./promises.js";
 import { ReportMessageData } from "./reports.js";
 import { AnyOptionalSchema, InferredObject } from "./shapes.js";
@@ -99,3 +99,15 @@ export type RuleVisitor<ASTNode> = (node: ASTNode) => void;
 export type RuleVisitors<AstNodesByName> = {
 	[Kind in keyof AstNodesByName]?: RuleVisitor<AstNodesByName[Kind]>;
 };
+
+// utilities
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type RuleContextForLang<
+	L extends Language<any, any>,
+	MessageId extends string = string,
+> =
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	L extends Language<any, infer ContextServices>
+		? ContextServices & RuleContext<MessageId>
+		: never;

--- a/packages/ts/src/language.ts
+++ b/packages/ts/src/language.ts
@@ -1,4 +1,4 @@
-import { createLanguage } from "@flint.fyi/core";
+import { createLanguage, RuleContextForLang } from "@flint.fyi/core";
 import { createProjectService } from "@typescript-eslint/project-service";
 import {
 	createFSBackedSystem,
@@ -16,6 +16,10 @@ import { TSNodesByName } from "./nodes.js";
 const log = debugForFile(import.meta.filename);
 
 const projectRoot = path.join(import.meta.dirname, "../..");
+
+export type TypeScriptRuleContext = RuleContextForLang<
+	typeof typescriptLanguage
+>;
 
 export interface TypeScriptServices {
 	sourceFile: ts.SourceFile;

--- a/packages/ts/src/rules/explicitModuleBoundaryTypes.test.ts
+++ b/packages/ts/src/rules/explicitModuleBoundaryTypes.test.ts
@@ -105,6 +105,28 @@ const invalid = [
 	},
 	{
 		code: `
+            function foo(bar: string) {
+                return bar;
+            }
+			export { foo };
+            `,
+		output: `
+            function foo(bar: string): string {
+                return bar;
+            }
+			export { foo };
+            `,
+		snapshot: `
+            function foo(bar: string) {
+                           ~~~
+                           Public facing functions should have an explicit return type.
+                return bar;
+            }
+			export { foo };
+            `,
+	},
+	{
+		code: `
             export function foo(bar): string {
                 return bar;
             }


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to flint! ❤️‍🔥
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- ~~[ ] Addresses an existing open issue: fixes #000~~ it doesn't, but this rule is useful
- ~~[ ] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/flint/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)~~
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/flint/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Adds a new rule, `explicitModuleBoundaryTypes`, for typescript linting. It is inspired by [`@typescript-eslint/explicit-module-boundary-types`](https://typescript-eslint.io/rules/explicit-module-boundary-types/) but was written completely separately from that rule and is not yet as feature-rich.

## TODO
- [x] function declarations/expressions
- [x] arrow functions
- [x] namespaces
- [ ] classes
- [ ] exported HOC calls
   ```ts
   export default connect(thing)(withFoo(withBar(MyComponent)))
   ``` 