### PR TITLE
feat(ts): implement filenameCasing rule

### DIFF
--- a/packages/comparisons/src/data.json
+++ b/packages/comparisons/src/data.json
@@ -10287,7 +10287,7 @@
 		"flint": {
 			"name": "filenameCasing",
 			"plugin": "ts",
-			"status": "skipped"
+			"status": "implemented"
 		},
 		"oxlint": [
 			{

--- a/packages/site/src/content/docs/rules/ts/filenameCasing.mdx
+++ b/packages/site/src/content/docs/rules/ts/filenameCasing.mdx
@@ -1,0 +1,122 @@
+---
+description: "Reports filenames that do not match a consistent casing."
+title: "filenameCasing"
+topic: "rules"
+---
+
+import { Tabs, TabItem } from "@astrojs/starlight/components";
+import { RuleEquivalents } from "~/components/RuleEquivalents";
+import RuleSummary from "~/components/RuleSummary.astro";
+
+<RuleSummary plugin="ts" rule="filenameCasing" />
+
+Consistent filename casing makes files easier to find and helps avoid cross-platform issues with case-sensitive file systems.
+Different operating systems handle file casing differently: macOS and Windows are case-insensitive by default, while Linux is case-sensitive.
+This can lead to confusing bugs when developers on different platforms collaborate.
+
+## Examples
+
+<Tabs>
+<TabItem label="❌ Incorrect">
+
+```ts
+// myFile.ts
+const value = 1;
+```
+
+```ts
+// MyComponent.ts (with default kebab-case setting)
+export function MyComponent() {}
+```
+
+```ts
+// my_file.ts
+const value = 1;
+```
+
+</TabItem>
+<TabItem label="✅ Correct">
+
+```ts
+// my-file.ts
+const value = 1;
+```
+
+```ts
+// my-component.ts
+export function MyComponent() {}
+```
+
+```ts
+// index.ts (always allowed)
+export * from "./my-module.ts";
+```
+
+</TabItem>
+</Tabs>
+
+## Options
+
+### `cases`
+
+An object specifying which case styles are allowed.
+At least one should be set to `true`.
+
+- `camelCase`: Allows `myFileName.ts`
+- `kebabCase`: Allows `my-file-name.ts` (default)
+- `pascalCase`: Allows `MyFileName.ts`
+- `snakeCase`: Allows `my_file_name.ts`
+
+```json
+{
+	"rules": {
+		"ts/filenameCasing": [
+			"error",
+			{ "cases": { "camelCase": true, "pascalCase": true } }
+		]
+	}
+}
+```
+
+### `ignore`
+
+An array of regex patterns for filenames to ignore.
+Useful for files that cannot follow naming conventions.
+
+```json
+{
+	"rules": {
+		"ts/filenameCasing": ["error", { "ignore": ["^CHANGELOG", "^README"] }]
+	}
+}
+```
+
+### `multipleFileExtensions`
+
+When `true` (the default), treats parts after the first `.` as extensions.
+For example, in `MyComponent.test.ts`, only `MyComponent` is validated.
+
+When `false`, the entire filename before the final extension is validated.
+For example, in `MyComponent.test.ts`, `MyComponent.test` is validated.
+
+```json
+{
+	"rules": {
+		"ts/filenameCasing": ["error", { "multipleFileExtensions": false }]
+	}
+}
+```
+
+## When Not To Use It
+
+If your project has an established naming convention that differs from the available options, or if you have many legacy files that would require significant effort to rename, you might want to disable this rule.
+Some projects also have technical constraints that require specific filename patterns (e.g., certain bundlers or frameworks with special file naming requirements).
+
+## Further Reading
+
+- [MDN: File systems](https://developer.mozilla.org/en-US/docs/Learn_web_development/Extensions/Server-side/Express_Nodejs/development_environment#file_paths)
+- [Wikipedia: Case sensitivity](https://en.wikipedia.org/wiki/Case_sensitivity#In_filesystems)
+
+## Equivalents in Other Linters
+
+<RuleEquivalents pluginId="ts" ruleId="filenameCasing" />

--- a/packages/ts/package.json
+++ b/packages/ts/package.json
@@ -33,6 +33,7 @@
 		"@typescript-eslint/project-service": "^8.46.2",
 		"@typescript/vfs": "^1.6.1",
 		"cached-factory": "^0.1.0",
+		"change-case": "^5.4.4",
 		"debug-for-file": "^0.2.0",
 		"ts-api-utils": "^2.1.0",
 		"typescript": "^5.9.0 || ^6.0.0",

--- a/packages/ts/src/plugin.ts
+++ b/packages/ts/src/plugin.ts
@@ -59,6 +59,7 @@ import emptyDestructures from "./rules/emptyDestructures.ts";
 import emptyStaticBlocks from "./rules/emptyStaticBlocks.ts";
 import exceptionAssignments from "./rules/exceptionAssignments.ts";
 import fetchMethodBodies from "./rules/fetchMethodBodies.ts";
+import filenameCasing from "./rules/filenameCasing.ts";
 import finallyStatementSafety from "./rules/finallyStatementSafety.ts";
 import forDirections from "./rules/forDirections.ts";
 import forInArrays from "./rules/forInArrays.ts";
@@ -167,6 +168,7 @@ export const ts = createPlugin({
 		emptyStaticBlocks,
 		exceptionAssignments,
 		fetchMethodBodies,
+		filenameCasing,
 		finallyStatementSafety,
 		forDirections,
 		forInArrays,

--- a/packages/ts/src/rules/filenameCasing.test.ts
+++ b/packages/ts/src/rules/filenameCasing.test.ts
@@ -1,0 +1,205 @@
+import rule from "./filenameCasing.ts";
+import { ruleTester } from "./ruleTester.ts";
+
+ruleTester.describe(rule, {
+	invalid: [
+		{
+			code: `
+const value = 1;
+`,
+			fileName: "myFile.ts",
+			snapshot: `
+
+
+Filename \`myFile.ts\` does not match kebab case.
+const value = 1;
+`,
+		},
+		{
+			code: `
+const value = 1;
+`,
+			fileName: "MyFile.ts",
+			snapshot: `
+
+
+Filename \`MyFile.ts\` does not match kebab case.
+const value = 1;
+`,
+		},
+		{
+			code: `
+const value = 1;
+`,
+			fileName: "my_file.ts",
+			snapshot: `
+
+
+Filename \`my_file.ts\` does not match kebab case.
+const value = 1;
+`,
+		},
+		{
+			code: `
+const value = 1;
+`,
+			fileName: "myFile.test.ts",
+			snapshot: `
+
+
+Filename \`myFile.test.ts\` does not match kebab case.
+const value = 1;
+`,
+		},
+		{
+			code: `
+const value = 1;
+`,
+			fileName: "my-file.ts",
+			options: { cases: { camelCase: true } },
+			snapshot: `
+
+
+Filename \`my-file.ts\` does not match camel case.
+const value = 1;
+`,
+		},
+		{
+			code: `
+const value = 1;
+`,
+			fileName: "my-file.ts",
+			options: { cases: { pascalCase: true } },
+			snapshot: `
+
+
+Filename \`my-file.ts\` does not match pascal case.
+const value = 1;
+`,
+		},
+		{
+			code: `
+const value = 1;
+`,
+			fileName: "my-file.ts",
+			options: { cases: { snakeCase: true } },
+			snapshot: `
+
+
+Filename \`my-file.ts\` does not match snake case.
+const value = 1;
+`,
+		},
+		{
+			code: `
+const value = 1;
+`,
+			fileName: "my-file.ts",
+			options: { cases: { camelCase: true, pascalCase: true } },
+			snapshot: `
+
+
+Filename \`my-file.ts\` does not match camel case or pascal case.
+const value = 1;
+`,
+		},
+		{
+			code: `
+const value = 1;
+`,
+			fileName: "MyComponent.test.ts",
+			options: { multipleFileExtensions: false },
+			snapshot: `
+
+
+Filename \`MyComponent.test.ts\` does not match kebab case.
+const value = 1;
+`,
+		},
+	],
+	valid: [
+		{ code: `const value = 1;`, fileName: "my-file.ts" },
+		{ code: `const value = 1;`, fileName: "my-file.test.ts" },
+		{ code: `const value = 1;`, fileName: "index.ts" },
+		{ code: `const value = 1;`, fileName: "index.tsx" },
+		{
+			code: `const value = 1;`,
+			fileName: "myFile.ts",
+			options: { cases: { camelCase: true } },
+		},
+		{
+			code: `const value = 1;`,
+			fileName: "MyFile.ts",
+			options: { cases: { pascalCase: true } },
+		},
+		{
+			code: `const value = 1;`,
+			fileName: "my_file.ts",
+			options: { cases: { snakeCase: true } },
+		},
+		{
+			code: `const value = 1;`,
+			fileName: "_private.ts",
+			options: { cases: { camelCase: true } },
+		},
+		{
+			code: `const value = 1;`,
+			fileName: "__setup.ts",
+			options: { cases: { camelCase: true } },
+		},
+		{
+			code: `const value = 1;`,
+			fileName: "MyComponent.ts",
+			options: { cases: { camelCase: true, pascalCase: true } },
+		},
+		{
+			code: `const value = 1;`,
+			fileName: "myComponent.ts",
+			options: { cases: { camelCase: true, pascalCase: true } },
+		},
+		{
+			code: `const value = 1;`,
+			fileName: "CHANGELOG.ts",
+			options: { ignore: ["^CHANGELOG"] },
+		},
+		{
+			code: `const value = 1;`,
+			fileName: "MyComponent.test.ts",
+			options: { cases: { pascalCase: true } },
+		},
+		{
+			code: `const value = 1;`,
+			fileName: "my-component.test-utils.ts",
+		},
+		{ code: `const value = 1;`, fileName: "file.ts" },
+		{ code: `const value = 1;`, fileName: "file.d.ts" },
+		{
+			code: `const value = 1;`,
+			fileName: "my_long_file_name.ts",
+			options: { cases: { snakeCase: true } },
+		},
+		{
+			code: `const value = 1;`,
+			fileName: "myLongFileName.ts",
+			options: { cases: { camelCase: true } },
+		},
+		{
+			code: `const value = 1;`,
+			fileName: "MyLongFileName.ts",
+			options: { cases: { pascalCase: true } },
+		},
+		{
+			code: `const value = 1;`,
+			fileName: "my-long-file-name.ts",
+		},
+		{
+			code: `const value = 1;`,
+			fileName: "___.ts",
+		},
+		{
+			code: `const value = 1;`,
+			fileName: "___private.ts",
+			options: { cases: { camelCase: true } },
+		},
+	],
+});

--- a/packages/ts/src/rules/filenameCasing.ts
+++ b/packages/ts/src/rules/filenameCasing.ts
@@ -1,0 +1,257 @@
+import { camelCase, kebabCase, pascalCase, snakeCase } from "change-case";
+import path from "node:path";
+import { z } from "zod";
+
+import { typescriptLanguage } from "../language.ts";
+import { ruleCreator } from "./ruleCreator.ts";
+
+type CaseName = "camelCase" | "kebabCase" | "pascalCase" | "snakeCase";
+
+const caseFunctions: Record<CaseName, (value: string) => string> = {
+	camelCase,
+	kebabCase,
+	pascalCase,
+	snakeCase,
+};
+
+const caseDisplayNames: Record<CaseName, string> = {
+	camelCase: "camel case",
+	kebabCase: "kebab case",
+	pascalCase: "pascal case",
+	snakeCase: "snake case",
+};
+
+const casesSchema = z
+	.object({
+		camelCase: z.boolean().optional(),
+		kebabCase: z.boolean().optional(),
+		pascalCase: z.boolean().optional(),
+		snakeCase: z.boolean().optional(),
+	})
+	.describe("Which case styles to allow. At least one should be true.");
+
+const ignoredByDefault = new Set([
+	"index.cjs",
+	"index.js",
+	"index.jsx",
+	"index.mjs",
+	"index.ts",
+	"index.tsx",
+]);
+
+interface WordPart {
+	ignored: boolean;
+	word: string;
+}
+
+function englishJoinWords(words: string[]) {
+	return new Intl.ListFormat("en-US", { type: "disjunction" }).format(words);
+}
+
+function getRenamedFilenames(
+	leading: string,
+	words: WordPart[],
+	middle: string,
+	extension: string,
+	chosenCases: CaseName[],
+): string[] {
+	const caseConverters = chosenCases.map((name) => caseFunctions[name]);
+
+	const replacements = words.map(({ ignored, word }) =>
+		ignored ? [word] : caseConverters.map((converter) => converter(word)),
+	);
+
+	const combinations: string[][] = [[]];
+	for (const options of replacements) {
+		const newCombinations: string[][] = [];
+		for (const existing of combinations) {
+			for (const option of options) {
+				newCombinations.push([...existing, option]);
+			}
+		}
+		combinations.length = 0;
+		combinations.push(...newCombinations);
+	}
+
+	const renames = new Set<string>();
+	for (const parts of combinations) {
+		renames.add(`${leading}${parts.join("")}${middle}${extension}`);
+	}
+
+	return [...renames];
+}
+
+function getWords(text: string): WordPart[] {
+	const words: WordPart[] = [];
+
+	let lastWord: undefined | WordPart;
+	for (const char of text) {
+		const isIgnored = isIgnoredChar(char);
+
+		if (lastWord?.ignored === isIgnored) {
+			lastWord.word += char;
+		} else {
+			lastWord = {
+				ignored: isIgnored,
+				word: char,
+			};
+			words.push(lastWord);
+		}
+	}
+
+	return words;
+}
+
+function isIgnoredChar(char: string) {
+	return !/^[\w-]$/iu.test(char);
+}
+
+function splitFilename(filename: string) {
+	let leading = "";
+	let index = 0;
+	while (index < filename.length && filename[index] === "_") {
+		leading += "_";
+		index++;
+	}
+	const rest = filename.slice(index);
+	return { leading, rest };
+}
+
+function validateFilename(words: WordPart[], chosenCases: CaseName[]): boolean {
+	const caseConverters = chosenCases.map((name) => caseFunctions[name]);
+	return words
+		.filter(({ ignored }) => !ignored)
+		.every(({ word }) =>
+			caseConverters.some((converter) => converter(word) === word),
+		);
+}
+
+export default ruleCreator.createRule(typescriptLanguage, {
+	about: {
+		description: "Reports filenames that do not match a consistent casing.",
+		id: "filenameCasing",
+		presets: ["stylistic"],
+	},
+	messages: {
+		invalidCase: {
+			primary: "Filename `{{basename}}` does not match {{chosenCasesDisplay}}.",
+			secondary: [
+				"Consistent filename casing makes files easier to find and helps avoid cross-platform issues with case-sensitive file systems.",
+			],
+			suggestions: ["Rename to one of: {{renamedFilenames}}."],
+		},
+		invalidExtension: {
+			primary: "File extension `{{extension}}` should be lowercase.",
+			secondary: [
+				"Uppercase file extensions are unconventional and can cause issues on case-sensitive file systems.",
+			],
+			suggestions: ["Rename to `{{basename}}`"],
+		},
+	},
+	options: {
+		cases: casesSchema.default({ kebabCase: true }),
+		ignore: z
+			.array(z.string())
+			.default([])
+			.describe("Regex patterns for filenames to ignore."),
+		multipleFileExtensions: z
+			.boolean()
+			.default(true)
+			.describe(
+				"Whether to treat parts after the first `.` as extensions (e.g., `.test.ts`).",
+			),
+	},
+	setup(context) {
+		return {
+			visitors: {
+				SourceFile: (node, { options }) => {
+					const fileName = node.fileName;
+					const basename = path.basename(fileName);
+					const extension = path.extname(basename);
+					const filenameWithoutExtension = path.basename(basename, extension);
+
+					if (ignoredByDefault.has(basename)) {
+						return;
+					}
+
+					for (const pattern of options.ignore) {
+						if (new RegExp(pattern, "u").test(basename)) {
+							return;
+						}
+					}
+
+					if (extension && extension !== extension.toLowerCase()) {
+						context.report({
+							data: {
+								basename: filenameWithoutExtension + extension.toLowerCase(),
+								extension,
+							},
+							message: "invalidExtension",
+							range: { begin: 0, end: 0 },
+						});
+						return;
+					}
+
+					let filename: string;
+					let middle: string;
+
+					if (options.multipleFileExtensions) {
+						const firstDot = filenameWithoutExtension.indexOf(".");
+						if (firstDot === -1) {
+							filename = filenameWithoutExtension;
+							middle = "";
+						} else {
+							filename = filenameWithoutExtension.slice(0, firstDot);
+							middle = filenameWithoutExtension.slice(firstDot);
+						}
+					} else {
+						filename = filenameWithoutExtension;
+						middle = "";
+					}
+
+					const chosenCases = (
+						Object.entries(options.cases) as [CaseName, boolean | undefined][]
+					)
+						.filter(([, enabled]) => enabled)
+						.map(([name]) => name);
+
+					if (chosenCases.length === 0) {
+						chosenCases.push("kebabCase");
+					}
+
+					const { leading, rest } = splitFilename(filename);
+					const words = getWords(rest);
+
+					if (validateFilename(words, chosenCases)) {
+						return;
+					}
+
+					const renamedFilenames = getRenamedFilenames(
+						leading,
+						words,
+						middle,
+						extension,
+						chosenCases,
+					);
+
+					const chosenCasesDisplay = englishJoinWords(
+						chosenCases.map((name) => caseDisplayNames[name]),
+					);
+
+					context.report({
+						data: {
+							basename,
+							chosenCasesDisplay,
+							renamedFilenames: renamedFilenames
+								.slice(0, 3)
+								.map((name) => `\`${name}\``)
+								.join(", "),
+						},
+						message: "invalidCase",
+						range: { begin: 0, end: 0 },
+					});
+				},
+			},
+		};
+	},
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -676,6 +676,9 @@ importers:
       cached-factory:
         specifier: ^0.1.0
         version: 0.1.0
+      change-case:
+        specifier: ^5.4.4
+        version: 5.4.4
       debug-for-file:
         specifier: ^0.2.0
         version: 0.2.0


### PR DESCRIPTION
## Overview

Implements the `filenameCasing` rule for the TypeScript plugin. This rule reports filenames that do not match a consistent casing style, helping maintain consistency across projects.

## Features

- **Case styles**: camelCase, kebabCase (default), pascalCase, snakeCase
- **Multiple cases**: Can allow multiple case styles simultaneously  
- **Ignore patterns**: Regex patterns for files to skip
- **Multiple extensions**: Handles files like `.test.ts` by only validating the first part

Equivalent to:
- ESLint: `unicorn/filename-case`
- Biome: `useFilenamingConvention`
- Oxlint: `unicorn/filename-case`

## Checklist

- [x] Rule implementation
- [x] Unit tests
- [x] Documentation  
- [x] Updated comparisons data
- [x] Added to plugin

Closes #1579