### PR TITLE
chore: bumped OctoGuide to 0.21.0

### DIFF
--- a/.github/workflows/octoguide.yaml
+++ b/.github/workflows/octoguide.yaml
@@ -2,7 +2,7 @@ jobs:
   octoguide:
     runs-on: ubuntu-latest
     steps:
-      - uses: JoshuaKGoldberg/octoguide@2323755a369bb2daf760304df78385f144cb4ce0 # 0.21.0
+      - uses: OctoGuide/bot@2323755a369bb2daf760304df78385f144cb4ce0 # 0.21.0
         with:
           config: strict
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Overview

This version includes the feature to ignore owners and collaborators from scans.

❤️‍🔥