### PR TITLE
fix(cli): separate multiple diagnostics by newlines in CLI output

### DIFF
--- a/.changeset/breezy-planes-cross.md
+++ b/.changeset/breezy-planes-cross.md
@@ -1,0 +1,5 @@
+---
+"@flint.fyi/cli": patch
+---
+
+fix(cli): separate multiple diagnostics by newlines in CLI output

--- a/packages/cli/src/presenters/shared/presentDiagnostics.ts
+++ b/packages/cli/src/presenters/shared/presentDiagnostics.ts
@@ -20,7 +20,8 @@ export function* presentDiagnostics(filesResults: Map<string, FileResults>) {
 
 	for (const diagnostic of diagnostics) {
 		yield diagnostic.text;
+		yield "\n";
 	}
 
-	yield "\n\n";
+	yield "\n";
 }


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to flint! ❤️‍🔥
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #1002
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/flint/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/flint/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->
