### PR TITLE
chore: enable all relevant rules internally

### DIFF
--- a/flint.config.ts
+++ b/flint.config.ts
@@ -1,4 +1,5 @@
 import { flint } from "@flint.fyi/plugin-flint";
+import { node } from "@flint.fyi/plugin-node";
 import { spelling } from "@flint.fyi/plugin-spelling";
 import { defineConfig, globs, json, md, ts, yaml } from "flint";
 
@@ -17,7 +18,13 @@ export default defineConfig({
 				exclude: process.env.LINT_FIXTURES ? [] : ["packages/fixtures"],
 				include: ts.files.all,
 			},
-			rules: [flint.presets.logical, ts.presets.logical],
+			rules: [
+				flint.presets.logical,
+				node.presets.logical,
+				node.presets.stylistic,
+				ts.presets.logical,
+				ts.presets.stylistic,
+			],
 		},
 		{
 			files: {


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #1021
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/flint/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/flint/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Enables the full list of internally-relevant rules, as originally attempted in #998. This is now doable because of fixes that landed later:

* #1025
* #1028

❤️‍🔥