### PR TITLE
feat(ts): implement asyncUnnecessaryPromiseWrappers rule

### DIFF
--- a/packages/comparisons/src/data.json
+++ b/packages/comparisons/src/data.json
@@ -7945,7 +7945,8 @@
 		"flint": {
 			"name": "asyncUnnecessaryPromiseWrappers",
 			"plugin": "ts",
-			"preset": "logical"
+			"preset": "logical",
+			"status": "implemented"
 		},
 		"oxlint": [
 			{

--- a/packages/site/src/content/docs/rules/ts/asyncUnnecessaryPromiseWrappers.mdx
+++ b/packages/site/src/content/docs/rules/ts/asyncUnnecessaryPromiseWrappers.mdx
@@ -1,0 +1,98 @@
+---
+description: "Reports unnecessary Promise.resolve() or Promise.reject() in async functions or promise callbacks."
+title: "asyncUnnecessaryPromiseWrappers"
+topic: "rules"
+---
+
+import { Tabs, TabItem } from "@astrojs/starlight/components";
+import { RuleEquivalents } from "~/components/RuleEquivalents";
+import RuleSummary from "~/components/RuleSummary.astro";
+
+<RuleSummary plugin="ts" rule="asyncUnnecessaryPromiseWrappers" />
+
+Return values in async functions and promise callbacks are automatically wrapped in a Promise.
+Using `Promise.resolve()` is redundant in these contexts.
+Similarly, errors thrown in async functions are automatically caught and wrapped in a rejected Promise, making `Promise.reject()` unnecessary.
+
+## Examples
+
+<Tabs>
+<TabItem label="❌ Incorrect">
+
+```ts
+async function getData() {
+	return Promise.resolve(42);
+}
+```
+
+```ts
+async function handleError() {
+	return Promise.reject(new Error("failed"));
+}
+```
+
+```ts
+promise.then(() => {
+	return Promise.resolve(result);
+});
+```
+
+```ts
+async function* generator() {
+	yield Promise.resolve(value);
+}
+```
+
+</TabItem>
+<TabItem label="✅ Correct">
+
+```ts
+async function getData() {
+	return 42;
+}
+```
+
+```ts
+async function handleError() {
+	throw new Error("failed");
+}
+```
+
+```ts
+promise.then(() => {
+	return result;
+});
+```
+
+```ts
+async function* generator() {
+	yield value;
+}
+```
+
+```ts
+function createPromise() {
+	return Promise.resolve(42);
+}
+```
+
+</TabItem>
+</Tabs>
+
+## Options
+
+This rule is not configurable.
+
+## When Not To Use It
+
+If you prefer explicit Promise wrapping for consistency or readability, or if your codebase has patterns that intentionally use `Promise.resolve()` for type inference purposes, you can disable this rule.
+
+## Further Reading
+
+- [MDN: async function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/async_function)
+- [MDN: Promise.resolve()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/resolve)
+- [MDN: Promise.reject()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/reject)
+
+## Equivalents in Other Linters
+
+<RuleEquivalents pluginId="ts" ruleId="asyncUnnecessaryPromiseWrappers" />

--- a/packages/ts/src/plugin.ts
+++ b/packages/ts/src/plugin.ts
@@ -2,6 +2,7 @@ import { createPlugin } from "@flint.fyi/core";
 
 import anyReturns from "./rules/anyReturns.ts";
 import asyncPromiseExecutors from "./rules/asyncPromiseExecutors.ts";
+import asyncUnnecessaryPromiseWrappers from "./rules/asyncUnnecessaryPromiseWrappers.ts";
 import caseDeclarations from "./rules/caseDeclarations.ts";
 import caseDuplicates from "./rules/caseDuplicates.ts";
 import chainedAssignments from "./rules/chainedAssignments.ts";
@@ -66,6 +67,7 @@ export const ts = createPlugin({
 	rules: [
 		anyReturns,
 		asyncPromiseExecutors,
+		asyncUnnecessaryPromiseWrappers,
 		caseDeclarations,
 		caseDuplicates,
 		chainedAssignments,

--- a/packages/ts/src/rules/asyncUnnecessaryPromiseWrappers.test.ts
+++ b/packages/ts/src/rules/asyncUnnecessaryPromiseWrappers.test.ts
@@ -1,0 +1,143 @@
+import rule from "./asyncUnnecessaryPromiseWrappers.ts";
+import { ruleTester } from "./ruleTester.ts";
+
+ruleTester.describe(rule, {
+	invalid: [
+		{
+			code: `
+async function getData() {
+    return Promise.resolve(42);
+}
+`,
+			snapshot: `
+async function getData() {
+    return Promise.resolve(42);
+           ~~~~~~~~~~~~~~~
+           Prefer returning the value directly instead of wrapping it with Promise.resolve().
+}
+`,
+		},
+		{
+			code: `
+async function handleError() {
+    return Promise.reject(new Error("failed"));
+}
+`,
+			snapshot: `
+async function handleError() {
+    return Promise.reject(new Error("failed"));
+           ~~~~~~~~~~~~~~
+           Prefer throwing the error directly instead of wrapping it with Promise.reject().
+}
+`,
+		},
+		{
+			code: `
+const asyncFn = async () => {
+    return Promise.resolve("value");
+};
+`,
+			snapshot: `
+const asyncFn = async () => {
+    return Promise.resolve("value");
+           ~~~~~~~~~~~~~~~
+           Prefer returning the value directly instead of wrapping it with Promise.resolve().
+};
+`,
+		},
+		{
+			code: `
+const asyncArrow = async () => Promise.resolve(42);
+`,
+			snapshot: `
+const asyncArrow = async () => Promise.resolve(42);
+                               ~~~~~~~~~~~~~~~
+                               Prefer returning the value directly instead of wrapping it with Promise.resolve().
+`,
+		},
+		{
+			code: `
+const promise: Promise<number> = Promise.resolve(1);
+promise.then(() => {
+    return Promise.resolve(42);
+});
+`,
+			snapshot: `
+const promise: Promise<number> = Promise.resolve(1);
+promise.then(() => {
+    return Promise.resolve(42);
+           ~~~~~~~~~~~~~~~
+           Prefer returning the value directly instead of wrapping it with Promise.resolve().
+});
+`,
+		},
+		{
+			code: `
+const promise: Promise<number> = Promise.resolve(1);
+promise.catch(() => {
+    return Promise.reject(new Error("failed"));
+});
+`,
+			snapshot: `
+const promise: Promise<number> = Promise.resolve(1);
+promise.catch(() => {
+    return Promise.reject(new Error("failed"));
+           ~~~~~~~~~~~~~~
+           Prefer throwing the error directly instead of wrapping it with Promise.reject().
+});
+`,
+		},
+		{
+			code: `
+async function* generator() {
+    yield Promise.resolve(42);
+}
+`,
+			snapshot: `
+async function* generator() {
+    yield Promise.resolve(42);
+          ~~~~~~~~~~~~~~~
+          Prefer returning the value directly instead of wrapping it with Promise.resolve().
+}
+`,
+		},
+	],
+	valid: [
+		`
+async function getData() {
+    return 42;
+}
+`,
+		`
+async function getData() {
+    return await fetch("/api");
+}
+`,
+		`
+function regularFn() {
+    return Promise.resolve(42);
+}
+`,
+		`
+const arrow = () => Promise.resolve(42);
+`,
+		`
+function createPromise() {
+    return Promise.resolve(42);
+}
+`,
+		`
+async function storePromise() {
+    const p = Promise.resolve(42);
+    return p;
+}
+`,
+		`
+promise.then((value) => value * 2);
+`,
+		`
+const promise: Promise<number> = Promise.resolve(1);
+promise.then((value) => value * 2);
+`,
+	],
+});

--- a/packages/ts/src/rules/asyncUnnecessaryPromiseWrappers.ts
+++ b/packages/ts/src/rules/asyncUnnecessaryPromiseWrappers.ts
@@ -1,0 +1,236 @@
+import * as tsutils from "ts-api-utils";
+import * as ts from "typescript";
+
+import {
+	type TypeScriptFileServices,
+	typescriptLanguage,
+} from "../language.ts";
+import { isGlobalDeclaration } from "../utils/isGlobalDeclaration.ts";
+
+export default typescriptLanguage.createRule({
+	about: {
+		description:
+			"Reports unnecessary Promise.resolve() or Promise.reject() in async functions or promise callbacks.",
+		id: "asyncUnnecessaryPromiseWrappers",
+		preset: "logical",
+	},
+	messages: {
+		unnecessaryReject: {
+			primary:
+				"Prefer throwing the error directly instead of wrapping it with Promise.reject().",
+			secondary: [
+				"Thrown errors in async functions and promise callbacks are automatically caught and wrapped in a rejected Promise.",
+				"Using Promise.reject() is redundant and adds unnecessary complexity.",
+			],
+			suggestions: [
+				"Throw the error directly instead of wrapping it with Promise.reject().",
+			],
+		},
+		unnecessaryResolve: {
+			primary:
+				"Prefer returning the value directly instead of wrapping it with Promise.resolve().",
+			secondary: [
+				"Return values in async functions and promise callbacks are automatically wrapped in a Promise.",
+				"Using Promise.resolve() is redundant and adds unnecessary complexity.",
+			],
+			suggestions: [
+				"Return the value directly instead of wrapping it with Promise.resolve().",
+			],
+		},
+	},
+	setup(context) {
+		return {
+			visitors: {
+				CallExpression: (
+					node: ts.CallExpression,
+					{ sourceFile, typeChecker }: TypeScriptFileServices,
+				) => {
+					if (!isPromiseResolveOrReject(node, typeChecker)) {
+						return;
+					}
+
+					const containingFunction = getContainingFunction(node);
+					if (!containingFunction) {
+						return;
+					}
+
+					if (!isInAsyncOrPromiseContext(containingFunction, typeChecker)) {
+						return;
+					}
+
+					const returnOrYield = getReturnOrYieldParent(
+						node,
+						containingFunction,
+					);
+					if (!returnOrYield) {
+						return;
+					}
+
+					const methodName = getPromiseMethodName(node);
+					const message =
+						methodName === "reject"
+							? "unnecessaryReject"
+							: "unnecessaryResolve";
+
+					context.report({
+						message,
+						range: {
+							begin: node.expression.getStart(sourceFile),
+							end: node.expression.getEnd(),
+						},
+					});
+				},
+			},
+		};
+	},
+});
+
+function getContainingFunction(
+	node: ts.Node,
+):
+	| ts.ArrowFunction
+	| ts.FunctionDeclaration
+	| ts.FunctionExpression
+	| ts.MethodDeclaration
+	| undefined {
+	let current = node.parent as ts.Node | undefined;
+	while (current !== undefined) {
+		if (tsutils.isFunctionScopeBoundary(current)) {
+			return current as
+				| ts.ArrowFunction
+				| ts.FunctionDeclaration
+				| ts.FunctionExpression
+				| ts.MethodDeclaration;
+		}
+		current = current.parent as ts.Node | undefined;
+	}
+	return undefined;
+}
+
+function getPromiseMethodName(node: ts.CallExpression) {
+	const propertyAccess = node.expression as ts.PropertyAccessExpression;
+	return propertyAccess.name.text;
+}
+
+function getReturnOrYieldParent(
+	node: ts.Node,
+	containingFunction: ts.Node,
+): ts.ReturnStatement | ts.YieldExpression | undefined {
+	let current = node.parent as ts.Node | undefined;
+	while (current !== undefined && current !== containingFunction) {
+		if (ts.isReturnStatement(current)) {
+			return current;
+		}
+
+		if (ts.isYieldExpression(current)) {
+			return current;
+		}
+
+		if (ts.isArrowFunction(current) && current.body === node) {
+			return undefined;
+		}
+
+		current = current.parent as ts.Node | undefined;
+	}
+
+	if (
+		ts.isArrowFunction(containingFunction) &&
+		!ts.isBlock(containingFunction.body) &&
+		isDescendantOf(node, containingFunction.body)
+	) {
+		return {} as ts.ReturnStatement;
+	}
+
+	return undefined;
+}
+
+function isDescendantOf(node: ts.Node, ancestor: ts.Node): boolean {
+	let current = node as ts.Node | undefined;
+	while (current !== undefined) {
+		if (current === ancestor) {
+			return true;
+		}
+		current = current.parent as ts.Node | undefined;
+	}
+	return false;
+}
+
+function isInAsyncOrPromiseContext(
+	func:
+		| ts.ArrowFunction
+		| ts.FunctionDeclaration
+		| ts.FunctionExpression
+		| ts.MethodDeclaration,
+	typeChecker: ts.TypeChecker,
+) {
+	const asyncModifier = func.modifiers?.find(
+		(modifier) => modifier.kind === ts.SyntaxKind.AsyncKeyword,
+	);
+
+	if (asyncModifier) {
+		return true;
+	}
+
+	return isPromiseCallback(func, typeChecker);
+}
+
+function isPromiseCallback(
+	func:
+		| ts.ArrowFunction
+		| ts.FunctionDeclaration
+		| ts.FunctionExpression
+		| ts.MethodDeclaration,
+	typeChecker: ts.TypeChecker,
+) {
+	const parent = func.parent;
+
+	if (!ts.isCallExpression(parent)) {
+		return false;
+	}
+
+	if (!ts.isPropertyAccessExpression(parent.expression)) {
+		return false;
+	}
+
+	const methodName = parent.expression.name.text;
+
+	if (
+		methodName !== "then" &&
+		methodName !== "catch" &&
+		methodName !== "finally"
+	) {
+		return false;
+	}
+
+	const callee = parent.expression.expression;
+	const type = typeChecker.getTypeAtLocation(callee);
+	const symbol = type.getSymbol();
+
+	return symbol?.getName() === "Promise";
+}
+
+function isPromiseResolveOrReject(
+	node: ts.CallExpression,
+	typeChecker: ts.TypeChecker,
+) {
+	if (!ts.isPropertyAccessExpression(node.expression)) {
+		return false;
+	}
+
+	const propertyAccess = node.expression;
+	const methodName = propertyAccess.name.text;
+
+	if (methodName !== "resolve" && methodName !== "reject") {
+		return false;
+	}
+
+	if (!ts.isIdentifier(propertyAccess.expression)) {
+		return false;
+	}
+
+	if (propertyAccess.expression.text !== "Promise") {
+		return false;
+	}
+
+	return isGlobalDeclaration(propertyAccess.expression, typeChecker);
+}


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #831
- [x] That issue was marked as [`status: accepting prs`](https://github.com/flint-fyi/flint/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/flint-fyi/flint/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Implements the `asyncUnnecessaryPromiseWrappers` rule for the TypeScript plugin. This rule reports unnecessary uses of `Promise.resolve()` or `Promise.reject()` in async functions or promise callbacks, where return values are already automatically wrapped in a Promise.

The rule handles:
- Async function declarations and expressions
- Async arrow functions
- Async method declarations
- Async generator functions (yield)
- Promise callbacks (`.then()`, `.catch()`, `.finally()`)