### PR TITLE
feat(ts): implement directiveRequireDescriptions rule

### DIFF
--- a/packages/comparisons/src/data.json
+++ b/packages/comparisons/src/data.json
@@ -9269,6 +9269,7 @@
 			"name": "directiveRequireDescriptions",
 			"plugin": "ts",
 			"preset": "stylistic",
+			"status": "implemented",
 			"strictness": "strict"
 		}
 	},

--- a/packages/site/src/content/docs/rules/ts/directiveRequireDescriptions.mdx
+++ b/packages/site/src/content/docs/rules/ts/directiveRequireDescriptions.mdx
@@ -1,0 +1,70 @@
+---
+description: "Require descriptions in flint directive comments."
+title: "directiveRequireDescriptions"
+topic: "rules"
+---
+
+import { Tabs, TabItem } from "@astrojs/starlight/components";
+import { RuleEquivalents } from "~/components/RuleEquivalents";
+import RuleSummary from "~/components/RuleSummary.astro";
+
+<RuleSummary plugin="ts" rule="directiveRequireDescriptions" />
+
+When disabling lint rules, it's helpful to include a description explaining why the rule is being disabled.
+Descriptions help future developers understand the context and intent behind the disable.
+
+This rule warns when `flint-disable` directive comments don't include a description.
+Descriptions should be added after the rule name, separated by `--`.
+
+## Examples
+
+<Tabs>
+<TabItem label="❌ Incorrect">
+
+```ts
+// flint-disable someRule
+const value = 1;
+```
+
+```ts
+// flint-disable-next-line someRule
+const legacyCode = getValue();
+```
+
+</TabItem>
+<TabItem label="✅ Correct">
+
+```ts
+// flint-disable someRule -- Required for backwards compatibility with legacy API
+const value = 1;
+```
+
+```ts
+// flint-disable-next-line someRule -- Legacy code that cannot be refactored
+const legacyCode = getValue();
+```
+
+```ts
+// flint-enable someRule
+const value = 1;
+```
+
+</TabItem>
+</Tabs>
+
+## Options
+
+This rule is not configurable.
+
+## When Not To Use It
+
+If your team doesn't require explanations for disabled rules, you may disable this rule.
+However, adding descriptions is generally considered a best practice for maintainability.
+
+## Further Reading
+
+- [ESLint RFC - Description in directive comments](https://github.com/eslint/rfcs/blob/main/designs/2019-description-in-directive-comments/README.md)
+
+## Equivalents in Other Linters
+
+<RuleEquivalents pluginId="ts" ruleId="directiveRequireDescriptions" />

--- a/packages/ts/src/plugin.ts
+++ b/packages/ts/src/plugin.ts
@@ -27,6 +27,7 @@ import constantAssignments from "./rules/constantAssignments.ts";
 import constructorReturns from "./rules/constructorReturns.ts";
 import debuggerStatements from "./rules/debuggerStatements.ts";
 import defaultCaseLast from "./rules/defaultCaseLast.ts";
+import directiveRequireDescriptions from "./rules/directiveRequireDescriptions.ts";
 import duplicateArguments from "./rules/duplicateArguments.ts";
 import elseIfDuplicates from "./rules/elseIfDuplicates.ts";
 import emptyBlocks from "./rules/emptyBlocks.ts";
@@ -108,6 +109,7 @@ export const ts = createPlugin({
 		constructorReturns,
 		debuggerStatements,
 		defaultCaseLast,
+		directiveRequireDescriptions,
 		duplicateArguments,
 		elseIfDuplicates,
 		emptyBlocks,

--- a/packages/ts/src/rules/directiveRequireDescriptions.test.ts
+++ b/packages/ts/src/rules/directiveRequireDescriptions.test.ts
@@ -1,0 +1,49 @@
+import rule from "./directiveRequireDescriptions.ts";
+import { ruleTester } from "./ruleTester.ts";
+
+ruleTester.describe(rule, {
+	invalid: [
+		{
+			code: `
+// flint-disable someRule
+const value = 1;
+`,
+			snapshot: `
+// flint-disable someRule
+~~~~~~~~~~~~~~~~~~~~~~~~~
+Flint directive comments should include a description.
+const value = 1;
+`,
+		},
+		{
+			code: `
+// flint-disable
+const value = 1;
+`,
+			snapshot: `
+// flint-disable
+~~~~~~~~~~~~~~~~
+Flint directive comments should include a description.
+const value = 1;
+`,
+		},
+		{
+			code: `
+// flint-disable-next-line someRule
+const value = 1;
+`,
+			snapshot: `
+// flint-disable-next-line someRule
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Flint directive comments should include a description.
+const value = 1;
+`,
+		},
+	],
+	valid: [
+		"// flint-disable someRule -- This is needed for backwards compatibility\nconst value = 1;",
+		"// flint-disable-next-line someRule -- Legacy API requires this\nconst value = 1;",
+		"// flint-enable someRule\nconst value = 1;",
+		"const value = 1;",
+	],
+});

--- a/packages/ts/src/rules/directiveRequireDescriptions.ts
+++ b/packages/ts/src/rules/directiveRequireDescriptions.ts
@@ -1,0 +1,74 @@
+import * as tsutils from "ts-api-utils";
+
+import { typescriptLanguage } from "../language.ts";
+
+export default typescriptLanguage.createRule({
+	about: {
+		description: "Require descriptions in flint directive comments.",
+		id: "directiveRequireDescriptions",
+		preset: "stylistic",
+	},
+	messages: {
+		missingDescription: {
+			primary: "Flint directive comments should include a description.",
+			secondary: [
+				"Adding a description explains why the rule is being disabled.",
+				"Descriptions help future developers understand the context of the disable.",
+			],
+			suggestions: [
+				"Add a description after the rule name, separated by ' -- '.",
+			],
+		},
+	},
+	setup(context) {
+		return {
+			visitors: {
+				SourceFile: (_, { sourceFile }) => {
+					tsutils.forEachComment(sourceFile, (fullText, sourceRange) => {
+						const commentText = fullText.slice(
+							sourceRange.pos,
+							sourceRange.end,
+						);
+
+						const match =
+							/^\/\/\s*flint-(disable-next-line|disable-line|disable|enable)(?:\s+(.*))?/.exec(
+								commentText,
+							);
+						if (!match) {
+							return;
+						}
+
+						const directiveType = match[1];
+						const rest = match[2]?.trim() ?? "";
+
+						if (directiveType === "enable") {
+							return;
+						}
+
+						if (!rest) {
+							context.report({
+								message: "missingDescription",
+								range: {
+									begin: sourceRange.pos,
+									end: sourceRange.end,
+								},
+							});
+							return;
+						}
+
+						const hasDescription = rest.includes(" -- ");
+						if (!hasDescription) {
+							context.report({
+								message: "missingDescription",
+								range: {
+									begin: sourceRange.pos,
+									end: sourceRange.end,
+								},
+							});
+						}
+					});
+				},
+			},
+		};
+	},
+});


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #1427
- [x] That issue was marked as [`status: accepting prs`](https://github.com/flint-fyi/flint/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/flint-fyi/flint/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Implements the `directiveRequireDescriptions` rule which requires descriptions in flint directive comments. Descriptions should be added after the rule name, separated by ` -- `.

Equivalent to ESLint's `@eslint-community/eslint-comments/require-description` rule.