### PR TITLE
chore: add rule-specific issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/01-rule-bug.yml
+++ b/.github/ISSUE_TEMPLATE/01-rule-bug.yml
@@ -1,0 +1,35 @@
+body:
+  - attributes:
+      description: If any of these required steps are not taken, we may not be able to review your issue. Help us to help you!
+      label: Bug Report Checklist
+      options:
+        - label: I am using the latest published version of all Flint packages.
+          required: true
+        - label: I have [searched for related issues](https://github.com/JoshuaKGoldberg/flint/issues?q=is%3Aissue) and found none that matched my issue.
+          required: true
+    type: checkboxes
+  - attributes:
+      description: What did you expect to happen?
+      label: Expected
+    type: textarea
+    validations:
+      required: true
+  - attributes:
+      description: What happened instead?
+      label: Actual
+    type: textarea
+    validations:
+      required: true
+  - attributes:
+      description: Any additional info you'd like to provide.
+      label: Additional Info
+    type: textarea
+
+description: Report a bug specific to a lint rule provided by Flint
+
+labels:
+  - "type: bug"
+
+name: 🐛 Bug
+
+title: "🐛 Bug: [plugin.ruleName] <short description of the bug>"

--- a/.github/ISSUE_TEMPLATE/02-rule-feature.yml
+++ b/.github/ISSUE_TEMPLATE/02-rule-feature.yml
@@ -3,7 +3,7 @@ body:
       description: If any of these required steps are not taken, we may not be able to review your issue. Help us to help you!
       label: Feature Request Checklist
       options:
-        - label: I have pulled the latest `main` branch of the repository.
+        - label: I am using the latest published version of all Flint packages.
           required: true
         - label: I have [searched for related issues](https://github.com/JoshuaKGoldberg/flint/issues?q=is%3Aissue) and found none that matched my issue.
           required: true
@@ -19,11 +19,11 @@ body:
       label: Additional Info
     type: textarea
 
-description: Request that a new feature be added or an existing feature improved
+description: Request a feature be added to a lint rule provided by Flint
 
 labels:
   - "type: feature"
 
 name: 🚀 Feature
 
-title: "🚀 Feature: <short description of the feature>"
+title: "🚀 Feature: [plugin.ruleName] <short description of the feature>"

--- a/.github/ISSUE_TEMPLATE/03-general-bug.yml
+++ b/.github/ISSUE_TEMPLATE/03-general-bug.yml
@@ -3,9 +3,7 @@ body:
       description: If any of these required steps are not taken, we may not be able to review your issue. Help us to help you!
       label: Bug Report Checklist
       options:
-        - label: I have tried restarting my IDE and the issue persists.
-          required: true
-        - label: I have pulled the latest `main` branch of the repository.
+        - label: I am using the latest published version of all Flint packages.
           required: true
         - label: I have [searched for related issues](https://github.com/JoshuaKGoldberg/flint/issues?q=is%3Aissue) and found none that matched my issue.
           required: true
@@ -27,11 +25,11 @@ body:
       label: Additional Info
     type: textarea
 
-description: Report a bug trying to run the code
+description: Report a non-rule-specific bug with Flint, its integrations, or its plugins
 
 labels:
   - "type: bug"
 
-name: 🐛 Bug
+name: 🐛 General Bug
 
 title: "🐛 Bug: <short description of the bug>"

--- a/.github/ISSUE_TEMPLATE/04-general-feature.yml
+++ b/.github/ISSUE_TEMPLATE/04-general-feature.yml
@@ -1,15 +1,15 @@
 body:
   - attributes:
       description: If any of these required steps are not taken, we may not be able to review your issue. Help us to help you!
-      label: Documentation Report Checklist
+      label: Feature Request Checklist
       options:
-        - label: I have pulled the latest `main` branch of the repository.
+        - label: I am using the latest published version of all Flint packages.
           required: true
         - label: I have [searched for related issues](https://github.com/JoshuaKGoldberg/flint/issues?q=is%3Aissue) and found none that matched my issue.
           required: true
     type: checkboxes
   - attributes:
-      description: What would you like to report?
+      description: What did you expect to be able to do?
       label: Overview
     type: textarea
     validations:
@@ -19,11 +19,11 @@ body:
       label: Additional Info
     type: textarea
 
-description: Report a typo or missing area of documentation
+description: Request that a new non-rule-specific feature be added or an existing feature improved to Flint, its integrations, or its plugins
 
 labels:
-  - "area: documentation"
+  - "type: feature"
 
-name: 📝 Documentation
+name: 🚀 General Feature
 
-title: "📝 Documentation: <short description of the request>"
+title: "🚀 Feature: <short description of the feature>"

--- a/.github/ISSUE_TEMPLATE/05-documentation.yml
+++ b/.github/ISSUE_TEMPLATE/05-documentation.yml
@@ -1,17 +1,15 @@
 body:
   - attributes:
       description: If any of these required steps are not taken, we may not be able to review your issue. Help us to help you!
-      label: Tooling Report Checklist
+      label: Documentation Report Checklist
       options:
-        - label: I have tried restarting my IDE and the issue persists.
-          required: true
-        - label: I have pulled the latest `main` branch of the repository.
+        - label: I am using the latest published version of all Flint packages.
           required: true
         - label: I have [searched for related issues](https://github.com/JoshuaKGoldberg/flint/issues?q=is%3Aissue) and found none that matched my issue.
           required: true
     type: checkboxes
   - attributes:
-      description: What did you expect to be able to do?
+      description: What would you like to report?
       label: Overview
     type: textarea
     validations:
@@ -21,11 +19,11 @@ body:
       label: Additional Info
     type: textarea
 
-description: Report a bug or request an enhancement in repository tooling
+description: Report a typo or missing area of documentation
 
 labels:
-  - "area: tooling"
+  - "area: documentation"
 
-name: 🛠 Tooling
+name: 📝 Documentation
 
-title: "🛠 Tooling: <short description of the change>"
+title: "📝 Documentation: <short description of the request>"

--- a/.github/ISSUE_TEMPLATE/06-tooling.yml
+++ b/.github/ISSUE_TEMPLATE/06-tooling.yml
@@ -1,0 +1,29 @@
+body:
+  - attributes:
+      description: If any of these required steps are not taken, we may not be able to review your issue. Help us to help you!
+      label: Tooling Report Checklist
+      options:
+        - label: I am using the latest published version of all Flint packages.
+          required: true
+        - label: I have [searched for related issues](https://github.com/JoshuaKGoldberg/flint/issues?q=is%3Aissue) and found none that matched my issue.
+          required: true
+    type: checkboxes
+  - attributes:
+      description: What did you expect to be able to do?
+      label: Overview
+    type: textarea
+    validations:
+      required: true
+  - attributes:
+      description: Any additional info you'd like to provide.
+      label: Additional Info
+    type: textarea
+
+description: Report a bug or request an enhancement in repository tooling
+
+labels:
+  - "area: tooling"
+
+name: 🛠 Tooling
+
+title: "🛠 Tooling: <short description of the change>"


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #1022
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/flint/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/flint/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Streamlines the existing templates too, while I'm in the area.

❤️‍🔥