### PR TITLE
feat: implement imageAltRedundancy for JSX plugin

### DIFF
--- a/packages/comparisons/src/data.json
+++ b/packages/comparisons/src/data.json
@@ -1174,6 +1174,7 @@
 			}
 		],
 		"flint": {
+			"implemented": true,
 			"name": "imageAltRedundancy",
 			"plugin": "jsx",
 			"preset": "Logical"

--- a/packages/plugin-jsx/src/jsx.ts
+++ b/packages/plugin-jsx/src/jsx.ts
@@ -11,6 +11,7 @@ import distractingElements from "./rules/distractingElements.js";
 import headingContents from "./rules/headingContents.js";
 import htmlLangs from "./rules/htmlLangs.js";
 import iframeTitles from "./rules/iframeTitles.js";
+import imageAltRedundancy from "./rules/imageAltRedundancy.js";
 import mediaCaptions from "./rules/mediaCaptions.js";
 import mouseEventKeyEvents from "./rules/mouseEventKeyEvents.js";
 import scopeProps from "./rules/scopeProps.js";
@@ -30,6 +31,7 @@ export const jsx = createPlugin({
 		headingContents,
 		htmlLangs,
 		iframeTitles,
+		imageAltRedundancy,
 		mediaCaptions,
 		mouseEventKeyEvents,
 		scopeProps,

--- a/packages/plugin-jsx/src/rules/imageAltRedundancy.test.ts
+++ b/packages/plugin-jsx/src/rules/imageAltRedundancy.test.ts
@@ -1,0 +1,52 @@
+import rule from "./imageAltRedundancy.js";
+import { ruleTester } from "./ruleTester.js";
+
+ruleTester.describe(rule, {
+	invalid: [
+		{
+			code: `<img src="foo.jpg" alt="Photo of foo" />`,
+			fileName: "file.tsx",
+			snapshot: `<img src="foo.jpg" alt="Photo of foo" />
+                   ~~~~~~~~~~~~~~~~~~
+                   Alt text should not contain the word 'photo'. Screen readers already announce images as images.`,
+		},
+		{
+			code: `<img src="bar.jpg" alt="Image of bar" />`,
+			fileName: "file.tsx",
+			snapshot: `<img src="bar.jpg" alt="Image of bar" />
+                   ~~~~~~~~~~~~~~~~~~
+                   Alt text should not contain the word 'image'. Screen readers already announce images as images.`,
+		},
+		{
+			code: `<img src="baz.jpg" alt="Picture of baz" />`,
+			fileName: "file.tsx",
+			snapshot: `<img src="baz.jpg" alt="Picture of baz" />
+                   ~~~~~~~~~~~~~~~~~~~~
+                   Alt text should not contain the word 'picture'. Screen readers already announce images as images.`,
+		},
+		{
+			code: `<img src="test.jpg" alt="A nice PHOTO" />`,
+			fileName: "file.tsx",
+			snapshot: `<img src="test.jpg" alt="A nice PHOTO" />
+                    ~~~~~~~~~~~~~~~~~~
+                    Alt text should not contain the word 'photo'. Screen readers already announce images as images.`,
+		},
+	],
+	valid: [
+		{
+			code: `<img src="foo.jpg" alt="Foo eating a sandwich" />`,
+			fileName: "file.tsx",
+		},
+		{
+			code: `<img src="bar.jpg" alt="Bar at the beach" />`,
+			fileName: "file.tsx",
+		},
+		{ code: `<img src="baz.jpg" alt="" />`, fileName: "file.tsx" },
+		{
+			code: `<img src="pic.jpg" aria-hidden="true" alt="Picture of something" />`,
+			fileName: "file.tsx",
+		},
+		{ code: `<img src="photo.jpg" alt={description} />`, fileName: "file.tsx" },
+		{ code: `<div alt="Photo" />`, fileName: "file.tsx" },
+	],
+});

--- a/packages/plugin-jsx/src/rules/imageAltRedundancy.ts
+++ b/packages/plugin-jsx/src/rules/imageAltRedundancy.ts
@@ -1,0 +1,113 @@
+import { getTSNodeRange, typescriptLanguage } from "@flint.fyi/ts";
+import * as ts from "typescript";
+
+const redundantWords = ["image", "photo", "picture"];
+
+export default typescriptLanguage.createRule({
+	about: {
+		description:
+			"Reports img alt text containing redundant words like 'image' or 'photo'.",
+		id: "imageAltRedundancy",
+		preset: "logical",
+	},
+	messages: {
+		redundantAlt: {
+			primary:
+				"Alt text should not contain the word '{{ word }}'. Screen readers already announce images as images.",
+			secondary: [
+				"Words like 'image', 'photo', and 'picture' are redundant in alt text.",
+				"Screen readers already identify the element as an image.",
+				"Focus on describing the content of the image instead.",
+			],
+			suggestions: [
+				"Remove redundant words from the alt text",
+				"Describe what the image shows instead",
+			],
+		},
+	},
+	setup(context) {
+		function checkImageAlt(
+			tagName: ts.JsxTagNameExpression,
+			attributes: ts.JsxAttributes,
+		) {
+			if (!ts.isIdentifier(tagName) || tagName.text !== "img") {
+				return;
+			}
+
+			// Check if image is hidden with aria-hidden
+			const ariaHidden = attributes.properties.find(
+				(attr) =>
+					ts.isJsxAttribute(attr) &&
+					ts.isIdentifier(attr.name) &&
+					attr.name.text === "aria-hidden",
+			);
+
+			if (ariaHidden && ts.isJsxAttribute(ariaHidden)) {
+				// If aria-hidden is present and true, skip validation
+				if (!ariaHidden.initializer) {
+					// aria-hidden with no value defaults to true
+					return;
+				}
+
+				if (ts.isStringLiteral(ariaHidden.initializer)) {
+					// aria-hidden="true"
+					if (ariaHidden.initializer.text === "true") {
+						return;
+					}
+				} else if (
+					ts.isJsxExpression(ariaHidden.initializer) &&
+					ariaHidden.initializer.expression
+				) {
+					const expr = ariaHidden.initializer.expression;
+					if (
+						expr.kind === ts.SyntaxKind.TrueKeyword ||
+						(ts.isIdentifier(expr) && expr.text === "true")
+					) {
+						return;
+					}
+				}
+			}
+
+			// Find alt attribute
+			const altAttr = attributes.properties.find(
+				(attr) =>
+					ts.isJsxAttribute(attr) &&
+					ts.isIdentifier(attr.name) &&
+					attr.name.text === "alt",
+			);
+
+			if (!altAttr || !ts.isJsxAttribute(altAttr)) {
+				return;
+			}
+
+			// Check the alt value
+			if (altAttr.initializer && ts.isStringLiteral(altAttr.initializer)) {
+				const altText = altAttr.initializer.text.toLowerCase();
+
+				for (const word of redundantWords) {
+					// Use word boundary regex to match whole words
+					const regex = new RegExp(`\\b${word}\\b`, "i");
+					if (regex.test(altText)) {
+						context.report({
+							data: { word },
+							message: "redundantAlt",
+							range: getTSNodeRange(altAttr, context.sourceFile),
+						});
+						break; // Report only once per alt attribute
+					}
+				}
+			}
+		}
+
+		return {
+			visitors: {
+				JsxOpeningElement(node: ts.JsxOpeningElement) {
+					checkImageAlt(node.tagName, node.attributes);
+				},
+				JsxSelfClosingElement(node: ts.JsxSelfClosingElement) {
+					checkImageAlt(node.tagName, node.attributes);
+				},
+			},
+		};
+	},
+});

--- a/packages/site/src/content/docs/rules/jsx/imageAltRedundancy.mdx
+++ b/packages/site/src/content/docs/rules/jsx/imageAltRedundancy.mdx
@@ -1,0 +1,62 @@
+---
+description: "Reports img alt text containing redundant words like 'image' or 'photo'."
+title: "imageAltRedundancy"
+topic: "rules"
+---
+
+import { Tabs, TabItem } from "@astrojs/starlight/components";
+import { RuleEquivalents } from "~/components/RuleEquivalents";
+import RuleSummary from "~/components/RuleSummary.astro";
+
+<RuleSummary plugin="jsx" rule="imageAltRedundancy" />
+
+Screen readers already announce `img` elements as images. Using words like "image", "photo", or "picture" in alt text is redundant and provides no additional value to users.
+
+Focus on describing what the image shows rather than stating that it is an image.
+
+## Examples
+
+<Tabs>
+<TabItem label="❌ Incorrect">
+
+```tsx
+<img src="foo.jpg" alt="Photo of foo" />
+```
+
+```tsx
+<img src="bar.jpg" alt="Image of bar" />
+```
+
+```tsx
+<img src="baz.jpg" alt="Picture of baz" />
+```
+
+</TabItem>
+<TabItem label="✅ Correct">
+
+```tsx
+<img src="foo.jpg" alt="Foo eating a sandwich" />
+```
+
+```tsx
+<img src="bar.jpg" alt="Bar at the beach" />
+```
+
+```tsx
+<img src="pic.jpg" aria-hidden alt="Picture of something" />
+```
+
+</TabItem>
+</Tabs>
+
+## When Not To Use It
+
+If you need to use these words in a different language or context, you can disable this rule.
+
+## Further Reading
+
+- [WebAIM: Alternative Text](https://webaim.org/techniques/alttext/)
+
+## Equivalents in Other Linters
+
+<RuleEquivalents pluginId="jsx" ruleId="imageAltRedundancy" />


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #533
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/flint/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/flint/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Implements the `imageAltRedundancy` rule for the JSX plugin, which prevents redundant words in img alt text.

Screen readers already announce images as images. Words like 'image', 'photo', and 'picture' are redundant in alt text.

### Features
- Checks for redundant words: image, photo, picture
- Case-insensitive matching
- Skips aria-hidden images
- Comprehensive test coverage