### PR TITLE
feat: implement exportGroups for TypeScript plugin

### DIFF
--- a/packages/comparisons/src/data.json
+++ b/packages/comparisons/src/data.json
@@ -10153,7 +10153,7 @@
 		"flint": {
 			"name": "exportGroups",
 			"plugin": "ts",
-			"status": "skipped"
+			"status": "implemented"
 		},
 		"oxlint": [
 			{

--- a/packages/site/src/content/docs/rules/ts/exportGroups.mdx
+++ b/packages/site/src/content/docs/rules/ts/exportGroups.mdx
@@ -1,0 +1,72 @@
+---
+description: "Reports when named exports are not grouped together in a single export statement."
+title: "exportGroups"
+topic: "rules"
+---
+
+import { Tabs, TabItem } from "@astrojs/starlight/components";
+import { RuleEquivalents } from "~/components/RuleEquivalents";
+import RuleSummary from "~/components/RuleSummary.astro";
+
+<RuleSummary plugin="ts" rule="exportGroups" />
+
+Having exports scattered across a file makes it harder to see what a module provides at a glance.
+This rule encourages grouping all named exports in a single `export { ... }` statement, improving readability and maintainability.
+
+## Examples
+
+<Tabs>
+<TabItem label="❌ Incorrect">
+
+```ts
+export const a = 1;
+export const b = 2;
+```
+
+```ts
+export function getValue() {
+	return 1;
+}
+export function getOther() {
+	return 2;
+}
+```
+
+</TabItem>
+<TabItem label="✅ Correct">
+
+```ts
+const a = 1;
+const b = 2;
+export { a, b };
+```
+
+```ts
+function getValue() {
+	return 1;
+}
+function getOther() {
+	return 2;
+}
+export { getValue, getOther };
+```
+
+</TabItem>
+</Tabs>
+
+## Options
+
+This rule is not configurable.
+
+## When Not To Use It
+
+If you prefer declaring exports inline with their definitions for better locality, you may not want this rule.
+Some projects prefer inline exports to make it immediately clear what is exported when reading the definition.
+
+## Further Reading
+
+- [MDN: export](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/export)
+
+## Equivalents in Other Linters
+
+<RuleEquivalents pluginId="ts" ruleId="exportGroups" />

--- a/packages/ts/src/plugin.ts
+++ b/packages/ts/src/plugin.ts
@@ -59,6 +59,7 @@ import emptyBlocks from "./rules/emptyBlocks.ts";
 import emptyDestructures from "./rules/emptyDestructures.ts";
 import emptyStaticBlocks from "./rules/emptyStaticBlocks.ts";
 import exceptionAssignments from "./rules/exceptionAssignments.ts";
+import exportGroups from "./rules/exportGroups.ts";
 import fetchMethodBodies from "./rules/fetchMethodBodies.ts";
 import finallyStatementSafety from "./rules/finallyStatementSafety.ts";
 import forDirections from "./rules/forDirections.ts";
@@ -168,6 +169,7 @@ export const ts = createPlugin({
 		emptyDestructures,
 		emptyStaticBlocks,
 		exceptionAssignments,
+		exportGroups,
 		fetchMethodBodies,
 		finallyStatementSafety,
 		forDirections,

--- a/packages/ts/src/rules/exportGroups.test.ts
+++ b/packages/ts/src/rules/exportGroups.test.ts
@@ -1,0 +1,54 @@
+import rule from "./exportGroups.ts";
+import { ruleTester } from "./ruleTester.ts";
+
+ruleTester.describe(rule, {
+	invalid: [
+		{
+			code: `
+export const a = 1;
+export const b = 2;
+`,
+			snapshot: `
+export const a = 1;
+export const b = 2;
+~~~~~~~~~~~~~~~~~~~
+Multiple named exports found. Group all named exports in a single export statement.
+`,
+		},
+		{
+			code: `
+export function getValue() { return 1; }
+export function getOther() { return 2; }
+`,
+			snapshot: `
+export function getValue() { return 1; }
+export function getOther() { return 2; }
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Multiple named exports found. Group all named exports in a single export statement.
+`,
+		},
+		{
+			code: `
+const a = 1;
+const b = 2;
+export { a };
+export { b };
+`,
+			snapshot: `
+const a = 1;
+const b = 2;
+export { a };
+export { b };
+~~~~~~~~~~~~~
+Multiple named exports found. Group all named exports in a single export statement.
+`,
+		},
+	],
+	valid: [
+		`export const value = 1;`,
+		`const a = 1; const b = 2; export { a, b };`,
+		`export default function getValue() { return 1; }`,
+		`export type MyType = string;`,
+		`export { value } from './other';`,
+	],
+});

--- a/packages/ts/src/rules/exportGroups.ts
+++ b/packages/ts/src/rules/exportGroups.ts
@@ -1,0 +1,101 @@
+import ts, { SyntaxKind } from "typescript";
+
+import { getTSNodeRange } from "../getTSNodeRange.ts";
+import { typescriptLanguage } from "../language.ts";
+import { ruleCreator } from "./ruleCreator.ts";
+
+function hasDefaultModifier(
+	modifiers: ts.NodeArray<ts.ModifierLike> | undefined,
+) {
+	return modifiers?.some((mod) => mod.kind === SyntaxKind.DefaultKeyword);
+}
+
+function hasExportModifier(
+	modifiers: ts.NodeArray<ts.ModifierLike> | undefined,
+) {
+	return modifiers?.some((mod) => mod.kind === SyntaxKind.ExportKeyword);
+}
+
+export default ruleCreator.createRule(typescriptLanguage, {
+	about: {
+		description:
+			"Reports when named exports are not grouped together in a single export statement.",
+		id: "exportGroups",
+		presets: ["stylistic"],
+	},
+	messages: {
+		groupExports: {
+			primary:
+				"Multiple named exports found. Group all named exports in a single export statement.",
+			secondary: [
+				"Having exports scattered across a file makes it harder to see what a module provides.",
+				"Grouping all named exports in one place improves readability.",
+			],
+			suggestions: [
+				"Move all named exports to a single `export { ... }` statement at the end of the file.",
+			],
+		},
+	},
+	setup(context) {
+		return {
+			visitors: {
+				SourceFile: (sourceFile) => {
+					const exportStatements: ts.Node[] = [];
+
+					for (const statement of sourceFile.statements) {
+						switch (statement.kind) {
+							case SyntaxKind.ClassDeclaration:
+							case SyntaxKind.FunctionDeclaration: {
+								const decl = statement as
+									| ts.ClassDeclaration
+									| ts.FunctionDeclaration;
+								if (
+									hasExportModifier(decl.modifiers) &&
+									!hasDefaultModifier(decl.modifiers)
+								) {
+									exportStatements.push(decl);
+								}
+								break;
+							}
+
+							case SyntaxKind.ExportDeclaration: {
+								const exportDecl = statement as ts.ExportDeclaration;
+								if (
+									exportDecl.exportClause &&
+									ts.isNamedExports(exportDecl.exportClause) &&
+									!exportDecl.moduleSpecifier &&
+									!exportDecl.isTypeOnly
+								) {
+									exportStatements.push(exportDecl);
+								}
+								break;
+							}
+
+							case SyntaxKind.VariableStatement: {
+								const varStmt = statement as ts.VariableStatement;
+								if (hasExportModifier(varStmt.modifiers)) {
+									exportStatements.push(varStmt);
+								}
+								break;
+							}
+						}
+					}
+
+					if (exportStatements.length <= 1) {
+						return;
+					}
+
+					const firstExport = exportStatements[1];
+					if (!firstExport) {
+						return;
+					}
+
+					context.report({
+						message: "groupExports",
+						range: getTSNodeRange(firstExport, sourceFile),
+					});
+				},
+			},
+		};
+	},
+});


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #1575
- [x] That issue was marked as [`status: accepting prs`](https://github.com/flint-fyi/flint/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/flint-fyi/flint/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Implements the `exportGroups` rule for the TypeScript plugin, which reports when named exports are not grouped together in a single export statement.