### PR TITLE
feat: implement functionDefinitionScopeConsistency rule (TypeScript)

### DIFF
--- a/packages/comparisons/src/data.json
+++ b/packages/comparisons/src/data.json
@@ -10492,6 +10492,7 @@
 			"name": "functionDefinitionScopeConsistency",
 			"plugin": "ts",
 			"preset": "stylistic",
+			"status": "implemented",
 			"strictness": "strict"
 		},
 		"oxlint": [

--- a/packages/site/src/content/docs/rules/ts/functionDefinitionScopeConsistency.mdx
+++ b/packages/site/src/content/docs/rules/ts/functionDefinitionScopeConsistency.mdx
@@ -1,0 +1,98 @@
+---
+description: "Move function definitions to the highest possible scope."
+title: "functionDefinitionScopeConsistency"
+topic: "rules"
+---
+
+import { Tabs, TabItem } from "@astrojs/starlight/components";
+import { RuleEquivalents } from "~/components/RuleEquivalents";
+import RuleSummary from "~/components/RuleSummary.astro";
+
+<RuleSummary plugin="ts" rule="functionDefinitionScopeConsistency" />
+
+A function definition should be placed as close to the top-level scope as possible without breaking its captured values.
+This improves readability, directly improves performance, and allows JavaScript engines to better optimize performance.
+
+When a function doesn't reference any variables from its enclosing scope, it can be moved to the outer scope.
+This rule reports nested functions that could be moved up.
+
+## Examples
+
+<Tabs>
+<TabItem label="❌ Incorrect">
+
+```ts
+function outer(value: string) {
+	function inner(text: string) {
+		return text === "test";
+	}
+	return inner;
+}
+```
+
+```ts
+function outer(value: string) {
+	const inner = (text: string) => {
+		return text === "test";
+	};
+	return inner;
+}
+```
+
+```ts
+function outer() {
+	return (dispatch: Function) => dispatch({ type: "ACTION" });
+}
+```
+
+</TabItem>
+<TabItem label="✅ Correct">
+
+```ts
+function inner(text: string) {
+	return text === "test";
+}
+
+function outer(value: string) {
+	return inner;
+}
+```
+
+```ts
+function outer(value: string) {
+	function inner() {
+		return value === "test";
+	}
+	return inner;
+}
+```
+
+```ts
+function outer() {
+	return function inner() {
+		return this;
+	};
+}
+```
+
+</TabItem>
+</Tabs>
+
+## Options
+
+This rule is not configurable.
+
+## When Not To Use It
+
+If you prefer to keep related functions close together for readability, even when they don't share scope, you may want to disable this rule.
+
+For large existing codebases, this rule may produce many warnings that are not critical to fix.
+
+## Further Reading
+
+- [MDN: Closures](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Closures)
+- [JavaScript Performance Pitfalls in V8](https://ponyfoo.com/articles/javascript-performance-pitfalls-v8)
+
+## Equivalents in Other Linters
+
+<RuleEquivalents pluginId="ts" ruleId="functionDefinitionScopeConsistency" />

--- a/packages/ts/src/plugin.ts
+++ b/packages/ts/src/plugin.ts
@@ -49,6 +49,7 @@ import forDirections from "./rules/forDirections.ts";
 import forInArrays from "./rules/forInArrays.ts";
 import functionAssignments from "./rules/functionAssignments.ts";
 import functionCurryingRedundancy from "./rules/functionCurryingRedundancy.ts";
+import functionDefinitionScopeConsistency from "./rules/functionDefinitionScopeConsistency.ts";
 import functionNewCalls from "./rules/functionNewCalls.ts";
 import generatorFunctionYields from "./rules/generatorFunctionYields.ts";
 import globalAssignments from "./rules/globalAssignments.ts";
@@ -141,6 +142,7 @@ export const ts = createPlugin({
 		forInArrays,
 		functionAssignments,
 		functionCurryingRedundancy,
+		functionDefinitionScopeConsistency,
 		functionNewCalls,
 		generatorFunctionYields,
 		globalAssignments,

--- a/packages/ts/src/rules/functionDefinitionScopeConsistency.test.ts
+++ b/packages/ts/src/rules/functionDefinitionScopeConsistency.test.ts
@@ -1,0 +1,135 @@
+import rule from "./functionDefinitionScopeConsistency.ts";
+import { ruleTester } from "./ruleTester.ts";
+
+ruleTester.describe(rule, {
+	invalid: [
+		{
+			code: `
+function outer(value: string) {
+    function inner(text: string) {
+        return text === "test";
+    }
+    return inner;
+}
+`,
+			snapshot: `
+function outer(value: string) {
+    function inner(text: string) {
+    ~~~~~~~~
+    Function does not capture any variables from the enclosing scope and can be moved to the outer scope.
+        return text === "test";
+    }
+    return inner;
+}
+`,
+		},
+		{
+			code: `
+function outer(value: string) {
+    const inner = (text: string) => {
+        return text === "test";
+    };
+    return inner;
+}
+`,
+			snapshot: `
+function outer(value: string) {
+    const inner = (text: string) => {
+                  ~
+                  Function does not capture any variables from the enclosing scope and can be moved to the outer scope.
+        return text === "test";
+    };
+    return inner;
+}
+`,
+		},
+		{
+			code: `
+function outer() {
+    return (dispatch: Function) => dispatch({ type: "ACTION" });
+}
+`,
+			snapshot: `
+function outer() {
+    return (dispatch: Function) => dispatch({ type: "ACTION" });
+           ~
+           Function does not capture any variables from the enclosing scope and can be moved to the outer scope.
+}
+`,
+		},
+		{
+			code: `
+const outer = () => {
+    function helper(value: number) {
+        return value * 2;
+    }
+    return helper;
+};
+`,
+			snapshot: `
+const outer = () => {
+    function helper(value: number) {
+    ~~~~~~~~
+    Function does not capture any variables from the enclosing scope and can be moved to the outer scope.
+        return value * 2;
+    }
+    return helper;
+};
+`,
+		},
+	],
+	valid: [
+		`function doBar(value: string) { return value === "bar"; }`,
+		`const doBar = (value: string) => value === "bar";`,
+		`
+function outer(value: string) {
+    function inner() {
+        return value === "test";
+    }
+    return inner;
+}
+`,
+		`
+function outer(multiplier: number) {
+    const inner = (value: number) => value * multiplier;
+    return inner;
+}
+`,
+		`
+function outer() {
+    return function inner() {
+        return this;
+    };
+}
+`,
+		`
+class Example {
+    method() {
+        const handler = () => {
+            return this.value;
+        };
+        return handler;
+    }
+    value = 1;
+}
+`,
+		`
+function outer() {
+    const data = "test";
+    function inner() {
+        return data;
+    }
+    return inner;
+}
+`,
+		`
+function outer(data: string) {
+    function helper() { return data; }
+    function inner() {
+        return helper();
+    }
+    return inner;
+}
+`,
+	],
+});

--- a/packages/ts/src/rules/functionDefinitionScopeConsistency.ts
+++ b/packages/ts/src/rules/functionDefinitionScopeConsistency.ts
@@ -1,0 +1,190 @@
+import * as tsutils from "ts-api-utils";
+import ts, { SyntaxKind } from "typescript";
+
+import { typescriptLanguage } from "../language.ts";
+import type * as AST from "../types/ast.ts";
+import type { Checker } from "../types/checker.ts";
+
+export default typescriptLanguage.createRule({
+	about: {
+		description: "Move function definitions to the highest possible scope.",
+		id: "functionDefinitionScopeConsistency",
+		preset: "stylistic",
+		strictness: "strict",
+	},
+	messages: {
+		moveToOuterScope: {
+			primary:
+				"Function does not capture any variables from the enclosing scope and can be moved to the outer scope.",
+			secondary: [
+				"Functions that don't use variables from their enclosing scope can be defined at a higher level.",
+				"This improves readability and allows JavaScript engines to better optimize performance.",
+			],
+			suggestions: [
+				"Move the function to the outer scope, above its current containing function.",
+			],
+		},
+	},
+	setup(context) {
+		function collectScopeVariables(scopeNode: ts.Node, typeChecker: Checker) {
+			const variables = new Set<ts.Symbol>();
+
+			function collectFromNode(node: ts.Node) {
+				if (ts.isVariableDeclaration(node) && ts.isIdentifier(node.name)) {
+					const symbol = typeChecker.getSymbolAtLocation(node.name);
+					if (symbol) {
+						variables.add(symbol);
+					}
+				}
+
+				if (ts.isParameter(node) && ts.isIdentifier(node.name)) {
+					const symbol = typeChecker.getSymbolAtLocation(node.name);
+					if (symbol) {
+						variables.add(symbol);
+					}
+				}
+
+				if (ts.isFunctionDeclaration(node) && node.name) {
+					const symbol = typeChecker.getSymbolAtLocation(node.name);
+					if (symbol) {
+						variables.add(symbol);
+					}
+				}
+
+				if (tsutils.isFunctionScopeBoundary(node) && node !== scopeNode) {
+					return;
+				}
+
+				ts.forEachChild(node, collectFromNode);
+			}
+
+			collectFromNode(scopeNode);
+			return variables;
+		}
+
+		function referencesVariable(
+			node: ts.Node,
+			variables: Set<ts.Symbol>,
+			typeChecker: Checker,
+			selfSymbol: ts.Symbol | undefined,
+		): boolean | undefined {
+			if (ts.isIdentifier(node)) {
+				const symbol = typeChecker.getSymbolAtLocation(node);
+				if (symbol && symbol !== selfSymbol && variables.has(symbol)) {
+					return true;
+				}
+			}
+
+			if (node.kind === SyntaxKind.ThisKeyword) {
+				return true;
+			}
+
+			return ts.forEachChild(node, (child) =>
+				referencesVariable(child, variables, typeChecker, selfSymbol),
+			);
+		}
+
+		function isNestedFunction(node: ts.Node) {
+			for (
+				let current = node.parent;
+				!ts.isSourceFile(current);
+				current = current.parent
+			) {
+				if (tsutils.isFunctionScopeBoundary(current)) {
+					return true;
+				}
+			}
+
+			return false;
+		}
+
+		function getEnclosingFunction(
+			node: ts.Node,
+		): ts.FunctionLikeDeclaration | undefined {
+			for (
+				let current = node.parent;
+				!ts.isSourceFile(current);
+				current = current.parent
+			) {
+				if (tsutils.isFunctionScopeBoundary(current)) {
+					return current as ts.FunctionLikeDeclaration;
+				}
+			}
+
+			return undefined;
+		}
+
+		function checkFunction(
+			node:
+				| AST.ArrowFunction
+				| AST.FunctionDeclaration
+				| AST.FunctionExpression,
+			sourceFile: AST.SourceFile,
+			typeChecker: Checker,
+		) {
+			if (!isNestedFunction(node)) {
+				return;
+			}
+
+			const enclosingFunction = getEnclosingFunction(node);
+			if (!enclosingFunction) {
+				return;
+			}
+
+			const enclosingScopeVariables = collectScopeVariables(
+				enclosingFunction,
+				typeChecker,
+			);
+
+			let selfSymbol: ts.Symbol | undefined;
+			if (ts.isFunctionDeclaration(node) && node.name) {
+				selfSymbol = typeChecker.getSymbolAtLocation(node.name);
+			}
+			if (ts.isFunctionExpression(node) && node.name) {
+				selfSymbol = typeChecker.getSymbolAtLocation(node.name);
+			}
+
+			if (
+				referencesVariable(
+					node,
+					enclosingScopeVariables,
+					typeChecker,
+					selfSymbol,
+				)
+			) {
+				return;
+			}
+
+			const functionKeyword =
+				node.kind === SyntaxKind.ArrowFunction
+					? undefined
+					: node
+							.getChildren(sourceFile)
+							.find((child) => child.kind === SyntaxKind.FunctionKeyword);
+
+			const start = functionKeyword
+				? functionKeyword.getStart(sourceFile)
+				: node.getStart(sourceFile);
+			const end = functionKeyword ? functionKeyword.getEnd() : start + 1;
+
+			context.report({
+				message: "moveToOuterScope",
+				range: { begin: start, end },
+			});
+		}
+
+		return {
+			visitors: {
+				ArrowFunction: (node, { sourceFile, typeChecker }) => {
+					checkFunction(node, sourceFile, typeChecker);
+				},
+				FunctionDeclaration: (node, { sourceFile, typeChecker }) => {
+					checkFunction(node, sourceFile, typeChecker);
+				},
+				FunctionExpression: (node, { sourceFile, typeChecker }) => {
+					checkFunction(node, sourceFile, typeChecker);
+				},
+			},
+		};
+	},
+});


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #1464
- [x] That issue was marked as [`status: accepting prs`](https://github.com/flint-fyi/flint/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/flint-fyi/flint/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Implements the `functionDefinitionScopeConsistency` rule for the TypeScript plugin. This rule reports nested function definitions that don't capture any variables from their enclosing scope and can be moved to the outer scope.

Moving functions to the highest possible scope improves readability and allows JavaScript engines to better optimize performance.

Equivalent to `unicorn/consistent-function-scoping`.