### PR TITLE
feat(ts): implement arguments rule

### DIFF
--- a/packages/comparisons/src/data.json
+++ b/packages/comparisons/src/data.json
@@ -7126,7 +7126,8 @@
 		"flint": {
 			"name": "arguments",
 			"plugin": "ts",
-			"preset": "logical"
+			"preset": "logical",
+			"status": "implemented"
 		},
 		"oxlint": [
 			{

--- a/packages/site/src/content/docs/rules/ts/arguments.mdx
+++ b/packages/site/src/content/docs/rules/ts/arguments.mdx
@@ -1,0 +1,69 @@
+---
+description: "Use rest parameters instead of `arguments`."
+title: "arguments"
+topic: "rules"
+---
+
+import { Tabs, TabItem } from "@astrojs/starlight/components";
+import { RuleEquivalents } from "~/components/RuleEquivalents";
+import RuleSummary from "~/components/RuleSummary.astro";
+
+<RuleSummary plugin="ts" rule="arguments" />
+
+The `arguments` object is an array-like object available inside non-arrow functions that contains the values of the arguments passed to that function.
+While it can be useful, it has several drawbacks compared to rest parameters:
+
+- It is not a real array, so methods like `map`, `filter`, and `forEach` are not available
+- Arrow functions do not have their own `arguments` binding
+- It makes code less readable and harder to understand
+
+Rest parameters (`...args`) provide a real array and are the modern way to access variadic function arguments.
+
+## Examples
+
+<Tabs>
+<TabItem label="❌ Incorrect">
+
+```ts
+function sum() {
+	let total = 0;
+	for (let i = 0; i < arguments.length; i++) {
+		total += arguments[i];
+	}
+	return total;
+}
+```
+
+</TabItem>
+<TabItem label="✅ Correct">
+
+```ts
+function sum(...args: number[]) {
+	let total = 0;
+	for (const arg of args) {
+		total += arg;
+	}
+	return total;
+}
+```
+
+</TabItem>
+</Tabs>
+
+## Options
+
+This rule is not configurable.
+
+## When Not To Use It
+
+If you need to support very old JavaScript environments that do not support rest parameters (ES5 or earlier), you may need to disable this rule.
+However, most modern environments support rest parameters.
+
+## Further Reading
+
+- [MDN documentation on rest parameters](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/rest_parameters)
+- [MDN documentation on the `arguments` object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/arguments)
+
+## Equivalents in Other Linters
+
+<RuleEquivalents pluginId="ts" ruleId="arguments" />

--- a/packages/ts/src/plugin.ts
+++ b/packages/ts/src/plugin.ts
@@ -1,6 +1,7 @@
 import { createPlugin } from "@flint.fyi/core";
 
 import anyReturns from "./rules/anyReturns.ts";
+import args from "./rules/arguments.ts";
 import asyncPromiseExecutors from "./rules/asyncPromiseExecutors.ts";
 import caseDeclarations from "./rules/caseDeclarations.ts";
 import caseDuplicates from "./rules/caseDuplicates.ts";
@@ -65,6 +66,7 @@ export const ts = createPlugin({
 	name: "TypeScript",
 	rules: [
 		anyReturns,
+		args,
 		asyncPromiseExecutors,
 		caseDeclarations,
 		caseDuplicates,

--- a/packages/ts/src/rules/arguments.test.ts
+++ b/packages/ts/src/rules/arguments.test.ts
@@ -1,0 +1,99 @@
+import rule from "./arguments.ts";
+import { ruleTester } from "./ruleTester.ts";
+
+ruleTester.describe(rule, {
+	invalid: [
+		{
+			code: `
+function test() {
+	return arguments;
+}
+`,
+			snapshot: `
+function test() {
+	return arguments;
+	       ~~~~~~~~~
+	       Use rest parameters instead of \`arguments\`.
+}
+`,
+		},
+		{
+			code: `
+function test() {
+	console.log(arguments[0]);
+}
+`,
+			snapshot: `
+function test() {
+	console.log(arguments[0]);
+	            ~~~~~~~~~
+	            Use rest parameters instead of \`arguments\`.
+}
+`,
+		},
+		{
+			code: `
+function test() {
+	for (let i = 0; i < arguments.length; i++) {
+		console.log(arguments[i]);
+	}
+}
+`,
+			snapshot: `
+function test() {
+	for (let i = 0; i < arguments.length; i++) {
+	                    ~~~~~~~~~
+	                    Use rest parameters instead of \`arguments\`.
+		console.log(arguments[i]);
+		            ~~~~~~~~~
+		            Use rest parameters instead of \`arguments\`.
+	}
+}
+`,
+		},
+		{
+			code: `
+const obj = {
+	method() {
+		return arguments;
+	}
+};
+`,
+			snapshot: `
+const obj = {
+	method() {
+		return arguments;
+		       ~~~~~~~~~
+		       Use rest parameters instead of \`arguments\`.
+	}
+};
+`,
+		},
+		{
+			code: `
+function outer() {
+	function inner() {
+		return arguments;
+	}
+}
+`,
+			snapshot: `
+function outer() {
+	function inner() {
+		return arguments;
+		       ~~~~~~~~~
+		       Use rest parameters instead of \`arguments\`.
+	}
+}
+`,
+		},
+	],
+	valid: [
+		`function test(...args) { return args; }`,
+		`function test(arguments) { return arguments; }`,
+		`const arguments = [1, 2, 3]; console.log(arguments);`,
+		`const arrow = (...args) => args;`,
+		`() => { const args = []; }`,
+		`class Test { method(...args) { return args; } }`,
+	],
+});

--- a/packages/ts/src/rules/arguments.ts
+++ b/packages/ts/src/rules/arguments.ts
@@ -1,0 +1,77 @@
+import ts from "typescript";
+
+import { typescriptLanguage } from "../language.ts";
+
+export default typescriptLanguage.createRule({
+	about: {
+		description: "Reports using the `arguments` object.",
+		id: "arguments",
+		preset: "logical",
+	},
+	messages: {
+		noArguments: {
+			primary: "Use rest parameters instead of `arguments`.",
+			secondary: [
+				"The `arguments` object is an array-like object that does not have array methods like `map`, `filter`, or `forEach`.",
+				"Rest parameters provide a real array and are the modern way to access variadic function arguments.",
+			],
+			suggestions: [
+				"Replace `arguments` with a rest parameter like `...args`.",
+			],
+		},
+	},
+	setup(context) {
+		return {
+			visitors: {
+				Identifier: (node, { sourceFile, typeChecker }) => {
+					if (node.text !== "arguments") {
+						return;
+					}
+
+					if (!isArgumentsReference(node, typeChecker)) {
+						return;
+					}
+
+					context.report({
+						message: "noArguments",
+						range: {
+							begin: node.getStart(sourceFile),
+							end: node.getEnd(),
+						},
+					});
+				},
+			},
+		};
+	},
+});
+
+function isArgumentsReference(
+	node: ts.Identifier,
+	typeChecker: ts.TypeChecker,
+): boolean {
+	const symbol = typeChecker.getSymbolAtLocation(node);
+	if (!symbol) {
+		return true;
+	}
+
+	const declarations = symbol.getDeclarations();
+	if (!declarations || declarations.length === 0) {
+		return true;
+	}
+
+	for (const declaration of declarations) {
+		if (ts.isParameter(declaration)) {
+			return false;
+		}
+
+		if (ts.isVariableDeclaration(declaration)) {
+			return false;
+		}
+
+		if (ts.isFunctionDeclaration(declaration)) {
+			return false;
+		}
+	}
+
+	return true;
+}


### PR DESCRIPTION
Reports using the `arguments` object and suggests using rest parameters instead.

## Summary

This PR implements the `arguments` rule for the TypeScript plugin, which:
- Reports usage of the `arguments` object in functions
- Suggests using rest parameters (`...args`) instead

The `arguments` object is an array-like object that doesn't have array methods, while rest parameters provide a real array.

## Changes

- Added `arguments.ts` rule implementation
- Added `arguments.test.ts` with test cases
- Added `arguments.mdx` documentation
- Updated `plugin.ts` to include the rule
- Updated `data.json` to mark rule as implemented

Closes #446