### PR TITLE
chore: add more Prettier settings to VS Code settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,4 @@
 {
-	"editor.codeActionsOnSave": { "source.fixAll.eslint": "explicit" },
-	"editor.defaultFormatter": "prettier.prettier-vscode",
 	"[javascript]": { "editor.defaultFormatter": "prettier.prettier-vscode" },
 	"[javascriptreact]": {
 		"editor.defaultFormatter": "prettier.prettier-vscode"
@@ -13,6 +11,8 @@
 		"editor.defaultFormatter": "prettier.prettier-vscode"
 	},
 	"[yaml]": { "editor.defaultFormatter": "prettier.prettier-vscode" },
+	"editor.codeActionsOnSave": { "source.fixAll.eslint": "explicit" },
+	"editor.defaultFormatter": "prettier.prettier-vscode",
 	"editor.formatOnSave": true,
 	"editor.rulers": [80],
 	"eslint.probe": [


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to flint! ❤️‍🔥
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/flint/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/flint/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

> I believe these are unnecessary since `editor.defaultFormatter` is set in the root? I'll remove, but please yell at me if I'm wrong - I can add them back (or approve a PR to) if they're actually necessary. 

 _Originally posted by @JoshuaKGoldberg in [#1118](https://github.com/JoshuaKGoldberg/flint/pull/1118/changes/BASE..1d4edd815eda7e476e67d630e49c9f4e9ebd3832#r2649285529)_

> CTA adds them because a user-level `[js].formatter` will override a local, unscoped `formatter` setting. My user settings are set to prettier.prettier-vscode so it doesn't break me, but it'll annoy anyone who has a different default (which is common because vscode is buggy and "randomly" writes them). 

 _Originally posted by @lishaduck in [#1118](https://github.com/JoshuaKGoldberg/flint/pull/1118/changes/BASE..1d4edd815eda7e476e67d630e49c9f4e9ebd3832#r2649289991)_

So actually this wasn't from CTA, "you" added them @JoshuaKGoldberg. By which I mean VS Code added them.
It doesn't hurt anything to add them and it'll make setup smoother for people with different formatters set (which is most due to the esbenp -> prettier migration).
