### PR TITLE
feat: implement anyReturns rule for TypeScript plugin

### DIFF
--- a/packages/comparisons/src/data.json
+++ b/packages/comparisons/src/data.json
@@ -3687,6 +3687,7 @@
 			}
 		],
 		"flint": {
+			"implemented": true,
 			"name": "anyReturns",
 			"plugin": "ts",
 			"preset": "Logical"

--- a/packages/site/src/content/docs/rules/ts/anyReturns.mdx
+++ b/packages/site/src/content/docs/rules/ts/anyReturns.mdx
@@ -1,0 +1,68 @@
+---
+description: "Reports returning a value with type `any` from a function."
+title: "anyReturns"
+topic: "rules"
+---
+
+import { Tabs, TabItem } from "@astrojs/starlight/components";
+import { RuleEquivalents } from "~/components/RuleEquivalents";
+import RuleSummary from "~/components/RuleSummary.astro";
+
+<RuleSummary plugin="ts" rule="anyReturns" />
+
+Returning values typed as `any` in TypeScript effectively disables type checking and undermines the safety guarantees of the type system. This rule prevents functions from returning `any`, `any[]`, or `Promise<any>`, as well as from returning generics that contain `any` in positions where a specific type is expected.
+
+Prefer using more specific or unknown types to maintain strong type safety.
+
+## Examples
+
+<Tabs>
+<TabItem label="❌ Incorrect">
+
+```ts
+function foo1() {
+	return 1 as any;
+}
+function foo2() {
+	return [] as any[];
+}
+async function foo3() {
+	return Promise.resolve({} as any);
+}
+function assignability(): Set<string> {
+	return new Set<any>();
+}
+```
+
+</TabItem>
+<TabItem label="✅ Correct">
+
+```ts
+function foo1() {
+	return 1;
+}
+function foo2() {
+	return [];
+}
+async function foo3() {
+	return Promise.resolve({});
+}
+function assignability(): Set<string> {
+	return new Set<string>();
+}
+```
+
+</TabItem>
+</Tabs>
+
+## Options
+
+This rule is not configurable.
+
+## When Not To Use It
+
+If your codebase already contains many `any` types or areas of unsafe code, enabling this rule may be challenging. It may be more practical to defer enabling this rule until type safety has been improved in those areas. You might consider using [Flint disable comments](/) and/or [configuration file disables](/) for specific cases instead of completely disabling this rule.
+
+## Equivalents in Other Linters
+
+<RuleEquivalents pluginId="ts" ruleId="anyReturns" />

--- a/packages/ts/src/plugin.ts
+++ b/packages/ts/src/plugin.ts
@@ -1,5 +1,6 @@
 import { createPlugin } from "@flint.fyi/core";
 
+import anyReturns from "./rules/anyReturns.js";
 import asyncPromiseExecutors from "./rules/asyncPromiseExecutors.js";
 import caseDeclarations from "./rules/caseDeclarations.js";
 import caseDuplicates from "./rules/caseDuplicates.js";
@@ -52,6 +53,7 @@ export const ts = createPlugin({
 	},
 	name: "ts",
 	rules: [
+		anyReturns,
 		asyncPromiseExecutors,
 		caseDeclarations,
 		caseDuplicates,

--- a/packages/ts/src/rules/anyReturns.test.ts
+++ b/packages/ts/src/rules/anyReturns.test.ts
@@ -1,0 +1,649 @@
+import rule from "./anyReturns.js";
+import { ruleTester } from "./ruleTester.js";
+
+ruleTester.describe(rule, {
+	invalid: [
+		{
+			code: `
+function foo() {
+  return 1 as any;
+}
+      `,
+			snapshot: `
+function foo() {
+  return 1 as any;
+  ~~~~~~~~~~~~~~~~
+  Unsafe return of a value of type \`any\`.
+}
+      `,
+		},
+		{
+			code: `
+function foo() {
+  return Object.create(null);
+}
+      `,
+			snapshot: `
+function foo() {
+  return Object.create(null);
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  Unsafe return of a value of type \`any\`.
+}
+      `,
+		},
+		{
+			code: `
+const foo = () => {
+  return 1 as any;
+};
+      `,
+			snapshot: `
+const foo = () => {
+  return 1 as any;
+  ~~~~~~~~~~~~~~~~
+  Unsafe return of a value of type \`any\`.
+};
+      `,
+		},
+		{
+			code: `
+const foo = () => Object.create(null);'
+      `,
+			snapshot: `
+const foo = () => Object.create(null);'
+                  ~~~~~~~~~~~~~~~~~~~
+                  Unsafe return of a value of type \`any\`.
+      `,
+		},
+		{
+			code: `
+function foo() {
+  return [] as any[];
+}
+      `,
+			snapshot: `
+function foo() {
+  return [] as any[];
+  ~~~~~~~~~~~~~~~~~~~
+  Unsafe return of a value of type \`any[]\`.
+}
+      `,
+		},
+		{
+			code: `
+function foo() {
+  return [] as Array<any>;
+}
+      `,
+			snapshot: `
+function foo() {
+  return [] as Array<any>;
+  ~~~~~~~~~~~~~~~~~~~~~~~~
+  Unsafe return of a value of type \`any[]\`.
+}
+      `,
+		},
+		{
+			code: `
+function foo() {
+  return [] as readonly any[];
+}
+      `,
+			snapshot: `
+function foo() {
+  return [] as readonly any[];
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  Unsafe return of a value of type \`any[]\`.
+}
+      `,
+		},
+		{
+			code: `
+function foo() {
+  return [] as Readonly<any[]>;
+}
+      `,
+			snapshot: `
+function foo() {
+  return [] as Readonly<any[]>;
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  Unsafe return of a value of type \`any[]\`.
+}
+      `,
+		},
+		{
+			code: `
+const foo = () => {
+  return [] as any[];
+};
+      `,
+			snapshot: `
+const foo = () => {
+  return [] as any[];
+  ~~~~~~~~~~~~~~~~~~~
+  Unsafe return of a value of type \`any[]\`.
+};
+      `,
+		},
+		{
+			code: `
+const foo = () => [] as any[];
+      `,
+			snapshot: `
+const foo = () => [] as any[];
+                  ~~~~~~~~~~~
+                  Unsafe return of a value of type \`any[]\`.
+      `,
+		},
+		{
+			code: `
+function foo(): Set<string> {
+  return new Set<any>();
+}
+      `,
+			snapshot: `
+function foo(): Set<string> {
+  return new Set<any>();
+  ~~~~~~~~~~~~~~~~~~~~~~
+  Unsafe return of type \`Set<any>\` from function with return type \`Set<string>\`.
+}
+      `,
+		},
+		{
+			code: `
+function foo(): Map<string, string> {
+  return new Map<string, any>();
+}
+      `,
+			snapshot: `
+function foo(): Map<string, string> {
+  return new Map<string, any>();
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  Unsafe return of type \`Map<string, any>\` from function with return type \`Map<string, string>\`.
+}
+      `,
+		},
+		{
+			code: `
+function foo(): Set<string[]> {
+  return new Set<any[]>();
+}
+      `,
+			snapshot: `
+function foo(): Set<string[]> {
+  return new Set<any[]>();
+  ~~~~~~~~~~~~~~~~~~~~~~~~
+  Unsafe return of type \`Set<any[]>\` from function with return type \`Set<string[]>\`.
+}
+      `,
+		},
+		{
+			code: `
+function foo(): Set<Set<Set<string>>> {
+  return new Set<Set<Set<any>>>();
+}
+      `,
+			snapshot: `
+function foo(): Set<Set<Set<string>>> {
+  return new Set<Set<Set<any>>>();
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  Unsafe return of type \`Set<Set<Set<any>>>\` from function with return type \`Set<Set<Set<string>>>\`.
+}
+      `,
+		},
+
+		{
+			code: `
+type Fn = () => Set<string>;
+const foo1: Fn = () => new Set<any>();
+const foo2: Fn = function test() {
+  return new Set<any>();
+};
+      `,
+			snapshot: `
+type Fn = () => Set<string>;
+const foo1: Fn = () => new Set<any>();
+                       ~~~~~~~~~~~~~~
+                       Unsafe return of type \`Set<any>\` from function with return type \`Set<string>\`.
+const foo2: Fn = function test() {
+  return new Set<any>();
+  ~~~~~~~~~~~~~~~~~~~~~~
+  Unsafe return of type \`Set<any>\` from function with return type \`Set<string>\`.
+};
+      `,
+		},
+		{
+			code: `
+type Fn = () => Set<string>;
+function receiver(arg: Fn) {}
+receiver(() => new Set<any>());
+receiver(function test() {
+  return new Set<any>();
+});
+      `,
+			snapshot: `
+type Fn = () => Set<string>;
+function receiver(arg: Fn) {}
+receiver(() => new Set<any>());
+               ~~~~~~~~~~~~~~
+               Unsafe return of type \`Set<any>\` from function with return type \`Set<string>\`.
+receiver(function test() {
+  return new Set<any>();
+  ~~~~~~~~~~~~~~~~~~~~~~
+  Unsafe return of type \`Set<any>\` from function with return type \`Set<string>\`.
+});
+      `,
+		},
+		{
+			code: `
+function foo() {
+  return this;
+}
+
+function bar() {
+  return () => this;
+}
+      `,
+			snapshot: `
+function foo() {
+  return this;
+  ~~~~~~~~~~~~
+  Unsafe return of a value of type \`any\`.
+}
+
+function bar() {
+  return () => this;
+               ~~~~
+               Unsafe return of a value of type \`any\`.
+}
+      `,
+		},
+		{
+			code: `
+declare function foo(arg: null | (() => any)): void;
+foo(() => 'foo' as any);
+      `,
+			snapshot: `
+declare function foo(arg: null | (() => any)): void;
+foo(() => 'foo' as any);
+          ~~~~~~~~~~~~
+          Unsafe return of a value of type \`any\`.
+      `,
+		},
+		{
+			code: `
+let value: NotKnown;
+
+function example() {
+  return value;
+}
+      `,
+			snapshot: `
+let value: NotKnown;
+
+function example() {
+  return value;
+  ~~~~~~~~~~~~~
+  Unsafe return of a value of type error.
+}
+      `,
+		},
+		{
+			code: `
+declare const value: any;
+async function foo() {
+  return value;
+}
+      `,
+			snapshot: `
+declare const value: any;
+async function foo() {
+  return value;
+  ~~~~~~~~~~~~~
+  Unsafe return of a value of type \`any\`.
+}
+      `,
+		},
+		{
+			code: `
+declare const value: Promise<any>;
+async function foo(): Promise<number> {
+  return value;
+}
+      `,
+			snapshot: `
+declare const value: Promise<any>;
+async function foo(): Promise<number> {
+  return value;
+  ~~~~~~~~~~~~~
+  Unsafe return of a value of type \`Promise<any>\`.
+}
+      `,
+		},
+		{
+			code: `
+async function foo(arg: number) {
+  return arg as Promise<any>;
+}
+      `,
+			snapshot: `
+async function foo(arg: number) {
+  return arg as Promise<any>;
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  Unsafe return of a value of type \`Promise<any>\`.
+}
+      `,
+		},
+		{
+			code: `
+function foo(): Promise<any> {
+  return {} as any;
+}
+      `,
+			snapshot: `
+function foo(): Promise<any> {
+  return {} as any;
+  ~~~~~~~~~~~~~~~~~
+  Unsafe return of a value of type \`any\`.
+}
+      `,
+		},
+		{
+			code: `
+function foo(): Promise<object> {
+  return {} as any;
+}
+      `,
+			snapshot: `
+function foo(): Promise<object> {
+  return {} as any;
+  ~~~~~~~~~~~~~~~~~
+  Unsafe return of a value of type \`any\`.
+}
+      `,
+		},
+		{
+			code: `
+async function foo(): Promise<object> {
+  return Promise.resolve<any>({});
+}
+      `,
+			snapshot: `
+async function foo(): Promise<object> {
+  return Promise.resolve<any>({});
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  Unsafe return of a value of type \`Promise<any>\`.
+}
+      `,
+		},
+		{
+			code: `
+async function foo(): Promise<object> {
+  return Promise.resolve<Promise<Promise<any>>>({} as Promise<any>);
+}
+      `,
+			snapshot: `
+async function foo(): Promise<object> {
+  return Promise.resolve<Promise<Promise<any>>>({} as Promise<any>);
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  Unsafe return of a value of type \`Promise<any>\`.
+}
+      `,
+		},
+		{
+			code: `
+async function foo(): Promise<object> {
+  return {} as Promise<Promise<Promise<Promise<any>>>>;
+}
+      `,
+			snapshot: `
+async function foo(): Promise<object> {
+  return {} as Promise<Promise<Promise<Promise<any>>>>;
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  Unsafe return of a value of type \`Promise<any>\`.
+}
+      `,
+		},
+		{
+			code: `
+async function foo() {
+  return {} as Promise<Promise<Promise<Promise<any>>>>;
+}
+      `,
+			snapshot: `
+async function foo() {
+  return {} as Promise<Promise<Promise<Promise<any>>>>;
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  Unsafe return of a value of type \`Promise<any>\`.
+}
+      `,
+		},
+		{
+			code: `
+async function foo() {
+  return {} as Promise<any> | Promise<object>;
+}
+      `,
+			snapshot: `
+async function foo() {
+  return {} as Promise<any> | Promise<object>;
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  Unsafe return of a value of type \`Promise<any>\`.
+}
+      `,
+		},
+		{
+			code: `
+async function foo() {
+  return {} as Promise<any | object>;
+}
+      `,
+			snapshot: `
+async function foo() {
+  return {} as Promise<any | object>;
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  Unsafe return of a value of type \`Promise<any>\`.
+}
+      `,
+		},
+		{
+			code: `
+async function foo() {
+  return {} as Promise<any> & { __brand: 'any' };
+}
+      `,
+			snapshot: `
+async function foo() {
+  return {} as Promise<any> & { __brand: 'any' };
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  Unsafe return of a value of type \`Promise<any>\`.
+}
+      `,
+		},
+		{
+			code: `
+interface Alias<T> extends Promise<any> {
+  foo: 'bar';
+}
+
+declare const value: Alias<number>;
+async function foo() {
+  return value;
+}
+      `,
+			snapshot: `
+interface Alias<T> extends Promise<any> {
+  foo: 'bar';
+}
+
+declare const value: Alias<number>;
+async function foo() {
+  return value;
+  ~~~~~~~~~~~~~
+  Unsafe return of a value of type \`Promise<any>\`.
+}
+      `,
+		},
+	],
+	valid: [
+		`
+return 1 as any;
+    `,
+		`
+function foo() {
+  return;
+}
+    `,
+		`
+function foo() {
+  return 1;
+}
+    `,
+		`
+function foo() {
+  return '';
+}
+    `,
+		`
+function foo() {
+  return true;
+}
+    `,
+		// this actually types as `never[]`
+		`
+function foo() {
+  return [];
+}
+    `,
+		// explicit any return type is allowed, if you want to be unsafe like that
+		`
+function foo(): any {
+  return {} as any;
+}
+    `,
+		`
+declare function foo(arg: () => any): void;
+foo((): any => 'foo' as any);
+    `,
+		`
+declare function foo(arg: null | (() => any)): void;
+foo((): any => 'foo' as any);
+    `,
+		// explicit any array return type is allowed, if you want to be unsafe like that
+		`
+function foo(): any[] {
+  return [] as any[];
+}
+    `,
+		// explicit any generic return type is allowed, if you want to be unsafe like that
+		`
+function foo(): Set<any> {
+  return new Set<any>();
+}
+    `,
+		`
+async function foo(): Promise<any> {
+  return Promise.resolve({} as any);
+}
+    `,
+		`
+async function foo(): Promise<any> {
+  return {} as any;
+}
+    `,
+		`
+function foo(): object {
+  return Promise.resolve({} as any);
+}
+    `,
+		// TODO - this should error, but it's hard to detect, as the type references are different
+		`
+function foo(): ReadonlySet<number> {
+  return new Set<any>();
+}
+    `,
+		`
+function foo(): Set<number> {
+  return new Set([1]);
+}
+    `,
+		`
+      type Foo<T = number> = { prop: T };
+      function foo(): Foo {
+        return { prop: 1 } as Foo<number>;
+      }
+    `,
+		`
+      type Foo = { prop: any };
+      function foo(): Foo {
+        return { prop: '' } as Foo;
+      }
+    `,
+		// TS 3.9 changed this to be safe
+		`
+      function fn<T extends any>(x: T) {
+        return x;
+      }
+    `,
+		`
+      function fn<T extends any>(x: T): unknown {
+        return x as any;
+      }
+    `,
+		`
+      function fn<T extends any>(x: T): unknown[] {
+        return x as any[];
+      }
+    `,
+		`
+      function fn<T extends any>(x: T): Set<unknown> {
+        return x as Set<any>;
+      }
+    `,
+		`
+      async function fn<T extends any>(x: T): Promise<unknown> {
+        return x as any;
+      }
+    `,
+		`
+      function fn<T extends any>(x: T): Promise<unknown> {
+        return Promise.resolve(x as any);
+      }
+    `,
+		// https://github.com/typescript-eslint/typescript-eslint/issues/2109
+		`
+      function test(): Map<string, string> {
+        return new Map();
+      }
+    `,
+		// https://github.com/typescript-eslint/typescript-eslint/issues/3549
+		`
+      function foo(): any {
+        return [] as any[];
+      }
+    `,
+		`
+      function foo(): unknown {
+        return [] as any[];
+      }
+    `,
+		`
+      declare const value: Promise<any>;
+      function foo() {
+        return value;
+      }
+    `,
+		"const foo: (() => void) | undefined = () => 1;",
+		`
+      class Foo {
+        public foo(): this {
+          return this;
+        }
+
+        protected then(resolve: () => void): void {
+          resolve();
+        }
+      }
+    `,
+	],
+});

--- a/packages/ts/src/rules/anyReturns.ts
+++ b/packages/ts/src/rules/anyReturns.ts
@@ -1,0 +1,263 @@
+import * as tsutils from "ts-api-utils";
+import * as ts from "typescript";
+
+import { typescriptLanguage } from "../language.js";
+import { AnyType, discriminateAnyType } from "./utils/discriminateAnyType.js";
+import { getConstrainedTypeAtLocation } from "./utils/getConstrainedType.js";
+import { getThisExpression } from "./utils/getThisExpression.js";
+import { isUnsafeAssignment } from "./utils/isUnsafeAssignment.js";
+
+export default typescriptLanguage.createRule({
+	about: {
+		description: "Reports returning a value with type `any` from a function.",
+		id: "anyReturns",
+		preset: "logical",
+	},
+	messages: {
+		unsafeReturn: {
+			primary: "Unsafe return of a value of type {{ type }}.",
+			secondary: [
+				"Returning a value of type `any` or a similar unsafe type defeats TypeScript's type safety guarantees.",
+				"This can allow unexpected types to propagate through your codebase, potentially causing runtime errors.",
+			],
+			suggestions: [
+				"Ensure the returned value has a well-defined, specific type.",
+			],
+		},
+		unsafeReturnAssignment: {
+			primary:
+				"Unsafe return of type `{{ sender }}` from function with return type `{{ receiver }}`.",
+			secondary: [
+				"The function's declared return type does not safely accept the value being returned.",
+				"This can allow unexpected types to propagate through your codebase, potentially causing runtime errors.",
+			],
+			suggestions: [
+				"Adjust the return type of the function to match the returned value, if appropriate.",
+				"Otherwise, refine the returned value to ensure it matches the expected return type.",
+			],
+		},
+		unsafeReturnThis: {
+			primary:
+				"Unsafe return of a value of type `{{ type }}`. `this` is typed as `any`.",
+			secondary: [
+				"Returning `this` when it is implicitly typed as `any` introduces type-unsafe behavior.",
+				"This can allow unexpected types to propagate through your codebase, potentially causing runtime errors.",
+			],
+			suggestions: [
+				"Enable the `noImplicitThis` compiler option to enforce explicit `this` types.",
+				"Add an explicit `this` parameter to the function to clarify its type.",
+			],
+		},
+	},
+	setup(context) {
+		const isNoImplicitThis = tsutils.isStrictCompilerOptionEnabled(
+			context.program.getCompilerOptions(),
+			"noImplicitThis",
+		);
+
+		function checkReturn(returnNode: ts.Node, reportingNode: ts.Node): void {
+			const type = context.typeChecker.getTypeAtLocation(returnNode);
+
+			const anyType = discriminateAnyType(
+				type,
+				context.typeChecker,
+				context.program,
+				returnNode,
+			);
+			const functionNode = ts.findAncestor(
+				returnNode,
+				// TODO: I believe isFunctionLikeDeclaration was incorrectly marked
+				// as deprecated in https://github.com/JoshuaKGoldberg/ts-api-utils/pull/124
+				// It says "With TypeScript v5, in favor of typescript's `isFunctionLike`."
+				// However, isFunctionLike also checks for signature-like nodes,
+				// whereas isFunctionLikeDeclaration checks only for function-like nodes.
+				// eslint-disable-next-line @typescript-eslint/no-deprecated
+				tsutils.isFunctionLikeDeclaration,
+			);
+			if (!functionNode) {
+				return;
+			}
+
+			// function has an explicit return type, so ensure it's a safe return
+			const returnNodeType = getConstrainedTypeAtLocation(
+				returnNode,
+				context.typeChecker,
+			);
+
+			// function expressions will not have their return type modified based on receiver typing
+			// so we have to use the contextual typing in these cases, i.e.
+			// const foo1: () => Set<string> = () => new Set<any>();
+			// the return type of the arrow function is Set<any> even though the variable is typed as Set<string>
+			let functionType =
+				ts.isFunctionExpression(functionNode) ||
+				ts.isArrowFunction(functionNode)
+					? context.typeChecker.getContextualType(functionNode)
+					: context.typeChecker.getTypeAtLocation(functionNode);
+			functionType ??= context.typeChecker.getTypeAtLocation(functionNode);
+			const callSignatures = tsutils.getCallSignaturesOfType(functionType);
+			// If there is an explicit type annotation *and* that type matches the actual
+			// function return type, we shouldn't complain (it's intentional, even if unsafe)
+			if (functionNode.type) {
+				for (const signature of callSignatures) {
+					const signatureReturnType = signature.getReturnType();
+
+					if (
+						returnNodeType === signatureReturnType ||
+						tsutils.isTypeFlagSet(
+							signatureReturnType,
+							ts.TypeFlags.Any | ts.TypeFlags.Unknown,
+						)
+					) {
+						return;
+					}
+					if (
+						tsutils.includesModifier(
+							functionNode.modifiers,
+							ts.SyntaxKind.AsyncKeyword,
+						)
+					) {
+						const awaitedSignatureReturnType =
+							context.typeChecker.getAwaitedType(signatureReturnType);
+
+						const awaitedReturnNodeType =
+							context.typeChecker.getAwaitedType(returnNodeType);
+						if (
+							awaitedReturnNodeType === awaitedSignatureReturnType ||
+							(awaitedSignatureReturnType &&
+								tsutils.isTypeFlagSet(
+									awaitedSignatureReturnType,
+									ts.TypeFlags.Any | ts.TypeFlags.Unknown,
+								))
+						) {
+							return;
+						}
+					}
+				}
+			}
+
+			if (anyType !== AnyType.Safe) {
+				// Allow cases when the declared return type of the function is either unknown or unknown[]
+				// and the function is returning any or any[].
+				for (const signature of callSignatures) {
+					const functionReturnType = signature.getReturnType();
+					if (
+						anyType === AnyType.Any &&
+						tsutils.isTypeFlagSet(functionReturnType, ts.TypeFlags.Unknown)
+					) {
+						return;
+					}
+					if (
+						anyType === AnyType.AnyArray &&
+						context.typeChecker.isArrayType(functionReturnType) &&
+						tsutils.isTypeFlagSet(
+							context.typeChecker.getTypeArguments(
+								functionReturnType as ts.TypeReference,
+							)[0],
+							ts.TypeFlags.Unknown,
+						)
+					) {
+						return;
+					}
+					const awaitedType =
+						context.typeChecker.getAwaitedType(functionReturnType);
+					if (
+						awaitedType &&
+						anyType === AnyType.PromiseAny &&
+						tsutils.isTypeFlagSet(awaitedType, ts.TypeFlags.Unknown)
+					) {
+						return;
+					}
+				}
+
+				if (
+					anyType === AnyType.PromiseAny &&
+					!tsutils.includesModifier(
+						functionNode.modifiers,
+						ts.SyntaxKind.AsyncKeyword,
+					)
+				) {
+					return;
+				}
+
+				let message: "unsafeReturn" | "unsafeReturnThis" = "unsafeReturn";
+				const isErrorType = tsutils.isIntrinsicErrorType(returnNodeType);
+
+				if (!isNoImplicitThis) {
+					// `return this`
+					const thisExpression = getThisExpression(returnNode);
+					if (
+						thisExpression &&
+						tsutils.isTypeFlagSet(
+							getConstrainedTypeAtLocation(thisExpression, context.typeChecker),
+							ts.TypeFlags.Any,
+						)
+					) {
+						message = "unsafeReturnThis";
+					}
+				}
+
+				// If the function return type was not unknown/unknown[], mark usage as unsafeReturn.
+				context.report({
+					data: {
+						type: isErrorType
+							? "error"
+							: anyType === AnyType.Any
+								? "`any`"
+								: anyType === AnyType.PromiseAny
+									? "`Promise<any>`"
+									: "`any[]`",
+					},
+					message,
+					range: {
+						begin: reportingNode.getStart(),
+						end: reportingNode.getEnd(),
+					},
+				});
+				return;
+			}
+
+			const signature = functionType.getCallSignatures().at(0);
+			if (signature) {
+				const functionReturnType = signature.getReturnType();
+				const result = isUnsafeAssignment(
+					returnNodeType,
+					functionReturnType,
+					context.typeChecker,
+					returnNode,
+				);
+				if (!result) {
+					return;
+				}
+
+				const { receiver, sender } = result;
+				context.report({
+					data: {
+						receiver: context.typeChecker.typeToString(receiver),
+						sender: context.typeChecker.typeToString(sender),
+					},
+					message: "unsafeReturnAssignment",
+					range: {
+						begin: reportingNode.getStart(),
+						end: reportingNode.getEnd(),
+					},
+				});
+				return;
+			}
+		}
+
+		return {
+			visitors: {
+				ArrowFunction: (node) => {
+					if (!ts.isBlock(node.body)) {
+						checkReturn(node.body, node.body);
+					}
+				},
+				ReturnStatement: (node) => {
+					if (node.expression != null) {
+						checkReturn(node.expression, node);
+					}
+				},
+			},
+		};
+	},
+});

--- a/packages/ts/src/rules/utils/discriminateAnyType.ts
+++ b/packages/ts/src/rules/utils/discriminateAnyType.ts
@@ -1,0 +1,66 @@
+import * as tsutils from "ts-api-utils";
+import * as ts from "typescript";
+
+export enum AnyType {
+	Any,
+	PromiseAny,
+	AnyArray,
+	Safe,
+}
+
+/**
+ * @returns `AnyType.Any` if the type is `any`, `AnyType.AnyArray` if the type is `any[]` or `readonly any[]`, `AnyType.PromiseAny` if the type is `Promise&lt;any>`,
+ * otherwise it returns `AnyType.Safe`.
+ */
+export function discriminateAnyType(
+	type: ts.Type,
+	checker: ts.TypeChecker,
+	program: ts.Program,
+	tsNode: ts.Node,
+): AnyType {
+	return discriminateAnyTypeWorker(type, checker, program, tsNode, new Set());
+}
+
+function discriminateAnyTypeWorker(
+	type: ts.Type,
+	checker: ts.TypeChecker,
+	program: ts.Program,
+	tsNode: ts.Node,
+	visited: Set<ts.Type>,
+) {
+	if (visited.has(type)) {
+		return AnyType.Safe;
+	}
+	visited.add(type);
+	if (tsutils.isTypeFlagSet(type, ts.TypeFlags.Any)) {
+		return AnyType.Any;
+	}
+	if (
+		checker.isArrayType(type) &&
+		tsutils.isTypeFlagSet(
+			checker.getTypeArguments(type as ts.TypeReference)[0],
+			ts.TypeFlags.Any,
+		)
+	) {
+		return AnyType.AnyArray;
+	}
+	for (const part of tsutils.typeConstituents(type)) {
+		if (tsutils.isThenableType(checker, tsNode, part)) {
+			const awaitedType = checker.getAwaitedType(part);
+			if (awaitedType) {
+				const awaitedAnyType = discriminateAnyTypeWorker(
+					awaitedType,
+					checker,
+					program,
+					tsNode,
+					visited,
+				);
+				if (awaitedAnyType === AnyType.Any) {
+					return AnyType.PromiseAny;
+				}
+			}
+		}
+	}
+
+	return AnyType.Safe;
+}

--- a/packages/ts/src/rules/utils/getThisExpression.ts
+++ b/packages/ts/src/rules/utils/getThisExpression.ts
@@ -1,0 +1,24 @@
+import * as tsutils from "ts-api-utils";
+import * as ts from "typescript";
+
+export function getThisExpression(node: ts.Node): null | ts.ThisExpression {
+	while (true) {
+		node = skipParentheses(node);
+		if (ts.isCallExpression(node) || tsutils.isAccessExpression(node)) {
+			node = node.expression;
+		} else if (tsutils.isThisExpression(node)) {
+			return node;
+		} else {
+			break;
+		}
+	}
+
+	return null;
+}
+
+function skipParentheses(node: ts.Node): ts.Node {
+	while (ts.isParenthesizedExpression(node)) {
+		node = node.expression;
+	}
+	return node;
+}

--- a/packages/ts/src/rules/utils/isUnsafeAssignment.ts
+++ b/packages/ts/src/rules/utils/isUnsafeAssignment.ts
@@ -1,0 +1,113 @@
+import * as tsutils from "ts-api-utils";
+import * as ts from "typescript";
+
+/**
+ * Does a simple check to see if there is an any being assigned to a non-any type.
+ *
+ * This also checks generic positions to ensure there's no unsafe sub-assignments.
+ * Note: in the case of generic positions, it makes the assumption that the two types are the same.
+ * @example See tests for examples
+ * @returns false if it's safe, or an object with the two types if it's unsafe
+ */
+export function isUnsafeAssignment(
+	type: ts.Type,
+	receiver: ts.Type,
+	checker: ts.TypeChecker,
+	senderNode: null | ts.Node,
+): false | { receiver: ts.Type; sender: ts.Type } {
+	return isUnsafeAssignmentWorker(
+		type,
+		receiver,
+		checker,
+		senderNode,
+		new Map(),
+	);
+}
+
+function isUnsafeAssignmentWorker(
+	type: ts.Type,
+	receiver: ts.Type,
+	checker: ts.TypeChecker,
+	senderNode: null | ts.Node,
+	visited: Map<ts.Type, Set<ts.Type>>,
+): false | { receiver: ts.Type; sender: ts.Type } {
+	if (tsutils.isTypeFlagSet(type, ts.TypeFlags.Any)) {
+		// Allow assignment of any ==> unknown.
+		if (tsutils.isTypeFlagSet(receiver, ts.TypeFlags.Unknown)) {
+			return false;
+		}
+
+		if (!tsutils.isTypeFlagSet(receiver, ts.TypeFlags.Any)) {
+			return { receiver, sender: type };
+		}
+	}
+
+	const typeAlreadyVisited = visited.get(type);
+
+	if (typeAlreadyVisited) {
+		if (typeAlreadyVisited.has(receiver)) {
+			return false;
+		}
+		typeAlreadyVisited.add(receiver);
+	} else {
+		visited.set(type, new Set([receiver]));
+	}
+
+	if (tsutils.isTypeReference(type) && tsutils.isTypeReference(receiver)) {
+		// TODO - figure out how to handle cases like this,
+		// where the types are assignable, but not the same type
+		/*
+    function foo(): ReadonlySet<number> { return new Set<any>(); }
+
+    // and
+
+    type Test<T> = { prop: T }
+    type Test2 = { prop: string }
+    declare const a: Test<any>;
+    const b: Test2 = a;
+    */
+
+		if (type.target !== receiver.target) {
+			// if the type references are different, assume safe, as we won't know how to compare the two types
+			// the generic positions might not be equivalent for both types
+			return false;
+		}
+
+		if (
+			senderNode != null &&
+			ts.isNewExpression(senderNode) &&
+			ts.isIdentifier(senderNode.expression) &&
+			senderNode.expression.text === "Map" &&
+			(senderNode.arguments == null || senderNode.arguments.length === 0) &&
+			senderNode.typeArguments == null
+		) {
+			// special case to handle `new Map()`
+			// unfortunately Map's default empty constructor is typed to return `Map<any, any>` :(
+			// https://github.com/typescript-eslint/typescript-eslint/issues/2109#issuecomment-634144396
+			return false;
+		}
+
+		const typeArguments = type.typeArguments ?? [];
+		const receiverTypeArguments = receiver.typeArguments ?? [];
+
+		for (let i = 0; i < typeArguments.length; i += 1) {
+			const arg = typeArguments[i];
+			const receiverArg = receiverTypeArguments[i];
+
+			const unsafe = isUnsafeAssignmentWorker(
+				arg,
+				receiverArg,
+				checker,
+				senderNode,
+				visited,
+			);
+			if (unsafe) {
+				return { receiver, sender: type };
+			}
+		}
+
+		return false;
+	}
+
+	return false;
+}


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to flint! ❤️‍🔥
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #617
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/flint/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/flint/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

I adapted the implementation from https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/src/rules/no-unsafe-return.ts

And copied the tests from https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/tests/rules/no-unsafe-return.test.ts
