### PR TITLE
feat: implement exportLast for TypeScript plugin

### DIFF
--- a/packages/comparisons/src/data.json
+++ b/packages/comparisons/src/data.json
@@ -10172,7 +10172,7 @@
 		"flint": {
 			"name": "exportLast",
 			"plugin": "ts",
-			"status": "skipped"
+			"status": "implemented"
 		},
 		"oxlint": [
 			{

--- a/packages/site/src/content/docs/rules/ts/exportLast.mdx
+++ b/packages/site/src/content/docs/rules/ts/exportLast.mdx
@@ -1,0 +1,68 @@
+---
+description: "Reports export declarations that come before non-export statements."
+title: "exportLast"
+topic: "rules"
+---
+
+import { Tabs, TabItem } from "@astrojs/starlight/components";
+import { RuleEquivalents } from "~/components/RuleEquivalents";
+import RuleSummary from "~/components/RuleSummary.astro";
+
+<RuleSummary plugin="ts" rule="exportLast" />
+
+Exports scattered throughout a file make it harder to see what a module provides at a glance.
+This rule enforces that all exports are declared at the bottom of the file, improving code readability.
+
+## Examples
+
+<Tabs>
+<TabItem label="❌ Incorrect">
+
+```ts
+export const a = 1;
+const b = 2;
+```
+
+```ts
+export function getValue() {
+	return 1;
+}
+const value = 2;
+```
+
+</TabItem>
+<TabItem label="✅ Correct">
+
+```ts
+const a = 1;
+const b = 2;
+export { a };
+```
+
+```ts
+function getValue() {
+	return 1;
+}
+const value = 2;
+export { getValue, value };
+```
+
+</TabItem>
+</Tabs>
+
+## Options
+
+This rule is not configurable.
+
+## When Not To Use It
+
+If you prefer declaring exports inline with their definitions for better locality, you may not want this rule.
+Some projects prefer inline exports to make it immediately clear what is exported when reading the definition.
+
+## Further Reading
+
+- [MDN: export](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/export)
+
+## Equivalents in Other Linters
+
+<RuleEquivalents pluginId="ts" ruleId="exportLast" />

--- a/packages/ts/src/plugin.ts
+++ b/packages/ts/src/plugin.ts
@@ -59,6 +59,7 @@ import emptyBlocks from "./rules/emptyBlocks.ts";
 import emptyDestructures from "./rules/emptyDestructures.ts";
 import emptyStaticBlocks from "./rules/emptyStaticBlocks.ts";
 import exceptionAssignments from "./rules/exceptionAssignments.ts";
+import exportLast from "./rules/exportLast.ts";
 import fetchMethodBodies from "./rules/fetchMethodBodies.ts";
 import finallyStatementSafety from "./rules/finallyStatementSafety.ts";
 import forDirections from "./rules/forDirections.ts";
@@ -168,6 +169,7 @@ export const ts = createPlugin({
 		emptyDestructures,
 		emptyStaticBlocks,
 		exceptionAssignments,
+		exportLast,
 		fetchMethodBodies,
 		finallyStatementSafety,
 		forDirections,

--- a/packages/ts/src/rules/exportLast.test.ts
+++ b/packages/ts/src/rules/exportLast.test.ts
@@ -1,0 +1,55 @@
+import rule from "./exportLast.ts";
+import { ruleTester } from "./ruleTester.ts";
+
+ruleTester.describe(rule, {
+	invalid: [
+		{
+			code: `
+export const a = 1;
+const b = 2;
+`,
+			snapshot: `
+export const a = 1;
+~~~~~~~~~~~~~~~~~~~
+Export statement should be at the end of the file.
+const b = 2;
+`,
+		},
+		{
+			code: `
+export function getValue() { return 1; }
+const value = 2;
+export const other = 3;
+`,
+			snapshot: `
+export function getValue() { return 1; }
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Export statement should be at the end of the file.
+const value = 2;
+export const other = 3;
+`,
+		},
+		{
+			code: `
+const a = 1;
+export { a };
+const b = 2;
+`,
+			snapshot: `
+const a = 1;
+export { a };
+~~~~~~~~~~~~~
+Export statement should be at the end of the file.
+const b = 2;
+`,
+		},
+	],
+	valid: [
+		`const a = 1; export { a };`,
+		`const a = 1; const b = 2; export { a, b };`,
+		`const value = 1; export default value;`,
+		`function getValue() { return 1; } export { getValue };`,
+		`export const a = 1;`,
+		`export default function getValue() { return 1; }`,
+	],
+});

--- a/packages/ts/src/rules/exportLast.ts
+++ b/packages/ts/src/rules/exportLast.ts
@@ -1,0 +1,86 @@
+import ts, { SyntaxKind } from "typescript";
+
+import { getTSNodeRange } from "../getTSNodeRange.ts";
+import { typescriptLanguage } from "../language.ts";
+import { ruleCreator } from "./ruleCreator.ts";
+
+function hasExportModifier(
+	modifiers: ts.NodeArray<ts.ModifierLike> | undefined,
+) {
+	return modifiers?.some((mod) => mod.kind === SyntaxKind.ExportKeyword);
+}
+
+function isExportStatement(statement: ts.Statement) {
+	switch (statement.kind) {
+		case SyntaxKind.ClassDeclaration:
+		case SyntaxKind.FunctionDeclaration: {
+			const decl = statement as ts.ClassDeclaration | ts.FunctionDeclaration;
+			return hasExportModifier(decl.modifiers);
+		}
+
+		case SyntaxKind.ExportAssignment:
+		case SyntaxKind.ExportDeclaration:
+			return true;
+
+		case SyntaxKind.VariableStatement: {
+			const varStmt = statement as ts.VariableStatement;
+			return hasExportModifier(varStmt.modifiers);
+		}
+
+		default:
+			return false;
+	}
+}
+
+export default ruleCreator.createRule(typescriptLanguage, {
+	about: {
+		description:
+			"Reports export declarations that come before non-export statements.",
+		id: "exportLast",
+		presets: ["stylistic"],
+	},
+	messages: {
+		exportLast: {
+			primary: "Export statement should be at the end of the file.",
+			secondary: [
+				"Exports scattered throughout the file make it harder to see what a module provides.",
+				"Moving all exports to the end of the file improves code readability.",
+			],
+			suggestions: ["Move this export to the end of the file."],
+		},
+	},
+	setup(context) {
+		return {
+			visitors: {
+				SourceFile: (sourceFile) => {
+					let lastNonExportIndex = -1;
+
+					for (let i = sourceFile.statements.length - 1; i >= 0; i--) {
+						const statement = sourceFile.statements[i];
+						if (!statement || isExportStatement(statement)) {
+							continue;
+						}
+						lastNonExportIndex = i;
+						break;
+					}
+
+					if (lastNonExportIndex === -1) {
+						return;
+					}
+
+					for (let i = 0; i < lastNonExportIndex; i++) {
+						const statement = sourceFile.statements[i];
+						if (!statement || !isExportStatement(statement)) {
+							continue;
+						}
+
+						context.report({
+							message: "exportLast",
+							range: getTSNodeRange(statement, sourceFile),
+						});
+					}
+				},
+			},
+		};
+	},
+});


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #1576
- [x] That issue was marked as [`status: accepting prs`](https://github.com/flint-fyi/flint/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/flint-fyi/flint/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Implements the `exportLast` rule for the TypeScript plugin, which reports export declarations that come before non-export statements. Encourages moving all exports to the end of the file for better readability.