### PR TITLE
fix(rule-tester): correct snapshot alignment calculations

### DIFF
--- a/packages/json/src/rules/duplicateKeys.ts
+++ b/packages/json/src/rules/duplicateKeys.ts
@@ -47,8 +47,8 @@ export default jsonLanguage.createRule({
 						context.report({
 							message: "duplicateKey",
 							range: {
-								begin: property.name.getStart(context.sourceFile) + 1,
-								end: property.name.end + 1,
+								begin: property.name.getStart(context.sourceFile),
+								end: property.name.end,
 							},
 						});
 					}

--- a/packages/plugin-cspell/src/rules/spelling.test.ts
+++ b/packages/plugin-cspell/src/rules/spelling.test.ts
@@ -10,8 +10,8 @@ ruleTester.describe(rule, {
             `,
 			snapshot: `
                 incorect
-               ~~~~~~~~
-               Forbidden or unknown word: "incorect".
+                ~~~~~~~~
+                Forbidden or unknown word: "incorect".
             `,
 			suggestions: [
 				{

--- a/packages/plugin-flint/src/rules/duplicateTestCases.test.ts
+++ b/packages/plugin-flint/src/rules/duplicateTestCases.test.ts
@@ -13,8 +13,8 @@ ruleTester.describe(rule, {
 			snapshot: `
                 ruleTester.describe(rule, {
                     valid: ['a', 'a'],
-                                ~~~
-                                This test code already appeared in a previous test.
+                                 ~~~
+                                 This test code already appeared in a previous test.
                     invalid: []
                 });
             `,
@@ -34,8 +34,8 @@ ruleTester.describe(rule, {
                     valid: [
                         'a',
                         "a",
-                       ~~~
-                       This test code already appeared in a previous test.
+                        ~~~
+                        This test code already appeared in a previous test.
                     ],
                     invalid: []
                 });
@@ -56,8 +56,8 @@ ruleTester.describe(rule, {
                     valid: [
                         \`a\`,
                         \`a\`,
-                       ~~~
-                       This test code already appeared in a previous test.
+                        ~~~
+                        This test code already appeared in a previous test.
                     ],
                     invalid: []
                 });
@@ -78,8 +78,8 @@ ruleTester.describe(rule, {
                     valid: [
                         { code: "a" },
                         { code: "a" },
-                       ~~~~~~~~~~~~~
-                       This test code already appeared in a previous test.
+                        ~~~~~~~~~~~~~
+                        This test code already appeared in a previous test.
                     ],
                     invalid: []
                 });
@@ -100,8 +100,8 @@ ruleTester.describe(rule, {
                     valid: [
                         { code: "a", fileName: "b.ts" },
                         { code: "a", fileName: "b.ts" },
-                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-                       This test code already appeared in a previous test.
+                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                        This test code already appeared in a previous test.
                     ],
                     invalid: []
                 });
@@ -122,8 +122,8 @@ ruleTester.describe(rule, {
                     valid: [
                         { code: "a", fileName: "b.ts", options: { c: "d" } },
                         { code: "a", fileName: "b.ts", options: { c: "d" } },
-                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-                       This test code already appeared in a previous test.
+                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                        This test code already appeared in a previous test.
                     ],
                     invalid: []
                 });

--- a/packages/rule-tester/src/createReportSnapshot.ts
+++ b/packages/rule-tester/src/createReportSnapshot.ts
@@ -25,7 +25,7 @@ function createReportSnapshotAt(sourceText: string, report: NormalizedReport) {
 		0,
 	);
 
-	const column = ifNegative(range.begin.raw - lineStartIndex - 2, 0);
+	const column = ifNegative(range.begin.raw - lineStartIndex - 1, 0);
 	const width = range.end.raw - range.begin.raw;
 
 	const injectionPrefix = " ".repeat(column);

--- a/packages/ts/src/rules/consecutiveNonNullAssertions.ts
+++ b/packages/ts/src/rules/consecutiveNonNullAssertions.ts
@@ -26,8 +26,8 @@ export default typescriptLanguage.createRule({
 					}
 
 					const range = {
-						begin: node.end,
-						end: node.parent.end + 1,
+						begin: node.end - 1,
+						end: node.parent.end,
 					};
 
 					context.report({

--- a/packages/yml/src/rules/emptyMappingKeys.test.ts
+++ b/packages/yml/src/rules/emptyMappingKeys.test.ts
@@ -21,8 +21,8 @@ a:
 			snapshot: `
 a:
     : b
-   ~
-   This mapping has an empty key, which is often a mistake.
+    ~
+    This mapping has an empty key, which is often a mistake.
 `,
 		},
 		{
@@ -33,8 +33,8 @@ a:
 			snapshot: `
 a:
   : b
- ~
- This mapping has an empty key, which is often a mistake.
+  ~
+  This mapping has an empty key, which is often a mistake.
 `,
 		},
 	],


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to flint! ❤️‍🔥
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #165
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/flint/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/flint/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Fixes snapshot alignment calculations in the rule-tester package. The previous implementation had incorrect offset calculations that caused misaligned snapshots when comparing expected vs actual test results.

From what I could see, some rules had compensated for the incorrect offset calculations, masking the underlying issue. Other snapshots appeared correct because alignment started at the beginning of the line (position defaulted to 0 even when it should have been -1)