### PR TITLE
chore: remove outdated NPM_TOKEN and provenance: true entries

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,7 +11,6 @@ jobs:
       - run: pnpm build
       - env:
           GITHUB_TOKEN: ${{ secrets.ACCESS_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         name: Create Release Pull Request
         uses: changesets/action@v1
         with:

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -43,7 +43,6 @@
 		"node": ">=24.0.0"
 	},
 	"publishConfig": {
-		"access": "public",
-		"provenance": true
+		"access": "public"
 	}
 }

--- a/packages/comparisons/package.json
+++ b/packages/comparisons/package.json
@@ -28,7 +28,6 @@
 		"node": ">=24.0.0"
 	},
 	"publishConfig": {
-		"access": "public",
-		"provenance": true
+		"access": "public"
 	}
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -36,7 +36,6 @@
 		"node": ">=24.0.0"
 	},
 	"publishConfig": {
-		"access": "public",
-		"provenance": true
+		"access": "public"
 	}
 }

--- a/packages/json/package.json
+++ b/packages/json/package.json
@@ -34,7 +34,6 @@
 		"node": ">=24.0.0"
 	},
 	"publishConfig": {
-		"access": "public",
-		"provenance": true
+		"access": "public"
 	}
 }

--- a/packages/md/package.json
+++ b/packages/md/package.json
@@ -36,7 +36,6 @@
 		"node": ">=24.0.0"
 	},
 	"publishConfig": {
-		"access": "public",
-		"provenance": true
+		"access": "public"
 	}
 }

--- a/packages/plugin-astro/package.json
+++ b/packages/plugin-astro/package.json
@@ -29,7 +29,6 @@
 		"node": ">=24.0.0"
 	},
 	"publishConfig": {
-		"access": "public",
-		"provenance": true
+		"access": "public"
 	}
 }

--- a/packages/plugin-browser/package.json
+++ b/packages/plugin-browser/package.json
@@ -34,7 +34,6 @@
 		"node": ">=24.0.0"
 	},
 	"publishConfig": {
-		"access": "public",
-		"provenance": true
+		"access": "public"
 	}
 }

--- a/packages/plugin-flint/package.json
+++ b/packages/plugin-flint/package.json
@@ -35,7 +35,6 @@
 		"node": ">=24.0.0"
 	},
 	"publishConfig": {
-		"access": "public",
-		"provenance": true
+		"access": "public"
 	}
 }

--- a/packages/plugin-jsx/package.json
+++ b/packages/plugin-jsx/package.json
@@ -36,7 +36,6 @@
 		"node": ">=24.0.0"
 	},
 	"publishConfig": {
-		"access": "public",
-		"provenance": true
+		"access": "public"
 	}
 }

--- a/packages/plugin-next/package.json
+++ b/packages/plugin-next/package.json
@@ -29,7 +29,6 @@
 		"node": ">=24.0.0"
 	},
 	"publishConfig": {
-		"access": "public",
-		"provenance": true
+		"access": "public"
 	}
 }

--- a/packages/plugin-node/package.json
+++ b/packages/plugin-node/package.json
@@ -34,7 +34,6 @@
 		"node": ">=24.0.0"
 	},
 	"publishConfig": {
-		"access": "public",
-		"provenance": true
+		"access": "public"
 	}
 }

--- a/packages/plugin-nuxt/package.json
+++ b/packages/plugin-nuxt/package.json
@@ -29,7 +29,6 @@
 		"node": ">=24.0.0"
 	},
 	"publishConfig": {
-		"access": "public",
-		"provenance": true
+		"access": "public"
 	}
 }

--- a/packages/plugin-performance/package.json
+++ b/packages/plugin-performance/package.json
@@ -35,7 +35,6 @@
 		"node": ">=24.0.0"
 	},
 	"publishConfig": {
-		"access": "public",
-		"provenance": true
+		"access": "public"
 	}
 }

--- a/packages/plugin-react/package.json
+++ b/packages/plugin-react/package.json
@@ -29,7 +29,6 @@
 		"node": ">=24.0.0"
 	},
 	"publishConfig": {
-		"access": "public",
-		"provenance": true
+		"access": "public"
 	}
 }

--- a/packages/plugin-solid/package.json
+++ b/packages/plugin-solid/package.json
@@ -29,7 +29,6 @@
 		"node": ">=24.0.0"
 	},
 	"publishConfig": {
-		"access": "public",
-		"provenance": true
+		"access": "public"
 	}
 }

--- a/packages/plugin-spelling/package.json
+++ b/packages/plugin-spelling/package.json
@@ -36,7 +36,6 @@
 		"node": ">=24.0.0"
 	},
 	"publishConfig": {
-		"access": "public",
-		"provenance": true
+		"access": "public"
 	}
 }

--- a/packages/rule-tester/package.json
+++ b/packages/rule-tester/package.json
@@ -33,7 +33,6 @@
 		"node": ">=24.0.0"
 	},
 	"publishConfig": {
-		"access": "public",
-		"provenance": true
+		"access": "public"
 	}
 }

--- a/packages/text/package.json
+++ b/packages/text/package.json
@@ -29,7 +29,6 @@
 		"node": ">=24.0.0"
 	},
 	"publishConfig": {
-		"access": "public",
-		"provenance": true
+		"access": "public"
 	}
 }

--- a/packages/ts-patch/package.json
+++ b/packages/ts-patch/package.json
@@ -41,7 +41,6 @@
 		"node": ">=24.0.0"
 	},
 	"publishConfig": {
-		"access": "public",
-		"provenance": true
+		"access": "public"
 	}
 }

--- a/packages/ts/package.json
+++ b/packages/ts/package.json
@@ -39,7 +39,6 @@
 		"node": ">=24.0.0"
 	},
 	"publishConfig": {
-		"access": "public",
-		"provenance": true
+		"access": "public"
 	}
 }

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -25,7 +25,6 @@
 		"node": ">=24.0.0"
 	},
 	"publishConfig": {
-		"access": "public",
-		"provenance": true
+		"access": "public"
 	}
 }

--- a/packages/yaml/package.json
+++ b/packages/yaml/package.json
@@ -34,7 +34,6 @@
 		"node": ">=24.0.0"
 	},
 	"publishConfig": {
-		"access": "public",
-		"provenance": true
+		"access": "public"
 	}
 }


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #1239
- [x] That issue was marked as [`status: accepting prs`](https://github.com/flint-fyi/flint/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/flint-fyi/flint/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Applies the same removals as https://github.com/JoshuaKGoldberg/create-typescript-app/pull/2337.

* `NPM_TOKEN`: I think trying to use it is what's causing the auth issues
* `provenance: true`: no longer necessary

❤️‍🔥