### PR TITLE
fix: ignore source & declaration maps when packing

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -19,7 +19,7 @@
 	},
 	"files": [
 		"lib/",
-		"!lib/**/*.*s.map"
+		"!lib/**/*.map"
 	],
 	"dependencies": {
 		"@flint.fyi/core": "workspace:",

--- a/packages/comparisons/package.json
+++ b/packages/comparisons/package.json
@@ -19,7 +19,7 @@
 	},
 	"files": [
 		"lib/",
-		"!lib/**/*.*s.map"
+		"!lib/**/*.map"
 	],
 	"dependencies": {
 		"prettier": "3.7.4"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -25,7 +25,7 @@
 	},
 	"files": [
 		"lib/",
-		"!lib/**/*.*s.map"
+		"!lib/**/*.map"
 	],
 	"dependencies": {
 		"@flint.fyi/utils": "workspace:",

--- a/packages/flint/package.json
+++ b/packages/flint/package.json
@@ -22,7 +22,7 @@
 	},
 	"files": [
 		"lib/",
-		"!lib/**/*.*s.map"
+		"!lib/**/*.map"
 	],
 	"dependencies": {
 		"@flint.fyi/cli": "workspace:",

--- a/packages/json/package.json
+++ b/packages/json/package.json
@@ -19,7 +19,7 @@
 	},
 	"files": [
 		"lib/",
-		"!lib/**/*.*s.map"
+		"!lib/**/*.map"
 	],
 	"dependencies": {
 		"@flint.fyi/core": "workspace:",

--- a/packages/md/package.json
+++ b/packages/md/package.json
@@ -19,7 +19,7 @@
 	},
 	"files": [
 		"lib/",
-		"!lib/**/*.*s.map"
+		"!lib/**/*.map"
 	],
 	"dependencies": {
 		"@flint.fyi/core": "workspace:",

--- a/packages/plugin-astro/package.json
+++ b/packages/plugin-astro/package.json
@@ -19,7 +19,7 @@
 	},
 	"files": [
 		"lib/",
-		"!lib/**/*.*s.map"
+		"!lib/**/*.map"
 	],
 	"dependencies": {
 		"@flint.fyi/core": "workspace:",

--- a/packages/plugin-browser/package.json
+++ b/packages/plugin-browser/package.json
@@ -19,7 +19,7 @@
 	},
 	"files": [
 		"lib/",
-		"!lib/**/*.*s.map"
+		"!lib/**/*.map"
 	],
 	"dependencies": {
 		"@flint.fyi/core": "workspace:",

--- a/packages/plugin-flint/package.json
+++ b/packages/plugin-flint/package.json
@@ -19,7 +19,7 @@
 	},
 	"files": [
 		"lib/",
-		"!lib/**/*.*s.map"
+		"!lib/**/*.map"
 	],
 	"dependencies": {
 		"@flint.fyi/core": "workspace:",

--- a/packages/plugin-jsx/package.json
+++ b/packages/plugin-jsx/package.json
@@ -19,7 +19,7 @@
 	},
 	"files": [
 		"lib/",
-		"!lib/**/*.*s.map"
+		"!lib/**/*.map"
 	],
 	"dependencies": {
 		"@flint.fyi/core": "workspace:",

--- a/packages/plugin-next/package.json
+++ b/packages/plugin-next/package.json
@@ -19,7 +19,7 @@
 	},
 	"files": [
 		"lib/",
-		"!lib/**/*.*s.map"
+		"!lib/**/*.map"
 	],
 	"dependencies": {
 		"@flint.fyi/core": "workspace:",

--- a/packages/plugin-node/package.json
+++ b/packages/plugin-node/package.json
@@ -19,7 +19,7 @@
 	},
 	"files": [
 		"lib/",
-		"!lib/**/*.*s.map"
+		"!lib/**/*.map"
 	],
 	"dependencies": {
 		"@flint.fyi/core": "workspace:",

--- a/packages/plugin-nuxt/package.json
+++ b/packages/plugin-nuxt/package.json
@@ -19,7 +19,7 @@
 	},
 	"files": [
 		"lib/",
-		"!lib/**/*.*s.map"
+		"!lib/**/*.map"
 	],
 	"dependencies": {
 		"@flint.fyi/core": "workspace:",

--- a/packages/plugin-performance/package.json
+++ b/packages/plugin-performance/package.json
@@ -19,7 +19,7 @@
 	},
 	"files": [
 		"lib/",
-		"!lib/**/*.*s.map"
+		"!lib/**/*.map"
 	],
 	"dependencies": {
 		"@flint.fyi/core": "workspace:",

--- a/packages/plugin-react/package.json
+++ b/packages/plugin-react/package.json
@@ -19,7 +19,7 @@
 	},
 	"files": [
 		"lib/",
-		"!lib/**/*.*s.map"
+		"!lib/**/*.map"
 	],
 	"dependencies": {
 		"@flint.fyi/core": "workspace:",

--- a/packages/plugin-solid/package.json
+++ b/packages/plugin-solid/package.json
@@ -19,7 +19,7 @@
 	},
 	"files": [
 		"lib/",
-		"!lib/**/*.*s.map"
+		"!lib/**/*.map"
 	],
 	"dependencies": {
 		"@flint.fyi/core": "workspace:",

--- a/packages/plugin-spelling/package.json
+++ b/packages/plugin-spelling/package.json
@@ -19,7 +19,7 @@
 	},
 	"files": [
 		"lib/",
-		"!lib/**/*.*s.map"
+		"!lib/**/*.map"
 	],
 	"dependencies": {
 		"@cspell/url": "^9.2.2",

--- a/packages/rule-tester/package.json
+++ b/packages/rule-tester/package.json
@@ -19,7 +19,7 @@
 	},
 	"files": [
 		"lib/",
-		"!lib/**/*.*s.map"
+		"!lib/**/*.map"
 	],
 	"dependencies": {
 		"@flint.fyi/core": "workspace:",

--- a/packages/text/package.json
+++ b/packages/text/package.json
@@ -19,7 +19,7 @@
 	},
 	"files": [
 		"lib/",
-		"!lib/**/*.*s.map"
+		"!lib/**/*.map"
 	],
 	"dependencies": {
 		"@flint.fyi/core": "workspace:",

--- a/packages/ts/package.json
+++ b/packages/ts/package.json
@@ -19,7 +19,7 @@
 	},
 	"files": [
 		"lib/",
-		"!lib/**/*.*s.map"
+		"!lib/**/*.map"
 	],
 	"dependencies": {
 		"@flint.fyi/core": "workspace:",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -19,7 +19,7 @@
 	},
 	"files": [
 		"lib/",
-		"!lib/**/*.*s.map"
+		"!lib/**/*.map"
 	],
 	"dependencies": {
 		"typescript": "^5.9.3"

--- a/packages/yaml/package.json
+++ b/packages/yaml/package.json
@@ -19,7 +19,7 @@
 	},
 	"files": [
 		"lib/",
-		"!lib/**/*.*s.map"
+		"!lib/**/*.map"
 	],
 	"dependencies": {
 		"@flint.fyi/core": "workspace:",


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to flint! ❤️‍🔥
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #1154
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/flint/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/flint/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->
TIL that using negated globs in `files` is [UB](https://github.com/npm/cli/wiki/Files-&-Ignores). Nonetheless, I tested and it works fine in both pnpm & npm, and enough people (aka everyone) uses it, so I think we're safe.

🔥 