### PR TITLE
docs: reduced custom --sl-content-width

### DIFF
--- a/packages/site/src/styles.css
+++ b/packages/site/src/styles.css
@@ -33,7 +33,7 @@
 
 /* General customizations. */
 :root {
-	--sl-content-width: 63rem;
+	--sl-content-width: 56rem;
 }
 
 table code {


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #1195
- [x] That issue was marked as [`status: accepting prs`](https://github.com/flint-fyi/flint/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/flint-fyi/flint/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

The current width override is a little too much for less-wide screens. But the default `45rem` is a little too narrow for the rich data tables under `rules`. 😕 

❤️‍🔥