### PR TITLE
feat: implement mappingKeyCasing rule for YAML plugin

### DIFF
--- a/packages/comparisons/src/data.json
+++ b/packages/comparisons/src/data.json
@@ -21570,7 +21570,9 @@
 		"flint": {
 			"name": "mappingKeyCasing",
 			"plugin": "yaml",
-			"status": "skipped"
+			"preset": "stylistic",
+			"status": "implemented",
+			"strictness": "strict"
 		}
 	},
 	{

--- a/packages/site/src/content/docs/rules/yaml/mappingKeyCasing.mdx
+++ b/packages/site/src/content/docs/rules/yaml/mappingKeyCasing.mdx
@@ -1,0 +1,66 @@
+---
+description: "Enforces consistent casing for mapping keys."
+title: "mappingKeyCasing"
+topic: "rules"
+---
+
+import { Tabs, TabItem } from "@astrojs/starlight/components";
+import { RuleEquivalents } from "~/components/RuleEquivalents";
+import RuleSummary from "~/components/RuleSummary.astro";
+
+<RuleSummary plugin="yaml" rule="mappingKeyCasing" />
+
+Using consistent casing for mapping keys improves readability and maintainability.
+This rule enforces snake_case for all mapping keys, which is a common convention for YAML configuration files.
+
+## Examples
+
+<Tabs>
+<TabItem label="❌ Incorrect">
+
+```yaml
+camelCase: value
+```
+
+```yaml
+PascalCase: value
+```
+
+```yaml
+kebab-case: value
+```
+
+</TabItem>
+<TabItem label="✅ Correct">
+
+```yaml
+snake_case: value
+```
+
+```yaml
+simple: value
+```
+
+```yaml
+multi_word_key: value
+```
+
+</TabItem>
+</Tabs>
+
+## Options
+
+This rule is not configurable.
+
+## When Not To Use It
+
+If your project uses a different naming convention for YAML keys, such as camelCase or kebab-case, you may not need this rule.
+Projects that integrate with systems requiring specific key naming patterns may also choose to disable this rule.
+
+## Further Reading
+
+- [YAML Specification - Mapping](https://yaml.org/spec/1.2.2/#mapping)
+
+## Equivalents in Other Linters
+
+<RuleEquivalents pluginId="yaml" ruleId="mappingKeyCasing" />

--- a/packages/yaml/src/plugin.ts
+++ b/packages/yaml/src/plugin.ts
@@ -4,11 +4,18 @@ import blockMappings from "./rules/blockMappings.ts";
 import blockSequences from "./rules/blockSequences.ts";
 import emptyDocuments from "./rules/emptyDocuments.ts";
 import emptyMappingKeys from "./rules/emptyMappingKeys.ts";
+import mappingKeyCasing from "./rules/mappingKeyCasing.ts";
 
 export const yaml = createPlugin({
 	files: {
 		all: ["**/*.{yaml,yml}"],
 	},
 	name: "YAML",
-	rules: [blockMappings, blockSequences, emptyDocuments, emptyMappingKeys],
+	rules: [
+		blockMappings,
+		blockSequences,
+		emptyDocuments,
+		emptyMappingKeys,
+		mappingKeyCasing,
+	],
 });

--- a/packages/yaml/src/rules/mappingKeyCasing.test.ts
+++ b/packages/yaml/src/rules/mappingKeyCasing.test.ts
@@ -1,0 +1,37 @@
+import rule from "./mappingKeyCasing.ts";
+import { ruleTester } from "./ruleTester.ts";
+
+ruleTester.describe(rule, {
+	invalid: [
+		{
+			code: `camelCase: value`,
+			snapshot: `camelCase: value
+~~~~~~~~~
+Mapping key should use snake_case.`,
+		},
+		{
+			code: `PascalCase: value`,
+			snapshot: `PascalCase: value
+~~~~~~~~~~
+Mapping key should use snake_case.`,
+		},
+		{
+			code: `kebab-case: value`,
+			snapshot: `kebab-case: value
+~~~~~~~~~~
+Mapping key should use snake_case.`,
+		},
+		{
+			code: `SCREAMING_SNAKE: value`,
+			snapshot: `SCREAMING_SNAKE: value
+~~~~~~~~~~~~~~~
+Mapping key should use snake_case.`,
+		},
+	],
+	valid: [
+		`snake_case: value`,
+		`simple: value`,
+		`key123: value`,
+		`multi_word_key: value`,
+	],
+});

--- a/packages/yaml/src/rules/mappingKeyCasing.ts
+++ b/packages/yaml/src/rules/mappingKeyCasing.ts
@@ -1,0 +1,72 @@
+import type * as yaml from "yaml-unist-parser";
+
+import { yamlLanguage } from "../language.ts";
+import { ruleCreator } from "./ruleCreator.ts";
+
+function isSnakeCase(str: string) {
+	return /^[a-z][a-z0-9]*(?:_[a-z0-9]+)*$/.test(str);
+}
+
+function getKeyValue(node: yaml.MappingKey): string | undefined {
+	if (node.children.length === 0) {
+		return undefined;
+	}
+
+	const child = node.children[0];
+	if (!child) {
+		return undefined;
+	}
+
+	if (
+		child.type === "plain" ||
+		child.type === "quoteDouble" ||
+		child.type === "quoteSingle"
+	) {
+		return child.value;
+	}
+
+	return undefined;
+}
+
+export default ruleCreator.createRule(yamlLanguage, {
+	about: {
+		description: "Enforces consistent casing for mapping keys.",
+		id: "mappingKeyCasing",
+		presets: ["stylisticStrict"],
+	},
+	messages: {
+		invalidCasing: {
+			primary: "Mapping key should use snake_case.",
+			secondary: [
+				"Using consistent casing for keys improves readability and maintainability.",
+				"snake_case is a common convention for YAML configuration files.",
+			],
+			suggestions: ["Rename the key to use snake_case format."],
+		},
+	},
+	setup(context) {
+		return {
+			visitors: {
+				mappingKey: (node) => {
+					const keyValue = getKeyValue(node);
+
+					if (keyValue === undefined) {
+						return;
+					}
+
+					if (isSnakeCase(keyValue)) {
+						return;
+					}
+
+					context.report({
+						message: "invalidCasing",
+						range: {
+							begin: node.position.start.offset,
+							end: node.position.end.offset,
+						},
+					});
+				},
+			},
+		};
+	},
+});


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #697
- [x] That issue was marked as [`status: accepting prs`](https://github.com/flint-fyi/flint/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/flint-fyi/flint/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Implements the `mappingKeyCasing` rule for the YAML plugin. This rule enforces snake_case for mapping keys, which is a common convention for YAML configuration files.

Equivalent to [`yml/key-name-casing`](https://ota-meshi.github.io/eslint-plugin-yml/rules/key-name-casing.html) from eslint-plugin-yml, but with a simpler approach that enforces snake_case only.