### PR TITLE
docs: shrink hero image and vertical padding

### DIFF
--- a/packages/site/src/styles.css
+++ b/packages/site/src/styles.css
@@ -49,4 +49,5 @@ table code {
 .hero img {
 	max-height: 15rem;
 	object-position: right;
+	user-select: none;
 }


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #1188
- [x] That issue was marked as [`status: accepting prs`](https://github.com/flint-fyi/flint/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/flint-fyi/flint/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Seen at 50% zoom: 

<table>
<thead>
<tr>
<th>Before</th>
<th>After</th>
</tr>
</thead>
<tbody>
<tr>
<td>
<img width="946" height="929" alt="Flint homepage with a huge hero image logo and lots of vertical padding" src="https://github.com/user-attachments/assets/b415214c-ac19-4b47-bc74-07e672764df1" />
</td>
<td>
<img width="946" height="929" alt="Flint homepage with a much smaller hero image logo and less vertical padding" src="https://github.com/user-attachments/assets/ef2a0661-80ad-44ba-a9cb-201c37d37050" />
</td>
</tr>
</tbody>
</table>

❤️‍🔥