### PR TITLE
docs: remove misleading 'always be enabled' rule docs

### DIFF
--- a/packages/site/src/content/docs/rules/browser/removeEventListenerExpressions.mdx
+++ b/packages/site/src/content/docs/rules/browser/removeEventListenerExpressions.mdx
@@ -67,7 +67,8 @@ This rule is not configurable.
 
 ## When Not To Use It
 
-This rule should generally always be enabled, as inline function expressions in `removeEventListener` calls are always ineffective and represent programming errors.
+If your codebase uses code generation that relies on uncommon JavaScript semantics such as inline function expressions in `removeEventListener` calls, this rule might not be for you.
+For example, if you use a framework that automatically deduplicates similar function expressions behind-the-scenes, this rule might not apply.
 
 ## Further Reading
 

--- a/packages/site/src/content/docs/rules/jsx/duplicateProps.mdx
+++ b/packages/site/src/content/docs/rules/jsx/duplicateProps.mdx
@@ -62,8 +62,7 @@ This rule is not configurable.
 
 ## When Not To Use It
 
-This rule should generally always be enabled as duplicate props are almost always a mistake.
-The only scenario where you might want to disable it is if you're using advanced JSX transformations that intentionally rely on duplicate props for some specific behavior.
+If your codebase uses code generation that relies on uncommon JavaScript semantics such as duplicate prop names, this rule might not be for you.
 
 ## Further Reading
 

--- a/packages/site/src/content/docs/rules/ts/constantAssignments.mdx
+++ b/packages/site/src/content/docs/rules/ts/constantAssignments.mdx
@@ -83,8 +83,8 @@ This rule is not configurable.
 
 ## When Not To Use It
 
-This rule should always be enabled.
-Reassigning a const variable is a runtime error in JavaScript and TypeScript, so this rule helps catch such issues during development.
+If your codebase relies on non-standard behavior that involves reassigning constant variables (which is highly discouraged), you might choose to disable this rule.
+For example, if you target a legacy runtime with non-standard JavaScript semantics, standard practices may not apply to you.
 
 ## Further Reading
 

--- a/packages/site/src/content/docs/rules/ts/duplicateArguments.mdx
+++ b/packages/site/src/content/docs/rules/ts/duplicateArguments.mdx
@@ -67,8 +67,8 @@ This rule is not configurable.
 
 ## When Not To Use It
 
-This rule should always be enabled, as duplicate parameter names are either a syntax error (in strict mode) or a source of confusion (in non-strict mode).
-Modern JavaScript and TypeScript code should never use duplicate parameter names.
+If your codebase relies on non-standard behavior that involves duplicate argument names (which is highly discouraged), you might choose to disable this rule.
+For example, if you target a legacy runtime with non-standard JavaScript semantics, standard practices may not apply to you.
 
 ## Further Reading
 

--- a/packages/site/src/content/docs/rules/ts/elseIfDuplicates.mdx
+++ b/packages/site/src/content/docs/rules/ts/elseIfDuplicates.mdx
@@ -91,8 +91,8 @@ This rule is not configurable.
 
 ## When Not To Use It
 
-This rule should always be enabled.
-Duplicate conditions in if-else-if chains represent unreachable code and are almost always a mistake.
+If your project intentionally uses patterns that look like duplicate conditions but actually modify state behind-the-scenes, you might not want to enable this rule.
+For example, projects that modify state in computed object `get()` properties or use `Proxy` are often considered overly difficult to reason about for both humans and lint rules.
 
 ## Further Reading
 

--- a/packages/site/src/content/docs/rules/ts/globalAssignments.mdx
+++ b/packages/site/src/content/docs/rules/ts/globalAssignments.mdx
@@ -76,8 +76,8 @@ This rule is not configurable.
 
 ## When Not To Use It
 
-This rule should always be enabled, as attempting to reassign read-only global variables is always incorrect behavior in JavaScript and TypeScript.
-Modern JavaScript environments enforce these restrictions in strict mode, and violating them can cause runtime errors.
+If your codebase intentionally assigns to global objects and is guaranteed to run in an environment that allows that, you might not want to enable this rule.
+For example, if you target a legacy runtime with legacy non-standard JavaScript semantics, modern standard practices may not apply to you.
 
 ## Further Reading
 

--- a/packages/site/src/content/docs/rules/ts/globalObjectCalls.mdx
+++ b/packages/site/src/content/docs/rules/ts/globalObjectCalls.mdx
@@ -51,8 +51,8 @@ This rule is not configurable.
 
 ## When Not To Use It
 
-If your codebase redefines these objects, you likely will not want to enable this rule.
-Otherwise this rule should generally always be enabled, as calling these global objects as functions will always result in a runtime error.
+If your codebase redefines these objects and is guaranteed to run in an environment that allows that, you might not want to enable this rule.
+For example, if you target a legacy runtime with legacy non-standard JavaScript semantics, modern standard practices may not apply to you.
 
 ## Further Reading
 

--- a/packages/site/src/content/docs/rules/ts/nonOctalDecimalEscapes.mdx
+++ b/packages/site/src/content/docs/rules/ts/nonOctalDecimalEscapes.mdx
@@ -63,7 +63,8 @@ This rule is not configurable.
 
 ## When Not To Use It
 
-This rule should always be enabled as these escape sequences are legacy features that should not be used in modern JavaScript code.
+If your project has portions that perform raw string manipulations and rely on legacy octal escape sequences, it might be difficult to refactor towards code that passes this rule.
+You might consider using [Flint disable comments](/) and/or [configuration file disables](/) for those specific situations instead of completely disabling this rule.
 
 ## Further Reading
 

--- a/packages/site/src/content/docs/rules/ts/variableDeletions.mdx
+++ b/packages/site/src/content/docs/rules/ts/variableDeletions.mdx
@@ -48,7 +48,8 @@ This rule is not configurable.
 
 ## When Not To Use It
 
-This rule should always be enabled, as attempting to delete variables is always incorrect behavior in JavaScript and TypeScript.
+If your codebase relies on non-standard behavior that involves deleting variables (which is highly discouraged), you might choose to disable this rule.
+For example, if you target a legacy runtime with non-standard JavaScript semantics, standard practices may not apply to you.
 
 ## Further Reading
 


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #1017
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/flint/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/flint/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Falls back to the rarely-applicable justifications of _"well, if you're using weird legacy behavior, you're on your own"_.

❤️‍🔥