### PR TITLE
feat: implement exportDefault for TypeScript plugin

### DIFF
--- a/packages/comparisons/src/data.json
+++ b/packages/comparisons/src/data.json
@@ -10115,7 +10115,7 @@
 		"flint": {
 			"name": "exportDefault",
 			"plugin": "ts",
-			"status": "skipped"
+			"status": "implemented"
 		},
 		"oxlint": [
 			{

--- a/packages/site/src/content/docs/rules/ts/exportDefault.mdx
+++ b/packages/site/src/content/docs/rules/ts/exportDefault.mdx
@@ -1,0 +1,81 @@
+---
+description: "Reports modules that have only one named export but no default export."
+title: "exportDefault"
+topic: "rules"
+---
+
+import { Tabs, TabItem } from "@astrojs/starlight/components";
+import { RuleEquivalents } from "~/components/RuleEquivalents";
+import RuleSummary from "~/components/RuleSummary.astro";
+
+<RuleSummary plugin="ts" rule="exportDefault" />
+
+When a module has only one export, using a default export can make imports more concise and readable.
+This rule encourages using default exports for single-export modules, which can help standardize module structure across a codebase.
+
+## Examples
+
+<Tabs>
+<TabItem label="❌ Incorrect">
+
+```ts
+export const value = 1;
+```
+
+```ts
+export function getValue() {
+	return 1;
+}
+```
+
+</TabItem>
+<TabItem label="✅ Correct">
+
+```ts
+export default 1;
+```
+
+```ts
+export default function getValue() {
+	return 1;
+}
+```
+
+```ts
+export const a = 1;
+export const b = 2;
+```
+
+</TabItem>
+</Tabs>
+
+## Options
+
+### `target`
+
+Configuration option to specify the target type for preferring default exports.
+
+- `"single"` (default): Prefer default export when there is only one export in the module.
+- `"any"`: Prefer default export in any module that has exports.
+
+```ts
+ts.rules({
+	exportDefault: {
+		target: "any",
+	},
+});
+```
+
+## When Not To Use It
+
+If your project uses a style guide that prefers named exports for consistency or to support tree-shaking, you may not want this rule.
+Some teams prefer named exports because they enforce consistent import names and make refactoring easier.
+
+## Further Reading
+
+- [MDN: export](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/export)
+- [TypeScript handbook: Modules](https://www.typescriptlang.org/docs/handbook/modules.html)
+
+## Equivalents in Other Linters
+
+<RuleEquivalents pluginId="ts" ruleId="exportDefault" />

--- a/packages/ts/src/plugin.ts
+++ b/packages/ts/src/plugin.ts
@@ -59,6 +59,7 @@ import emptyBlocks from "./rules/emptyBlocks.ts";
 import emptyDestructures from "./rules/emptyDestructures.ts";
 import emptyStaticBlocks from "./rules/emptyStaticBlocks.ts";
 import exceptionAssignments from "./rules/exceptionAssignments.ts";
+import exportDefault from "./rules/exportDefault.ts";
 import fetchMethodBodies from "./rules/fetchMethodBodies.ts";
 import finallyStatementSafety from "./rules/finallyStatementSafety.ts";
 import forDirections from "./rules/forDirections.ts";
@@ -168,6 +169,7 @@ export const ts = createPlugin({
 		emptyDestructures,
 		emptyStaticBlocks,
 		exceptionAssignments,
+		exportDefault,
 		fetchMethodBodies,
 		finallyStatementSafety,
 		forDirections,

--- a/packages/ts/src/rules/exportDefault.test.ts
+++ b/packages/ts/src/rules/exportDefault.test.ts
@@ -1,0 +1,79 @@
+import rule from "./exportDefault.ts";
+import { ruleTester } from "./ruleTester.ts";
+
+ruleTester.describe(rule, {
+	invalid: [
+		{
+			code: `
+export const value = 1;
+`,
+			snapshot: `
+export const value = 1;
+             ~~~~~~~~~
+             A single named export was found. Prefer using a default export when there is only one export.
+`,
+		},
+		{
+			code: `
+export function getValue() {
+    return 1;
+}
+`,
+			snapshot: `
+export function getValue() {
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+A single named export was found. Prefer using a default export when there is only one export.
+    return 1;
+    ~~~~~~~~~
+}
+~
+`,
+		},
+		{
+			code: `
+export class Example {}
+`,
+			snapshot: `
+export class Example {}
+~~~~~~~~~~~~~~~~~~~~~~~
+A single named export was found. Prefer using a default export when there is only one export.
+`,
+		},
+		{
+			code: `
+export { value };
+const value = 1;
+`,
+			snapshot: `
+export { value };
+         ~~~~~
+         A single named export was found. Prefer using a default export when there is only one export.
+const value = 1;
+`,
+		},
+		{
+			code: `
+export const value = 1;
+export const other = 2;
+`,
+			options: { target: "any" },
+			snapshot: `
+export const value = 1;
+             ~~~~~~~~~
+             A single named export was found. Prefer using a default export when there is only one export.
+export const other = 2;
+`,
+		},
+	],
+	valid: [
+		`export default function getValue() { return 1; }`,
+		`export default class Example {}`,
+		`export default 42;`,
+		`export const a = 1; export const b = 2;`,
+		`export function a() {} export function b() {}`,
+		`export type MyType = string;`,
+		`export interface MyInterface {}`,
+		`export { value }; export default other;`,
+		`// no exports`,
+	],
+});

--- a/packages/ts/src/rules/exportDefault.ts
+++ b/packages/ts/src/rules/exportDefault.ts
@@ -1,0 +1,140 @@
+import ts, { SyntaxKind } from "typescript";
+import { z } from "zod";
+
+import { getTSNodeRange } from "../getTSNodeRange.ts";
+import { typescriptLanguage } from "../language.ts";
+import { ruleCreator } from "./ruleCreator.ts";
+
+function hasDefaultModifier(
+	modifiers: ts.NodeArray<ts.ModifierLike> | undefined,
+) {
+	return modifiers?.some((mod) => mod.kind === SyntaxKind.DefaultKeyword);
+}
+
+function hasExportModifier(
+	modifiers: ts.NodeArray<ts.ModifierLike> | undefined,
+) {
+	return modifiers?.some((mod) => mod.kind === SyntaxKind.ExportKeyword);
+}
+
+export default ruleCreator.createRule(typescriptLanguage, {
+	about: {
+		description:
+			"Reports modules that have only one named export but no default export.",
+		id: "exportDefault",
+		presets: ["stylistic"],
+	},
+	messages: {
+		preferDefault: {
+			primary:
+				"A single named export was found. Prefer using a default export when there is only one export.",
+			secondary: [
+				"When a module has only one export, using a default export can make imports more concise.",
+			],
+			suggestions: [
+				"Add `default` to the export, or use `export default` with the value.",
+			],
+		},
+	},
+	options: {
+		target: z
+			.enum(["single", "any"])
+			.default("single")
+			.describe(
+				'When "single", only flags modules with exactly one export. When "any", flags any module without a default export.',
+			),
+	},
+	setup(context) {
+		return {
+			visitors: {
+				SourceFile: (sourceFile, { options: { target } }) => {
+					let hasDefaultExport = false;
+					const namedExports: ts.Node[] = [];
+
+					for (const statement of sourceFile.statements) {
+						switch (statement.kind) {
+							case SyntaxKind.ClassDeclaration:
+							case SyntaxKind.FunctionDeclaration: {
+								const decl = statement as
+									| ts.ClassDeclaration
+									| ts.FunctionDeclaration;
+								if (hasExportModifier(decl.modifiers)) {
+									if (hasDefaultModifier(decl.modifiers)) {
+										hasDefaultExport = true;
+									} else {
+										namedExports.push(decl);
+									}
+								}
+								break;
+							}
+
+							case SyntaxKind.EnumDeclaration:
+							case SyntaxKind.InterfaceDeclaration:
+							case SyntaxKind.TypeAliasDeclaration: {
+								break;
+							}
+
+							case SyntaxKind.ExportAssignment:
+								if (!statement.isExportEquals) {
+									hasDefaultExport = true;
+								}
+								break;
+
+							case SyntaxKind.ExportDeclaration: {
+								const exportDecl = statement as ts.ExportDeclaration;
+								if (exportDecl.exportClause) {
+									if (ts.isNamespaceExport(exportDecl.exportClause)) {
+										namedExports.push(exportDecl);
+									} else if (ts.isNamedExports(exportDecl.exportClause)) {
+										if (exportDecl.isTypeOnly) {
+											continue;
+										}
+										for (const specifier of exportDecl.exportClause.elements) {
+											if (specifier.isTypeOnly) {
+												continue;
+											}
+											namedExports.push(specifier);
+										}
+									}
+								}
+								break;
+							}
+
+							case SyntaxKind.VariableStatement: {
+								const varStmt = statement as ts.VariableStatement;
+								if (hasExportModifier(varStmt.modifiers)) {
+									for (const decl of varStmt.declarationList.declarations) {
+										namedExports.push(decl);
+									}
+								}
+								break;
+							}
+						}
+					}
+
+					if (hasDefaultExport) {
+						return;
+					}
+
+					if (namedExports.length === 0) {
+						return;
+					}
+
+					if (target === "single" && namedExports.length !== 1) {
+						return;
+					}
+
+					const firstExport = namedExports[0];
+					if (!firstExport) {
+						return;
+					}
+
+					context.report({
+						message: "preferDefault",
+						range: getTSNodeRange(firstExport, sourceFile),
+					});
+				},
+			},
+		};
+	},
+});


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #1574
- [x] That issue was marked as [`status: accepting prs`](https://github.com/flint-fyi/flint/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/flint-fyi/flint/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Implements the `exportDefault` rule for the TypeScript plugin, which reports modules that have only one named export but no default export.

Includes a `target` option:
- `"single"` (default): Only flags modules with exactly one export
- `"any"`: Flags any module without a default export