### PR TITLE
feat(rule-tester): allow output strings to be functions for assertions

### DIFF
--- a/packages/json/src/rules/keyDuplicates.test.ts
+++ b/packages/json/src/rules/keyDuplicates.test.ts
@@ -1,3 +1,5 @@
+import { expect } from "vitest";
+
 import rule from "./keyDuplicates.js";
 import { ruleTester } from "./ruleTester.js";
 
@@ -10,14 +12,18 @@ ruleTester.describe(rule, {
   "a": "second",
 }
 `,
-			snapshot: `
-{
-  "a": "first",
-  ~~~
-  This key is made redundant by an identical key later in the object.
-  "a": "second",
-}
-`,
+			snapshot: (text) => {
+				expect(text).toMatchInlineSnapshot(`
+					"
+					{
+					  "a": "first",
+					  ~~~
+					  This key is made redundant by an identical key later in the object.
+					  "a": "second",
+					}
+					"
+				`);
+			},
 		},
 		{
 			code: `
@@ -29,14 +35,18 @@ ruleTester.describe(rule, {
 			options: {
 				allowKeys: ["//"],
 			},
-			snapshot: `
-{
-  "a": "first",
-  ~~~
-  This key is made redundant by an identical key later in the object.
-  "a": "second",
-}
-`,
+			snapshot: (text) => {
+				expect(text).toMatchInlineSnapshot(`
+					"
+					{
+					  "a": "first",
+					  ~~~
+					  This key is made redundant by an identical key later in the object.
+					  "a": "second",
+					}
+					"
+				`);
+			},
 		},
 	],
 	valid: [

--- a/packages/json/src/rules/keyNormalization.test.ts
+++ b/packages/json/src/rules/keyNormalization.test.ts
@@ -1,3 +1,5 @@
+import { expect } from "vitest";
+
 import rule from "./keyNormalization.js";
 import { ruleTester } from "./ruleTester.js";
 
@@ -11,21 +13,29 @@ ruleTester.describe(rule, {
     "cafe\u0301": "value"
 }
 `,
-			snapshot: `
-{
-    "cafe\u0301": "value"
-    ~~~~~~~
-    This key is not normalized using the NFC normalization form.
-}
-`,
+			snapshot: (text) => {
+				expect(text).toMatchInlineSnapshot(`
+					"
+					{
+					    "café": "value"
+					    ~~~~~~~
+					    This key is not normalized using the NFC normalization form.
+					}
+					"
+				`);
+			},
 			suggestions: [
 				{
 					id: "normalizeKey",
-					updated: `
-{
-    "café": "value"
-}
-`,
+					updated: (text) => {
+						expect(text).toMatchInlineSnapshot(`
+							"
+							{
+							    "café": "value"
+							}
+							"
+						`);
+					},
 				},
 			],
 		},
@@ -36,23 +46,31 @@ ruleTester.describe(rule, {
     "cafe\u0301": "latte"
 }
 `,
-			snapshot: `
-{
-    "résumé": "document",
-    "cafe\u0301": "latte"
-    ~~~~~~~
-    This key is not normalized using the NFC normalization form.
-}
-`,
+			snapshot: (text) => {
+				expect(text).toMatchInlineSnapshot(`
+					"
+					{
+					    "résumé": "document",
+					    "café": "latte"
+					    ~~~~~~~
+					    This key is not normalized using the NFC normalization form.
+					}
+					"
+				`);
+			},
 			suggestions: [
 				{
 					id: "normalizeKey",
-					updated: `
-{
-    "résumé": "document",
-    "café": "latte"
-}
-`,
+					updated: (text) => {
+						expect(text).toMatchInlineSnapshot(`
+							"
+							{
+							    "résumé": "document",
+							    "café": "latte"
+							}
+							"
+						`);
+					},
 				},
 			],
 		},
@@ -65,21 +83,29 @@ ruleTester.describe(rule, {
 			options: {
 				form: "NFD",
 			},
-			snapshot: `
-{
-    "café": "value"
-    ~~~~~~
-    This key is not normalized using the NFD normalization form.
-}
-`,
+			snapshot: (text) => {
+				expect(text).toMatchInlineSnapshot(`
+					"
+					{
+					    "café": "value"
+					    ~~~~~~
+					    This key is not normalized using the NFD normalization form.
+					}
+					"
+				`);
+			},
 			suggestions: [
 				{
 					id: "normalizeKey",
-					updated: `
-{
-    "cafe\u0301": "value"
-}
-`,
+					updated: (text) => {
+						expect(text).toMatchInlineSnapshot(`
+							"
+							{
+							    "café": "value"
+							}
+							"
+						`);
+					},
 				},
 			],
 		},
@@ -93,34 +119,46 @@ ruleTester.describe(rule, {
 			options: {
 				form: "NFD",
 			},
-			snapshot: `
-{
-    "café": "espresso",
-    ~~~~~~
-    This key is not normalized using the NFD normalization form.
-    "naïve": "approach"
-    ~~~~~~~
-    This key is not normalized using the NFD normalization form.
-}
-`,
+			snapshot: (text) => {
+				expect(text).toMatchInlineSnapshot(`
+					"
+					{
+					    "café": "espresso",
+					    ~~~~~~
+					    This key is not normalized using the NFD normalization form.
+					    "naïve": "approach"
+					    ~~~~~~~
+					    This key is not normalized using the NFD normalization form.
+					}
+					"
+				`);
+			},
 			suggestions: [
 				{
 					id: "normalizeKey",
-					updated: `
-{
-    "cafe\u0301": "espresso",
-    "naïve": "approach"
-}
-`,
+					updated: (text) => {
+						expect(text).toMatchInlineSnapshot(`
+							"
+							{
+							    "café": "espresso",
+							    "naïve": "approach"
+							}
+							"
+						`);
+					},
 				},
 				{
 					id: "normalizeKey",
-					updated: `
-{
-    "café": "espresso",
-    "nai\u0308ve": "approach"
-}
-`,
+					updated: (text) => {
+						expect(text).toMatchInlineSnapshot(`
+							"
+							{
+							    "café": "espresso",
+							    "naïve": "approach"
+							}
+							"
+						`);
+					},
 				},
 			],
 		},

--- a/packages/plugin-browser/src/rules/classListToggles.test.ts
+++ b/packages/plugin-browser/src/rules/classListToggles.test.ts
@@ -1,3 +1,5 @@
+import { expect } from "vitest";
+
 import rule from "./classListToggles.js";
 import { ruleTester } from "./ruleTester.js";
 
@@ -11,15 +13,26 @@ if (condition) {
     element.classList.remove("active");
 }
 `,
-			snapshot: `
-if (condition) {
-    element.classList.add("active");
-                      ~~~
-                      Prefer using \`classList.toggle()\` instead of conditional \`classList.add()\` and \`classList.remove()\`.
-} else {
-    element.classList.remove("active");
-}
-`,
+			output: (text) => {
+				expect(text).toMatchInlineSnapshot(`
+					"
+					element.classList.toggle("active", condition);
+					"
+				`);
+			},
+			snapshot: (text) => {
+				expect(text).toMatchInlineSnapshot(`
+					"
+					if (condition) {
+					    element.classList.add("active");
+					                      ~~~
+					                      Prefer using \`classList.toggle()\` instead of conditional \`classList.add()\` and \`classList.remove()\`.
+					} else {
+					    element.classList.remove("active");
+					}
+					"
+				`);
+			},
 		},
 		{
 			code: `
@@ -29,15 +42,26 @@ if (isVisible) {
     button.classList.add("hidden");
 }
 `,
-			snapshot: `
-if (isVisible) {
-    button.classList.remove("hidden");
-                     ~~~~~~
-                     Prefer using \`classList.toggle()\` instead of conditional \`classList.add()\` and \`classList.remove()\`.
-} else {
-    button.classList.add("hidden");
-}
-`,
+			output: (text) => {
+				expect(text).toMatchInlineSnapshot(`
+					"
+					button.classList.toggle("hidden", !(isVisible));
+					"
+				`);
+			},
+			snapshot: (text) => {
+				expect(text).toMatchInlineSnapshot(`
+					"
+					if (isVisible) {
+					    button.classList.remove("hidden");
+					                     ~~~~~~
+					                     Prefer using \`classList.toggle()\` instead of conditional \`classList.add()\` and \`classList.remove()\`.
+					} else {
+					    button.classList.add("hidden");
+					}
+					"
+				`);
+			},
 		},
 		{
 			code: `
@@ -46,14 +70,25 @@ if (flag)
 else
     element.classList.remove("active");
 `,
-			snapshot: `
-if (flag)
-    element.classList.add("active");
-                      ~~~
-                      Prefer using \`classList.toggle()\` instead of conditional \`classList.add()\` and \`classList.remove()\`.
-else
-    element.classList.remove("active");
-`,
+			output: (text) => {
+				expect(text).toMatchInlineSnapshot(`
+					"
+					element.classList.toggle("active", flag);
+					"
+				`);
+			},
+			snapshot: (text) => {
+				expect(text).toMatchInlineSnapshot(`
+					"
+					if (flag)
+					    element.classList.add("active");
+					                      ~~~
+					                      Prefer using \`classList.toggle()\` instead of conditional \`classList.add()\` and \`classList.remove()\`.
+					else
+					    element.classList.remove("active");
+					"
+				`);
+			},
 		},
 	],
 	valid: [

--- a/packages/plugin-browser/src/rules/nodeRemoveMethods.test.ts
+++ b/packages/plugin-browser/src/rules/nodeRemoveMethods.test.ts
@@ -1,3 +1,5 @@
+import { expect } from "vitest";
+
 import rule from "./nodeRemoveMethods.js";
 import { ruleTester } from "./ruleTester.js";
 
@@ -9,63 +11,95 @@ declare const parentNode: HTMLElement;
 declare const childNode: HTMLElement;
 parentNode.removeChild(childNode);
 `,
-			output: `
-declare const parentNode: HTMLElement;
-declare const childNode: HTMLElement;
-childNode.remove();
-			`,
-			snapshot: `
-declare const parentNode: HTMLElement;
-declare const childNode: HTMLElement;
-parentNode.removeChild(childNode);
-           ~~~~~~~~~~~
-           Prefer the modern \`childNode.remove()\` over \`parentNode.removeChild(childNode)\`.
-`,
+			output: (text) => {
+				expect(text).toMatchInlineSnapshot(`
+					"
+					declare const parentNode: HTMLElement;
+					declare const childNode: HTMLElement;
+					childNode.remove();
+					"
+				`);
+			},
+			snapshot: (text) => {
+				expect(text).toMatchInlineSnapshot(`
+					"
+					declare const parentNode: HTMLElement;
+					declare const childNode: HTMLElement;
+					parentNode.removeChild(childNode);
+					           ~~~~~~~~~~~
+					           Prefer the modern \`childNode.remove()\` over \`parentNode.removeChild(childNode)\`.
+					"
+				`);
+			},
 		},
 		{
 			code: `
 declare const element: HTMLElement;
 element.parentNode.removeChild(element);
 `,
-			output: `
-declare const element: HTMLElement;
-element.remove();
-			`,
-			snapshot: `
-declare const element: HTMLElement;
-element.parentNode.removeChild(element);
-                   ~~~~~~~~~~~
-                   Prefer the modern \`element.remove()\` over \`element.parentNode.removeChild(element)\`.
-`,
+			output: (text) => {
+				expect(text).toMatchInlineSnapshot(`
+					"
+					declare const element: HTMLElement;
+					element.remove();
+					"
+				`);
+			},
+			snapshot: (text) => {
+				expect(text).toMatchInlineSnapshot(`
+					"
+					declare const element: HTMLElement;
+					element.parentNode.removeChild(element);
+					                   ~~~~~~~~~~~
+					                   Prefer the modern \`element.remove()\` over \`element.parentNode.removeChild(element)\`.
+					"
+				`);
+			},
 		},
 		{
 			code: `
 declare const node: HTMLElement;
 node.parentElement.removeChild(node);
 `,
-			output: `
-declare const node: HTMLElement;
-node.remove();
-`,
-			snapshot: `
-declare const node: HTMLElement;
-node.parentElement.removeChild(node);
-                   ~~~~~~~~~~~
-                   Prefer the modern \`node.remove()\` over \`node.parentElement.removeChild(node)\`.
-`,
+			output: (text) => {
+				expect(text).toMatchInlineSnapshot(`
+					"
+					declare const node: HTMLElement;
+					node.remove();
+					"
+				`);
+			},
+			snapshot: (text) => {
+				expect(text).toMatchInlineSnapshot(`
+					"
+					declare const node: HTMLElement;
+					node.parentElement.removeChild(node);
+					                   ~~~~~~~~~~~
+					                   Prefer the modern \`node.remove()\` over \`node.parentElement.removeChild(node)\`.
+					"
+				`);
+			},
 		},
 		{
 			code: `
 document.body.removeChild(footer);
 `,
-			output: `
-footer.remove();
-`,
-			snapshot: `
-document.body.removeChild(footer);
-              ~~~~~~~~~~~
-              Prefer the modern \`footer.remove()\` over \`document.body.removeChild(footer)\`.
-`,
+			output: (text) => {
+				expect(text).toMatchInlineSnapshot(`
+					"
+					footer.remove();
+					"
+				`);
+			},
+			snapshot: (text) => {
+				expect(text).toMatchInlineSnapshot(`
+					"
+					document.body.removeChild(footer);
+					              ~~~~~~~~~~~
+					              Prefer the modern \`footer.remove()\` over \`document.body.removeChild(footer)\`.
+					"
+				`);
+			},
 		},
 	],
 	valid: [

--- a/packages/plugin-flint/src/rules/invalidCodeLines.test.ts
+++ b/packages/plugin-flint/src/rules/invalidCodeLines.test.ts
@@ -1,3 +1,5 @@
+import { expect } from "vitest";
+
 import rule from "./invalidCodeLines.js";
 import { ruleTester } from "./ruleTester.js";
 
@@ -18,38 +20,48 @@ Rule report message.
     ],
 });
 `,
-			output: `
-ruleTester.describe(rule, {
-    valid: ['a', 'a'],
-    invalid: [
-      {
-        code: \`
 
-\`,
-        snapshot: \`
-~
-Rule report message.
-\`,
-      }
-    ],
-});
-`,
-			snapshot: `
-ruleTester.describe(rule, {
-    valid: ['a', 'a'],
-    invalid: [
-      {
-        code: "",
-              ~~
-              This code block should be formatted across multiple lines for more readable reports.
-        snapshot: \`
-~
-Rule report message.
-\`,
-      }
-    ],
-});
-`,
+			output: (text) => {
+				expect(text).toMatchInlineSnapshot(`
+					"
+					ruleTester.describe(rule, {
+					    valid: ['a', 'a'],
+					    invalid: [
+					      {
+					        code: \`
+
+					\`,
+					        snapshot: \`
+
+					~
+					Rule report message.
+					\`,
+					      }
+					    ],
+					});
+					"
+				`);
+			},
+			snapshot: (text) => {
+				expect(text).toMatchInlineSnapshot(`
+					"
+					ruleTester.describe(rule, {
+					    valid: ['a', 'a'],
+					    invalid: [
+					      {
+					        code: "",
+					              ~~
+					              This code block should be formatted across multiple lines for more readable reports.
+					        snapshot: \`
+					~
+					Rule report message.
+					\`,
+					      }
+					    ],
+					});
+					"
+				`);
+			},
 		},
 		{
 			code: `
@@ -68,44 +80,51 @@ Rule report message.
     ],
 });
 `,
-			output: `
-ruleTester.describe(rule, {
-    valid: ['a', 'a'],
-    invalid: [
-      {
-        code: \`
-console.log(
-);
-\`,
-        snapshot: \`
-console.log(
-);
-~
-Rule report message.
-\`,
-      }
-    ],
-});
-`,
-			snapshot: `
-ruleTester.describe(rule, {
-    valid: ['a', 'a'],
-    invalid: [
-      {
-        code: \`console.log(
-              ~~~~~~~~~~~~~
-              This code block should be formatted across multiple lines for more readable reports.
-);\`,
-~~~
-        snapshot: \`console.log(
-);
-~
-Rule report message.
-\`,
-      }
-    ],
-});
-`,
+			output: (text) => {
+				expect(text).toMatchInlineSnapshot(`
+					"
+					ruleTester.describe(rule, {
+					    valid: ['a', 'a'],
+					    invalid: [
+					      {
+					        code: \`
+					console.log(
+					);\`,
+					        snapshot: \`
+					console.log(
+					);
+					~
+					Rule report message.
+					\`,
+					      }
+					    ],
+					});
+					"
+				`);
+			},
+			snapshot: (text) => {
+				expect(text).toMatchInlineSnapshot(`
+					"
+					ruleTester.describe(rule, {
+					    valid: ['a', 'a'],
+					    invalid: [
+					      {
+					        code: \`console.log(
+					              ~~~~~~~~~~~~~
+					              This code block should be formatted across multiple lines for more readable reports.
+					);\`,
+					~~~
+					        snapshot: \`console.log(
+					);
+					~
+					Rule report message.
+					\`,
+					      }
+					    ],
+					});
+					"
+				`);
+			},
 		},
 		{
 			code: `
@@ -122,39 +141,47 @@ Rule report message.
     ],
 });
 `,
-			output: `
-ruleTester.describe(rule, {
-    valid: ['a', 'a'],
-    invalid: [
-      {
-        code: \`
-console.log();
-\`,
-        snapshot: \`
-console.log();
-~~~~~~~~~~~~~
-Rule report message.
-\`,
-      }
-    ],
-});
-`,
-			snapshot: `
-ruleTester.describe(rule, {
-    valid: ['a', 'a'],
-    invalid: [
-      {
-        code: \`console.log();\`,
-              ~~~~~~~~~~~~~~~~
-              This code block should be formatted across multiple lines for more readable reports.
-        snapshot: \`console.log();
-~~~~~~~~~~~~
-Rule report message.
-\`,
-      }
-    ],
-});
-`,
+
+			output: (text) => {
+				expect(text).toMatchInlineSnapshot(`
+					"
+					ruleTester.describe(rule, {
+					    valid: ['a', 'a'],
+					    invalid: [
+					      {
+					        code: \`
+					console.log();\`,
+					        snapshot: \`
+					console.log();
+					~~~~~~~~~~~~
+					Rule report message.
+					\`,
+					      }
+					    ],
+					});
+					"
+				`);
+			},
+			snapshot: (text) => {
+				expect(text).toMatchInlineSnapshot(`
+					"
+					ruleTester.describe(rule, {
+					    valid: ['a', 'a'],
+					    invalid: [
+					      {
+					        code: \`console.log();\`,
+					              ~~~~~~~~~~~~~~~~
+					              This code block should be formatted across multiple lines for more readable reports.
+					        snapshot: \`console.log();
+					~~~~~~~~~~~~
+					Rule report message.
+					\`,
+					      }
+					    ],
+					});
+					"
+				`);
+			},
 		},
 	],
 	valid: [

--- a/packages/rule-tester/src/assertions/assertString.test.ts
+++ b/packages/rule-tester/src/assertions/assertString.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { assertString } from "./assertString.js";
+
+describe(assertString, () => {
+	it("calls expected when the expected is a function", () => {
+		const actual = "actual";
+		const expected = vi.fn();
+
+		assertString(actual, expected);
+
+		expect(expected).toHaveBeenCalledWith(actual);
+	});
+
+	it("throws an error when expected is a different string than actual", () => {
+		const actual = "test";
+		const expected = "expected";
+
+		expect(() => {
+			assertString(actual, expected);
+		}).toThrow();
+	});
+
+	it("does not throw an error when expected is the same string as actual", () => {
+		const actual = "test";
+		const expected = actual;
+
+		expect(() => {
+			assertString(actual, expected);
+		}).not.toThrow();
+	});
+});

--- a/packages/rule-tester/src/assertions/assertString.ts
+++ b/packages/rule-tester/src/assertions/assertString.ts
@@ -1,0 +1,11 @@
+import assert from "node:assert/strict";
+
+import { StringExpectation } from "../types.js";
+
+export function assertString(actual: string, expected: StringExpectation) {
+	if (typeof expected === "function") {
+		expected(actual);
+	} else {
+		assert.strictEqual(actual, expected);
+	}
+}

--- a/packages/rule-tester/src/assertions/assertValue.test.ts
+++ b/packages/rule-tester/src/assertions/assertValue.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { assertValue } from "./assertValue.js";
+
+const mockAssertString = vi.fn();
+
+vi.mock("./assertString.js", () => ({
+	get assertString() {
+		return mockAssertString;
+	},
+}));
+
+describe(assertValue, () => {
+	it("calls assertString when a value is a string", () => {
+		const actual = { value: "a" };
+		const expected = { value: "b" };
+
+		assertValue(actual, expected);
+
+		expect(mockAssertString.mock.calls).toEqual([["a", "b"]]);
+	});
+
+	it("throws an error when a non-string property mismatches", () => {
+		const actual = { value: 1 };
+		const expected = { value: 2 };
+
+		expect(() => {
+			assertValue(actual, expected);
+		}).toThrow();
+	});
+});

--- a/packages/rule-tester/src/assertions/assertValue.ts
+++ b/packages/rule-tester/src/assertions/assertValue.ts
@@ -1,0 +1,19 @@
+import assert from "node:assert/strict";
+
+import { StringExpectation } from "../types.js";
+import { assertString } from "./assertString.js";
+
+export function assertValue<Value extends object>(
+	actual: Value,
+	expected: Value,
+) {
+	for (const [key, actualValue] of Object.entries(actual)) {
+		const expectedValue = expected[key as keyof Value] as StringExpectation;
+
+		if (typeof actualValue === "string") {
+			assertString(actualValue, expectedValue);
+		} else {
+			assert.deepStrictEqual(actualValue, expectedValue);
+		}
+	}
+}

--- a/packages/rule-tester/src/assertions/assertValues.test.ts
+++ b/packages/rule-tester/src/assertions/assertValues.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { assertValues } from "./assertValues.js";
+
+const mockAssertValue = vi.fn();
+
+vi.mock("./assertValue.js", () => ({
+	get assertValue() {
+		return mockAssertValue;
+	},
+}));
+
+describe(assertValues, () => {
+	it("throws an error when actual is undefined and expected is defined", () => {
+		const actual = undefined;
+		const expected = [{ value: "a" }, { value: "b" }];
+
+		expect(() => {
+			assertValues(actual, expected);
+		}).toThrow();
+	});
+
+	it("throws an error when actual is defined and expected is undefined", () => {
+		const actual = [{ value: "a" }, { value: "b" }];
+		const expected = undefined;
+
+		expect(() => {
+			assertValues(actual, expected);
+		}).toThrow();
+	});
+
+	it("throws an error when actual is a different length than expected", () => {
+		const actual = [{ value: "a" }, { value: "b" }];
+		const expected = [{ value: "a" }];
+
+		expect(() => {
+			assertValues(actual, expected);
+		}).toThrow();
+	});
+
+	it("calls assertValue on each item when actual and expected have the same length", () => {
+		const actual = [{ value: "a" }, { value: "b" }];
+		const expected = [{ value: "a" }, { value: "b" }];
+
+		assertValues(actual, expected);
+
+		expect(mockAssertValue.mock.calls).toEqual([
+			[actual[0], expected[0]],
+			[actual[1], expected[1]],
+		]);
+	});
+});

--- a/packages/rule-tester/src/assertions/assertValues.ts
+++ b/packages/rule-tester/src/assertions/assertValues.ts
@@ -1,0 +1,18 @@
+import assert from "node:assert/strict";
+
+import { assertValue } from "./assertValue.js";
+
+export function assertValues<Value extends object>(
+	actual: undefined | Value[],
+	expected: undefined | Value[],
+) {
+	assert.equal(actual?.length, expected?.length);
+
+	if (!actual || !expected) {
+		return;
+	}
+
+	for (let i = 0; i < actual.length; i += 1) {
+		assertValue(actual[i], expected[i]);
+	}
+}

--- a/packages/rule-tester/src/createReportsFixed.ts
+++ b/packages/rule-tester/src/createReportsFixed.ts
@@ -1,0 +1,20 @@
+import { applyChangesToText, NormalizedReport } from "@flint.fyi/core";
+
+export function createReportsFixed(
+	sourceText: string,
+	reports: NormalizedReport[],
+) {
+	let hadFix = false;
+	let output = sourceText;
+
+	for (const report of reports) {
+		if (!report.fix) {
+			continue;
+		}
+
+		hadFix = true;
+		output = applyChangesToText(report.fix, output);
+	}
+
+	return hadFix ? output : undefined;
+}

--- a/packages/rule-tester/src/createReportsOutput.ts
+++ b/packages/rule-tester/src/createReportsOutput.ts
@@ -1,50 +1,52 @@
 import { formatReportPrimary, NormalizedReport } from "@flint.fyi/core";
 
-export function createReportSnapshot(
+export function createReportsOutput(
 	sourceText: string,
 	reports: NormalizedReport[],
 ) {
 	let result = sourceText;
 
 	for (const report of reports.toReversed()) {
-		result = createReportSnapshotAt(result, report);
+		result = createReportsOutputAt(result, report);
 	}
 
 	return result;
 }
 
-function createReportSnapshotAt(sourceText: string, report: NormalizedReport) {
+function createReportsOutputAt(sourceText: string, report: NormalizedReport) {
 	const { begin, end } = report.range;
 	const lineStartIndex = sourceText.lastIndexOf("\n", begin.raw) + 1;
 	let lineEndIndex = sourceText.indexOf("\n", end.raw);
 	if (lineEndIndex < 0) {
 		lineEndIndex = sourceText.length;
 	}
-	const lines = sourceText.slice(lineStartIndex, lineEndIndex).split("\n");
-	const output: string[] = [];
+	const sourceLines = sourceText
+		.slice(lineStartIndex, lineEndIndex)
+		.split("\n");
+	const reportedLines: string[] = [];
 
 	for (let i = begin.line; i <= end.line; i++) {
-		const line = lines[i - begin.line];
-		output.push(line);
+		const line = sourceLines[i - begin.line];
+		reportedLines.push(line);
 
 		const prevLineIndent = /^[\t ]*/.exec(line)?.[0] ?? "";
 
 		if (i === begin.line) {
 			const indent = prevLineIndent.padEnd(begin.column, " ");
 			const squiggleEnd = begin.line === end.line ? end.column : line.length;
-			output.push(indent.padEnd(squiggleEnd, "~"));
+			reportedLines.push(indent.padEnd(squiggleEnd, "~"));
 			for (const errorMessageLine of formatReportPrimary(report).split("\n")) {
-				output.push(indent + errorMessageLine);
+				reportedLines.push(indent + errorMessageLine);
 			}
 		} else {
 			const squiggleEnd = i === end.line ? end.column : line.length;
-			output.push(prevLineIndent.padEnd(squiggleEnd, "~"));
+			reportedLines.push(prevLineIndent.padEnd(squiggleEnd, "~"));
 		}
 	}
 
 	return (
 		sourceText.slice(0, lineStartIndex) +
-		output.join("\n") +
+		reportedLines.join("\n") +
 		sourceText.slice(lineEndIndex)
 	);
 }

--- a/packages/rule-tester/src/types.ts
+++ b/packages/rule-tester/src/types.ts
@@ -1,10 +1,14 @@
 export interface InvalidTestCase<
 	Options extends object | undefined = object | undefined,
 > extends TestCase<Options> {
-	output?: string;
-	snapshot: string;
+	output?: StringExpectation;
+	snapshot: StringExpectation;
 	suggestions?: TestSuggestion[];
 }
+
+export type StringExpectation = string | StringExpectationFunction;
+
+export type StringExpectationFunction = (actual: string) => void;
 
 export interface TestCase<
 	Options extends object | undefined = object | undefined,
@@ -38,7 +42,7 @@ export interface TestSuggestionFileCase {
 
 export interface TestSuggestionForFile {
 	id: string;
-	updated: string;
+	updated: StringExpectation;
 }
 
 export interface TestSuggestionForFiles {

--- a/packages/ts/src/rules/consecutiveNonNullAssertions.test.ts
+++ b/packages/ts/src/rules/consecutiveNonNullAssertions.test.ts
@@ -1,3 +1,5 @@
+import { expect } from "vitest";
+
 import rule from "./consecutiveNonNullAssertions.js";
 import { ruleTester } from "./ruleTester.js";
 
@@ -8,16 +10,24 @@ ruleTester.describe(rule, {
 declare const outer: { inner: number } | null;
 outer!!.inner;
 `,
-			output: `
-declare const outer: { inner: number } | null;
-outer!.inner;
-`,
-			snapshot: `
-declare const outer: { inner: number } | null;
-outer!!.inner;
-     ~~
-     Consecutive non-null assertion operators are unnecessary.
-`,
+			output: (text) => {
+				expect(text).toMatchInlineSnapshot(`
+					"
+					declare const outer: { inner: number } | null;
+					outer.inner;
+					"
+				`);
+			},
+			snapshot: (text) => {
+				expect(text).toMatchInlineSnapshot(`
+					"
+					declare const outer: { inner: number } | null;
+					outer!!.inner;
+					     ~~
+					     Consecutive non-null assertion operators are unnecessary.
+					"
+				`);
+			},
 		},
 	],
 	valid: [


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #1044
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/flint/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/flint/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Reference implementation for triaging #1044. I'm keeping this as a draft for now.

Changes `output`, `snapshot`, and `suggestions` > `updated` from `string` to `string | (text: string) => void`. `RuleTester` will now call those functions as needed. This allows tests to provide lines like `expect(text).toMatchInlineSnapshot()`. With Vitest, it just works!

Also includes an addition of testing the fixed `output` property. Which wasn't being done before. Whoops. I'll split that into a separate issue -> PR when I have a chance soon.

❤️‍🔥