### PR TITLE
feat(ts): implement builtinCoercions rule

### DIFF
--- a/packages/comparisons/src/data.json
+++ b/packages/comparisons/src/data.json
@@ -8155,6 +8155,7 @@
 			"name": "builtinCoercions",
 			"plugin": "ts",
 			"preset": "stylistic",
+			"status": "implemented",
 			"strictness": "strict"
 		},
 		"oxlint": [

--- a/packages/site/src/content/docs/rules/ts/builtinCoercions.mdx
+++ b/packages/site/src/content/docs/rules/ts/builtinCoercions.mdx
@@ -1,0 +1,81 @@
+---
+description: "Reports functions that can be replaced with built-in coercion functions like String, Number, Boolean, BigInt, or Symbol."
+title: "builtinCoercions"
+topic: "rules"
+---
+
+import { Tabs, TabItem } from "@astrojs/starlight/components";
+import { RuleEquivalents } from "~/components/RuleEquivalents";
+import RuleSummary from "~/components/RuleSummary.astro";
+
+<RuleSummary plugin="ts" rule="builtinCoercions" />
+
+If a function is equivalent to `String`, `Number`, `BigInt`, `Boolean`, or `Symbol`, you should use the built-in function directly.
+Wrapping a built-in coercion function in another function adds unnecessary overhead and complexity.
+The built-in functions are concise, universally understood, and can be passed directly as callbacks.
+
+This rule also catches identity functions like `(value) => value` when used in contexts where `Boolean` would be more appropriate (such as `array.some()` or `array.filter()`).
+
+## Examples
+
+<Tabs>
+<TabItem label="❌ Incorrect">
+
+```ts
+const toBoolean = (value: unknown) => Boolean(value);
+```
+
+```ts
+const toString = (value: unknown) => String(value);
+```
+
+```ts
+const hasTruthyValue = array.some((element) => element);
+```
+
+```ts
+array.filter((item) => Boolean(item));
+```
+
+</TabItem>
+<TabItem label="✅ Correct">
+
+```ts
+const toBoolean = Boolean;
+```
+
+```ts
+const toString = String;
+```
+
+```ts
+const hasTruthyValue = array.some(Boolean);
+```
+
+```ts
+array.filter(Boolean);
+```
+
+</TabItem>
+</Tabs>
+
+## Options
+
+This rule is not configurable.
+
+## When Not To Use It
+
+If you prefer the explicitness of wrapper functions or are working with a codebase that has established patterns using wrapper functions, you may choose to disable this rule.
+Some teams prefer wrapper functions for consistency with other utility functions in their codebase.
+
+## Further Reading
+
+- [MDN documentation on String](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)
+- [MDN documentation on Number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)
+- [MDN documentation on Boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)
+- [MDN documentation on BigInt](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt)
+- [MDN documentation on Symbol](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol)
+
+## Equivalents in Other Linters
+
+<RuleEquivalents pluginId="ts" ruleId="builtinCoercions" />

--- a/packages/ts/src/plugin.ts
+++ b/packages/ts/src/plugin.ts
@@ -2,6 +2,7 @@ import { createPlugin } from "@flint.fyi/core";
 
 import anyReturns from "./rules/anyReturns.ts";
 import asyncPromiseExecutors from "./rules/asyncPromiseExecutors.ts";
+import builtinCoercions from "./rules/builtinCoercions.ts";
 import caseDeclarations from "./rules/caseDeclarations.ts";
 import caseDuplicates from "./rules/caseDuplicates.ts";
 import chainedAssignments from "./rules/chainedAssignments.ts";
@@ -66,6 +67,7 @@ export const ts = createPlugin({
 	rules: [
 		anyReturns,
 		asyncPromiseExecutors,
+		builtinCoercions,
 		caseDeclarations,
 		caseDuplicates,
 		chainedAssignments,

--- a/packages/ts/src/rules/builtinCoercions.test.ts
+++ b/packages/ts/src/rules/builtinCoercions.test.ts
@@ -1,0 +1,111 @@
+import rule from "./builtinCoercions.ts";
+import { ruleTester } from "./ruleTester.ts";
+
+ruleTester.describe(rule, {
+	invalid: [
+		{
+			code: `
+const toBoolean = (value: unknown) => Boolean(value);
+`,
+			snapshot: `
+const toBoolean = (value: unknown) => Boolean(value);
+                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                  Use Boolean directly instead of wrapping it in a function.
+`,
+		},
+		{
+			code: `
+const toString = (value: unknown) => String(value);
+`,
+			snapshot: `
+const toString = (value: unknown) => String(value);
+                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                 Use String directly instead of wrapping it in a function.
+`,
+		},
+		{
+			code: `
+const toNumber = (value: unknown) => Number(value);
+`,
+			snapshot: `
+const toNumber = (value: unknown) => Number(value);
+                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                 Use Number directly instead of wrapping it in a function.
+`,
+		},
+		{
+			code: `
+const toBigInt = (value: bigint) => BigInt(value);
+`,
+			snapshot: `
+const toBigInt = (value: bigint) => BigInt(value);
+                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                 Use BigInt directly instead of wrapping it in a function.
+`,
+		},
+		{
+			code: `
+const toSymbol = (value: string) => Symbol(value);
+`,
+			snapshot: `
+const toSymbol = (value: string) => Symbol(value);
+                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                 Use Symbol directly instead of wrapping it in a function.
+`,
+		},
+		{
+			code: `
+const toBoolean = function(value: unknown) { return Boolean(value); };
+`,
+			snapshot: `
+const toBoolean = function(value: unknown) { return Boolean(value); };
+                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                  Use Boolean directly instead of wrapping it in a function.
+`,
+		},
+		{
+			code: `
+const identity = (element: unknown) => element;
+`,
+			snapshot: `
+const identity = (element: unknown) => element;
+                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                 Use Boolean directly instead of wrapping it in a function.
+`,
+		},
+		{
+			code: `
+const hasTruthyValue = array.some((element: unknown) => element);
+`,
+			snapshot: `
+const hasTruthyValue = array.some((element: unknown) => element);
+                                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                                  Use Boolean directly instead of wrapping it in a function.
+`,
+		},
+		{
+			code: `
+array.filter((item: unknown) => Boolean(item));
+`,
+			snapshot: `
+array.filter((item: unknown) => Boolean(item));
+             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+             Use Boolean directly instead of wrapping it in a function.
+`,
+		},
+	],
+	valid: [
+		"const toBoolean = Boolean;",
+		"const toString = String;",
+		"const toNumber = Number;",
+		"const toBigInt = BigInt;",
+		"const toSymbol = Symbol;",
+		"const toStringObject = (value: unknown) => new String(value);",
+		"const transform = (value: unknown) => value.toString();",
+		"const transform = (value: unknown) => Boolean(value) && doSomething();",
+		"const transform = (a: unknown, b: unknown) => Boolean(a);",
+		"const transform = () => Boolean(someGlobal);",
+		"const transform = (value: unknown) => customBoolean(value);",
+		"const transform = (value: unknown) => { console.log(value); return Boolean(value); };",
+	],
+});

--- a/packages/ts/src/rules/builtinCoercions.ts
+++ b/packages/ts/src/rules/builtinCoercions.ts
@@ -1,0 +1,162 @@
+import * as ts from "typescript";
+
+import { typescriptLanguage } from "../language.ts";
+import { isGlobalDeclarationOfName } from "../utils/isGlobalDeclarationOfName.ts";
+
+const coercionFunctions = new Set([
+	"BigInt",
+	"Boolean",
+	"Number",
+	"String",
+	"Symbol",
+]);
+
+export default typescriptLanguage.createRule({
+	about: {
+		description:
+			"Reports functions that can be replaced with built-in coercion functions like String, Number, Boolean, BigInt, or Symbol.",
+		id: "builtinCoercions",
+		preset: "stylistic",
+		strictness: "strict",
+	},
+	messages: {
+		preferBuiltin: {
+			primary:
+				"Use {{ builtin }} directly instead of wrapping it in a function.",
+			secondary: [
+				"Wrapping built-in coercion functions like `String`, `Number`, `Boolean`, `BigInt`, or `Symbol` in another function adds unnecessary overhead.",
+				"The built-in functions are concise and universally understood.",
+			],
+			suggestions: ["Replace the wrapper function with {{ builtin }}."],
+		},
+	},
+	setup(context) {
+		function getReturnedExpression(
+			body: ts.ConciseBody,
+		): ts.Expression | undefined {
+			if (ts.isBlock(body)) {
+				if (body.statements.length !== 1) {
+					return undefined;
+				}
+
+				const statement = body.statements[0];
+				if (!ts.isReturnStatement(statement) || !statement.expression) {
+					return undefined;
+				}
+
+				return statement.expression;
+			}
+
+			return body;
+		}
+
+		function isCoercionCall(
+			expression: ts.Expression,
+			parameterName: string,
+			typeChecker: ts.TypeChecker,
+		): string | undefined {
+			if (!ts.isCallExpression(expression)) {
+				return undefined;
+			}
+
+			if (!ts.isIdentifier(expression.expression)) {
+				return undefined;
+			}
+
+			const calledName = expression.expression.text;
+			if (!coercionFunctions.has(calledName)) {
+				return undefined;
+			}
+
+			if (
+				!isGlobalDeclarationOfName(
+					expression.expression,
+					calledName,
+					typeChecker,
+				)
+			) {
+				return undefined;
+			}
+
+			if (expression.arguments.length !== 1) {
+				return undefined;
+			}
+
+			const argument = expression.arguments[0];
+			if (!ts.isIdentifier(argument) || argument.text !== parameterName) {
+				return undefined;
+			}
+
+			return calledName;
+		}
+
+		function isIdentityReturn(
+			expression: ts.Expression,
+			parameterName: string,
+		): boolean {
+			return ts.isIdentifier(expression) && expression.text === parameterName;
+		}
+
+		function checkFunction(
+			node: ts.ArrowFunction | ts.FunctionExpression,
+			sourceFile: ts.SourceFile,
+			typeChecker: ts.TypeChecker,
+		) {
+			if (node.parameters.length !== 1) {
+				return;
+			}
+
+			const parameter = node.parameters[0];
+			if (!ts.isIdentifier(parameter.name)) {
+				return;
+			}
+
+			const parameterName = parameter.name.text;
+			const returnExpression = getReturnedExpression(node.body);
+
+			if (!returnExpression) {
+				return;
+			}
+
+			const coercionName = isCoercionCall(
+				returnExpression,
+				parameterName,
+				typeChecker,
+			);
+
+			if (coercionName) {
+				context.report({
+					data: { builtin: coercionName },
+					message: "preferBuiltin",
+					range: {
+						begin: node.getStart(sourceFile),
+						end: node.getEnd(),
+					},
+				});
+				return;
+			}
+
+			if (isIdentityReturn(returnExpression, parameterName)) {
+				context.report({
+					data: { builtin: "Boolean" },
+					message: "preferBuiltin",
+					range: {
+						begin: node.getStart(sourceFile),
+						end: node.getEnd(),
+					},
+				});
+			}
+		}
+
+		return {
+			visitors: {
+				ArrowFunction: (node, { sourceFile, typeChecker }) => {
+					checkFunction(node, sourceFile, typeChecker);
+				},
+				FunctionExpression: (node, { sourceFile, typeChecker }) => {
+					checkFunction(node, sourceFile, typeChecker);
+				},
+			},
+		};
+	},
+});


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #1302
- [x] That issue was marked as [`status: accepting prs`](https://github.com/flint-fyi/flint/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/flint-fyi/flint/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Implements the `builtinCoercions` rule which reports functions that can be replaced with built-in coercion functions like `String`, `Number`, `Boolean`, `BigInt`, or `Symbol`.

The rule detects:
- Arrow functions and function expressions that wrap a single coercion call (e.g., `(value) => Boolean(value)`)
- Identity functions that return their parameter directly (e.g., `(element) => element`), which can be replaced with `Boolean` in filter/some contexts

These wrapper functions add unnecessary overhead and complexity when the built-in functions can be used directly.