### PR TITLE
feat: implement irregularWhitespace rule for YAML plugin

### DIFF
--- a/packages/comparisons/src/data.json
+++ b/packages/comparisons/src/data.json
@@ -21555,7 +21555,8 @@
 		"flint": {
 			"name": "irregularWhitespace",
 			"plugin": "yaml",
-			"preset": "stylistic"
+			"preset": "logical",
+			"status": "implemented"
 		}
 	},
 	{

--- a/packages/site/src/content/docs/rules/yaml/irregularWhitespace.mdx
+++ b/packages/site/src/content/docs/rules/yaml/irregularWhitespace.mdx
@@ -1,0 +1,69 @@
+---
+description: "Reports irregular whitespace characters."
+title: "irregularWhitespace"
+topic: "rules"
+---
+
+import { Tabs, TabItem } from "@astrojs/starlight/components";
+import { RuleEquivalents } from "~/components/RuleEquivalents";
+import RuleSummary from "~/components/RuleSummary.astro";
+
+<RuleSummary plugin="yaml" rule="irregularWhitespace" />
+
+Irregular whitespace characters like non-breaking spaces, zero-width spaces, or other Unicode whitespace characters can cause parsing issues or debugging difficulties.
+These characters are often invisible and can be accidentally introduced when copying text from other sources.
+
+## Examples
+
+<Tabs>
+<TabItem label="❌ Incorrect">
+
+```yaml
+# Contains non-breaking space (U+00A0) after the colon
+key: value
+```
+
+</TabItem>
+<TabItem label="✅ Correct">
+
+```yaml
+key: value
+```
+
+</TabItem>
+</Tabs>
+
+## Irregular Characters Detected
+
+This rule detects the following characters:
+
+- Vertical tab (`\v`, U+000B)
+- Form feed (`\f`, U+000C)
+- Next line (U+0085)
+- Non-breaking space (U+00A0)
+- Ogham space mark (U+1680)
+- Mongolian vowel separator (U+180E)
+- En quad through hair space (U+2000-U+200B)
+- Line separator (U+2028)
+- Paragraph separator (U+2029)
+- Narrow no-break space (U+202F)
+- Medium mathematical space (U+205F)
+- Ideographic space (U+3000)
+- Byte order mark (U+FEFF)
+
+## Options
+
+This rule is not configurable.
+
+## When Not To Use It
+
+If your YAML files intentionally contain special Unicode whitespace characters for specific purposes, you may not need this rule.
+
+## Further Reading
+
+- [ESLint no-irregular-whitespace](https://eslint.org/docs/rules/no-irregular-whitespace)
+- [Unicode Character Categories - Space Separator](https://www.unicode.org/reports/tr44/)
+
+## Equivalents in Other Linters
+
+<RuleEquivalents pluginId="yaml" ruleId="irregularWhitespace" />

--- a/packages/yaml/src/plugin.ts
+++ b/packages/yaml/src/plugin.ts
@@ -4,11 +4,18 @@ import blockMappings from "./rules/blockMappings.ts";
 import blockSequences from "./rules/blockSequences.ts";
 import emptyDocuments from "./rules/emptyDocuments.ts";
 import emptyMappingKeys from "./rules/emptyMappingKeys.ts";
+import irregularWhitespace from "./rules/irregularWhitespace.ts";
 
 export const yaml = createPlugin({
 	files: {
 		all: ["**/*.{yaml,yml}"],
 	},
 	name: "YAML",
-	rules: [blockMappings, blockSequences, emptyDocuments, emptyMappingKeys],
+	rules: [
+		blockMappings,
+		blockSequences,
+		emptyDocuments,
+		emptyMappingKeys,
+		irregularWhitespace,
+	],
 });

--- a/packages/yaml/src/rules/irregularWhitespace.test.ts
+++ b/packages/yaml/src/rules/irregularWhitespace.test.ts
@@ -1,0 +1,29 @@
+import rule from "./irregularWhitespace.ts";
+import { ruleTester } from "./ruleTester.ts";
+
+ruleTester.describe(rule, {
+	invalid: [
+		{
+			code: `key:\u00a0value`,
+			snapshot: `key:\u00a0value
+    ~
+    Irregular whitespace character found.`,
+		},
+		{
+			code: `name:\u2003test`,
+			snapshot: `name:\u2003test
+     ~
+     Irregular whitespace character found.`,
+		},
+		{
+			code: `a:\u00a0b\nc:\u00a0d`,
+			snapshot: `a:\u00a0b
+  ~
+  Irregular whitespace character found.
+c:\u00a0d
+  ~
+  Irregular whitespace character found.`,
+		},
+	],
+	valid: [`key: value`, `name: test`, `multi:\n  line: value`],
+});

--- a/packages/yaml/src/rules/irregularWhitespace.ts
+++ b/packages/yaml/src/rules/irregularWhitespace.ts
@@ -1,0 +1,55 @@
+import { yamlLanguage } from "../language.ts";
+import { ruleCreator } from "./ruleCreator.ts";
+
+const IRREGULAR_WHITESPACE =
+	/[\v\f\u0085\u00a0\u1680\u180e\u2000-\u200b\u202f\u205f\u3000\ufeff]/gu;
+const IRREGULAR_LINE_TERMINATORS = /[\u2028\u2029]/gu;
+
+export default ruleCreator.createRule(yamlLanguage, {
+	about: {
+		description: "Reports irregular whitespace characters.",
+		id: "irregularWhitespace",
+		presets: ["logical"],
+	},
+	messages: {
+		irregularWhitespace: {
+			primary: "Irregular whitespace character found.",
+			secondary: [
+				"Irregular whitespace characters like non-breaking spaces or zero-width spaces can cause parsing issues or debugging difficulties.",
+				"These characters are often invisible and can be accidentally introduced when copying text from other sources.",
+			],
+			suggestions: ["Replace the irregular whitespace with a regular space."],
+		},
+	},
+	setup(context) {
+		return {
+			visitors: {
+				root: (node, { sourceText }) => {
+					let match;
+
+					while ((match = IRREGULAR_WHITESPACE.exec(sourceText)) !== null) {
+						context.report({
+							message: "irregularWhitespace",
+							range: {
+								begin: match.index,
+								end: match.index + match[0].length,
+							},
+						});
+					}
+
+					while (
+						(match = IRREGULAR_LINE_TERMINATORS.exec(sourceText)) !== null
+					) {
+						context.report({
+							message: "irregularWhitespace",
+							range: {
+								begin: match.index,
+								end: match.index + match[0].length,
+							},
+						});
+					}
+				},
+			},
+		};
+	},
+});


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #696
- [x] That issue was marked as [`status: accepting prs`](https://github.com/flint-fyi/flint/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/flint-fyi/flint/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Implements the `irregularWhitespace` rule for the YAML plugin. This rule detects irregular whitespace characters like non-breaking spaces, zero-width spaces, and other Unicode whitespace that can cause parsing issues or debugging difficulties.

Equivalent to [`yml/no-irregular-whitespace`](https://ota-meshi.github.io/eslint-plugin-yml/rules/no-irregular-whitespace.html) from eslint-plugin-yml.