### PR TITLE
feat(ts): implement arrayExistenceChecksConsistency rule

### DIFF
--- a/packages/comparisons/src/data.json
+++ b/packages/comparisons/src/data.json
@@ -7310,7 +7310,8 @@
 		"flint": {
 			"name": "arrayExistenceChecksConsistency",
 			"plugin": "ts",
-			"preset": "stylistic"
+			"preset": "stylistic",
+			"status": "implemented"
 		},
 		"oxlint": [
 			{

--- a/packages/site/src/content/docs/rules/ts/arrayExistenceChecksConsistency.mdx
+++ b/packages/site/src/content/docs/rules/ts/arrayExistenceChecksConsistency.mdx
@@ -1,0 +1,91 @@
+---
+description: "Enforces consistent style when checking if an index exists."
+title: "arrayExistenceChecksConsistency"
+topic: "rules"
+---
+
+import { Tabs, TabItem } from "@astrojs/starlight/components";
+import { RuleEquivalents } from "~/components/RuleEquivalents";
+import RuleSummary from "~/components/RuleSummary.astro";
+
+<RuleSummary plugin="ts" rule="arrayExistenceChecksConsistency" />
+
+When checking if an element exists in an array or string using index-returning methods like `indexOf`, `lastIndexOf`, `findIndex`, or `findLastIndex`, there are multiple ways to express the check.
+This rule enforces using explicit equality checks with `-1` instead of comparison operators.
+
+This rule reports:
+
+- `index < 0` → prefer `index === -1`
+- `index >= 0` → prefer `index !== -1`
+- `index > -1` → prefer `index !== -1`
+
+## Examples
+
+<Tabs>
+<TabItem label="❌ Incorrect">
+
+```ts
+declare const array: string[];
+const index = array.indexOf("value");
+if (index < 0) {
+}
+```
+
+```ts
+declare const array: string[];
+const index = array.indexOf("value");
+if (index >= 0) {
+}
+```
+
+```ts
+declare const array: string[];
+const index = array.indexOf("value");
+if (index > -1) {
+}
+```
+
+</TabItem>
+<TabItem label="✅ Correct">
+
+```ts
+declare const array: string[];
+const index = array.indexOf("value");
+if (index === -1) {
+}
+```
+
+```ts
+declare const array: string[];
+const index = array.indexOf("value");
+if (index !== -1) {
+}
+```
+
+```ts
+declare const array: number[];
+const index = array.findIndex((value) => value > 10);
+if (index === -1) {
+}
+```
+
+</TabItem>
+</Tabs>
+
+## Options
+
+This rule is not configurable.
+
+## When Not To Use It
+
+If your team prefers the comparison operator style (`>= 0` or `< 0`) for checking index existence, you can disable this rule.
+Some developers find the comparison style more intuitive when thinking about array indices.
+
+## Further Reading
+
+- [MDN: Array.prototype.indexOf()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/indexOf)
+- [MDN: Array.prototype.findIndex()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/findIndex)
+
+## Equivalents in Other Linters
+
+<RuleEquivalents pluginId="ts" ruleId="arrayExistenceChecksConsistency" />

--- a/packages/ts/src/plugin.ts
+++ b/packages/ts/src/plugin.ts
@@ -1,6 +1,7 @@
 import { createPlugin } from "@flint.fyi/core";
 
 import anyReturns from "./rules/anyReturns.ts";
+import arrayExistenceChecksConsistency from "./rules/arrayExistenceChecksConsistency.ts";
 import asyncPromiseExecutors from "./rules/asyncPromiseExecutors.ts";
 import caseDeclarations from "./rules/caseDeclarations.ts";
 import caseDuplicates from "./rules/caseDuplicates.ts";
@@ -65,6 +66,7 @@ export const ts = createPlugin({
 	name: "TypeScript",
 	rules: [
 		anyReturns,
+		arrayExistenceChecksConsistency,
 		asyncPromiseExecutors,
 		caseDeclarations,
 		caseDuplicates,

--- a/packages/ts/src/rules/arrayExistenceChecksConsistency.test.ts
+++ b/packages/ts/src/rules/arrayExistenceChecksConsistency.test.ts
@@ -1,0 +1,132 @@
+import rule from "./arrayExistenceChecksConsistency.ts";
+import { ruleTester } from "./ruleTester.ts";
+
+ruleTester.describe(rule, {
+	invalid: [
+		{
+			code: `
+declare const array: string[];
+const index = array.indexOf("value");
+if (index < 0) {}
+`,
+			snapshot: `
+declare const array: string[];
+const index = array.indexOf("value");
+if (index < 0) {}
+    ~~~~~~~~~
+    Prefer \`=== -1\` over \`< 0\` for checking existence.
+`,
+		},
+		{
+			code: `
+declare const array: string[];
+const index = array.indexOf("value");
+if (index >= 0) {}
+`,
+			snapshot: `
+declare const array: string[];
+const index = array.indexOf("value");
+if (index >= 0) {}
+    ~~~~~~~~~~
+    Prefer \`!== -1\` over \`>= 0\` for checking existence.
+`,
+		},
+		{
+			code: `
+declare const array: string[];
+const index = array.indexOf("value");
+if (index > -1) {}
+`,
+			snapshot: `
+declare const array: string[];
+const index = array.indexOf("value");
+if (index > -1) {}
+    ~~~~~~~~~~
+    Prefer \`!== -1\` over \`> -1\` for checking existence.
+`,
+		},
+		{
+			code: `
+declare const array: number[];
+const index = array.findIndex((value) => value > 10);
+if (index < 0) {}
+`,
+			snapshot: `
+declare const array: number[];
+const index = array.findIndex((value) => value > 10);
+if (index < 0) {}
+    ~~~~~~~~~
+    Prefer \`=== -1\` over \`< 0\` for checking existence.
+`,
+		},
+		{
+			code: `
+declare const text: string;
+const index = text.lastIndexOf("needle");
+if (index >= 0) {}
+`,
+			snapshot: `
+declare const text: string;
+const index = text.lastIndexOf("needle");
+if (index >= 0) {}
+    ~~~~~~~~~~
+    Prefer \`!== -1\` over \`>= 0\` for checking existence.
+`,
+		},
+		{
+			code: `
+declare const array: number[];
+const index = array.findLastIndex((value) => value < 0);
+if (index > -1) {}
+`,
+			snapshot: `
+declare const array: number[];
+const index = array.findLastIndex((value) => value < 0);
+if (index > -1) {}
+    ~~~~~~~~~~
+    Prefer \`!== -1\` over \`> -1\` for checking existence.
+`,
+		},
+	],
+	valid: [
+		`
+declare const array: string[];
+const index = array.indexOf("value");
+if (index === -1) {}
+`,
+		`
+declare const array: string[];
+const index = array.indexOf("value");
+if (index !== -1) {}
+`,
+		`
+declare const array: number[];
+const index = array.findIndex((value) => value > 10);
+if (index === -1) {}
+`,
+		`
+declare const array: number[];
+let index = array.indexOf("value");
+if (index < 0) {}
+`,
+		`
+declare const array: number[];
+const index = 0;
+if (index < 0) {}
+`,
+		`
+declare const index: number;
+if (index >= 0) {}
+`,
+		`
+declare const array: string[];
+const index = array.indexOf("value");
+if (index > 0) {}
+`,
+		`
+declare const array: string[];
+const index = array.indexOf("value");
+if (index < 10) {}
+`,
+	],
+});

--- a/packages/ts/src/rules/arrayExistenceChecksConsistency.ts
+++ b/packages/ts/src/rules/arrayExistenceChecksConsistency.ts
@@ -1,0 +1,156 @@
+import * as ts from "typescript";
+
+import { getTSNodeRange } from "../getTSNodeRange.ts";
+import { typescriptLanguage } from "../language.ts";
+
+const INDEX_METHODS = new Set([
+	"findIndex",
+	"findLastIndex",
+	"indexOf",
+	"lastIndexOf",
+]);
+
+function getReplacement(
+	operator: ts.BinaryOperator,
+	right: ts.Expression,
+): undefined | { originalValue: string; replacementOperator: string } {
+	if (operator === ts.SyntaxKind.LessThanToken && isZero(right)) {
+		return {
+			originalValue: "`< 0`",
+			replacementOperator: "`=== -1`",
+		};
+	}
+
+	if (operator === ts.SyntaxKind.GreaterThanToken && isNegativeOne(right)) {
+		return {
+			originalValue: "`> -1`",
+			replacementOperator: "`!== -1`",
+		};
+	}
+
+	if (operator === ts.SyntaxKind.GreaterThanEqualsToken && isZero(right)) {
+		return {
+			originalValue: "`>= 0`",
+			replacementOperator: "`!== -1`",
+		};
+	}
+
+	return undefined;
+}
+
+function isIndexMethodCall(node: ts.Expression): boolean {
+	if (!ts.isCallExpression(node)) {
+		return false;
+	}
+
+	if (!ts.isPropertyAccessExpression(node.expression)) {
+		return false;
+	}
+
+	const methodName = node.expression.name.text;
+	return INDEX_METHODS.has(methodName);
+}
+
+function isNegativeOne(node: ts.Expression): boolean {
+	if (
+		ts.isPrefixUnaryExpression(node) &&
+		node.operator === ts.SyntaxKind.MinusToken &&
+		ts.isNumericLiteral(node.operand) &&
+		node.operand.text === "1"
+	) {
+		return true;
+	}
+
+	return false;
+}
+
+function isZero(node: ts.Expression): boolean {
+	return ts.isNumericLiteral(node) && node.text === "0";
+}
+
+export default typescriptLanguage.createRule({
+	about: {
+		description: "Enforces consistent style when checking if an index exists.",
+		id: "arrayExistenceChecksConsistency",
+		preset: "stylistic",
+	},
+	messages: {
+		preferEqualityCheck: {
+			primary:
+				"Prefer {{ replacementOperator }} over {{ originalValue }} for checking existence.",
+			secondary: [
+				"Using explicit equality checks with `-1` is more readable than comparison operators.",
+				"This pattern makes it clearer that you're checking whether an element exists or not.",
+			],
+			suggestions: [
+				"Replace the comparison with an explicit check against `-1`.",
+			],
+		},
+	},
+	setup(context) {
+		const indexVariables = new Map<ts.Symbol, true>();
+
+		return {
+			visitors: {
+				BinaryExpression: (node, { sourceFile, typeChecker }) => {
+					if (
+						node.operatorToken.kind !== ts.SyntaxKind.LessThanToken &&
+						node.operatorToken.kind !== ts.SyntaxKind.GreaterThanToken &&
+						node.operatorToken.kind !== ts.SyntaxKind.GreaterThanEqualsToken
+					) {
+						return;
+					}
+
+					if (!ts.isIdentifier(node.left)) {
+						return;
+					}
+
+					const symbol = typeChecker.getSymbolAtLocation(node.left);
+					if (!symbol || !indexVariables.has(symbol)) {
+						return;
+					}
+
+					const replacement = getReplacement(
+						node.operatorToken.kind,
+						node.right,
+					);
+					if (!replacement) {
+						return;
+					}
+
+					context.report({
+						data: replacement,
+						message: "preferEqualityCheck",
+						range: getTSNodeRange(node, sourceFile),
+					});
+				},
+				VariableDeclaration: (node, { typeChecker }) => {
+					if (!node.initializer) {
+						return;
+					}
+
+					const parent = node.parent;
+					if (
+						!ts.isVariableDeclarationList(parent) ||
+						!(parent.flags & ts.NodeFlags.Const)
+					) {
+						return;
+					}
+
+					if (!ts.isIdentifier(node.name)) {
+						return;
+					}
+
+					if (!isIndexMethodCall(node.initializer)) {
+						return;
+					}
+
+					const symbol = typeChecker.getSymbolAtLocation(node.name);
+					if (symbol) {
+						indexVariables.set(symbol, true);
+					}
+				},
+			},
+		};
+	},
+});


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #810
- [x] That issue was marked as [`status: accepting prs`](https://github.com/flint-fyi/flint/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/flint-fyi/flint/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Implements the `arrayExistenceChecksConsistency` rule for the TypeScript plugin. This rule enforces consistent style when checking if an index exists using methods like `indexOf`, `lastIndexOf`, `findIndex`, or `findLastIndex`.

The rule prefers explicit equality checks with `-1` over comparison operators:
- `index < 0` → prefer `index === -1`
- `index >= 0` → prefer `index !== -1`
- `index > -1` → prefer `index !== -1`

This makes the intent clearer and provides a more explicit check for element existence.

This matches the behavior of `eslint-plugin-unicorn/consistent-existence-index-check` and `oxlint/unicorn/consistent-existence-index-check`.