### PR TITLE
fix: revert filter in collecting files

### DIFF
--- a/packages/core/src/running/collectFilesAndMetadata.ts
+++ b/packages/core/src/running/collectFilesAndMetadata.ts
@@ -69,17 +69,19 @@ export async function collectFilesAndMetadata(
 	const rulesFilesAndOptionsByRule = new Map(
 		Array.from(rulesOptionsByFile).map(([rule, optionsByFile]) => [
 			rule,
-			Array.from(optionsByFile).map(([filePath, options]) => ({
-				languageFiles: Array.from(
-					nullThrows(
-						languageFileMetadataByFilePath.get(filePath),
-						"Language file metadata is expected to be present by the map",
-					)
-						.values()
-						.map((value) => value.fileMetadata.file),
-				),
-				options,
-			})),
+			Array.from(optionsByFile)
+				.filter(([filePath]) => languageFileMetadataByFilePath.has(filePath))
+				.map(([filePath, options]) => ({
+					languageFiles: Array.from(
+						nullThrows(
+							languageFileMetadataByFilePath.get(filePath),
+							"Language file metadata is expected to be present by the map",
+						)
+							.values()
+							.map((value) => value.fileMetadata.file),
+					),
+					options,
+				})),
 		]),
 	);
 


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to flint! ❤️‍🔥
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [`status: accepting prs`](https://github.com/flint-fyi/flint/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/flint-fyi/flint/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Ref: https://github.com/flint-fyi/flint/pull/1297/changes#diff-27ab74dce1d5715e9487270ad4d27095b58809cc276ce9594be64ec3b2744988R72-R83

👆 this changes delete the filter added in #1274. This PR bring this filter back to fix the problem.

<img width="1260" height="548" alt="flint" src="https://github.com/user-attachments/assets/16627bd2-aefe-4c51-af21-a04f6c3a6e17" />


<!-- Description of what is changed and how the code change does that. -->
