### PR TITLE
fix(core): properly resolve `flint-disable-*` directives selection when comment has trailing whitespaces

### DIFF
--- a/.changeset/orange-rabbits-sip.md
+++ b/.changeset/orange-rabbits-sip.md
@@ -1,0 +1,5 @@
+---
+"@flint.fyi/core": patch
+---
+
+fix(core): properly resolve `flint-disable-*` directives selection when comment has trailing whitespaces

--- a/packages/core/src/directives/DirectivesCollector.test.ts
+++ b/packages/core/src/directives/DirectivesCollector.test.ts
@@ -102,6 +102,26 @@ describe(DirectivesCollector, () => {
 				],
 			});
 		});
+
+		it("trims whitespaces around selection", () => {
+			const collector = new DirectivesCollector(1);
+			const range = createRange(2);
+
+			collector.add(range, " a ", "disable-file");
+
+			const actual = collector.collect();
+
+			expect(actual).toEqual({
+				directives: [
+					{
+						range,
+						selections: ["a"],
+						type: "disable-file",
+					},
+				],
+				reports: [directiveReports.createFileAfterContent(range)],
+			});
+		});
 	});
 
 	describe("disable-lines-begin", () => {

--- a/packages/core/src/directives/DirectivesCollector.ts
+++ b/packages/core/src/directives/DirectivesCollector.ts
@@ -26,7 +26,10 @@ export class DirectivesCollector {
 			return;
 		}
 
-		const selections = selection.split(/\s+/).map((text) => text.trim());
+		const selections = selection
+			.trim()
+			.split(/\s+/)
+			.map((text) => text.trim());
 		const directive: CommentDirective = { range, selections, type };
 
 		this.#directives.push(directive);


### PR DESCRIPTION

## PR Checklist

- [x] Addresses an existing open issue: fixes #1009
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/flint/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/flint/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->
