### PR TITLE
feat(ts): implement arrayMapIdentities rule

### DIFF
--- a/packages/comparisons/src/data.json
+++ b/packages/comparisons/src/data.json
@@ -7564,7 +7564,8 @@
 		"flint": {
 			"name": "arrayMapIdentities",
 			"plugin": "ts",
-			"preset": "logical"
+			"preset": "logical",
+			"status": "implemented"
 		}
 	},
 	{

--- a/packages/site/src/content/docs/rules/ts/arrayMapIdentities.mdx
+++ b/packages/site/src/content/docs/rules/ts/arrayMapIdentities.mdx
@@ -1,0 +1,79 @@
+---
+description: "Reports identity callbacks in `flatMap` calls that can be replaced with `flat`."
+title: "arrayMapIdentities"
+topic: "rules"
+---
+
+import { Tabs, TabItem } from "@astrojs/starlight/components";
+import { RuleEquivalents } from "~/components/RuleEquivalents";
+import RuleSummary from "~/components/RuleSummary.astro";
+
+<RuleSummary plugin="ts" rule="arrayMapIdentities" />
+
+Using `.flatMap()` with a callback that returns its input unchanged is equivalent to calling `.flat()`.
+The `.flat()` method is more concise and makes the intent clearer.
+
+## Examples
+
+<Tabs>
+<TabItem label="❌ Incorrect">
+
+```ts
+const nested = [[1], [2], [3]];
+const flat = nested.flatMap((value) => value);
+```
+
+```ts
+const items = [["a"], ["b"]];
+const flat = items.flatMap((item) => {
+	return item;
+});
+```
+
+```ts
+const data = [
+	[1, 2],
+	[3, 4],
+];
+const flat = data.flatMap(function (element) {
+	return element;
+});
+```
+
+</TabItem>
+<TabItem label="✅ Correct">
+
+```ts
+const nested = [[1], [2], [3]];
+const flat = nested.flat();
+```
+
+```ts
+const values = [1, 2, 3];
+const doubled = values.flatMap((value) => [value, value]);
+```
+
+```ts
+const items = [["a", "b"], ["c"]];
+const transformed = items.flatMap((item) => item.map((i) => i.toUpperCase()));
+```
+
+</TabItem>
+</Tabs>
+
+## Options
+
+This rule is not configurable.
+
+## When Not To Use It
+
+If you prefer the explicit callback style for consistency with other array method chains, or if you're working with a codebase that uses `.flatMap()` with identity callbacks for documentation purposes, you may want to disable this rule.
+
+## Further Reading
+
+- [MDN: Array.prototype.flat()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/flat)
+- [MDN: Array.prototype.flatMap()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/flatMap)
+
+## Equivalents in Other Linters
+
+<RuleEquivalents pluginId="ts" ruleId="arrayMapIdentities" />

--- a/packages/ts/src/plugin.ts
+++ b/packages/ts/src/plugin.ts
@@ -1,6 +1,7 @@
 import { createPlugin } from "@flint.fyi/core";
 
 import anyReturns from "./rules/anyReturns.ts";
+import arrayMapIdentities from "./rules/arrayMapIdentities.ts";
 import asyncPromiseExecutors from "./rules/asyncPromiseExecutors.ts";
 import caseDeclarations from "./rules/caseDeclarations.ts";
 import caseDuplicates from "./rules/caseDuplicates.ts";
@@ -65,6 +66,7 @@ export const ts = createPlugin({
 	name: "TypeScript",
 	rules: [
 		anyReturns,
+		arrayMapIdentities,
 		asyncPromiseExecutors,
 		caseDeclarations,
 		caseDuplicates,

--- a/packages/ts/src/rules/arrayMapIdentities.test.ts
+++ b/packages/ts/src/rules/arrayMapIdentities.test.ts
@@ -1,0 +1,85 @@
+import rule from "./arrayMapIdentities.ts";
+import { ruleTester } from "./ruleTester.ts";
+
+ruleTester.describe(rule, {
+	invalid: [
+		{
+			code: `
+const values: number[][] = [[1], [2], [3]];
+const flat = values.flatMap((value) => value);
+`,
+			output: `
+const values: number[][] = [[1], [2], [3]];
+const flat = values.flat();
+`,
+			snapshot: `
+const values: number[][] = [[1], [2], [3]];
+const flat = values.flatMap((value) => value);
+                    ~~~~~~~~~~~~~~~~~~~~~~~~~
+                    Use \`.flat()\` instead of \`.flatMap()\` with an identity callback.
+`,
+		},
+		{
+			code: `
+const items: string[][] = [["a"], ["b"]];
+const flat = items.flatMap((item) => { return item; });
+`,
+			output: `
+const items: string[][] = [["a"], ["b"]];
+const flat = items.flat();
+`,
+			snapshot: `
+const items: string[][] = [["a"], ["b"]];
+const flat = items.flatMap((item) => { return item; });
+                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                   Use \`.flat()\` instead of \`.flatMap()\` with an identity callback.
+`,
+		},
+		{
+			code: `
+const nested: number[][] = [[1, 2], [3, 4]];
+const flat = nested.flatMap(function (element) { return element; });
+`,
+			output: `
+const nested: number[][] = [[1, 2], [3, 4]];
+const flat = nested.flat();
+`,
+			snapshot: `
+const nested: number[][] = [[1, 2], [3, 4]];
+const flat = nested.flatMap(function (element) { return element; });
+                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                    Use \`.flat()\` instead of \`.flatMap()\` with an identity callback.
+`,
+		},
+		{
+			code: `
+const data: number[][] = [[1], [2]];
+data.flatMap(x => x);
+`,
+			output: `
+const data: number[][] = [[1], [2]];
+data.flat();
+`,
+			snapshot: `
+const data: number[][] = [[1], [2]];
+data.flatMap(x => x);
+     ~~~~~~~~~~~~~~~
+     Use \`.flat()\` instead of \`.flatMap()\` with an identity callback.
+`,
+		},
+	],
+	valid: [
+		`const values: number[][] = [[1], [2]]; const flat = values.flat();`,
+		`const values: number[] = [1, 2, 3]; const doubled = values.flatMap((value) => [value, value]);`,
+		`const values: number[][] = [[1], [2]]; const filtered = values.flatMap((value) => value.length > 0 ? value : []);`,
+		`const values: number[][] = [[1], [2]]; const mapped = values.flatMap((value) => value.map((v) => v * 2));`,
+		`const values: number[][] = [[1], [2]]; const mapped = values.map((value) => value);`,
+		`const str = "a,b,c"; const parts = str.split(",").flatMap((part) => [part]);`,
+		`const values: number[][] = [[1], [2]]; const flat = values.flatMap((a, b) => a);`,
+		`const values: number[][] = [[1], [2]]; values.flatMap((value) => { doSomething(value); return value; });`,
+		`const values: number[][] = [[1], [2]]; values.flatMap((value) => { if (!value) return []; return value; });`,
+		`const values: number[][] = [[1], [2]]; values.flatMap((value) => { return value && value; });`,
+		`const values: number[][] = [[1], [2]]; values.flatMap(function (value) { if (value.length > 0) { return value; } return []; });`,
+		`const values: number[][] = [[1], [2]]; values.flatMap(({ length }) => length > 0 ? [[length]] : []);`,
+	],
+});

--- a/packages/ts/src/rules/arrayMapIdentities.ts
+++ b/packages/ts/src/rules/arrayMapIdentities.ts
@@ -1,0 +1,146 @@
+import * as ts from "typescript";
+
+import { typescriptLanguage } from "../language.ts";
+
+export default typescriptLanguage.createRule({
+	about: {
+		description:
+			"Reports identity callbacks in `flatMap` calls that can be replaced with `flat`.",
+		id: "arrayMapIdentities",
+		preset: "logical",
+	},
+	messages: {
+		preferFlat: {
+			primary:
+				"Use `.flat()` instead of `.flatMap()` with an identity callback.",
+			secondary: [
+				"An identity callback returns its input unchanged, making `.flatMap()` equivalent to `.flat()`.",
+			],
+			suggestions: ["Replace `.flatMap(...)` with `.flat()`."],
+		},
+	},
+	setup(context) {
+		return {
+			visitors: {
+				CallExpression: (node, { sourceFile, typeChecker }) => {
+					if (!ts.isPropertyAccessExpression(node.expression)) {
+						return;
+					}
+
+					if (node.expression.name.text !== "flatMap") {
+						return;
+					}
+
+					if (node.arguments.length !== 1) {
+						return;
+					}
+
+					const callback = node.arguments[0];
+					if (!isIdentityCallback(callback)) {
+						return;
+					}
+
+					if (!isArrayType(node.expression.expression, typeChecker)) {
+						return;
+					}
+
+					const arrayText = node.expression.expression.getText(sourceFile);
+
+					context.report({
+						fix: {
+							range: {
+								begin: node.getStart(sourceFile),
+								end: node.getEnd(),
+							},
+							text: `${arrayText}.flat()`,
+						},
+						message: "preferFlat",
+						range: {
+							begin: node.expression.name.getStart(sourceFile),
+							end: node.getEnd(),
+						},
+					});
+				},
+			},
+		};
+	},
+});
+
+function getSingleParameterName(
+	parameters: ts.NodeArray<ts.ParameterDeclaration>,
+) {
+	if (parameters.length !== 1) {
+		return undefined;
+	}
+
+	const param = parameters[0];
+	if (!ts.isIdentifier(param.name)) {
+		return undefined;
+	}
+
+	return param.name.text;
+}
+
+function isArrayType(node: ts.Node, typeChecker: ts.TypeChecker) {
+	const type = typeChecker.getTypeAtLocation(node);
+	return typeChecker.isArrayType(type);
+}
+
+function isIdentityArrowFunction(node: ts.ArrowFunction) {
+	const parameterName = getSingleParameterName(node.parameters);
+	if (!parameterName) {
+		return false;
+	}
+
+	if (ts.isIdentifier(node.body)) {
+		return node.body.text === parameterName;
+	}
+
+	if (ts.isBlock(node.body)) {
+		return isIdentityBlockBody(node.body, parameterName);
+	}
+
+	return false;
+}
+
+function isIdentityBlockBody(body: ts.Block, parameterName: string) {
+	if (body.statements.length !== 1) {
+		return false;
+	}
+
+	const statement = body.statements[0];
+	if (!ts.isReturnStatement(statement)) {
+		return false;
+	}
+
+	if (!statement.expression) {
+		return false;
+	}
+
+	if (!ts.isIdentifier(statement.expression)) {
+		return false;
+	}
+
+	return statement.expression.text === parameterName;
+}
+
+function isIdentityCallback(node: ts.Node): boolean {
+	if (ts.isArrowFunction(node)) {
+		return isIdentityArrowFunction(node);
+	}
+
+	if (ts.isFunctionExpression(node)) {
+		return isIdentityFunctionExpression(node);
+	}
+
+	return false;
+}
+
+function isIdentityFunctionExpression(node: ts.FunctionExpression) {
+	const parameterName = getSingleParameterName(node.parameters);
+	if (!parameterName) {
+		return false;
+	}
+
+	return isIdentityBlockBody(node.body, parameterName);
+}


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #820
- [x] That issue was marked as [`status: accepting prs`](https://github.com/flint-fyi/flint/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/flint-fyi/flint/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Implements the `arrayMapIdentities` rule which reports identity callbacks in `flatMap` calls that can be replaced with `flat`. This is equivalent to Biome's `noFlatMapIdentity` rule.