### PR TITLE
feat(ts): implement awaitThenable rule

### DIFF
--- a/packages/comparisons/src/data.json
+++ b/packages/comparisons/src/data.json
@@ -8040,7 +8040,8 @@
 		"flint": {
 			"name": "awaitThenable",
 			"plugin": "ts",
-			"preset": "logical"
+			"preset": "logical",
+			"status": "implemented"
 		},
 		"oxlint": [
 			{

--- a/packages/site/src/content/docs/rules/ts/awaitThenable.mdx
+++ b/packages/site/src/content/docs/rules/ts/awaitThenable.mdx
@@ -1,0 +1,96 @@
+---
+description: "Reports awaiting a value that is not a Thenable."
+title: "awaitThenable"
+topic: "rules"
+---
+
+import { Tabs, TabItem } from "@astrojs/starlight/components";
+import { RuleEquivalents } from "~/components/RuleEquivalents";
+import RuleSummary from "~/components/RuleSummary.astro";
+
+<RuleSummary plugin="ts" rule="awaitThenable" />
+
+A "Thenable" value is an object with a `then` method, such as a Promise.
+The `await` keyword is designed to retrieve the result of calling a Thenable's `then` method.
+If `await` is used on a non-Thenable value, the value is directly resolved, but execution still pauses until the next microtask.
+This is often a programmer error, such as forgetting to add parentheses to call a function that returns a Promise.
+
+This rule also checks `for await...of` loops to ensure the iterated value is async iterable.
+Using `for await...of` on a synchronous iterable works, but introduces subtle error handling differences and obscures intent.
+
+## Examples
+
+<Tabs>
+<TabItem label="❌ Incorrect">
+
+```ts
+async function getValue() {
+	const value = 42;
+	return await value;
+}
+```
+
+```ts
+async function example() {
+	await null;
+}
+```
+
+```ts
+async function processItems() {
+	const items = [1, 2, 3];
+	for await (const item of items) {
+		console.log(item);
+	}
+}
+```
+
+</TabItem>
+<TabItem label="✅ Correct">
+
+```ts
+async function fetchData() {
+	const data = await fetch("/api");
+	return data;
+}
+```
+
+```ts
+async function waitForPromise() {
+	const promise = Promise.resolve(42);
+	return await promise;
+}
+```
+
+```ts
+async function* asyncGenerator() {
+	yield 1;
+	yield 2;
+}
+async function iterateAsync() {
+	for await (const value of asyncGenerator()) {
+		console.log(value);
+	}
+}
+```
+
+</TabItem>
+</Tabs>
+
+## Options
+
+This rule is not configurable.
+
+## When Not To Use It
+
+If your codebase is transitioning from one style of asynchronous code to another, it may be useful to include `await` on non-Promise values for visual consistency.
+Additionally, if you have generic code that might receive either synchronous or asynchronous values, you might disable this rule.
+
+## Further Reading
+
+- [MDN documentation on await](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/await)
+- [MDN documentation on for await...of](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for-await...of)
+
+## Equivalents in Other Linters
+
+<RuleEquivalents pluginId="ts" ruleId="awaitThenable" />

--- a/packages/ts/src/plugin.ts
+++ b/packages/ts/src/plugin.ts
@@ -2,6 +2,7 @@ import { createPlugin } from "@flint.fyi/core";
 
 import anyReturns from "./rules/anyReturns.ts";
 import asyncPromiseExecutors from "./rules/asyncPromiseExecutors.ts";
+import awaitThenable from "./rules/awaitThenable.ts";
 import caseDeclarations from "./rules/caseDeclarations.ts";
 import caseDuplicates from "./rules/caseDuplicates.ts";
 import chainedAssignments from "./rules/chainedAssignments.ts";
@@ -66,6 +67,7 @@ export const ts = createPlugin({
 	rules: [
 		anyReturns,
 		asyncPromiseExecutors,
+		awaitThenable,
 		caseDeclarations,
 		caseDuplicates,
 		chainedAssignments,

--- a/packages/ts/src/rules/awaitThenable.test.ts
+++ b/packages/ts/src/rules/awaitThenable.test.ts
@@ -1,0 +1,162 @@
+import rule from "./awaitThenable.ts";
+import { ruleTester } from "./ruleTester.ts";
+
+ruleTester.describe(rule, {
+	invalid: [
+		{
+			code: `
+async function getValue() {
+    const value = 42;
+    return await value;
+}
+`,
+			snapshot: `
+async function getValue() {
+    const value = 42;
+    return await value;
+           ~~~~~
+           Awaiting a non-Promise (non-Thenable) value is unnecessary and indicates a likely mistake.
+}
+`,
+		},
+		{
+			code: `
+async function getString() {
+    return await "hello";
+}
+`,
+			snapshot: `
+async function getString() {
+    return await "hello";
+           ~~~~~
+           Awaiting a non-Promise (non-Thenable) value is unnecessary and indicates a likely mistake.
+}
+`,
+		},
+		{
+			code: `
+async function getObject() {
+    const obj = { key: "value" };
+    return await obj;
+}
+`,
+			snapshot: `
+async function getObject() {
+    const obj = { key: "value" };
+    return await obj;
+           ~~~~~
+           Awaiting a non-Promise (non-Thenable) value is unnecessary and indicates a likely mistake.
+}
+`,
+		},
+		{
+			code: `
+async function example() {
+    await null;
+}
+`,
+			snapshot: `
+async function example() {
+    await null;
+    ~~~~~
+    Awaiting a non-Promise (non-Thenable) value is unnecessary and indicates a likely mistake.
+}
+`,
+		},
+		{
+			code: `
+async function example() {
+    await undefined;
+}
+`,
+			snapshot: `
+async function example() {
+    await undefined;
+    ~~~~~
+    Awaiting a non-Promise (non-Thenable) value is unnecessary and indicates a likely mistake.
+}
+`,
+		},
+		{
+			code: `
+async function processItems() {
+    const items = [1, 2, 3];
+    for await (const item of items) {
+        console.log(item);
+    }
+}
+`,
+			snapshot: `
+async function processItems() {
+    const items = [1, 2, 3];
+    for await (const item of items) {
+        ~~~~~
+        Using \`for await...of\` on a value that is not async iterable is unnecessary.
+        console.log(item);
+    }
+}
+`,
+		},
+		{
+			code: `
+async function processStrings() {
+    for await (const char of "hello") {
+        console.log(char);
+    }
+}
+`,
+			snapshot: `
+async function processStrings() {
+    for await (const char of "hello") {
+        ~~~~~
+        Using \`for await...of\` on a value that is not async iterable is unnecessary.
+        console.log(char);
+    }
+}
+`,
+		},
+	],
+	valid: [
+		`
+async function fetchData() {
+    const data = await fetch("/api");
+    return data;
+}
+`,
+		`
+async function waitForPromise() {
+    const promise = Promise.resolve(42);
+    return await promise;
+}
+`,
+		`
+async function awaitThenable() {
+    const thenable = { then: (resolve: (value: number) => void) => resolve(42) };
+    return await thenable;
+}
+`,
+		`
+async function awaitAny(value: any) {
+    return await value;
+}
+`,
+		`
+async function* asyncGenerator() {
+    yield 1;
+    yield 2;
+}
+async function iterateAsync() {
+    for await (const value of asyncGenerator()) {
+        console.log(value);
+    }
+}
+`,
+		`
+async function processReadable(stream: AsyncIterable<string>) {
+    for await (const chunk of stream) {
+        console.log(chunk);
+    }
+}
+`,
+	],
+});

--- a/packages/ts/src/rules/awaitThenable.ts
+++ b/packages/ts/src/rules/awaitThenable.ts
@@ -1,0 +1,106 @@
+import * as tsutils from "ts-api-utils";
+import * as ts from "typescript";
+
+import { typescriptLanguage } from "../language.ts";
+
+export default typescriptLanguage.createRule({
+	about: {
+		description: "Reports awaiting a value that is not a Thenable.",
+		id: "awaitThenable",
+		preset: "logical",
+	},
+	messages: {
+		awaitNonThenable: {
+			primary:
+				"Awaiting a non-Promise (non-Thenable) value is unnecessary and indicates a likely mistake.",
+			secondary: [
+				"The `await` keyword is designed for values with a `then` method, such as Promises.",
+				"If `await` is used on a non-Thenable value, the value is directly resolved, but execution still pauses until the next microtask.",
+				"This often indicates a programmer error, such as forgetting to call a function that returns a Promise.",
+			],
+			suggestions: [
+				"Remove the unnecessary `await` keyword.",
+				"Ensure you are awaiting the correct value, such as a function call that returns a Promise.",
+			],
+		},
+		forAwaitNonAsyncIterable: {
+			primary:
+				"Using `for await...of` on a value that is not async iterable is unnecessary.",
+			secondary: [
+				"The `for await...of` statement is designed for async iterable objects.",
+				"Using it on a synchronous iterable works but introduces subtle error handling differences and obscures intent.",
+			],
+			suggestions: [
+				"Use an ordinary `for...of` loop instead.",
+				"If you need to await each value, use `for...of` with `await` inside the loop body.",
+			],
+		},
+	},
+	setup(context) {
+		return {
+			visitors: {
+				AwaitExpression: (node, { sourceFile, typeChecker }) => {
+					const type = typeChecker.getTypeAtLocation(node.expression);
+
+					if (tsutils.isTypeFlagSet(type, ts.TypeFlags.Any)) {
+						return;
+					}
+
+					if (tsutils.isThenableType(typeChecker, node.expression, type)) {
+						return;
+					}
+
+					const awaitKeyword = node.getFirstToken(sourceFile);
+					if (
+						!awaitKeyword ||
+						awaitKeyword.kind !== ts.SyntaxKind.AwaitKeyword
+					) {
+						return;
+					}
+
+					context.report({
+						message: "awaitNonThenable",
+						range: {
+							begin: awaitKeyword.getStart(sourceFile),
+							end: awaitKeyword.getEnd(),
+						},
+					});
+				},
+				ForOfStatement: (node, { sourceFile, typeChecker }) => {
+					if (!node.awaitModifier) {
+						return;
+					}
+
+					const type = typeChecker.getTypeAtLocation(node.expression);
+
+					if (tsutils.isTypeFlagSet(type, ts.TypeFlags.Any)) {
+						return;
+					}
+
+					const hasAsyncIteratorSymbol = tsutils
+						.unionConstituents(type)
+						.some(
+							(typePart) =>
+								tsutils.getWellKnownSymbolPropertyOfType(
+									typePart,
+									"asyncIterator",
+									typeChecker,
+								) !== undefined,
+						);
+
+					if (hasAsyncIteratorSymbol) {
+						return;
+					}
+
+					context.report({
+						message: "forAwaitNonAsyncIterable",
+						range: {
+							begin: node.awaitModifier.getStart(sourceFile),
+							end: node.awaitModifier.getEnd(),
+						},
+					});
+				},
+			},
+		};
+	},
+});


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #834
- [x] That issue was marked as [`status: accepting prs`](https://github.com/flint-fyi/flint/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/flint-fyi/flint/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Implements the `awaitThenable` rule which reports awaiting values that are not Thenables (e.g., Promises).

The rule checks:
- `await` expressions where the awaited value is not a Thenable
- `for await...of` loops where the iterated value is not async iterable

Using `await` on a non-Thenable value is usually a programmer error, such as forgetting to call a function that returns a Promise.