### PR TITLE
feat: implement accessorThisRecursion rule for TypeScript plugin

### DIFF
--- a/packages/comparisons/src/data.json
+++ b/packages/comparisons/src/data.json
@@ -7005,6 +7005,7 @@
 			"name": "accessorThisRecursion",
 			"plugin": "ts",
 			"preset": "logical",
+			"status": "implemented",
 			"strictness": "strict"
 		},
 		"oxlint": [

--- a/packages/site/src/content/docs/rules/ts/accessorThisRecursion.mdx
+++ b/packages/site/src/content/docs/rules/ts/accessorThisRecursion.mdx
@@ -1,0 +1,112 @@
+---
+description: "Reports recursive access to `this` within getters and setters, which causes infinite recursion."
+title: "accessorThisRecursion"
+topic: "rules"
+---
+
+import { Tabs, TabItem } from "@astrojs/starlight/components";
+import { RuleEquivalents } from "~/components/RuleEquivalents";
+import RuleSummary from "~/components/RuleSummary.astro";
+
+<RuleSummary plugin="ts" rule="accessorThisRecursion" />
+
+When a getter accesses `this.propertyName` where `propertyName` is the same as the getter's name, it creates infinite recursion.
+Similarly, when a setter assigns to `this.propertyName` where `propertyName` is the same as the setter's name, it also creates infinite recursion.
+Both patterns cause a stack overflow at runtime.
+
+## Examples
+
+<Tabs>
+<TabItem label="❌ Incorrect">
+
+```ts
+const value = {
+	get name() {
+		return this.name;
+	},
+};
+```
+
+```ts
+const value = {
+	set name(input) {
+		this.name = input;
+	},
+};
+```
+
+```ts
+class Example {
+	get name() {
+		return this.name;
+	}
+}
+```
+
+```ts
+class Example {
+	set name(input) {
+		this.name = input;
+	}
+}
+```
+
+</TabItem>
+<TabItem label="✅ Correct">
+
+```ts
+const value = {
+	get name() {
+		return this._name;
+	},
+};
+```
+
+```ts
+const value = {
+	set name(input) {
+		this._name = input;
+	},
+};
+```
+
+```ts
+class Example {
+	private _name = "";
+
+	get name() {
+		return this._name;
+	}
+}
+```
+
+```ts
+class Example {
+	private _name = "";
+
+	set name(input: string) {
+		this._name = input;
+	}
+}
+```
+
+</TabItem>
+</Tabs>
+
+## Options
+
+This rule is not configurable.
+
+## When Not To Use It
+
+There are no valid reasons to use recursive accessor access.
+If you believe you have a false positive, please report it as a bug.
+
+## Further Reading
+
+- [MDN: Getter](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/get)
+- [MDN: Setter](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/set)
+
+## Equivalents in Other Linters
+
+<RuleEquivalents pluginId="ts" ruleId="accessorThisRecursion" />

--- a/packages/ts/src/nodes.ts
+++ b/packages/ts/src/nodes.ts
@@ -48,6 +48,7 @@ export interface TypeScriptNodesByName {
 	ForStatement: ts.ForStatement;
 	FunctionDeclaration: ts.FunctionDeclaration;
 	FunctionExpression: ts.FunctionExpression;
+	GetAccessor: ts.GetAccessorDeclaration;
 	HeritageClause: ts.HeritageClause;
 	Identifier: ts.Identifier;
 	IfStatement: ts.IfStatement;
@@ -111,6 +112,7 @@ export interface TypeScriptNodesByName {
 	ReturnStatement: ts.ReturnStatement;
 	SatisfiesExpression: ts.SatisfiesExpression;
 	SemicolonClassElement: ts.SemicolonClassElement;
+	SetAccessor: ts.SetAccessorDeclaration;
 	ShorthandPropertyAssignment: ts.ShorthandPropertyAssignment;
 	SourceFile: ts.SourceFile;
 	SpreadAssignment: ts.SpreadAssignment;

--- a/packages/ts/src/plugin.ts
+++ b/packages/ts/src/plugin.ts
@@ -1,5 +1,6 @@
 import { createPlugin } from "@flint.fyi/core";
 
+import accessorThisRecursion from "./rules/accessorThisRecursion.ts";
 import anyReturns from "./rules/anyReturns.ts";
 import asyncPromiseExecutors from "./rules/asyncPromiseExecutors.ts";
 import caseDeclarations from "./rules/caseDeclarations.ts";
@@ -64,6 +65,7 @@ export const ts = createPlugin({
 	},
 	name: "TypeScript",
 	rules: [
+		accessorThisRecursion,
 		anyReturns,
 		asyncPromiseExecutors,
 		caseDeclarations,

--- a/packages/ts/src/rules/accessorThisRecursion.test.ts
+++ b/packages/ts/src/rules/accessorThisRecursion.test.ts
@@ -1,0 +1,131 @@
+import rule from "./accessorThisRecursion.ts";
+import { ruleTester } from "./ruleTester.ts";
+
+ruleTester.describe(rule, {
+	invalid: [
+		{
+			code: `
+const value = {
+    get name() {
+        return this.name;
+    }
+};
+`,
+			snapshot: `
+const value = {
+    get name() {
+        return this.name;
+               ~~~~~~~~~
+               Getting \`this\` property within its own getter causes infinite recursion.
+    }
+};
+`,
+		},
+		{
+			code: `
+const value = {
+    set name(input) {
+        this.name = input;
+    }
+};
+`,
+			snapshot: `
+const value = {
+    set name(input) {
+        this.name = input;
+        ~~~~~~~~~
+        Setting \`this\` property within its own setter causes infinite recursion.
+    }
+};
+`,
+		},
+		{
+			code: `
+class Example {
+    get name() {
+        return this.name;
+    }
+}
+`,
+			snapshot: `
+class Example {
+    get name() {
+        return this.name;
+               ~~~~~~~~~
+               Getting \`this\` property within its own getter causes infinite recursion.
+    }
+}
+`,
+		},
+		{
+			code: `
+class Example {
+    set name(input) {
+        this.name = input;
+    }
+}
+`,
+			snapshot: `
+class Example {
+    set name(input) {
+        this.name = input;
+        ~~~~~~~~~
+        Setting \`this\` property within its own setter causes infinite recursion.
+    }
+}
+`,
+		},
+		{
+			code: `
+const value = {
+    get name() {
+        if (condition) {
+            return this.name;
+        }
+        return "";
+    }
+};
+`,
+			snapshot: `
+const value = {
+    get name() {
+        if (condition) {
+            return this.name;
+                   ~~~~~~~~~
+                   Getting \`this\` property within its own getter causes infinite recursion.
+        }
+        return "";
+    }
+};
+`,
+		},
+		{
+			code: `
+const value = {
+    get "computed"() {
+        return this.computed;
+    }
+};
+`,
+			snapshot: `
+const value = {
+    get "computed"() {
+        return this.computed;
+               ~~~~~~~~~~~~~
+               Getting \`this\` property within its own getter causes infinite recursion.
+    }
+};
+`,
+		},
+	],
+	valid: [
+		`const value = { get name() { return this.other; } };`,
+		`const value = { set name(input) { this.other = input; } };`,
+		`const value = { get name() { return this._name; } };`,
+		`const value = { set name(input) { this._name = input; } };`,
+		`class Example { get name() { return this._name; } }`,
+		`class Example { set name(input) { this._name = input; } }`,
+		`const value = { set name(input) { console.log(this.name); } };`,
+		`const value = { get [computed]() { return this.computed; } };`,
+	],
+});

--- a/packages/ts/src/rules/accessorThisRecursion.ts
+++ b/packages/ts/src/rules/accessorThisRecursion.ts
@@ -1,0 +1,134 @@
+import * as ts from "typescript";
+
+import { getTSNodeRange } from "../getTSNodeRange.ts";
+import { typescriptLanguage } from "../language.ts";
+
+export default typescriptLanguage.createRule({
+	about: {
+		description:
+			"Reports recursive access to `this` within getters and setters, which causes infinite recursion.",
+		id: "accessorThisRecursion",
+		preset: "logical",
+	},
+	messages: {
+		getterRecursion: {
+			primary:
+				"Getting `this` property within its own getter causes infinite recursion.",
+			secondary: [
+				"When a getter accesses itself via `this.propertyName`, it will infinitely recurse and cause a stack overflow.",
+			],
+			suggestions: [
+				"Use a different backing property name such as an underscore-prefixed field.",
+			],
+		},
+		setterRecursion: {
+			primary:
+				"Setting `this` property within its own setter causes infinite recursion.",
+			secondary: [
+				"When a setter assigns to itself via `this.propertyName`, it will infinitely recurse and cause a stack overflow.",
+			],
+			suggestions: [
+				"Use a different backing property name such as an underscore-prefixed field.",
+			],
+		},
+	},
+	setup(context) {
+		function getAccessorName(
+			accessor: ts.GetAccessorDeclaration | ts.SetAccessorDeclaration,
+		) {
+			if (ts.isIdentifier(accessor.name)) {
+				return accessor.name.text;
+			}
+
+			if (ts.isStringLiteral(accessor.name)) {
+				return accessor.name.text;
+			}
+
+			return undefined;
+		}
+
+		function checkPropertyAccess(
+			node: ts.PropertyAccessExpression,
+			accessorName: string,
+			sourceFile: ts.SourceFile,
+			messageKey: "getterRecursion" | "setterRecursion",
+		) {
+			if (
+				node.expression.kind === ts.SyntaxKind.ThisKeyword &&
+				ts.isIdentifier(node.name) &&
+				node.name.text === accessorName
+			) {
+				context.report({
+					message: messageKey,
+					range: getTSNodeRange(node, sourceFile),
+				});
+			}
+		}
+
+		function visitDescendantsForPropertyAccess(
+			node: ts.Node,
+			accessorName: string,
+			sourceFile: ts.SourceFile,
+			isGetter: boolean,
+		) {
+			const visit = (child: ts.Node) => {
+				if (ts.isPropertyAccessExpression(child)) {
+					if (isGetter) {
+						checkPropertyAccess(
+							child,
+							accessorName,
+							sourceFile,
+							"getterRecursion",
+						);
+					} else if (
+						ts.isBinaryExpression(child.parent) &&
+						child.parent.left === child &&
+						child.parent.operatorToken.kind === ts.SyntaxKind.EqualsToken
+					) {
+						checkPropertyAccess(
+							child,
+							accessorName,
+							sourceFile,
+							"setterRecursion",
+						);
+					}
+				}
+
+				ts.forEachChild(child, visit);
+			};
+
+			ts.forEachChild(node, visit);
+		}
+
+		return {
+			visitors: {
+				GetAccessor: (node, { sourceFile }) => {
+					const accessorName = getAccessorName(node);
+					if (!accessorName || !node.body) {
+						return;
+					}
+
+					visitDescendantsForPropertyAccess(
+						node.body,
+						accessorName,
+						sourceFile,
+						true,
+					);
+				},
+				SetAccessor: (node, { sourceFile }) => {
+					const accessorName = getAccessorName(node);
+					if (!accessorName || !node.body) {
+						return;
+					}
+
+					visitDescendantsForPropertyAccess(
+						node.body,
+						accessorName,
+						sourceFile,
+						false,
+					);
+				},
+			},
+		};
+	},
+});


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #800
- [x] That issue was marked as [`status: accepting prs`](https://github.com/flint-fyi/flint/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/flint-fyi/flint/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Implements the `accessorThisRecursion` rule for the TypeScript plugin. This rule reports recursive access to `this` within getters and setters, which causes infinite recursion and stack overflow errors.

The rule detects:
- Getters that return `this.propertyName` where `propertyName` matches the getter's name
- Setters that assign to `this.propertyName` where `propertyName` matches the setter's name