### PR TITLE
feat: implement unpublishedImports rule (Node.js)

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -50,6 +50,7 @@ export default defineConfig(
 		"packages/*/.astro",
 		"packages/*/dist",
 		"packages/*/lib",
+		"packages/*/src/rules/fixtures",
 		"packages/fixtures",
 		"pnpm-lock.yaml",
 	]),

--- a/packages/comparisons/src/data.json
+++ b/packages/comparisons/src/data.json
@@ -4685,7 +4685,8 @@
 		"flint": {
 			"name": "unpublishedImports",
 			"plugin": "node",
-			"preset": "logical"
+			"preset": "logical",
+			"status": "implemented"
 		}
 	},
 	{

--- a/packages/plugin-node/src/node.ts
+++ b/packages/plugin-node/src/node.ts
@@ -11,6 +11,7 @@ import filePathsFromImportMeta from "./rules/filePathsFromImportMeta.ts";
 import fileReadJSONBuffers from "./rules/fileReadJSONBuffers.ts";
 import nodeProtocols from "./rules/nodeProtocols.ts";
 import processExits from "./rules/processExits.ts";
+import unpublishedImports from "./rules/unpublishedImports.ts";
 
 export const node = createPlugin({
 	name: "Node.js",
@@ -26,5 +27,6 @@ export const node = createPlugin({
 		fileReadJSONBuffers,
 		nodeProtocols,
 		processExits,
+		unpublishedImports,
 	],
 });

--- a/packages/plugin-node/src/rules/fixtures/unpublishedImports-dual/package.json
+++ b/packages/plugin-node/src/rules/fixtures/unpublishedImports-dual/package.json
@@ -1,0 +1,10 @@
+{
+	"name": "dual-test-package",
+	"version": "1.0.0",
+	"dependencies": {
+		"dual-dependency": "1.0.0"
+	},
+	"devDependencies": {
+		"dual-dependency": "1.0.0"
+	}
+}

--- a/packages/plugin-node/src/rules/fixtures/unpublishedImports-private/package.json
+++ b/packages/plugin-node/src/rules/fixtures/unpublishedImports-private/package.json
@@ -1,0 +1,11 @@
+{
+	"name": "private-test-package",
+	"version": "1.0.0",
+	"private": true,
+	"dependencies": {
+		"some-prod-dependency": "1.0.0"
+	},
+	"devDependencies": {
+		"some-dev-dependency": "1.0.0"
+	}
+}

--- a/packages/plugin-node/src/rules/fixtures/unpublishedImports/package.json
+++ b/packages/plugin-node/src/rules/fixtures/unpublishedImports/package.json
@@ -1,0 +1,18 @@
+{
+	"name": "test-package",
+	"version": "1.0.0",
+	"dependencies": {
+		"@scope/some-prod-dependency": "1.0.0",
+		"some-prod-dependency": "1.0.0"
+	},
+	"devDependencies": {
+		"@scope/some-dev-dependency": "1.0.0",
+		"some-dev-dependency": "1.0.0"
+	},
+	"peerDependencies": {
+		"some-peer-dependency": "1.0.0"
+	},
+	"optionalDependencies": {
+		"some-optional-dependency": "1.0.0"
+	}
+}

--- a/packages/plugin-node/src/rules/unpublishedImports.test.ts
+++ b/packages/plugin-node/src/rules/unpublishedImports.test.ts
@@ -1,0 +1,194 @@
+import nodePath from "node:path";
+
+import { ruleTester } from "./ruleTester.ts";
+import rule from "./unpublishedImports.ts";
+
+const testDir = nodePath.dirname(import.meta.filename);
+const fixtureDir = nodePath.join(testDir, "fixtures/unpublishedImports");
+const privateFixtureDir = nodePath.join(
+	testDir,
+	"fixtures/unpublishedImports-private",
+);
+const dualFixtureDir = nodePath.join(
+	testDir,
+	"fixtures/unpublishedImports-dual",
+);
+const fileName = nodePath.join(fixtureDir, "test.ts");
+const privateFileName = nodePath.join(privateFixtureDir, "test.ts");
+const dualFileName = nodePath.join(dualFixtureDir, "test.ts");
+
+ruleTester.describe(rule, {
+	invalid: [
+		{
+			code: `
+import devDep from "some-dev-dependency";
+`,
+			fileName,
+			snapshot: `
+import devDep from "some-dev-dependency";
+                   ~~~~~~~~~~~~~~~~~~~~~
+                   "some-dev-dependency" is listed in devDependencies but this file is published.
+`,
+		},
+		{
+			code: `
+import { something } from "some-dev-dependency";
+`,
+			fileName,
+			snapshot: `
+import { something } from "some-dev-dependency";
+                          ~~~~~~~~~~~~~~~~~~~~~
+                          "some-dev-dependency" is listed in devDependencies but this file is published.
+`,
+		},
+		{
+			code: `
+import * as devDep from "some-dev-dependency";
+`,
+			fileName,
+			snapshot: `
+import * as devDep from "some-dev-dependency";
+                        ~~~~~~~~~~~~~~~~~~~~~
+                        "some-dev-dependency" is listed in devDependencies but this file is published.
+`,
+		},
+		{
+			code: `
+export { something } from "some-dev-dependency";
+`,
+			fileName,
+			snapshot: `
+export { something } from "some-dev-dependency";
+                          ~~~~~~~~~~~~~~~~~~~~~
+                          "some-dev-dependency" is listed in devDependencies but this file is published.
+`,
+		},
+		{
+			code: `
+export * from "some-dev-dependency";
+`,
+			fileName,
+			snapshot: `
+export * from "some-dev-dependency";
+              ~~~~~~~~~~~~~~~~~~~~~
+              "some-dev-dependency" is listed in devDependencies but this file is published.
+`,
+		},
+		{
+			code: `
+const dep = require("some-dev-dependency");
+`,
+			fileName,
+			snapshot: `
+const dep = require("some-dev-dependency");
+                    ~~~~~~~~~~~~~~~~~~~~~
+                    "some-dev-dependency" is listed in devDependencies but this file is published.
+`,
+		},
+		{
+			code: `
+import devDep from "some-dev-dependency/subpath";
+`,
+			fileName,
+			snapshot: `
+import devDep from "some-dev-dependency/subpath";
+                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                   "some-dev-dependency" is listed in devDependencies but this file is published.
+`,
+		},
+		{
+			code: `
+import devDep from "@scope/some-dev-dependency";
+`,
+			fileName,
+			snapshot: `
+import devDep from "@scope/some-dev-dependency";
+                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                   "@scope/some-dev-dependency" is listed in devDependencies but this file is published.
+`,
+		},
+		{
+			code: `
+import devDep from "@scope/some-dev-dependency/subpath";
+`,
+			fileName,
+			snapshot: `
+import devDep from "@scope/some-dev-dependency/subpath";
+                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                   "@scope/some-dev-dependency" is listed in devDependencies but this file is published.
+`,
+		},
+		{
+			code: `
+import devDep = require("some-dev-dependency");
+`,
+			fileName,
+			snapshot: `
+import devDep = require("some-dev-dependency");
+                        ~~~~~~~~~~~~~~~~~~~~~
+                        "some-dev-dependency" is listed in devDependencies but this file is published.
+`,
+		},
+		{
+			code: `
+import "some-dev-dependency";
+`,
+			fileName,
+			snapshot: `
+import "some-dev-dependency";
+       ~~~~~~~~~~~~~~~~~~~~~
+       "some-dev-dependency" is listed in devDependencies but this file is published.
+`,
+		},
+		{
+			code: `
+import { type Type, value } from "some-dev-dependency";
+`,
+			fileName,
+			snapshot: `
+import { type Type, value } from "some-dev-dependency";
+                                 ~~~~~~~~~~~~~~~~~~~~~
+                                 "some-dev-dependency" is listed in devDependencies but this file is published.
+`,
+		},
+	],
+	valid: [
+		{ code: `import prodDep from "some-prod-dependency";`, fileName },
+		{ code: `import { something } from "some-prod-dependency";`, fileName },
+		{ code: `import * as prodDep from "some-prod-dependency";`, fileName },
+		{ code: `export { something } from "some-prod-dependency";`, fileName },
+		{ code: `export * from "some-prod-dependency";`, fileName },
+		{ code: `const dep = require("some-prod-dependency");`, fileName },
+		{ code: `import prodDep from "some-prod-dependency/subpath";`, fileName },
+		{ code: `import scopedDep from "@scope/some-prod-dependency";`, fileName },
+		{
+			code: `import scopedDep from "@scope/some-prod-dependency/subpath";`,
+			fileName,
+		},
+		{ code: `import fs from "node:fs";`, fileName },
+		{ code: `import path from "node:path";`, fileName },
+		{ code: `import fs from "fs";`, fileName },
+		{ code: `import path from "path";`, fileName },
+		{ code: `import local from "./local";`, fileName },
+		{ code: `import parent from "../parent";`, fileName },
+		{ code: `import absolute from "/absolute/path";`, fileName },
+		{ code: `import peerDep from "some-peer-dependency";`, fileName },
+		{ code: `import optionalDep from "some-optional-dependency";`, fileName },
+		// Private packages should be skipped
+		{
+			code: `import devDep from "some-dev-dependency";`,
+			fileName: privateFileName,
+		},
+		// Type-only imports
+		{ code: `import type { Type } from "some-dev-dependency";`, fileName },
+		{ code: `import { type Type } from "some-dev-dependency";`, fileName },
+		// Unknown packages (not in any deps) - no error, not our concern
+		{ code: `import unknown from "unknown-package";`, fileName },
+		// Side-effect only imports from devDependencies are still flagged (tested in invalid)
+		// Dual dependencies (in both dependencies and devDependencies) - no error
+		{
+			code: `import dual from "dual-dependency";`,
+			fileName: dualFileName,
+		},
+	],
+});

--- a/packages/plugin-node/src/rules/unpublishedImports.ts
+++ b/packages/plugin-node/src/rules/unpublishedImports.ts
@@ -1,0 +1,240 @@
+import { type AST, getTSNodeRange, typescriptLanguage } from "@flint.fyi/ts";
+import { parseJsonSafe } from "@flint.fyi/utils";
+import * as fsSync from "node:fs";
+import * as nodePath from "node:path";
+import ts, { SyntaxKind } from "typescript";
+
+import { ruleCreator } from "./ruleCreator.ts";
+
+interface PackageJson {
+	dependencies?: Record<string, string>;
+	devDependencies?: Record<string, string>;
+	files?: string[];
+	optionalDependencies?: Record<string, string>;
+	peerDependencies?: Record<string, string>;
+	private?: boolean;
+}
+
+const nodeBuiltins = new Set([
+	"assert",
+	"buffer",
+	"child_process",
+	"cluster",
+	"console",
+	"constants",
+	"crypto",
+	"dgram",
+	"dns",
+	"domain",
+	"events",
+	"fs",
+	"http",
+	"http2",
+	"https",
+	"inspector",
+	"module",
+	"net",
+	"os",
+	"path",
+	"perf_hooks",
+	"process",
+	"punycode",
+	"querystring",
+	"readline",
+	"repl",
+	"stream",
+	"string_decoder",
+	"sys",
+	"timers",
+	"tls",
+	"trace_events",
+	"tty",
+	"url",
+	"util",
+	"v8",
+	"vm",
+	"wasi",
+	"worker_threads",
+	"zlib",
+]);
+
+const packageJsonCache = new Map<string, PackageJson | undefined>();
+
+function findPackageJson(startDirectory: string): PackageJson | undefined {
+	const cached = packageJsonCache.get(startDirectory);
+	if (cached !== undefined) {
+		return cached;
+	}
+
+	let currentDirectory = startDirectory;
+	while (currentDirectory !== nodePath.dirname(currentDirectory)) {
+		const packageJsonPath = nodePath.join(currentDirectory, "package.json");
+		if (fsSync.existsSync(packageJsonPath)) {
+			const content = fsSync.readFileSync(packageJsonPath, "utf8");
+			const parsed = parseJsonSafe(content) as PackageJson | undefined;
+			packageJsonCache.set(startDirectory, parsed);
+			return parsed;
+		}
+
+		currentDirectory = nodePath.dirname(currentDirectory);
+	}
+
+	packageJsonCache.set(startDirectory, undefined);
+	return undefined;
+}
+
+function getModuleName(specifier: string): string {
+	if (specifier.startsWith("@")) {
+		const parts = specifier.split("/");
+		return parts.slice(0, 2).join("/");
+	}
+
+	const firstPart = specifier.split("/")[0];
+	return firstPart ?? specifier;
+}
+
+function isBuiltinModule(specifier: string) {
+	const moduleName = getModuleName(specifier);
+	return nodeBuiltins.has(moduleName);
+}
+
+function isRelativeOrAbsoluteImport(specifier: string) {
+	return (
+		specifier.startsWith(".") ||
+		specifier.startsWith("/") ||
+		specifier.startsWith("node:")
+	);
+}
+
+function isTypeOnlyImport(node: AST.ImportDeclaration) {
+	// Check for `import type {...}` (phaseModifier = TypeKeyword = 156)
+	if (node.importClause?.phaseModifier === SyntaxKind.TypeKeyword) {
+		return true;
+	}
+
+	// Check if all named imports are type-only (inline type imports like `import { type X }`)
+	const namedBindings = node.importClause?.namedBindings;
+	if (
+		namedBindings &&
+		namedBindings.kind === SyntaxKind.NamedImports &&
+		namedBindings.elements.length > 0 &&
+		namedBindings.elements.every((element) => element.isTypeOnly)
+	) {
+		return true;
+	}
+
+	return false;
+}
+
+export default ruleCreator.createRule(typescriptLanguage, {
+	about: {
+		description:
+			"Disallow importing packages from devDependencies in published files.",
+		id: "unpublishedImports",
+		presets: ["logical"],
+	},
+	messages: {
+		devDependencyInPublished: {
+			primary:
+				'"{{ moduleName }}" is listed in devDependencies but this file is published.',
+			secondary: [
+				"Packages in devDependencies are not installed when consumers install your package.",
+				"This import will fail with a Module Not Found error after npm publish.",
+			],
+			suggestions: [
+				"Move the dependency to dependencies if it's needed at runtime.",
+				"Exclude this file from the published package using the 'files' field in package.json or .npmignore.",
+			],
+		},
+	},
+	setup(context) {
+		function checkImportSpecifier(
+			specifier: string,
+			node: AST.Expression,
+			sourceFile: ts.SourceFile,
+		) {
+			if (isRelativeOrAbsoluteImport(specifier) || isBuiltinModule(specifier)) {
+				return;
+			}
+
+			const fileDirectory = nodePath.dirname(sourceFile.fileName);
+			const packageJson = findPackageJson(fileDirectory);
+			if (!packageJson) {
+				return;
+			}
+
+			if (packageJson.private) {
+				return;
+			}
+
+			const moduleName = getModuleName(specifier);
+			const isInDependencies =
+				moduleName in (packageJson.dependencies ?? {}) ||
+				moduleName in (packageJson.peerDependencies ?? {}) ||
+				moduleName in (packageJson.optionalDependencies ?? {});
+			const isInDevDependencies =
+				moduleName in (packageJson.devDependencies ?? {});
+
+			if (isInDevDependencies && !isInDependencies) {
+				context.report({
+					data: { moduleName },
+					message: "devDependencyInPublished",
+					range: getTSNodeRange(node, sourceFile),
+				});
+			}
+		}
+
+		return {
+			dependencies: ["package.json"],
+			visitors: {
+				CallExpression(node, { sourceFile }) {
+					const firstArgument = node.arguments[0];
+					if (
+						node.expression.kind === SyntaxKind.Identifier &&
+						node.expression.text === "require" &&
+						firstArgument?.kind === SyntaxKind.StringLiteral
+					) {
+						checkImportSpecifier(firstArgument.text, firstArgument, sourceFile);
+					}
+				},
+				ExportDeclaration(node, { sourceFile }) {
+					if (
+						node.moduleSpecifier &&
+						node.moduleSpecifier.kind === SyntaxKind.StringLiteral
+					) {
+						checkImportSpecifier(
+							node.moduleSpecifier.text,
+							node.moduleSpecifier,
+							sourceFile,
+						);
+					}
+				},
+				ImportDeclaration(node, { sourceFile }) {
+					if (isTypeOnlyImport(node)) {
+						return;
+					}
+
+					if (node.moduleSpecifier.kind === SyntaxKind.StringLiteral) {
+						checkImportSpecifier(
+							node.moduleSpecifier.text,
+							node.moduleSpecifier,
+							sourceFile,
+						);
+					}
+				},
+				ImportEqualsDeclaration(node, { sourceFile }) {
+					if (
+						node.moduleReference.kind === SyntaxKind.ExternalModuleReference &&
+						node.moduleReference.expression.kind === SyntaxKind.StringLiteral
+					) {
+						checkImportSpecifier(
+							node.moduleReference.expression.text,
+							node.moduleReference.expression,
+							sourceFile,
+						);
+					}
+				},
+			},
+		};
+	},
+});

--- a/packages/plugin-node/tsconfig.src.json
+++ b/packages/plugin-node/tsconfig.src.json
@@ -3,7 +3,7 @@
 		"tsBuildInfoFile": "node_modules/.cache/tsbuild/info.src.json",
 		"rootDir": "src/",
 		"outDir": "lib/",
-		"types": []
+		"types": ["node"]
 	},
 	"extends": "../../tsconfig.base.json",
 	"include": ["src"],

--- a/packages/plugin-node/tsconfig.test.json
+++ b/packages/plugin-node/tsconfig.test.json
@@ -3,7 +3,7 @@
 		"tsBuildInfoFile": "node_modules/.cache/tsbuild/info.test.json",
 		"rootDir": "src/",
 		"outDir": "node_modules/.cache/tsbuild/test",
-		"types": []
+		"types": ["node"]
 	},
 	"extends": "../../tsconfig.base.json",
 	"include": ["src/**/*.test.ts", "src/rules/ruleTester.ts"],

--- a/packages/site/src/content/docs/rules/node/unpublishedImports.mdx
+++ b/packages/site/src/content/docs/rules/node/unpublishedImports.mdx
@@ -1,0 +1,101 @@
+---
+description: "Disallow importing packages from devDependencies in published files."
+title: "unpublishedImports"
+topic: "rules"
+---
+
+import { Tabs, TabItem } from "@astrojs/starlight/components";
+
+import { RuleEquivalents } from "~/components/RuleEquivalents";
+import RuleSummary from "~/components/RuleSummary.astro";
+
+<RuleSummary plugin="node" rule="unpublishedImports" />
+
+Importing packages listed only in `devDependencies` within files that will be published to npm can cause "Module Not Found" errors for consumers of your package.
+When users install your package, only `dependencies`, `peerDependencies`, and `optionalDependencies` are installed — not `devDependencies`.
+
+This rule flags imports of packages that are listed in `devDependencies` but not in `dependencies`, `peerDependencies`, or `optionalDependencies`.
+
+## Examples
+
+<Tabs>
+<TabItem label="❌ Incorrect">
+
+```ts
+// With package.json: { "devDependencies": { "test-utils": "1.0.0" } }
+import { setup } from "test-utils";
+```
+
+```ts
+// With package.json: { "devDependencies": { "@scope/dev-tool": "1.0.0" } }
+import tool from "@scope/dev-tool";
+```
+
+```ts
+// With package.json: { "devDependencies": { "dev-lib": "1.0.0" } }
+const lib = require("dev-lib");
+```
+
+</TabItem>
+<TabItem label="✅ Correct">
+
+```ts
+// With package.json: { "dependencies": { "lodash": "4.0.0" } }
+import { debounce } from "lodash";
+```
+
+```ts
+// With package.json: { "peerDependencies": { "react": "18.0.0" } }
+import React from "react";
+```
+
+```ts
+// Type-only imports are allowed (they're erased at compile time)
+import type { TestUtils } from "test-utils";
+```
+
+```ts
+// Inline type-only imports are also allowed
+import { type Config } from "test-utils";
+```
+
+```ts
+// Node.js built-in modules are always allowed
+import fs from "node:fs";
+```
+
+```ts
+// Relative imports are not checked
+import { helper } from "./utils";
+```
+
+```ts
+// Private packages are not checked
+// With package.json: { "private": true, "devDependencies": { "test": "1.0.0" } }
+import test from "test";
+```
+
+</TabItem>
+</Tabs>
+
+## Options
+
+This rule is not configurable.
+
+## When Not To Use It
+
+If your project is a private package that will never be published to npm (e.g., an application rather than a library), this rule may not be necessary.
+The rule already skips packages with `"private": true` in their `package.json`.
+
+If you intentionally exclude certain files from publishing using the `files` field in `package.json` or `.npmignore`, this rule may produce false positives for those files.
+In those cases, you may want to disable the rule for specific files.
+
+## Further Reading
+
+- [npm: package.json dependencies](https://docs.npmjs.com/cli/v10/configuring-npm/package-json#dependencies)
+- [npm: package.json devDependencies](https://docs.npmjs.com/cli/v10/configuring-npm/package-json#devdependencies)
+- [npm: package.json files](https://docs.npmjs.com/cli/v10/configuring-npm/package-json#files)
+
+## Equivalents in Other Linters
+
+<RuleEquivalents pluginId="node" ruleId="unpublishedImports" />


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #930
- [x] That issue was marked as [`status: accepting prs`](https://github.com/flint-fyi/flint/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/flint-fyi/flint/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Implements the `unpublishedImports` rule for the Node.js plugin, which disallows importing packages from devDependencies in published files. This prevents "Module Not Found" errors after npm publish.

Key features:
- Flags imports of packages only listed in devDependencies
- Skips type-only imports (both `import type` and inline `{ type X }`)
- Skips private packages (`"private": true` in package.json)
- Allows packages in dependencies, peerDependencies, or optionalDependencies