### PR TITLE
chore: remove `canvaskit-wasm` from cspell and knip configurations

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -38,7 +38,6 @@
 		"barrymichaeldoyle",
 		"bday",
 		"bradzacher",
-		"canvaskit",
 		"codemod",
 		"contentinfo",
 		"deoptimizations",

--- a/knip.json
+++ b/knip.json
@@ -1,7 +1,6 @@
 {
 	"$schema": "./node_modules/knip/schema.json",
 	"ignore": ["packages/fixtures/*"],
-	"ignoreDependencies": ["canvaskit-wasm"],
 	"ignoreExportsUsedInFile": { "interface": true, "type": true },
 	"treatConfigHintsAsErrors": true,
 	"workspaces": {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
 		"flint": "workspace:^",
 		"husky": "9.1.7",
 		"jiti": "2.6.1",
-		"knip": "5.77.1",
+		"knip": "5.80.2",
 		"lint-staged": "16.2.7",
 		"prettier": "3.7.4",
 		"prettier-plugin-astro": "0.14.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -86,8 +86,8 @@ importers:
         specifier: 2.6.1
         version: 2.6.1
       knip:
-        specifier: 5.77.1
-        version: 5.77.1(@types/node@24.10.1)(typescript@5.9.3)
+        specifier: 5.80.2
+        version: 5.80.2(@types/node@24.10.1)(typescript@5.9.3)
       lint-staged:
         specifier: 16.2.7
         version: 16.2.7
@@ -3557,8 +3557,8 @@ packages:
     resolution: {integrity: sha512-dhG34DXATL5hSxJbIexCft8FChFXtmskoZYnoPWjXQuebWYCNkVeV3KkGegCK9CP1oswI/vQibS2GY7Em/sJJA==}
     engines: {node: '>= 8'}
 
-  knip@5.77.1:
-    resolution: {integrity: sha512-+yA/vfQUDEFUOcR0XRn/dOZmNEsS10pIMztS5JbKUhk9zvQiAFvr3Mcc3zC7Dn9gBG8LeImhaXA6/D3uhzwZvg==}
+  knip@5.80.2:
+    resolution: {integrity: sha512-Yt7iF8Uzl7pp3mGA6yvum6PZBcbGhjasZYuqIwcIAX1jsIhGRUAK0icP0qrB6FSPBI3BpIeMHl7n9meCLO6ovg==}
     engines: {node: '>=18.18.0'}
     hasBin: true
     peerDependencies:
@@ -8542,7 +8542,7 @@ snapshots:
 
   klona@2.0.6: {}
 
-  knip@5.77.1(@types/node@24.10.1)(typescript@5.9.3):
+  knip@5.80.2(@types/node@24.10.1)(typescript@5.9.3):
     dependencies:
       '@nodelib/fs.walk': 1.2.8
       '@types/node': 24.10.1


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to flint! ❤️‍🔥
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [`status: accepting prs`](https://github.com/flint-fyi/flint/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/flint-fyi/flint/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

ref:
- https://github.com/webpro-nl/knip/pull/1445
- https://github.com/streetsidesoftware/cspell-dicts/pull/5125