### PR TITLE
feat(ts): allow passing loose TS-based diagnostics to convertTypeScriptDiagnosticToLanguageFileDiagnostic

### DIFF
--- a/.changeset/bold-ducks-jog.md
+++ b/.changeset/bold-ducks-jog.md
@@ -1,0 +1,7 @@
+---
+"@flint.fyi/core": minor
+"@flint.fyi/ts": minor
+---
+
+feat(core): export getPositionOfColumnAndLine utility
+feat(ts): allow passing loose TS-based diagnostics to convertTypeScriptDiagnosticToLanguageFileDiagnostic

--- a/packages/core/src/types/ranges.ts
+++ b/packages/core/src/types/ranges.ts
@@ -1,7 +1,7 @@
 /**
  * The column and line of a character in a source file, as visualized to users.
  */
-export interface ColumnAndLine {
+export interface ColumnAndLineWithoutRaw {
 	/**
 	 * Column in a source file (0-indexed integer).
 	 */
@@ -11,7 +11,12 @@ export interface ColumnAndLine {
 	 * Line in a source file (0-indexed integer).
 	 */
 	line: number;
+}
 
+/**
+ * The column and line of a character in a source file, as visualized to users.
+ */
+export interface ColumnAndLine extends ColumnAndLineWithoutRaw {
 	/**
 	 * The original raw character position in the source file (0-indexed integer).
 	 */

--- a/packages/core/src/utils/getColumnAndLineOfPosition.test.ts
+++ b/packages/core/src/utils/getColumnAndLineOfPosition.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, test, vi } from "vitest";
 
-import { getColumnAndLineOfPosition } from "./getColumnAndLineOfPosition.js";
+import {
+	getColumnAndLineOfPosition,
+	getPositionOfColumnAndLine,
+} from "./getColumnAndLineOfPosition.js";
 
 describe("getColumnAndLineOfPosition", () => {
 	test("negative position", () => {
@@ -258,5 +261,43 @@ describe("getColumnAndLineOfPosition", () => {
 			lineMap: [0, 3],
 			text: "0\n23",
 		});
+	});
+});
+
+describe("getPositionOfColumnAndLine", () => {
+	test("clamps negative line", () => {
+		const res = getPositionOfColumnAndLine("012", { column: 1, line: -1 });
+
+		expect(res).toBe(1);
+	});
+
+	test("clamps line after EOF", () => {
+		const res = getPositionOfColumnAndLine("012", { column: 1, line: 1 });
+
+		expect(res).toBe(1);
+	});
+
+	test("clamps column", () => {
+		const res = getPositionOfColumnAndLine("012\n45", { column: 4, line: 0 });
+
+		expect(res).toBe(3);
+	});
+
+	test("clamps column with empty line before it", () => {
+		const res = getPositionOfColumnAndLine("012\n\n56", { column: 5, line: 1 });
+
+		expect(res).toBe(4);
+	});
+
+	test("clamps column on the last line to EOF", () => {
+		const res = getPositionOfColumnAndLine("012", { column: 5, line: 1 });
+
+		expect(res).toBe(3);
+	});
+
+	test("column on EOF", () => {
+		const res = getPositionOfColumnAndLine("012", { column: 3, line: 1 });
+
+		expect(res).toBe(3);
 	});
 });

--- a/packages/core/src/utils/getColumnAndLineOfPosition.ts
+++ b/packages/core/src/utils/getColumnAndLineOfPosition.ts
@@ -1,4 +1,4 @@
-import { ColumnAndLine } from "../types/ranges.js";
+import { ColumnAndLine, ColumnAndLineWithoutRaw } from "../types/ranges.js";
 import { binarySearch } from "./arrays.js";
 
 /** Subset of ts.SourceFileLike */
@@ -10,6 +10,11 @@ export interface SourceFileWithLineMap {
 	readonly text: string;
 	/** Used for caching the start positions of lines in `text` */
 	lineMap?: readonly number[];
+}
+
+export interface SourceFileWithLineMapAndFileName
+	extends SourceFileWithLineMap {
+	fileName: string;
 }
 
 /**
@@ -121,4 +126,41 @@ function computeLineStarts(source: string): readonly number[] {
 	}
 	res.push(lineStart);
 	return res;
+}
+
+/**
+ * Prefer passing a `source` of type `HasGetLineAndCharacterOfPosition` or `SourceFileWithLineMap`.
+ * This way, the expensive computation of the `lineMap` will be cached across multiple calls.
+ */
+export function getPositionOfColumnAndLine(
+	source: SourceFileWithLineMap | string,
+	columnAndLine: ColumnAndLineWithoutRaw,
+): number {
+	if (typeof source === "string") {
+		return computePositionOfColumnAndLine(
+			source,
+			computeLineStarts(source),
+			columnAndLine,
+		);
+	}
+	source.lineMap ??= computeLineStarts(source.text);
+	return computePositionOfColumnAndLine(
+		source.text,
+		source.lineMap,
+		columnAndLine,
+	);
+}
+
+function computePositionOfColumnAndLine(
+	sourceText: string,
+	lineStarts: readonly number[],
+	{ column, line }: ColumnAndLineWithoutRaw,
+): number {
+	line = Math.min(Math.max(line, 0), lineStarts.length - 1);
+
+	const res = lineStarts[line] + column;
+	if (line === lineStarts.length - 1) {
+		return Math.min(res, sourceText.length);
+	}
+	return Math.min(res, lineStarts[line + 1] - 1);
 }

--- a/packages/ts/src/convertTypeScriptDiagnosticToLanguageFileDiagnostic.ts
+++ b/packages/ts/src/convertTypeScriptDiagnosticToLanguageFileDiagnostic.ts
@@ -5,35 +5,31 @@
 // eslint-disable-next-line @eslint-community/eslint-comments/disable-enable-pair
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 
-import { LanguageFileDiagnostic } from "@flint.fyi/core";
-import ts, {
-	flattenDiagnosticMessageText,
-	getLineAndCharacterOfPosition,
-	getPositionOfLineAndCharacter,
-	type SourceFile,
-} from "typescript";
+import {
+	getColumnAndLineOfPosition,
+	getPositionOfColumnAndLine,
+	LanguageFileDiagnostic,
+	SourceFileWithLineMapAndFileName,
+} from "@flint.fyi/core";
+import ts, { flattenDiagnosticMessageText } from "typescript";
 
-interface RawDiagnostic {
-	file?: ts.SourceFile;
-	length: number;
-	message: string;
-	name: string;
-	relatedInformation?: ts.DiagnosticRelatedInformation[];
-	start: number;
+export interface TSBasedDiagnostic extends TSBasedDiagnosticRelatedInformation {
+	relatedInformation?: TSBasedDiagnosticRelatedInformation[];
+}
+export interface TSBasedDiagnosticRelatedInformation {
+	code: number;
+	file: SourceFileWithLineMapAndFileName | undefined;
+	length: number | undefined;
+	messageText: string | ts.DiagnosticMessageChain;
+	start: number | undefined;
 }
 
 export function convertTypeScriptDiagnosticToLanguageFileDiagnostic(
-	diagnostic: ts.Diagnostic,
+	diagnostic: TSBasedDiagnostic,
 ): LanguageFileDiagnostic {
 	return {
 		code: `TS${diagnostic.code}`,
-		text: formatDiagnostic({
-			...diagnostic,
-			length: diagnostic.length!,
-			message: ts.flattenDiagnosticMessageText(diagnostic.messageText, "\n"),
-			name: `TS${diagnostic.code}`,
-			start: diagnostic.start!,
-		}),
+		text: formatDiagnostic(diagnostic),
 	};
 }
 
@@ -41,22 +37,22 @@ function color(text: string, formatStyle: string) {
 	return formatStyle + text + resetEscapeSequence;
 }
 
-function formatDiagnostic(diagnostic: RawDiagnostic) {
+function formatDiagnostic(diagnostic: TSBasedDiagnostic) {
 	let output = "";
 
 	if (diagnostic.file !== undefined) {
-		output += formatLocation(diagnostic.file, diagnostic.start);
+		output += formatLocation(diagnostic.file, diagnostic.start!);
 		output += " - ";
 	}
-	output += color(diagnostic.name, COLOR.Grey);
+	output += color(`TS${diagnostic.code}`, COLOR.Grey);
 	output += ": ";
-	output += diagnostic.message;
+	output += ts.flattenDiagnosticMessageText(diagnostic.messageText, "\n");
 	if (diagnostic.file !== undefined) {
 		output += "\n";
 		output += formatCodeSpan(
 			diagnostic.file,
-			diagnostic.start,
-			diagnostic.length,
+			diagnostic.start!,
+			diagnostic.length!,
 			"",
 			COLOR.Red,
 		);
@@ -103,17 +99,21 @@ function displayFilename(name: string) {
 }
 
 function formatCodeSpan(
-	file: SourceFile,
+	file: SourceFileWithLineMapAndFileName,
 	start: number,
 	length: number,
 	indent: string,
 	squiggleColor: string,
 ) {
-	const { character: firstLineChar, line: firstLine } =
-		getLineAndCharacterOfPosition(file, start);
-	const { character: lastLineChar, line: lastLine } =
-		getLineAndCharacterOfPosition(file, start + length);
-	const lastLineInFile = getLineAndCharacterOfPosition(
+	const { column: firstLineChar, line: firstLine } = getColumnAndLineOfPosition(
+		file,
+		start,
+	);
+	const { column: lastLineChar, line: lastLine } = getColumnAndLineOfPosition(
+		file,
+		start + length,
+	);
+	const lastLineInFile = getColumnAndLineOfPosition(
 		file,
 		file.text.length,
 	).line;
@@ -134,10 +134,10 @@ function formatCodeSpan(
 				"\n";
 			i = lastLine - 1;
 		}
-		const lineStart = getPositionOfLineAndCharacter(file, i, 0);
+		const lineStart = getPositionOfColumnAndLine(file, { column: 0, line: i });
 		const lineEnd =
 			i < lastLineInFile
-				? getPositionOfLineAndCharacter(file, i + 1, 0)
+				? getPositionOfColumnAndLine(file, { column: 0, line: i + 1 })
 				: file.text.length;
 		let lineContent = file.text.slice(lineStart, lineEnd);
 		lineContent = lineContent.trimEnd();
@@ -169,14 +169,17 @@ function formatCodeSpan(
 	return context;
 }
 
-function formatLocation(file: SourceFile, start: number): string {
-	const { character, line } = getLineAndCharacterOfPosition(file, start);
+function formatLocation(
+	file: SourceFileWithLineMapAndFileName,
+	start: number,
+): string {
+	const { column, line } = getColumnAndLineOfPosition(file, start);
 	const relativeFileName = displayFilename(file.fileName);
 	let output = "";
 	output += color(relativeFileName, COLOR.Cyan);
 	output += ":";
 	output += color(`${line + 1}`, COLOR.Yellow);
 	output += ":";
-	output += color(`${character + 1}`, COLOR.Yellow);
+	output += color(`${column + 1}`, COLOR.Yellow);
 	return output;
 }


### PR DESCRIPTION

## PR Checklist

- [x] Addresses an existing open issue: fixes #1087
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/flint/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/flint/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

`TSBasedDiagnostic` is a subset of `ts.Diagnostic`
