### PR TITLE
fix(core): remove non-existent cached files

### DIFF
--- a/packages/core/src/cache/readFromCache.ts
+++ b/packages/core/src/cache/readFromCache.ts
@@ -122,6 +122,7 @@ export async function readFromCache(
 	for (const filePath of cached.keys()) {
 		if (!allFilePaths.has(filePath)) {
 			cached.delete(filePath);
+			log("Removing non-existent file from cache: %s", filePath);
 		}
 	}
 


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to flint! ❤️‍🔥
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [`status: accepting prs`](https://github.com/flint-fyi/flint/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/flint-fyi/flint/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

If we have a file named `a.ts`

1. first time run `flint` -> `a.ts` has been cached

2. delete `a.ts`

3. Re-run `flint`

<img width="1930" height="636" alt="CleanShot 2026-01-09 at 09 38 19@2x" src="https://github.com/user-attachments/assets/5dfebe7f-824a-472d-b9f9-485fbdd0b56b" />
