### PR TITLE
docs: remove comparisons from rules tables

### DIFF
--- a/packages/site/src/components/RulesTable.module.css
+++ b/packages/site/src/components/RulesTable.module.css
@@ -1,47 +1,35 @@
 .rulesTable {
-	font-size: var(--tableFontSize);
-	table-layout: fixed;
 	width: 100%;
-}
-
-.rulesTable.small {
-	--tableFontSize: 60%;
-}
-
-.rulesTable.normal {
-	--tableFontSize: 85%;
-}
-
-.rulesTable td.rulesWithPlugin {
-	--tableRuleCellWidth: 10%;
-}
-
-.rulesTable td.rulesWithoutPlugin {
-	--tableRuleCellWidth: 30%;
-}
-
-.rulesTable td:not(:empty) {
-	width: var(--tableRuleCellWidth);
 }
 
 .rulesTable code {
 	word-wrap: normal;
 }
 
-.small code {
-	font-size: var(--tableFontSize);
-}
-
 .rulesTable td,
 .rulesTable th {
 	padding: 0.25rem;
+	vertical-align: middle;
 }
 
 .rulesTable td:first-of-type,
 .rulesTable th:first-of-type {
 	padding-left: 0;
+	width: 100%;
 }
 
-.rulesTable td a:has(code) {
+.rulesTable td:not(:first-of-type),
+.rulesTable th:not(:first-of-type) {
+	min-width: 10vw;
+}
+
+.rulesTable code a {
+	font-size: var(--sl-text-code);
+	font-weight: bold;
+}
+
+.rulesTable small {
 	display: block;
+	font-size: var(--sl-text-xs);
+	font-style: italic;
 }

--- a/packages/site/src/components/RulesTable.tsx
+++ b/packages/site/src/components/RulesTable.tsx
@@ -2,16 +2,14 @@ import {
 	comparisons,
 	type FlintRuleReference,
 	type Comparison,
-	type Linter,
-	linterNames,
 } from "@flint.fyi/comparisons" with { type: "json" };
 import clsx from "clsx";
 
 import styles from "./RulesTable.module.css";
-import { RuleEquivalentLinks } from "./RuleEquivalentLinks";
+import { getRuleForPluginSafe } from "./getRuleForPlugin";
 
 const pluginNames: Record<string, string> = {
-	browser: "browser",
+	browser: "Browser",
 	cspell: "CSpell",
 	deno: "Deno",
 	flint: "Flint",
@@ -26,28 +24,20 @@ const pluginNames: Record<string, string> = {
 	yml: "YML",
 };
 
-function getSortKey(rule: Comparison) {
-	return [
-		rule.flint.plugin,
-		rule.flint.preset,
-		rule.flint.strictness,
-		rule.flint.name,
-	]
-		.join("-")
-		.replace("Not implemented", "Z-Not-implemented");
-}
-
 function renderFlintPreset(flint: Comparison["flint"]) {
-	return flint.strictness
-		? `${flint.preset} (${flint.strictness})`
-		: flint.preset;
+	const hrefBase = `/rules/${flint.plugin}#${flint.preset.toLowerCase()}`;
+	const [href, text] = flint.strictness
+		? [`${hrefBase}strict`, `${flint.preset} (${flint.strictness})`]
+		: [hrefBase, flint.preset];
+
+	return <a href={href}>{text}</a>;
 }
 
 export interface RulesTableProps {
 	implementing: boolean;
 	plugin?: string;
 	small?: boolean;
-	hidePreset?: boolean;
+	sortBy?: "name" | "preset";
 }
 
 function renderFlintName(flint: FlintRuleReference) {
@@ -58,6 +48,10 @@ function renderFlintName(flint: FlintRuleReference) {
 	) : (
 		flint.name
 	);
+}
+
+function renderFlintRuleDescription(flint: FlintRuleReference) {
+	return getRuleForPluginSafe(flint.plugin, flint.name)?.about.description;
 }
 
 function renderImplemented(values: Comparison[]) {
@@ -73,17 +67,18 @@ function renderImplemented(values: Comparison[]) {
 
 export function RulesTable({
 	implementing,
-	hidePreset,
+	sortBy,
 	plugin,
 	small,
 }: RulesTableProps) {
-	const foundLinters = {
-		biome: false,
-		deno: false,
-		eslint: false,
-		markdownlint: false,
-		oxlint: false,
-	};
+	const comparator: (a: Comparison, b: Comparison) => number =
+		sortBy === "name"
+			? (a, b) => a.flint.name.localeCompare(b.flint.name)
+			: (a, b) =>
+					a.flint.preset === b.flint.preset
+						? a.flint.name.localeCompare(b.flint.name)
+						: a.flint.preset.localeCompare(b.flint.preset);
+
 	const values = comparisons
 		.filter((comparison) => {
 			if ((comparison.flint.preset !== "Not implementing") !== implementing) {
@@ -94,19 +89,9 @@ export function RulesTable({
 				return false;
 			}
 
-			for (const linter in linterNames) {
-				if (comparison[linter as Linter]) {
-					foundLinters[linter as Linter] = true;
-				}
-			}
-
 			return true;
 		})
-		.sort((a, b) => getSortKey(a).localeCompare(getSortKey(b)));
-
-	const rulesClassName = plugin
-		? styles.rulesWithoutPlugin
-		: styles.rulesWithPlugin;
+		.sort(comparator);
 
 	return (
 		<div>
@@ -124,41 +109,29 @@ export function RulesTable({
 				)}
 			>
 				<thead>
-					<th>Flint Name</th>
+					<th>Flint Rule</th>
 					{!plugin && <th>Plugin</th>}
-					{!hidePreset && implementing && <th>Preset</th>}
-					{Object.entries(linterNames).map(
-						([linter, linterName]) =>
-							foundLinters[linter as Linter] && (
-								<th key={linterName}>{linterName}</th>
-							),
-					)}
-					{!implementing && <th>Notes</th>}
+					<th>{implementing ? "Preset" : "Notes"}</th>
 				</thead>
 				<tbody>
 					{values.map((comparison) => (
 						<tr key={comparison.flint.name}>
 							<td>
 								<code>{renderFlintName(comparison.flint)}</code>
+								<small>{renderFlintRuleDescription(comparison.flint)}</small>
 							</td>
-							{!plugin && <td>{pluginNames[comparison.flint.plugin]}</td>}
-							{!hidePreset && implementing && (
-								<td>{renderFlintPreset(comparison.flint)}</td>
+							{!plugin && (
+								<td>
+									<a href={`/rules/${comparison.flint.plugin}`}>
+										{pluginNames[comparison.flint.plugin]}
+									</a>
+								</td>
 							)}
-							{(Object.keys(linterNames) as Linter[]).map(
-								(linter) =>
-									foundLinters[linter] && (
-										<td className={rulesClassName} key={linter}>
-											{comparison[linter] && (
-												<RuleEquivalentLinks
-													comparison={comparison}
-													linter={linter}
-												/>
-											)}
-										</td>
-									),
-							)}
-							{!implementing && <td>{comparison.notes}</td>}
+							<td>
+								{implementing
+									? renderFlintPreset(comparison.flint)
+									: comparison.notes}
+							</td>
 						</tr>
 					))}
 				</tbody>

--- a/packages/site/src/components/getRuleForPlugin.ts
+++ b/packages/site/src/components/getRuleForPlugin.ts
@@ -33,3 +33,21 @@ export function getRuleForPlugin(pluginId: string, ruleId: string): AnyRule {
 
 	return rule as AnyRule;
 }
+
+export function getRuleForPluginSafe(
+	pluginId: string,
+	ruleId: string,
+): AnyRule | undefined {
+	if (!(pluginId in plugins)) {
+		return undefined;
+	}
+
+	const plugin = plugins[pluginId as keyof typeof plugins];
+	const rule = plugin.rulesById.get(ruleId);
+
+	if (!rule) {
+		return undefined;
+	}
+
+	return rule as AnyRule;
+}

--- a/packages/site/src/content/docs/rules/cspell.mdx
+++ b/packages/site/src/content/docs/rules/cspell.mdx
@@ -1,6 +1,6 @@
 ---
 description: "CSpell linting rules provided by Flint."
-title: "About"
+title: "CSpell Plugin"
 ---
 
 import { PackageManagers } from "starlight-package-managers";

--- a/packages/site/src/content/docs/rules/flint.mdx
+++ b/packages/site/src/content/docs/rules/flint.mdx
@@ -1,6 +1,6 @@
 ---
-description: "CSpell linting rules provided by Flint."
-title: "About"
+description: "Flint plugin linting rules provided by Flint. Meta!"
+title: "Flint Plugin"
 ---
 
 import { PackageManagers } from "starlight-package-managers";

--- a/packages/site/src/content/docs/rules/index.mdx
+++ b/packages/site/src/content/docs/rules/index.mdx
@@ -17,7 +17,7 @@ Flint will provide a comprehensive set of rules for all languages common to most
 These rules will be implemented as a part of Flint.
 Each is equivalent to at least one existing rule in another linter.
 
-<RulesTable implementing hidePreset small />
+<RulesTable implementing small sortBy="name" />
 
 ## Not Implementing
 
@@ -25,4 +25,4 @@ These rules will not be implemented as a part of Flint.
 They are all too opinionated and/or too niche to be kept in the Flint project.
 They're free to be implemented as a community third-party Flint plugin.
 
-<RulesTable implementing={false} hidePreset small />
+<RulesTable implementing={false} small sortBy="name" />

--- a/packages/site/src/content/docs/rules/json.mdx
+++ b/packages/site/src/content/docs/rules/json.mdx
@@ -1,6 +1,6 @@
 ---
 description: "JSON linting rules provided by Flint."
-title: "About"
+title: "JSON Plugin"
 ---
 
 import { RulesTable } from "~/components/RulesTable.tsx";

--- a/packages/site/src/content/docs/rules/md.mdx
+++ b/packages/site/src/content/docs/rules/md.mdx
@@ -1,6 +1,6 @@
 ---
 description: "Markdown linting rules provided by Flint."
-title: "About"
+title: "Markdown Plugin"
 ---
 
 import { RulesTable } from "~/components/RulesTable.tsx";

--- a/packages/site/src/content/docs/rules/ts.mdx
+++ b/packages/site/src/content/docs/rules/ts.mdx
@@ -1,6 +1,6 @@
 ---
 description: "Consecutive non-null assertion operators are unnecessary."
-title: "About"
+title: "TypeScript Plugin"
 ---
 
 import { RulesTable } from "~/components/RulesTable.tsx";

--- a/packages/site/src/content/docs/rules/yml.mdx
+++ b/packages/site/src/content/docs/rules/yml.mdx
@@ -1,6 +1,6 @@
 ---
 description: "YML linting rules provided by Flint."
-title: "About"
+title: "YML Plugin"
 ---
 
 import { RulesTable } from "~/components/RulesTable.tsx";


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #981
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/flint/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/flint/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Removes comparisons to other linter rules from the top-level rules tables. Instead, I added in rule descriptions -when they exist-, made sorting prioritize rule names, and made presets & plugins link to those docs pages.

Also fixed the titles on some plugin pages.

❤️‍🔥