### PR TITLE
feat: implement unsupportedGlobals rule (Node.js)

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -50,6 +50,7 @@ export default defineConfig(
 		"packages/*/.astro",
 		"packages/*/dist",
 		"packages/*/lib",
+		"packages/*/src/rules/fixtures",
 		"packages/fixtures",
 		"pnpm-lock.yaml",
 	]),

--- a/packages/comparisons/src/data.json
+++ b/packages/comparisons/src/data.json
@@ -4711,7 +4711,8 @@
 		"flint": {
 			"name": "unsupportedGlobals",
 			"plugin": "node",
-			"preset": "logical"
+			"preset": "logical",
+			"status": "implemented"
 		}
 	},
 	{

--- a/packages/plugin-node/package.json
+++ b/packages/plugin-node/package.json
@@ -31,10 +31,12 @@
 		"@flint.fyi/core": "workspace:^",
 		"@flint.fyi/ts": "workspace:^",
 		"@flint.fyi/utils": "workspace:^",
+		"semver": "^7.7.3",
 		"typescript": "^5.9.3"
 	},
 	"devDependencies": {
 		"@flint.fyi/rule-tester": "workspace:^",
+		"@types/semver": "^7.7.1",
 		"tsdown": "0.19.0-beta.2",
 		"vitest": "4.0.15"
 	},

--- a/packages/plugin-node/src/node.ts
+++ b/packages/plugin-node/src/node.ts
@@ -11,6 +11,7 @@ import filePathsFromImportMeta from "./rules/filePathsFromImportMeta.ts";
 import fileReadJSONBuffers from "./rules/fileReadJSONBuffers.ts";
 import nodeProtocols from "./rules/nodeProtocols.ts";
 import processExits from "./rules/processExits.ts";
+import unsupportedGlobals from "./rules/unsupportedGlobals.ts";
 
 export const node = createPlugin({
 	name: "Node.js",
@@ -26,5 +27,6 @@ export const node = createPlugin({
 		fileReadJSONBuffers,
 		nodeProtocols,
 		processExits,
+		unsupportedGlobals,
 	],
 });

--- a/packages/plugin-node/src/rules/fixtures/unsupportedGlobals-new/package.json
+++ b/packages/plugin-node/src/rules/fixtures/unsupportedGlobals-new/package.json
@@ -1,0 +1,7 @@
+{
+	"name": "test-new-node",
+	"version": "1.0.0",
+	"engines": {
+		"node": ">=20.0.0"
+	}
+}

--- a/packages/plugin-node/src/rules/fixtures/unsupportedGlobals-no-engines/package.json
+++ b/packages/plugin-node/src/rules/fixtures/unsupportedGlobals-no-engines/package.json
@@ -1,0 +1,4 @@
+{
+	"name": "test-no-engines",
+	"version": "1.0.0"
+}

--- a/packages/plugin-node/src/rules/fixtures/unsupportedGlobals-old/package.json
+++ b/packages/plugin-node/src/rules/fixtures/unsupportedGlobals-old/package.json
@@ -1,0 +1,7 @@
+{
+	"name": "test-old-node",
+	"version": "1.0.0",
+	"engines": {
+		"node": ">=10.0.0"
+	}
+}

--- a/packages/plugin-node/src/rules/unsupportedGlobals.test.ts
+++ b/packages/plugin-node/src/rules/unsupportedGlobals.test.ts
@@ -1,0 +1,101 @@
+import nodePath from "node:path";
+
+import { ruleTester } from "./ruleTester.ts";
+import rule from "./unsupportedGlobals.ts";
+
+const testDir = nodePath.dirname(import.meta.filename);
+const oldNodeDir = nodePath.join(testDir, "fixtures/unsupportedGlobals-old");
+const newNodeDir = nodePath.join(testDir, "fixtures/unsupportedGlobals-new");
+const noEnginesDir = nodePath.join(
+	testDir,
+	"fixtures/unsupportedGlobals-no-engines",
+);
+const oldNodeFile = nodePath.join(oldNodeDir, "test.ts");
+const newNodeFile = nodePath.join(newNodeDir, "test.ts");
+const noEnginesFile = nodePath.join(noEnginesDir, "test.ts");
+
+ruleTester.describe(rule, {
+	invalid: [
+		{
+			code: `
+const registry = new FinalizationRegistry(() => {});
+`,
+			fileName: oldNodeFile,
+			snapshot: `
+const registry = new FinalizationRegistry(() => {});
+                     ~~~~~~~~~~~~~~~~~~~~
+                     "FinalizationRegistry" is not supported until Node.js 14.6.0. The configured version range is ">=10.0.0".
+`,
+		},
+		{
+			code: `
+const ref = new WeakRef({});
+`,
+			fileName: oldNodeFile,
+			snapshot: `
+const ref = new WeakRef({});
+                ~~~~~~~
+                "WeakRef" is not supported until Node.js 14.6.0. The configured version range is ">=10.0.0".
+`,
+		},
+		{
+			code: `
+console.log(globalThis);
+`,
+			fileName: oldNodeFile,
+			snapshot: `
+console.log(globalThis);
+            ~~~~~~~~~~
+            "globalThis" is not supported until Node.js 12.0.0. The configured version range is ">=10.0.0".
+`,
+		},
+		{
+			code: `
+const error = new AggregateError([new Error("error1")]);
+`,
+			fileName: oldNodeFile,
+			snapshot: `
+const error = new AggregateError([new Error("error1")]);
+                  ~~~~~~~~~~~~~~
+                  "AggregateError" is not supported until Node.js 15.0.0. The configured version range is ">=10.0.0".
+`,
+		},
+	],
+	valid: [
+		// New Node.js version - all features supported
+		{
+			code: `const registry = new FinalizationRegistry(() => {});`,
+			fileName: newNodeFile,
+		},
+		{ code: `const ref = new WeakRef({});`, fileName: newNodeFile },
+		{ code: `console.log(globalThis);`, fileName: newNodeFile },
+		{ code: `const error = new AggregateError([]);`, fileName: newNodeFile },
+		// No engines field - no restrictions
+		{
+			code: `const finReg = new FinalizationRegistry((value) => console.log(value));`,
+			fileName: noEnginesFile,
+		},
+		{
+			code: `const weakReference = new WeakRef({ data: 1 });`,
+			fileName: noEnginesFile,
+		},
+		// Features supported on old Node (10.0.0)
+		{ code: `const arr = new Atomics();`, fileName: newNodeFile },
+		{ code: `const promise = Promise.resolve();`, fileName: oldNodeFile },
+		{ code: `const map = new Map();`, fileName: oldNodeFile },
+		{ code: `const set = new Set();`, fileName: oldNodeFile },
+		{ code: `const proxy = new Proxy({}, {});`, fileName: oldNodeFile },
+		{ code: `const reflect = Reflect.get({}, "key");`, fileName: oldNodeFile },
+		{ code: `const symbol = Symbol("test");`, fileName: oldNodeFile },
+		// Type references should not be flagged
+		{ code: `type Ref = WeakRef<object>;`, fileName: oldNodeFile },
+		{
+			code: `const value: FinalizationRegistry<object> = null!;`,
+			fileName: oldNodeFile,
+		},
+		// Property access should not be flagged
+		{ code: `const x = obj.WeakRef;`, fileName: oldNodeFile },
+		// Variable declarations with same name should not be flagged
+		{ code: `const WeakRef = class {};`, fileName: oldNodeFile },
+	],
+});

--- a/packages/plugin-node/src/rules/unsupportedGlobals.ts
+++ b/packages/plugin-node/src/rules/unsupportedGlobals.ts
@@ -1,0 +1,181 @@
+import { getTSNodeRange, typescriptLanguage } from "@flint.fyi/ts";
+import { parseJsonSafe } from "@flint.fyi/utils";
+import * as fsSync from "node:fs";
+import * as nodePath from "node:path";
+import semver from "semver";
+import { SyntaxKind } from "typescript";
+
+import { ruleCreator } from "./ruleCreator.ts";
+
+interface GlobalInfo {
+	name: string;
+	supportedSince: string;
+}
+
+interface PackageJson {
+	engines?: {
+		node?: string;
+	};
+}
+
+const unsupportedGlobals: Record<string, GlobalInfo> = {
+	AggregateError: { name: "AggregateError", supportedSince: "15.0.0" },
+	Array: {
+		name: "Array",
+		supportedSince: "0.10.0",
+	},
+	ArrayBuffer: { name: "ArrayBuffer", supportedSince: "0.10.0" },
+	Atomics: { name: "Atomics", supportedSince: "8.10.0" },
+	BigInt: { name: "BigInt", supportedSince: "10.4.0" },
+	BigInt64Array: { name: "BigInt64Array", supportedSince: "10.4.0" },
+	BigUint64Array: { name: "BigUint64Array", supportedSince: "10.4.0" },
+	FinalizationRegistry: {
+		name: "FinalizationRegistry",
+		supportedSince: "14.6.0",
+	},
+	globalThis: { name: "globalThis", supportedSince: "12.0.0" },
+	Map: { name: "Map", supportedSince: "0.12.0" },
+	Promise: { name: "Promise", supportedSince: "0.12.0" },
+	Proxy: { name: "Proxy", supportedSince: "6.0.0" },
+	Reflect: { name: "Reflect", supportedSince: "6.0.0" },
+	Set: { name: "Set", supportedSince: "0.12.0" },
+	SharedArrayBuffer: { name: "SharedArrayBuffer", supportedSince: "8.10.0" },
+	Symbol: { name: "Symbol", supportedSince: "0.12.0" },
+	WeakMap: { name: "WeakMap", supportedSince: "0.12.0" },
+	WeakRef: { name: "WeakRef", supportedSince: "14.6.0" },
+	WeakSet: { name: "WeakSet", supportedSince: "0.12.0" },
+};
+
+const packageJsonCache = new Map<string, PackageJson | undefined>();
+
+function findPackageJson(startDirectory: string): PackageJson | undefined {
+	const cached = packageJsonCache.get(startDirectory);
+	if (cached !== undefined) {
+		return cached;
+	}
+
+	let currentDirectory = startDirectory;
+	while (currentDirectory !== nodePath.dirname(currentDirectory)) {
+		const packageJsonPath = nodePath.join(currentDirectory, "package.json");
+		if (fsSync.existsSync(packageJsonPath)) {
+			const content = fsSync.readFileSync(packageJsonPath, "utf8");
+			const parsed = parseJsonSafe(content) as PackageJson | undefined;
+			packageJsonCache.set(startDirectory, parsed);
+			return parsed;
+		}
+
+		currentDirectory = nodePath.dirname(currentDirectory);
+	}
+
+	packageJsonCache.set(startDirectory, undefined);
+	return undefined;
+}
+
+function getMinNodeVersion(engineVersion: string): string | undefined {
+	const coerced = semver.coerce(engineVersion);
+	if (coerced) {
+		return coerced.version;
+	}
+
+	const minVersion = semver.minVersion(engineVersion);
+	return minVersion?.version;
+}
+
+function isGlobalSupported(
+	globalInfo: GlobalInfo,
+	configuredVersion: string | undefined,
+) {
+	if (!configuredVersion) {
+		return true;
+	}
+
+	const minVersion = getMinNodeVersion(configuredVersion);
+	if (!minVersion) {
+		return true;
+	}
+
+	return semver.gte(minVersion, globalInfo.supportedSince);
+}
+
+export default ruleCreator.createRule(typescriptLanguage, {
+	about: {
+		description:
+			"Disallow using ECMAScript built-in globals not supported in the configured Node.js version.",
+		id: "unsupportedGlobals",
+		presets: ["logical"],
+	},
+	messages: {
+		unsupportedGlobal: {
+			primary:
+				'"{{ name }}" is not supported until Node.js {{ supportedSince }}. The configured version range is "{{ configuredVersion }}".',
+			secondary: [
+				"Using features not supported by your target Node.js version will cause runtime errors.",
+				"Consider upgrading the minimum Node.js version in package.json or using a polyfill.",
+			],
+			suggestions: [
+				"Update the engines.node field in package.json to require a newer version.",
+				"Use a polyfill or alternative implementation for older Node.js versions.",
+			],
+		},
+	},
+	setup(context) {
+		let configuredVersion: string | null | undefined;
+
+		return {
+			dependencies: ["package.json"],
+			visitors: {
+				Identifier(node, { sourceFile }) {
+					const globalName = node.text;
+					const globalInfo = unsupportedGlobals[globalName];
+					if (!globalInfo) {
+						return;
+					}
+
+					// Skip if this is not a standalone reference (e.g., property access)
+					if (
+						node.parent.kind === SyntaxKind.PropertyAccessExpression &&
+						node.parent.name === node
+					) {
+						return;
+					}
+
+					// Skip if this is being declared
+					if (
+						node.parent.kind === SyntaxKind.VariableDeclaration &&
+						node.parent.name === node
+					) {
+						return;
+					}
+
+					// Skip if this is a type reference
+					if (node.parent.kind === SyntaxKind.TypeReference) {
+						return;
+					}
+
+					// Lazily fetch the configured version
+					if (configuredVersion === undefined) {
+						const fileDirectory = nodePath.dirname(sourceFile.fileName);
+						const packageJson = findPackageJson(fileDirectory);
+						configuredVersion = packageJson?.engines?.node ?? null;
+					}
+
+					if (!configuredVersion) {
+						return;
+					}
+
+					if (!isGlobalSupported(globalInfo, configuredVersion)) {
+						context.report({
+							data: {
+								configuredVersion,
+								name: globalInfo.name,
+								supportedSince: globalInfo.supportedSince,
+							},
+							message: "unsupportedGlobal",
+							range: getTSNodeRange(node, sourceFile),
+						});
+					}
+				},
+			},
+		};
+	},
+});

--- a/packages/plugin-node/tsconfig.src.json
+++ b/packages/plugin-node/tsconfig.src.json
@@ -3,7 +3,7 @@
 		"tsBuildInfoFile": "node_modules/.cache/tsbuild/info.src.json",
 		"rootDir": "src/",
 		"outDir": "lib/",
-		"types": []
+		"types": ["node"]
 	},
 	"extends": "../../tsconfig.base.json",
 	"include": ["src"],

--- a/packages/plugin-node/tsconfig.test.json
+++ b/packages/plugin-node/tsconfig.test.json
@@ -3,7 +3,7 @@
 		"tsBuildInfoFile": "node_modules/.cache/tsbuild/info.test.json",
 		"rootDir": "src/",
 		"outDir": "node_modules/.cache/tsbuild/test",
-		"types": []
+		"types": ["node"]
 	},
 	"extends": "../../tsconfig.base.json",
 	"include": ["src/**/*.test.ts", "src/rules/ruleTester.ts"],

--- a/packages/site/src/content/docs/rules/node/unsupportedGlobals.mdx
+++ b/packages/site/src/content/docs/rules/node/unsupportedGlobals.mdx
@@ -1,0 +1,95 @@
+---
+description: "Disallow using ECMAScript built-in globals not supported in the configured Node.js version."
+title: "unsupportedGlobals"
+topic: "rules"
+---
+
+import { Tabs, TabItem } from "@astrojs/starlight/components";
+
+import { RuleEquivalents } from "~/components/RuleEquivalents";
+import RuleSummary from "~/components/RuleSummary.astro";
+
+<RuleSummary plugin="node" rule="unsupportedGlobals" />
+
+ECMAScript introduces new built-in globals over time, and Node.js adds support for them in specific versions.
+Using globals not supported by your target Node.js version will cause runtime errors.
+
+This rule checks the `engines.node` field in your `package.json` and reports usage of globals that are not available in the specified version range.
+
+## Examples
+
+<Tabs>
+<TabItem label="❌ Incorrect">
+
+```ts
+// With package.json: { "engines": { "node": ">=10.0.0" } }
+// FinalizationRegistry was added in Node.js 14.6.0
+const registry = new FinalizationRegistry(() => {});
+```
+
+```ts
+// With package.json: { "engines": { "node": ">=10.0.0" } }
+// WeakRef was added in Node.js 14.6.0
+const ref = new WeakRef({});
+```
+
+```ts
+// With package.json: { "engines": { "node": ">=10.0.0" } }
+// globalThis was added in Node.js 12.0.0
+console.log(globalThis);
+```
+
+```ts
+// With package.json: { "engines": { "node": ">=10.0.0" } }
+// AggregateError was added in Node.js 15.0.0
+const error = new AggregateError([new Error("error1")]);
+```
+
+</TabItem>
+<TabItem label="✅ Correct">
+
+```ts
+// With package.json: { "engines": { "node": ">=20.0.0" } }
+// All modern globals are supported
+const registry = new FinalizationRegistry(() => {});
+const ref = new WeakRef({});
+console.log(globalThis);
+```
+
+```ts
+// Using only globals supported in your version
+// With package.json: { "engines": { "node": ">=10.0.0" } }
+const promise = Promise.resolve();
+const map = new Map();
+const set = new Set();
+const proxy = new Proxy({}, {});
+```
+
+```ts
+// Type references are not flagged
+type Ref = WeakRef<object>;
+```
+
+</TabItem>
+</Tabs>
+
+## Options
+
+This rule is not configurable.
+
+## When Not To Use It
+
+If you are transpiling your code with a tool like Babel that polyfills unsupported globals, this rule may produce false positives.
+Disable it for projects where you know polyfills are in place.
+
+If your project does not specify an `engines.node` field in `package.json`, this rule will not report any issues.
+
+## Further Reading
+
+- [node.green - Node.js ECMAScript compatibility tables](https://node.green/)
+- [npm: package.json engines](https://docs.npmjs.com/cli/v10/configuring-npm/package-json#engines)
+- [TC39 Finished Proposals](https://github.com/tc39/proposals/blob/main/finished-proposals.md)
+
+## Equivalents in Other Linters
+
+<RuleEquivalents pluginId="node" ruleId="unsupportedGlobals" />

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -433,6 +433,9 @@ importers:
       '@flint.fyi/utils':
         specifier: workspace:^
         version: link:../utils
+      semver:
+        specifier: ^7.7.3
+        version: 7.7.3
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -440,6 +443,9 @@ importers:
       '@flint.fyi/rule-tester':
         specifier: workspace:^
         version: link:../rule-tester
+      '@types/semver':
+        specifier: ^7.7.1
+        version: 7.7.1
       tsdown:
         specifier: 0.19.0-beta.2
         version: 0.19.0-beta.2(@arethetypeswrong/core@0.18.2)(oxc-resolver@11.15.0)(synckit@0.11.11)(typescript@5.9.3)
@@ -2167,6 +2173,9 @@ packages:
 
   '@types/sax@1.2.7':
     resolution: {integrity: sha512-rO73L89PJxeYM3s3pPPjiPgVVcymqU490g0YO5n5By0k2Erzj6tay/4lr1CHAAU4JyOWd1rpQ8bCf6cZfHU96A==}
+
+  '@types/semver@7.7.1':
+    resolution: {integrity: sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==}
 
   '@types/unist@2.0.11':
     resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
@@ -6817,6 +6826,8 @@ snapshots:
   '@types/sax@1.2.7':
     dependencies:
       '@types/node': 24.10.1
+
+  '@types/semver@7.7.1': {}
 
   '@types/unist@2.0.11': {}
 


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #931
- [x] That issue was marked as [`status: accepting prs`](https://github.com/flint-fyi/flint/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/flint-fyi/flint/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Implements the `unsupportedGlobals` rule for the Node.js plugin, which disallows using ECMAScript built-in globals not supported in the configured Node.js version (from `engines.node` in package.json).

Key features:
- Checks modern ES globals like `FinalizationRegistry`, `WeakRef`, `globalThis`, `AggregateError`, `BigInt`, `Atomics`, etc.
- Reads the target Node.js version from `package.json` `engines.node` field
- Uses semver for version comparison
- Skips type references and variable declarations with the same name