### PR TITLE
feat(plugin-node): add unsupportedSyntax rule

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -50,6 +50,7 @@ export default defineConfig(
 		"packages/*/.astro",
 		"packages/*/dist",
 		"packages/*/lib",
+		"packages/*/src/rules/fixtures",
 		"packages/fixtures",
 		"pnpm-lock.yaml",
 	]),

--- a/packages/comparisons/src/data.json
+++ b/packages/comparisons/src/data.json
@@ -4737,7 +4737,8 @@
 		"flint": {
 			"name": "unsupportedSyntax",
 			"plugin": "node",
-			"preset": "logical"
+			"preset": "logical",
+			"status": "implemented"
 		}
 	},
 	{

--- a/packages/plugin-node/package.json
+++ b/packages/plugin-node/package.json
@@ -31,10 +31,12 @@
 		"@flint.fyi/core": "workspace:^",
 		"@flint.fyi/ts": "workspace:^",
 		"@flint.fyi/utils": "workspace:^",
+		"semver": "^7.7.3",
 		"typescript": "^5.9.3"
 	},
 	"devDependencies": {
 		"@flint.fyi/rule-tester": "workspace:^",
+		"@types/semver": "^7.7.1",
 		"tsdown": "0.19.0-beta.2",
 		"vitest": "4.0.15"
 	},

--- a/packages/plugin-node/src/node.ts
+++ b/packages/plugin-node/src/node.ts
@@ -11,6 +11,7 @@ import filePathsFromImportMeta from "./rules/filePathsFromImportMeta.ts";
 import fileReadJSONBuffers from "./rules/fileReadJSONBuffers.ts";
 import nodeProtocols from "./rules/nodeProtocols.ts";
 import processExits from "./rules/processExits.ts";
+import unsupportedSyntax from "./rules/unsupportedSyntax.ts";
 
 export const node = createPlugin({
 	name: "Node.js",
@@ -26,5 +27,6 @@ export const node = createPlugin({
 		fileReadJSONBuffers,
 		nodeProtocols,
 		processExits,
+		unsupportedSyntax,
 	],
 });

--- a/packages/plugin-node/src/rules/fixtures/unsupportedSyntax-new/package.json
+++ b/packages/plugin-node/src/rules/fixtures/unsupportedSyntax-new/package.json
@@ -1,0 +1,7 @@
+{
+	"name": "test-new-syntax",
+	"version": "1.0.0",
+	"engines": {
+		"node": ">=20.0.0"
+	}
+}

--- a/packages/plugin-node/src/rules/fixtures/unsupportedSyntax-old/package.json
+++ b/packages/plugin-node/src/rules/fixtures/unsupportedSyntax-old/package.json
@@ -1,0 +1,7 @@
+{
+	"name": "test-old-syntax",
+	"version": "1.0.0",
+	"engines": {
+		"node": ">=12.0.0"
+	}
+}

--- a/packages/plugin-node/src/rules/unsupportedSyntax.test.ts
+++ b/packages/plugin-node/src/rules/unsupportedSyntax.test.ts
@@ -1,0 +1,92 @@
+import nodePath from "node:path";
+
+import { ruleTester } from "./ruleTester.ts";
+import rule from "./unsupportedSyntax.ts";
+
+const testDir = nodePath.dirname(import.meta.filename);
+const oldNodeDir = nodePath.join(testDir, "fixtures/unsupportedSyntax-old");
+const newNodeDir = nodePath.join(testDir, "fixtures/unsupportedSyntax-new");
+const oldNodeFile = nodePath.join(oldNodeDir, "test.ts");
+const newNodeFile = nodePath.join(newNodeDir, "test.ts");
+
+ruleTester.describe(rule, {
+	invalid: [
+		{
+			code: `
+const value = obj?.property;
+`,
+			fileName: oldNodeFile,
+			snapshot: `
+const value = obj?.property;
+                 ~~
+                 optional chaining (?.) is not supported until Node.js 14.0.0. The configured version range is ">=12.0.0".
+`,
+		},
+		{
+			code: `
+const result = value ?? defaultValue;
+`,
+			fileName: oldNodeFile,
+			snapshot: `
+const result = value ?? defaultValue;
+                     ~~
+                     nullish coalescing operator (??) is not supported until Node.js 14.0.0. The configured version range is ">=12.0.0".
+`,
+		},
+		{
+			code: `
+let count = 0;
+count ||= 1;
+`,
+			fileName: oldNodeFile,
+			snapshot: `
+let count = 0;
+count ||= 1;
+      ~~~
+      logical assignment operators (&&=, ||=, ??=) is not supported until Node.js 15.0.0. The configured version range is ">=12.0.0".
+`,
+		},
+		{
+			code: `
+class Example {
+    static {
+        console.log("init");
+    }
+}
+`,
+			fileName: oldNodeFile,
+			snapshot: `
+class Example {
+    static {
+    ~~~~~~~~
+    class static blocks is not supported until Node.js 16.11.0. The configured version range is ">=12.0.0".
+        console.log("init");
+        ~~~~~~~~~~~~~~~~~~~~
+    }
+    ~
+}
+`,
+		},
+	],
+	valid: [
+		// New Node.js version - all features supported
+		{ code: `const value = obj?.property;`, fileName: newNodeFile },
+		{ code: `const result = value ?? defaultValue;`, fileName: newNodeFile },
+		{ code: `count ||= 1;`, fileName: newNodeFile },
+		{
+			code: `class Example { static { console.log("init"); } }`,
+			fileName: newNodeFile,
+		},
+		// Features supported on old Node (12.0.0)
+		{
+			code: `async function doSomething() { await fetch(); }`,
+			fileName: oldNodeFile,
+		},
+		{
+			code: `class Example { field = 1; }`,
+			fileName: oldNodeFile,
+		},
+		// Numeric separators on new Node.js
+		{ code: `const num = 1_000_000;`, fileName: newNodeFile },
+	],
+});

--- a/packages/plugin-node/src/rules/unsupportedSyntax.ts
+++ b/packages/plugin-node/src/rules/unsupportedSyntax.ts
@@ -1,0 +1,256 @@
+import { getTSNodeRange, typescriptLanguage } from "@flint.fyi/ts";
+import { parseJsonSafe } from "@flint.fyi/utils";
+import * as fsSync from "node:fs";
+import * as nodePath from "node:path";
+import semver from "semver";
+import ts, { SyntaxKind } from "typescript";
+
+import { ruleCreator } from "./ruleCreator.ts";
+
+interface PackageJson {
+	engines?: {
+		node?: string;
+	};
+}
+
+interface SyntaxFeature {
+	name: string;
+	supportedSince: string;
+}
+
+const syntaxFeatures: Record<string, SyntaxFeature> = {
+	asyncAwait: { name: "async/await", supportedSince: "7.6.0" },
+	asyncIteration: {
+		name: "async iteration (for-await-of)",
+		supportedSince: "10.0.0",
+	},
+	classFields: { name: "class fields", supportedSince: "12.0.0" },
+	classStaticBlocks: { name: "class static blocks", supportedSince: "16.11.0" },
+	dynamicImport: { name: "dynamic import", supportedSince: "13.2.0" },
+	logicalAssignment: {
+		name: "logical assignment operators (&&=, ||=, ??=)",
+		supportedSince: "15.0.0",
+	},
+	nullishCoalescing: {
+		name: "nullish coalescing operator (??)",
+		supportedSince: "14.0.0",
+	},
+	numericSeparators: { name: "numeric separators", supportedSince: "12.5.0" },
+	optionalChaining: {
+		name: "optional chaining (?.)",
+		supportedSince: "14.0.0",
+	},
+	privateIdentifiers: {
+		name: "private class members (#)",
+		supportedSince: "12.0.0",
+	},
+	topLevelAwait: { name: "top-level await", supportedSince: "14.8.0" },
+};
+
+const packageJsonCache = new Map<string, PackageJson | undefined>();
+
+function findPackageJson(startDirectory: string): PackageJson | undefined {
+	const cached = packageJsonCache.get(startDirectory);
+	if (cached !== undefined) {
+		return cached;
+	}
+
+	let currentDirectory = startDirectory;
+	while (currentDirectory !== nodePath.dirname(currentDirectory)) {
+		const packageJsonPath = nodePath.join(currentDirectory, "package.json");
+		if (fsSync.existsSync(packageJsonPath)) {
+			const content = fsSync.readFileSync(packageJsonPath, "utf8");
+			const parsed = parseJsonSafe(content) as PackageJson | undefined;
+			packageJsonCache.set(startDirectory, parsed);
+			return parsed;
+		}
+
+		currentDirectory = nodePath.dirname(currentDirectory);
+	}
+
+	packageJsonCache.set(startDirectory, undefined);
+	return undefined;
+}
+
+function getMinNodeVersion(engineVersion: string): string | undefined {
+	const coerced = semver.coerce(engineVersion);
+	if (coerced) {
+		return coerced.version;
+	}
+
+	const minVersion = semver.minVersion(engineVersion);
+	return minVersion?.version;
+}
+
+function hasNumericSeparator(text: string) {
+	return text.includes("_");
+}
+
+function isFeatureSupported(
+	feature: SyntaxFeature,
+	configuredVersion: string | undefined,
+) {
+	if (!configuredVersion) {
+		return true;
+	}
+
+	const minVersion = getMinNodeVersion(configuredVersion);
+	if (!minVersion) {
+		return true;
+	}
+
+	return semver.gte(minVersion, feature.supportedSince);
+}
+
+export default ruleCreator.createRule(typescriptLanguage, {
+	about: {
+		description:
+			"Disallow using ECMAScript syntax not supported in the configured Node.js version.",
+		id: "unsupportedSyntax",
+		presets: ["logical"],
+	},
+	messages: {
+		unsupportedSyntax: {
+			primary:
+				'{{ name }} is not supported until Node.js {{ supportedSince }}. The configured version range is "{{ configuredVersion }}".',
+			secondary: [
+				"Using syntax not supported by your target Node.js version will cause syntax errors.",
+				"Consider upgrading the minimum Node.js version in package.json.",
+			],
+			suggestions: [
+				"Update the engines.node field in package.json to require a newer version.",
+				"Use an alternative syntax supported by your target Node.js version.",
+			],
+		},
+	},
+	setup(context) {
+		let configuredVersion: null | string | undefined;
+		let supportedFeatures: Map<string, boolean> | undefined;
+
+		function checkFeature(
+			featureKey: string,
+			node: ts.Node,
+			sourceFile: ts.SourceFile,
+		) {
+			if (configuredVersion === undefined) {
+				const fileDirectory = nodePath.dirname(sourceFile.fileName);
+				const packageJson = findPackageJson(fileDirectory);
+				configuredVersion = packageJson?.engines?.node ?? null;
+				supportedFeatures = new Map();
+			}
+
+			if (!configuredVersion) {
+				return;
+			}
+
+			let isSupported = supportedFeatures?.get(featureKey);
+			if (isSupported === undefined) {
+				const feature = syntaxFeatures[featureKey];
+				isSupported = feature
+					? isFeatureSupported(feature, configuredVersion)
+					: true;
+				supportedFeatures?.set(featureKey, isSupported);
+			}
+
+			if (!isSupported) {
+				const feature = syntaxFeatures[featureKey];
+				if (feature) {
+					context.report({
+						data: {
+							configuredVersion,
+							name: feature.name,
+							supportedSince: feature.supportedSince,
+						},
+						message: "unsupportedSyntax",
+						range: getTSNodeRange(node, sourceFile),
+					});
+				}
+			}
+		}
+
+		return {
+			dependencies: ["package.json"],
+			visitors: {
+				AwaitExpression(node, { sourceFile }) {
+					// Check for top-level await - if inside a function, it's not top-level
+					const enclosingFunction = ts.findAncestor(
+						node,
+						(ancestor) =>
+							ancestor.kind === SyntaxKind.FunctionDeclaration ||
+							ancestor.kind === SyntaxKind.FunctionExpression ||
+							ancestor.kind === SyntaxKind.ArrowFunction ||
+							ancestor.kind === SyntaxKind.MethodDeclaration,
+					);
+					if (!enclosingFunction) {
+						checkFeature("topLevelAwait", node, sourceFile);
+					}
+				},
+				BinaryExpression(node, { sourceFile }) {
+					// Check for nullish coalescing
+					if (node.operatorToken.kind === SyntaxKind.QuestionQuestionToken) {
+						checkFeature("nullishCoalescing", node.operatorToken, sourceFile);
+					}
+
+					// Check for logical assignment operators
+					if (
+						node.operatorToken.kind ===
+							SyntaxKind.AmpersandAmpersandEqualsToken ||
+						node.operatorToken.kind === SyntaxKind.BarBarEqualsToken ||
+						node.operatorToken.kind === SyntaxKind.QuestionQuestionEqualsToken
+					) {
+						checkFeature("logicalAssignment", node.operatorToken, sourceFile);
+					}
+				},
+				CallExpression(node, { sourceFile }) {
+					// Check for dynamic import
+					if (node.expression.kind === SyntaxKind.ImportKeyword) {
+						checkFeature("dynamicImport", node, sourceFile);
+					}
+				},
+				ClassStaticBlockDeclaration(node, { sourceFile }) {
+					checkFeature("classStaticBlocks", node, sourceFile);
+				},
+				ForOfStatement(node, { sourceFile }) {
+					// Check for async iteration (for-await-of)
+					if (node.awaitModifier) {
+						checkFeature("asyncIteration", node.awaitModifier, sourceFile);
+					}
+				},
+				FunctionDeclaration(node, { sourceFile }) {
+					// Check for async functions
+					if (
+						node.modifiers?.some((mod) => mod.kind === SyntaxKind.AsyncKeyword)
+					) {
+						checkFeature("asyncAwait", node, sourceFile);
+					}
+				},
+				MethodDeclaration(node, { sourceFile }) {
+					if (
+						node.modifiers?.some((mod) => mod.kind === SyntaxKind.AsyncKeyword)
+					) {
+						checkFeature("asyncAwait", node, sourceFile);
+					}
+				},
+				NumericLiteral(node, { sourceFile }) {
+					// Check for numeric separators
+					if (hasNumericSeparator(node.getText(sourceFile))) {
+						checkFeature("numericSeparators", node, sourceFile);
+					}
+				},
+				PrivateIdentifier(node, { sourceFile }) {
+					checkFeature("privateIdentifiers", node, sourceFile);
+				},
+				PropertyAccessExpression(node, { sourceFile }) {
+					// Check for optional chaining
+					if (node.questionDotToken) {
+						checkFeature("optionalChaining", node.questionDotToken, sourceFile);
+					}
+				},
+				PropertyDeclaration(node, { sourceFile }) {
+					// Check for class fields (properties declared in class body)
+					checkFeature("classFields", node, sourceFile);
+				},
+			},
+		};
+	},
+});

--- a/packages/plugin-node/tsconfig.src.json
+++ b/packages/plugin-node/tsconfig.src.json
@@ -3,7 +3,7 @@
 		"tsBuildInfoFile": "node_modules/.cache/tsbuild/info.src.json",
 		"rootDir": "src/",
 		"outDir": "lib/",
-		"types": []
+		"types": ["node"]
 	},
 	"extends": "../../tsconfig.base.json",
 	"include": ["src"],

--- a/packages/plugin-node/tsconfig.test.json
+++ b/packages/plugin-node/tsconfig.test.json
@@ -3,7 +3,7 @@
 		"tsBuildInfoFile": "node_modules/.cache/tsbuild/info.test.json",
 		"rootDir": "src/",
 		"outDir": "node_modules/.cache/tsbuild/test",
-		"types": []
+		"types": ["node"]
 	},
 	"extends": "../../tsconfig.base.json",
 	"include": ["src/**/*.test.ts", "src/rules/ruleTester.ts"],

--- a/packages/site/src/content/docs/rules/node/unsupportedSyntax.mdx
+++ b/packages/site/src/content/docs/rules/node/unsupportedSyntax.mdx
@@ -1,0 +1,113 @@
+---
+description: "Disallow using ECMAScript syntax not supported in the configured Node.js version."
+title: "unsupportedSyntax"
+topic: "rules"
+---
+
+import { Tabs, TabItem } from "@astrojs/starlight/components";
+
+import { RuleEquivalents } from "~/components/RuleEquivalents";
+import RuleSummary from "~/components/RuleSummary.astro";
+
+<RuleSummary plugin="node" rule="unsupportedSyntax" />
+
+ECMAScript introduces new syntax features over time, and Node.js adds support for them in specific versions.
+Using syntax not supported by your target Node.js version will cause syntax errors at runtime.
+
+This rule checks the `engines.node` field in your `package.json` and reports usage of syntax that is not available in the specified version range.
+
+## Supported Syntax Features
+
+This rule currently checks for:
+
+- **Optional chaining** (`?.`) - Node.js 14.0.0+
+- **Nullish coalescing** (`??`) - Node.js 14.0.0+
+- **Logical assignment operators** (`&&=`, `||=`, `??=`) - Node.js 15.0.0+
+- **Class static blocks** - Node.js 16.11.0+
+- **Private class members** (`#field`) - Node.js 12.0.0+
+- **Class fields** - Node.js 12.0.0+
+- **Numeric separators** (`1_000_000`) - Node.js 12.5.0+
+- **Async/await** - Node.js 7.6.0+
+- **Async iteration** (`for await...of`) - Node.js 10.0.0+
+- **Dynamic import** - Node.js 13.2.0+
+- **Top-level await** - Node.js 14.8.0+
+
+## Examples
+
+<Tabs>
+<TabItem label="❌ Incorrect">
+
+```ts
+// With package.json: { "engines": { "node": ">=12.0.0" } }
+// Optional chaining was added in Node.js 14.0.0
+const value = obj?.property;
+```
+
+```ts
+// With package.json: { "engines": { "node": ">=12.0.0" } }
+// Nullish coalescing was added in Node.js 14.0.0
+const result = value ?? defaultValue;
+```
+
+```ts
+// With package.json: { "engines": { "node": ">=12.0.0" } }
+// Logical assignment was added in Node.js 15.0.0
+count ||= 1;
+```
+
+```ts
+// With package.json: { "engines": { "node": ">=12.0.0" } }
+// Class static blocks were added in Node.js 16.11.0
+class Example {
+	static {
+		console.log("init");
+	}
+}
+```
+
+</TabItem>
+<TabItem label="✅ Correct">
+
+```ts
+// With package.json: { "engines": { "node": ">=20.0.0" } }
+// All modern syntax is supported
+const value = obj?.property;
+const result = value ?? defaultValue;
+count ||= 1;
+```
+
+```ts
+// Using only syntax supported in your version
+// With package.json: { "engines": { "node": ">=12.0.0" } }
+async function doWork() {
+	await fetch();
+}
+
+class Example {
+	field = 1;
+}
+```
+
+</TabItem>
+</Tabs>
+
+## Options
+
+This rule is not configurable.
+
+## When Not To Use It
+
+If you are transpiling your code with a tool like Babel or TypeScript that compiles modern syntax to older JavaScript, this rule may produce false positives.
+Disable it for projects where you know compilation is in place.
+
+If your project does not specify an `engines.node` field in `package.json`, this rule will not report any issues.
+
+## Further Reading
+
+- [node.green - Node.js ECMAScript compatibility tables](https://node.green/)
+- [npm: package.json engines](https://docs.npmjs.com/cli/v10/configuring-npm/package-json#engines)
+- [TC39 Finished Proposals](https://github.com/tc39/proposals/blob/main/finished-proposals.md)
+
+## Equivalents in Other Linters
+
+<RuleEquivalents pluginId="node" ruleId="unsupportedSyntax" />

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -433,6 +433,9 @@ importers:
       '@flint.fyi/utils':
         specifier: workspace:^
         version: link:../utils
+      semver:
+        specifier: ^7.7.3
+        version: 7.7.3
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -440,6 +443,9 @@ importers:
       '@flint.fyi/rule-tester':
         specifier: workspace:^
         version: link:../rule-tester
+      '@types/semver':
+        specifier: ^7.7.1
+        version: 7.7.1
       tsdown:
         specifier: 0.19.0-beta.2
         version: 0.19.0-beta.2(@arethetypeswrong/core@0.18.2)(oxc-resolver@11.15.0)(synckit@0.11.11)(typescript@5.9.3)
@@ -2167,6 +2173,9 @@ packages:
 
   '@types/sax@1.2.7':
     resolution: {integrity: sha512-rO73L89PJxeYM3s3pPPjiPgVVcymqU490g0YO5n5By0k2Erzj6tay/4lr1CHAAU4JyOWd1rpQ8bCf6cZfHU96A==}
+
+  '@types/semver@7.7.1':
+    resolution: {integrity: sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==}
 
   '@types/unist@2.0.11':
     resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
@@ -6817,6 +6826,8 @@ snapshots:
   '@types/sax@1.2.7':
     dependencies:
       '@types/node': 24.10.1
+
+  '@types/semver@7.7.1': {}
 
   '@types/unist@2.0.11': {}
 


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #933
- [x] That issue was marked as [`status: accepting prs`](https://github.com/flint-fyi/flint/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/flint-fyi/flint/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Adds a new `unsupportedSyntax` rule to the Node.js plugin that disallows using ECMAScript syntax not supported in the configured Node.js version.

The rule checks the `engines.node` field in `package.json` and reports usage of syntax features that are not available in the specified version range.

### Supported syntax features

| Feature | Supported Since |
|---------|-----------------|
| async/await | Node.js 7.6.0 |
| async iteration (for-await-of) | Node.js 10.0.0 |
| class fields | Node.js 12.0.0 |
| private class members (#) | Node.js 12.0.0 |
| numeric separators | Node.js 12.5.0 |
| dynamic import | Node.js 13.2.0 |
| optional chaining (?.) | Node.js 14.0.0 |
| nullish coalescing (??) | Node.js 14.0.0 |
| top-level await | Node.js 14.8.0 |
| logical assignment (&&=, ||=, ??=) | Node.js 15.0.0 |
| class static blocks | Node.js 16.11.0 |

### Changes

- Added rule implementation at `packages/plugin-node/src/rules/unsupportedSyntax.ts`
- Added tests at `packages/plugin-node/src/rules/unsupportedSyntax.test.ts`
- Added test fixtures for old/new Node.js versions
- Added documentation at `packages/site/src/content/docs/rules/node/unsupportedSyntax.mdx`
- Updated `packages/comparisons/src/data.json` to mark the rule as implemented
- Added `semver` dependency to `packages/plugin-node/package.json`