### PR TITLE
fix(cli): print the correct number of fixable errors in CLI output

### DIFF
--- a/packages/core/src/types/reports.ts
+++ b/packages/core/src/types/reports.ts
@@ -22,17 +22,17 @@ export interface NormalizedReportRangeObject {
  * A full rule report that can be used to display to users via a reporter.
  */
 export interface NormalizedReport {
-	data?: ReportInterpolationData;
+	data?: ReportInterpolationData | undefined;
 
 	/**
 	 * Any files that should be factored into caching this report.
 	 */
 	dependencies?: string[];
 
-	fix?: Fix[];
+	fix?: Fix[] | undefined;
 	message: ReportMessageData;
 	range: NormalizedReportRangeObject;
-	suggestions?: Suggestion[];
+	suggestions?: Suggestion[] | undefined;
 }
 
 export interface NormalizedRuleReportWithFix extends NormalizedReport {
@@ -45,16 +45,16 @@ export type ReportInterpolationData = Record<string, boolean | number | string>;
  * The internal raw rule report format used by rules themselves.
  */
 export interface RuleReport<Message extends string = string> {
-	data?: ReportInterpolationData;
+	data?: ReportInterpolationData | undefined;
 
 	/**
 	 * Any files that should be factored into caching this report.
 	 */
 	dependencies?: string[];
 
-	fix?: Fix | Fix[];
+	fix?: Fix | Fix[] | undefined;
 	message: Message;
-	suggestions?: Suggestion[];
+	suggestions?: Suggestion[] | undefined;
 
 	/**
 	 * Which specific characters in the source file are affected by this report.

--- a/packages/core/src/utils/predicates.ts
+++ b/packages/core/src/utils/predicates.ts
@@ -2,7 +2,7 @@ import { Change, SuggestionForFiles } from "../types/changes.js";
 import { FileReport, FileReportWithFix } from "../types/reports.js";
 
 export function hasFix(report: FileReport): report is FileReportWithFix {
-	return "fix" in report;
+	return report.fix != null;
 }
 
 export function isSuggestionForFiles(


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to flint! ❤️‍🔥
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #1003
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/flint/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/flint/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Allowing `undefined` to be passed for `data`, `fix` and `suggestions` in `context.report(...)` gives more flexibility to rule authors.
