### PR TITLE
feat(ts): implement directivePairs rule

### DIFF
--- a/packages/comparisons/src/data.json
+++ b/packages/comparisons/src/data.json
@@ -9255,6 +9255,7 @@
 			"name": "directivePairs",
 			"plugin": "ts",
 			"preset": "logical",
+			"status": "implemented",
 			"strictness": "strict"
 		}
 	},

--- a/packages/site/src/content/docs/rules/ts/directivePairs.mdx
+++ b/packages/site/src/content/docs/rules/ts/directivePairs.mdx
@@ -1,0 +1,71 @@
+---
+description: "Require a flint-enable comment for every flint-disable comment."
+title: "directivePairs"
+topic: "rules"
+---
+
+import { Tabs, TabItem } from "@astrojs/starlight/components";
+import { RuleEquivalents } from "~/components/RuleEquivalents";
+import RuleSummary from "~/components/RuleSummary.astro";
+
+<RuleSummary plugin="ts" rule="directivePairs" />
+
+`flint-disable` directive comments disable Flint rules in all lines after the comment.
+If you forget to add a corresponding `flint-enable` directive comment, you may overlook legitimate linting issues.
+
+This rule warns when a `flint-disable` directive does not have a matching `flint-enable` directive.
+
+## Examples
+
+<Tabs>
+<TabItem label="❌ Incorrect">
+
+```ts
+// flint-disable someRule
+const value = 1;
+```
+
+```ts
+// flint-disable
+const value = 1;
+```
+
+</TabItem>
+<TabItem label="✅ Correct">
+
+```ts
+// flint-disable someRule
+const value = 1;
+// flint-enable someRule
+```
+
+```ts
+// flint-disable
+const value = 1;
+// flint-enable
+```
+
+```ts
+// flint-disable-next-line someRule
+const value = 1;
+```
+
+</TabItem>
+</Tabs>
+
+## Options
+
+This rule is not configurable.
+
+## When Not To Use It
+
+If you intentionally disable rules for entire files without enabling them again, you may disable this rule.
+Consider using more targeted disable comments like `flint-disable-next-line` instead.
+
+## Further Reading
+
+- [Flint directive comments documentation](https://flint.fyi/docs)
+
+## Equivalents in Other Linters
+
+<RuleEquivalents pluginId="ts" ruleId="directivePairs" />

--- a/packages/ts/src/plugin.ts
+++ b/packages/ts/src/plugin.ts
@@ -27,6 +27,7 @@ import constantAssignments from "./rules/constantAssignments.ts";
 import constructorReturns from "./rules/constructorReturns.ts";
 import debuggerStatements from "./rules/debuggerStatements.ts";
 import defaultCaseLast from "./rules/defaultCaseLast.ts";
+import directivePairs from "./rules/directivePairs.ts";
 import duplicateArguments from "./rules/duplicateArguments.ts";
 import elseIfDuplicates from "./rules/elseIfDuplicates.ts";
 import emptyBlocks from "./rules/emptyBlocks.ts";
@@ -108,6 +109,7 @@ export const ts = createPlugin({
 		constructorReturns,
 		debuggerStatements,
 		defaultCaseLast,
+		directivePairs,
 		duplicateArguments,
 		elseIfDuplicates,
 		emptyBlocks,

--- a/packages/ts/src/rules/directivePairs.test.ts
+++ b/packages/ts/src/rules/directivePairs.test.ts
@@ -1,0 +1,42 @@
+import rule from "./directivePairs.ts";
+import { ruleTester } from "./ruleTester.ts";
+
+ruleTester.describe(rule, {
+	invalid: [
+		{
+			code: `
+// flint-disable someRule
+const value = 1;
+`,
+			snapshot: `
+// flint-disable someRule
+~~~~~~~~~~~~~~~~~~~~~~~~~
+This flint-disable directive is missing a corresponding flint-enable.
+const value = 1;
+`,
+		},
+		{
+			code: `
+// flint-disable
+const value = 1;
+`,
+			snapshot: `
+// flint-disable
+~~~~~~~~~~~~~~~~
+This flint-disable directive is missing a corresponding flint-enable.
+const value = 1;
+`,
+		},
+	],
+	valid: [
+		`// flint-disable someRule
+const value = 1;
+// flint-enable someRule`,
+		`// flint-disable
+const value = 1;
+// flint-enable`,
+		`// flint-disable-next-line someRule
+const value = 1;`,
+		"const value = 1;",
+	],
+});

--- a/packages/ts/src/rules/directivePairs.ts
+++ b/packages/ts/src/rules/directivePairs.ts
@@ -1,0 +1,92 @@
+import * as tsutils from "ts-api-utils";
+
+import { typescriptLanguage } from "../language.ts";
+
+interface DirectiveInfo {
+	begin: number;
+	end: number;
+	selection: string;
+	type: string;
+}
+
+export default typescriptLanguage.createRule({
+	about: {
+		description:
+			"Require a flint-enable comment for every flint-disable comment.",
+		id: "directivePairs",
+		preset: "logical",
+	},
+	messages: {
+		missingEnable: {
+			primary:
+				"This flint-disable directive is missing a corresponding flint-enable.",
+			secondary: [
+				"flint-disable directives without a matching flint-enable will disable rules for the rest of the file.",
+				"This may cause you to miss legitimate linting issues.",
+			],
+			suggestions: ["Add a flint-enable directive after the disabled code."],
+		},
+	},
+	setup(context) {
+		return {
+			visitors: {
+				SourceFile: (_, { sourceFile }) => {
+					const directives: DirectiveInfo[] = [];
+
+					tsutils.forEachComment(sourceFile, (fullText, sourceRange) => {
+						const commentText = fullText.slice(
+							sourceRange.pos,
+							sourceRange.end,
+						);
+						const match = /^\/\/\s*flint-(\S+)(?:\s+(.+))?/.exec(commentText);
+						if (!match) {
+							return;
+						}
+
+						const type = match[1] ?? "";
+						const selection = match[2] ?? "";
+
+						directives.push({
+							begin: sourceRange.pos,
+							end: sourceRange.end,
+							selection,
+							type,
+						});
+					});
+
+					const disables = new Map<string, DirectiveInfo[]>();
+
+					for (const directive of directives) {
+						const selection = directive.selection || "*";
+
+						if (directive.type === "disable") {
+							const existing = disables.get(selection);
+							if (existing) {
+								existing.push(directive);
+							} else {
+								disables.set(selection, [directive]);
+							}
+						} else if (directive.type === "enable") {
+							const stack = disables.get(selection);
+							if (stack && stack.length > 0) {
+								stack.pop();
+							}
+						}
+					}
+
+					for (const [, remaining] of disables) {
+						for (const directive of remaining) {
+							context.report({
+								message: "missingEnable",
+								range: {
+									begin: directive.begin,
+									end: directive.end,
+								},
+							});
+						}
+					}
+				},
+			},
+		};
+	},
+});


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #1426
- [x] That issue was marked as [`status: accepting prs`](https://github.com/flint-fyi/flint/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/flint-fyi/flint/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Implements the `directivePairs` rule which requires a `flint-enable` comment for every `flint-disable` comment. Unmatched disable directives may cause legitimate linting issues to be overlooked.

Equivalent to ESLint's `@eslint-community/eslint-comments/disable-enable-pair` rule.