### PR TITLE
feat(ts): implement awaitInsidePromiseMethods rule

### DIFF
--- a/packages/comparisons/src/data.json
+++ b/packages/comparisons/src/data.json
@@ -7998,6 +7998,7 @@
 			"name": "awaitInsidePromiseMethods",
 			"plugin": "ts",
 			"preset": "logical",
+			"status": "implemented",
 			"strictness": "strict"
 		},
 		"oxlint": [

--- a/packages/core/src/running/collectFileLanguagesAndRuleOptions.ts
+++ b/packages/core/src/running/collectFileLanguagesAndRuleOptions.ts
@@ -1,0 +1,104 @@
+import { makeAbsolute } from "@flint.fyi/utils";
+import { CachedFactory } from "cached-factory";
+import { debugForFile } from "debug-for-file";
+
+import { ProcessedConfigDefinition } from "../types/configs.js";
+import {
+	AnyLanguage,
+	AnyLanguageFileDefinition,
+	AnyLanguageFileMetadata,
+	LanguageFileMetadata,
+} from "../types/languages.js";
+import { AnyRule } from "../types/rules.js";
+import { computeUseDefinitions } from "./computeUseDefinitions.js";
+
+const log = debugForFile(import.meta.filename);
+
+export type GroupsOfFilesAndOptions = [AnyLanguageFileDefinition[], object][];
+
+export interface LanguageAndPreparedFiles {
+	language: AnyLanguage;
+	languageFilesMetadata: AnyLanguageFileMetadata[];
+}
+
+export interface LanguageFilesAndRulesOptions {
+	languagesPreparedByFilePath: Map<string, LanguageAndPreparedFiles>;
+	rulesFilesAndOptionsByRule: Map<AnyRule, GroupsOfFilesAndOptions>;
+}
+
+export async function collectFileLanguagesAndRuleOptions(
+	configDefinition: ProcessedConfigDefinition,
+): Promise<LanguageFilesAndRulesOptions> {
+	const useDefinitions = await computeUseDefinitions(configDefinition);
+
+	// 1. For each rule, create a map of the files it's enabled on & with which options
+	// Also store the total list of file paths
+
+	const allFoundFiles = new Set<string>(); // TODO: necessary?
+	const rulesOptionsByFile = new CachedFactory<AnyRule, Map<string, unknown>>(
+		() => new Map(),
+	);
+
+	for (const use of useDefinitions) {
+		for (const ruleDefinition of use.rules) {
+			const [options, rule] =
+				"rule" in ruleDefinition
+					? [ruleDefinition.options, ruleDefinition.rule]
+					: [undefined, ruleDefinition];
+
+			for (const filePath of use.found) {
+				allFoundFiles.add(filePath);
+				rulesOptionsByFile.get(rule).set(filePath, options);
+			}
+		}
+	}
+
+	// 2. From the rules' maps of files -> options, generate the corresponding language file(s)
+
+	const languageFilesMetadata = new CachedFactory((language: AnyLanguage) => ({
+		fileFactory: language.prepare(),
+		fileMetadataByPath: new Map<string, AnyLanguageFileMetadata>(),
+	}));
+	const languagesByFilePath = new CachedFactory<string, Set<AnyLanguage>>(
+		() => new Set<AnyLanguage>(),
+	);
+
+	for (const [rule, optionsByFile] of rulesOptionsByFile.entries()) {
+		for (const [filePath] of optionsByFile) {
+			const { fileFactory, fileMetadataByPath } = languageFilesMetadata.get(
+				rule.language,
+			);
+
+			fileMetadataByPath.set(
+				filePath,
+				fileFactory.prepareFromDisk({
+					filePath,
+					filePathAbsolute: makeAbsolute(filePath),
+				}),
+			);
+			languagesByFilePath.get(filePath).add(rule.language);
+		}
+	}
+
+	// 3. Join the two together: for each rule, collect its language and files
+
+	const rulesFilesAndOptionsByRule = new Map<
+		AnyRule,
+		GroupsOfFilesAndOptions
+	>();
+
+	for (const [rule, optionsByFilePath] of rulesOptionsByFile.entries()) {
+		// type GroupsOfFilesAndOptions = [AnyLanguageFileDefinition[], object][];
+		const groupsOfFilesAndOptions: GroupsOfFilesAndOptions = [];
+		rulesFilesAndOptionsByRule.set(rule, groupsOfFilesAndOptions);
+
+		for (const [filePath, options] of optionsByFilePath) {
+			const languagesForFilePath = languagesByFilePath.get(filePath);
+
+			groupsOfFilesAndOptions.push(
+				Array.from(languagesByFilePath.get(filePath)).map,
+				options,
+			);
+		}
+	}
+}

--- a/packages/site/src/content/docs/rules/ts/awaitInsidePromiseMethods.mdx
+++ b/packages/site/src/content/docs/rules/ts/awaitInsidePromiseMethods.mdx
@@ -1,0 +1,78 @@
+---
+description: "Reports using await on promises passed to Promise.all, Promise.allSettled, Promise.any, or Promise.race."
+title: "awaitInsidePromiseMethods"
+topic: "rules"
+---
+
+import { Tabs, TabItem } from "@astrojs/starlight/components";
+import { RuleEquivalents } from "~/components/RuleEquivalents";
+import RuleSummary from "~/components/RuleSummary.astro";
+
+<RuleSummary plugin="ts" rule="awaitInsidePromiseMethods" />
+
+Promise methods like `Promise.all()`, `Promise.allSettled()`, `Promise.any()`, and `Promise.race()` accept an iterable of promises and handle their resolution internally.
+Using `await` on individual promises before passing them defeats the purpose of parallel execution.
+The awaited promise will resolve before the others are even considered, eliminating any parallelism benefit.
+
+## Examples
+
+<Tabs>
+<TabItem label="❌ Incorrect">
+
+```ts
+Promise.all([await fetchUser(), await fetchPosts()]);
+```
+
+```ts
+Promise.allSettled([await task1, await task2]);
+```
+
+```ts
+Promise.any([await promiseA, await promiseB]);
+```
+
+```ts
+Promise.race([await firstPromise, await secondPromise]);
+```
+
+</TabItem>
+<TabItem label="✅ Correct">
+
+```ts
+Promise.all([fetchUser(), fetchPosts()]);
+```
+
+```ts
+Promise.allSettled([task1, task2]);
+```
+
+```ts
+Promise.any([promiseA, promiseB]);
+```
+
+```ts
+Promise.race([firstPromise, secondPromise]);
+```
+
+</TabItem>
+</Tabs>
+
+## Options
+
+This rule is not configurable.
+
+## When Not To Use It
+
+If you intentionally need to await promises sequentially before passing them to a Promise method (for example, to ensure ordering side effects), you might disable this rule on a per-case basis.
+However, such cases are rare and usually indicate that a different pattern would be more appropriate.
+
+## Further Reading
+
+- [MDN documentation on Promise.all()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/all)
+- [MDN documentation on Promise.allSettled()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/allSettled)
+- [MDN documentation on Promise.any()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/any)
+- [MDN documentation on Promise.race()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/race)
+
+## Equivalents in Other Linters
+
+<RuleEquivalents pluginId="ts" ruleId="awaitInsidePromiseMethods" />

--- a/packages/ts/src/plugin.ts
+++ b/packages/ts/src/plugin.ts
@@ -2,6 +2,7 @@ import { createPlugin } from "@flint.fyi/core";
 
 import anyReturns from "./rules/anyReturns.ts";
 import asyncPromiseExecutors from "./rules/asyncPromiseExecutors.ts";
+import awaitInsidePromiseMethods from "./rules/awaitInsidePromiseMethods.ts";
 import caseDeclarations from "./rules/caseDeclarations.ts";
 import caseDuplicates from "./rules/caseDuplicates.ts";
 import chainedAssignments from "./rules/chainedAssignments.ts";
@@ -66,6 +67,7 @@ export const ts = createPlugin({
 	rules: [
 		anyReturns,
 		asyncPromiseExecutors,
+		awaitInsidePromiseMethods,
 		caseDeclarations,
 		caseDuplicates,
 		chainedAssignments,

--- a/packages/ts/src/rules/awaitInsidePromiseMethods.test.ts
+++ b/packages/ts/src/rules/awaitInsidePromiseMethods.test.ts
@@ -1,0 +1,89 @@
+import rule from "./awaitInsidePromiseMethods.ts";
+import { ruleTester } from "./ruleTester.ts";
+
+ruleTester.describe(rule, {
+	invalid: [
+		{
+			code: `
+Promise.all([await promise, anotherPromise]);
+`,
+			snapshot: `
+Promise.all([await promise, anotherPromise]);
+             ~~~~~
+             Awaiting promises inside Promise.all() is redundant because it accepts promises directly.
+`,
+		},
+		{
+			code: `
+Promise.allSettled([await promise, anotherPromise]);
+`,
+			snapshot: `
+Promise.allSettled([await promise, anotherPromise]);
+                    ~~~~~
+                    Awaiting promises inside Promise.allSettled() is redundant because it accepts promises directly.
+`,
+		},
+		{
+			code: `
+Promise.any([await promise, anotherPromise]);
+`,
+			snapshot: `
+Promise.any([await promise, anotherPromise]);
+             ~~~~~
+             Awaiting promises inside Promise.any() is redundant because it accepts promises directly.
+`,
+		},
+		{
+			code: `
+Promise.race([await promise, anotherPromise]);
+`,
+			snapshot: `
+Promise.race([await promise, anotherPromise]);
+              ~~~~~
+              Awaiting promises inside Promise.race() is redundant because it accepts promises directly.
+`,
+		},
+		{
+			code: `
+Promise.all([await first, await second, await third]);
+`,
+			snapshot: `
+Promise.all([await first, await second, await third]);
+             ~~~~~
+             Awaiting promises inside Promise.all() is redundant because it accepts promises directly.
+                          ~~~~~
+                          Awaiting promises inside Promise.all() is redundant because it accepts promises directly.
+                                        ~~~~~
+                                        Awaiting promises inside Promise.all() is redundant because it accepts promises directly.
+`,
+		},
+		{
+			code: `
+async function fetchData() {
+    return Promise.all([await fetch("/a"), await fetch("/b")]);
+}
+`,
+			snapshot: `
+async function fetchData() {
+    return Promise.all([await fetch("/a"), await fetch("/b")]);
+                        ~~~~~
+                        Awaiting promises inside Promise.all() is redundant because it accepts promises directly.
+                                           ~~~~~
+                                           Awaiting promises inside Promise.all() is redundant because it accepts promises directly.
+}
+`,
+		},
+	],
+	valid: [
+		"Promise.all([promise, anotherPromise]);",
+		"Promise.allSettled([promise, anotherPromise]);",
+		"Promise.any([promise, anotherPromise]);",
+		"Promise.race([promise, anotherPromise]);",
+		"Promise.all([fetch('/a'), fetch('/b')]);",
+		"Promise.resolve(await promise);",
+		"Promise.reject(await error);",
+		"SomeOtherClass.all([await promise]);",
+		"Promise.all(promises);",
+		"Promise.all([...promises]);",
+	],
+});

--- a/packages/ts/src/rules/awaitInsidePromiseMethods.ts
+++ b/packages/ts/src/rules/awaitInsidePromiseMethods.ts
@@ -1,0 +1,75 @@
+import * as ts from "typescript";
+
+import { typescriptLanguage } from "../language.ts";
+import { isGlobalDeclarationOfName } from "../utils/isGlobalDeclarationOfName.ts";
+
+const promiseMethods = new Set(["all", "allSettled", "any", "race"]);
+
+export default typescriptLanguage.createRule({
+	about: {
+		description:
+			"Reports using await on promises passed to Promise.all, Promise.allSettled, Promise.any, or Promise.race.",
+		id: "awaitInsidePromiseMethods",
+		preset: "logical",
+		strictness: "strict",
+	},
+	messages: {
+		unnecessaryAwait: {
+			primary:
+				"Awaiting promises inside {{ method }} is redundant because it accepts promises directly.",
+			secondary: [
+				"Promise methods like `Promise.all()` accept an iterable of promises and handle their resolution internally.",
+				"Using `await` on individual promises before passing them defeats the purpose of parallel execution.",
+				"The awaited promise will resolve before the others are even considered, eliminating any parallelism benefit.",
+			],
+			suggestions: ["Remove the `await` keyword to allow parallel execution."],
+		},
+	},
+	setup(context) {
+		return {
+			visitors: {
+				CallExpression: (node, { sourceFile, typeChecker }) => {
+					if (!ts.isPropertyAccessExpression(node.expression)) {
+						return;
+					}
+
+					const { expression, name } = node.expression;
+
+					if (
+						!ts.isIdentifier(name) ||
+						!promiseMethods.has(name.text) ||
+						!ts.isIdentifier(expression) ||
+						!isGlobalDeclarationOfName(expression, "Promise", typeChecker)
+					) {
+						return;
+					}
+
+					const methodName = name.text;
+					if (
+						!node.arguments.length ||
+						!ts.isArrayLiteralExpression(node.arguments[0])
+					) {
+						return;
+					}
+
+					const arrayArgument = node.arguments[0];
+
+					for (const element of arrayArgument.elements) {
+						if (!ts.isAwaitExpression(element)) {
+							continue;
+						}
+
+						context.report({
+							data: { method: `Promise.${methodName}()` },
+							message: "unnecessaryAwait",
+							range: {
+								begin: element.getStart(sourceFile),
+								end: element.expression.getStart(sourceFile) - 1,
+							},
+						});
+					}
+				},
+			},
+		};
+	},
+});


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #833
- [x] That issue was marked as [`status: accepting prs`](https://github.com/flint-fyi/flint/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/flint-fyi/flint/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Implements the `awaitInsidePromiseMethods` rule which reports using `await` on promises passed to `Promise.all()`, `Promise.allSettled()`, `Promise.any()`, or `Promise.race()`.

Using `await` on individual promises before passing them to these methods defeats the purpose of parallel execution, as the awaited promise will resolve before the others are even considered.