### PR TITLE
feat(plugin-node): implement unsupportedNodeAPIs rule

### DIFF
--- a/packages/comparisons/src/data.json
+++ b/packages/comparisons/src/data.json
@@ -4724,7 +4724,8 @@
 		"flint": {
 			"name": "unsupportedNodeAPIs",
 			"plugin": "node",
-			"preset": "logical"
+			"preset": "logical",
+			"status": "implemented"
 		}
 	},
 	{

--- a/packages/plugin-node/package.json
+++ b/packages/plugin-node/package.json
@@ -31,10 +31,13 @@
 		"@flint.fyi/core": "workspace:^",
 		"@flint.fyi/ts": "workspace:^",
 		"@flint.fyi/utils": "workspace:^",
-		"typescript": "^5.9.3"
+		"semver": "^7.7.3",
+		"typescript": "^5.9.3",
+		"zod": "^4.2.1"
 	},
 	"devDependencies": {
 		"@flint.fyi/rule-tester": "workspace:^",
+		"@types/semver": "^7.7.0",
 		"tsdown": "0.19.0-beta.2",
 		"vitest": "4.0.15"
 	},

--- a/packages/plugin-node/src/node.ts
+++ b/packages/plugin-node/src/node.ts
@@ -11,6 +11,7 @@ import filePathsFromImportMeta from "./rules/filePathsFromImportMeta.ts";
 import fileReadJSONBuffers from "./rules/fileReadJSONBuffers.ts";
 import nodeProtocols from "./rules/nodeProtocols.ts";
 import processExits from "./rules/processExits.ts";
+import unsupportedNodeAPIs from "./rules/unsupportedNodeAPIs.ts";
 
 export const node = createPlugin({
 	name: "Node.js",
@@ -26,5 +27,6 @@ export const node = createPlugin({
 		fileReadJSONBuffers,
 		nodeProtocols,
 		processExits,
+		unsupportedNodeAPIs,
 	],
 });

--- a/packages/plugin-node/src/rules/unsupportedNodeAPIs.test.ts
+++ b/packages/plugin-node/src/rules/unsupportedNodeAPIs.test.ts
@@ -1,0 +1,403 @@
+import { ruleTester } from "./ruleTester.ts";
+import rule from "./unsupportedNodeAPIs.ts";
+
+ruleTester.describe(rule, {
+	invalid: [
+		{
+			code: `
+import * as fs from "fs/promises";
+`,
+			options: { minVersion: "8.0.0" },
+			snapshot: `
+import * as fs from "fs/promises";
+                    ~~~~~~~~~~~~~
+                    The \`fs/promises\` API is not available in Node.js 8.0.0.
+`,
+		},
+		{
+			code: `
+import fsPromises from "node:fs/promises";
+`,
+			options: { minVersion: "9.0.0" },
+			snapshot: `
+import fsPromises from "node:fs/promises";
+                       ~~~~~~~~~~~~~~~~~~
+                       The \`fs/promises\` API is not available in Node.js 9.0.0.
+`,
+		},
+		{
+			code: `
+import * as timers from "timers/promises";
+`,
+			options: { minVersion: "14.0.0" },
+			snapshot: `
+import * as timers from "timers/promises";
+                        ~~~~~~~~~~~~~~~~~
+                        The \`timers/promises\` API is not available in Node.js 14.0.0.
+`,
+		},
+		{
+			code: `
+import * as test from "node:test";
+`,
+			options: { minVersion: "16.0.0" },
+			snapshot: `
+import * as test from "node:test";
+                      ~~~~~~~~~~~
+                      The \`test\` API is not available in Node.js 16.0.0.
+`,
+		},
+		{
+			code: `
+const fs = require("fs/promises");
+`,
+			options: { minVersion: "8.0.0" },
+			snapshot: `
+const fs = require("fs/promises");
+                   ~~~~~~~~~~~~~
+                   The \`fs/promises\` API is not available in Node.js 8.0.0.
+`,
+		},
+		{
+			code: `
+const test = require("node:test");
+`,
+			options: { minVersion: "16.0.0" },
+			snapshot: `
+const test = require("node:test");
+                     ~~~~~~~~~~~
+                     The \`test\` API is not available in Node.js 16.0.0.
+`,
+		},
+		{
+			code: `
+import * as fs from "fs";
+fs.promises;
+`,
+			options: { minVersion: "8.0.0" },
+			snapshot: `
+import * as fs from "fs";
+fs.promises;
+~~~~~~~~~~~
+The \`fs.promises\` API is not available in Node.js 8.0.0.
+`,
+		},
+		{
+			code: `
+import * as fs from "node:fs";
+fs.rm("file.txt");
+`,
+			options: { minVersion: "12.0.0" },
+			snapshot: `
+import * as fs from "node:fs";
+fs.rm("file.txt");
+~~~~~
+The \`fs.rm\` API is not available in Node.js 12.0.0.
+`,
+		},
+		{
+			code: `
+import * as fs from "fs";
+fs.promises.rm("file.txt");
+`,
+			options: { minVersion: "12.0.0" },
+			snapshot: `
+import * as fs from "fs";
+fs.promises.rm("file.txt");
+~~~~~~~~~~~~~~
+The \`fs.promises.rm\` API is not available in Node.js 12.0.0.
+`,
+		},
+		{
+			code: `
+const fs = require("fs");
+fs.cp("source", "dest");
+`,
+			options: { minVersion: "14.0.0" },
+			snapshot: `
+const fs = require("fs");
+fs.cp("source", "dest");
+~~~~~
+The \`fs.cp\` API is not available in Node.js 14.0.0.
+`,
+		},
+		{
+			code: `
+import * as crypto from "crypto";
+crypto.webcrypto;
+`,
+			options: { minVersion: "14.0.0" },
+			snapshot: `
+import * as crypto from "crypto";
+crypto.webcrypto;
+~~~~~~~~~~~~~~~~
+The \`crypto.webcrypto\` API is not available in Node.js 14.0.0.
+`,
+		},
+		{
+			code: `
+import * as crypto from "node:crypto";
+crypto.randomUUID();
+`,
+			options: { minVersion: "14.0.0" },
+			snapshot: `
+import * as crypto from "node:crypto";
+crypto.randomUUID();
+~~~~~~~~~~~~~~~~~
+The \`crypto.randomUUID\` API is not available in Node.js 14.0.0.
+`,
+		},
+		{
+			code: `
+import * as stream from "stream";
+stream.promises;
+`,
+			options: { minVersion: "14.0.0" },
+			snapshot: `
+import * as stream from "stream";
+stream.promises;
+~~~~~~~~~~~~~~~
+The \`stream.promises\` API is not available in Node.js 14.0.0.
+`,
+		},
+		{
+			code: `
+import * as util from "util";
+util.parseArgs({});
+`,
+			options: { minVersion: "16.0.0" },
+			snapshot: `
+import * as util from "util";
+util.parseArgs({});
+~~~~~~~~~~~~~~
+The \`util.parseArgs\` API is not available in Node.js 16.0.0.
+`,
+		},
+		{
+			code: `
+globalThis.value;
+`,
+			options: { minVersion: "10.0.0" },
+			snapshot: `
+globalThis.value;
+~~~~~~~~~~
+The \`globalThis\` API is not available in Node.js 10.0.0.
+`,
+		},
+		{
+			code: `
+const value = globalThis;
+`,
+			options: { minVersion: "10.0.0" },
+			snapshot: `
+const value = globalThis;
+              ~~~~~~~~~~
+              The \`globalThis\` API is not available in Node.js 10.0.0.
+`,
+		},
+		{
+			code: `
+new Blob([]);
+`,
+			options: { minVersion: "14.0.0" },
+			snapshot: `
+new Blob([]);
+    ~~~~
+    The \`Blob\` API is not available in Node.js 14.0.0.
+`,
+		},
+		{
+			code: `
+fetch("https://example.com");
+`,
+			options: { minVersion: "16.0.0" },
+			snapshot: `
+fetch("https://example.com");
+~~~~~
+The \`fetch\` API is not available in Node.js 16.0.0.
+`,
+		},
+		{
+			code: `
+const response = new Response("body");
+`,
+			options: { minVersion: "16.0.0" },
+			snapshot: `
+const response = new Response("body");
+                     ~~~~~~~~
+                     The \`Response\` API is not available in Node.js 16.0.0.
+`,
+		},
+		{
+			code: `
+structuredClone({ value: 1 });
+`,
+			options: { minVersion: "16.0.0" },
+			snapshot: `
+structuredClone({ value: 1 });
+~~~~~~~~~~~~~~~
+The \`structuredClone\` API is not available in Node.js 16.0.0.
+`,
+		},
+		{
+			code: `
+const encoded = atob("dGVzdA==");
+`,
+			options: { minVersion: "14.0.0" },
+			snapshot: `
+const encoded = atob("dGVzdA==");
+                ~~~~
+                The \`atob\` API is not available in Node.js 14.0.0.
+`,
+		},
+		{
+			code: `
+const channel = new BroadcastChannel("test");
+`,
+			options: { minVersion: "14.0.0" },
+			snapshot: `
+const channel = new BroadcastChannel("test");
+                    ~~~~~~~~~~~~~~~~
+                    The \`BroadcastChannel\` API is not available in Node.js 14.0.0.
+`,
+		},
+		{
+			code: `
+import * as process from "process";
+process.loadEnvFile();
+`,
+			options: { minVersion: "20.0.0" },
+			snapshot: `
+import * as process from "process";
+process.loadEnvFile();
+~~~~~~~~~~~~~~~~~~~
+The \`process.loadEnvFile\` API is not available in Node.js 20.0.0.
+`,
+		},
+		{
+			code: `
+import * as buffer from "buffer";
+buffer.Blob;
+`,
+			options: { minVersion: "14.0.0" },
+			snapshot: `
+import * as buffer from "buffer";
+buffer.Blob;
+~~~~~~~~~~~
+The \`buffer.Blob\` API is not available in Node.js 14.0.0.
+`,
+		},
+	],
+	valid: [
+		{
+			code: `import * as fs from "fs/promises";`,
+			options: { minVersion: "10.0.0" },
+		},
+		{
+			code: `import * as fs from "node:fs/promises";`,
+			options: { minVersion: "14.0.0" },
+		},
+		{
+			code: `import * as test from "node:test";`,
+			options: { minVersion: "18.0.0" },
+		},
+		{
+			code: `const fs = require("fs/promises");`,
+			options: { minVersion: "10.0.0" },
+		},
+		{
+			code: `
+import * as fs from "fs";
+fs.promises;
+`,
+			options: { minVersion: "10.0.0" },
+		},
+		{
+			code: `
+import * as fs from "fs";
+fs.rm("file.txt");
+`,
+			options: { minVersion: "14.14.0" },
+		},
+		{
+			code: `
+import * as fs from "fs";
+fs.promises.rm("file.txt");
+`,
+			options: { minVersion: "14.14.0" },
+		},
+		{
+			code: `
+import * as crypto from "crypto";
+crypto.webcrypto;
+`,
+			options: { minVersion: "15.0.0" },
+		},
+		{
+			code: `globalThis.value;`,
+			options: { minVersion: "12.0.0" },
+		},
+		{
+			code: `new Blob([]);`,
+			options: { minVersion: "15.7.0" },
+		},
+		{
+			code: `fetch("https://example.com");`,
+			options: { minVersion: "18.0.0" },
+		},
+		{
+			code: `structuredClone({ value: 1 });`,
+			options: { minVersion: "17.0.0" },
+		},
+		// Non-Node.js modules should be ignored
+		{
+			code: `import * as fs from "fs-extra";`,
+			options: { minVersion: "8.0.0" },
+		},
+		{
+			code: `const fs = require("fs-extra");`,
+			options: { minVersion: "8.0.0" },
+		},
+		// Same-named user variables should not be flagged
+		{
+			code: `
+const fetch = () => {};
+fetch();
+export {};
+`,
+			options: { minVersion: "14.0.0" },
+		},
+		{
+			code: `
+import fs from "fs";
+fs.readFile("file.txt");
+`,
+			options: { minVersion: "8.0.0" },
+		},
+		// Regular fs methods that have been available for a long time
+		{
+			code: `
+import * as fs from "fs";
+fs.readFileSync("file.txt");
+`,
+			options: { minVersion: "8.0.0" },
+		},
+		// Base module imports should not be flagged (only subpaths)
+		{
+			code: `import * as crypto from "crypto";`,
+			options: { minVersion: "8.0.0" },
+		},
+		{
+			code: `import * as stream from "node:stream";`,
+			options: { minVersion: "8.0.0" },
+		},
+		// Dynamic require is not flagged (can't track)
+		{
+			code: `
+const moduleName = "fs";
+const fs = require(moduleName);
+`,
+			options: { minVersion: "8.0.0" },
+		},
+	],
+});

--- a/packages/plugin-node/src/rules/unsupportedNodeAPIs.ts
+++ b/packages/plugin-node/src/rules/unsupportedNodeAPIs.ts
@@ -1,0 +1,327 @@
+import {
+	getTSNodeRange,
+	isGlobalVariable,
+	typescriptLanguage,
+} from "@flint.fyi/ts";
+import * as semver from "semver";
+import ts, { SyntaxKind } from "typescript";
+import { z } from "zod";
+
+import { ruleCreator } from "./ruleCreator.ts";
+import {
+	nodeBuiltinAPIs,
+	type NodeBuiltinAPISupport,
+	nodeBuiltinModules,
+} from "./utils/nodeBuiltinsData.ts";
+
+const nodeModuleNames = new Set([
+	"assert",
+	"async_hooks",
+	"buffer",
+	"child_process",
+	"cluster",
+	"console",
+	"constants",
+	"crypto",
+	"dgram",
+	"diagnostics_channel",
+	"dns",
+	"domain",
+	"events",
+	"fs",
+	"http",
+	"http2",
+	"https",
+	"inspector",
+	"module",
+	"net",
+	"os",
+	"path",
+	"perf_hooks",
+	"process",
+	"punycode",
+	"querystring",
+	"readline",
+	"repl",
+	"sea",
+	"sqlite",
+	"stream",
+	"string_decoder",
+	"sys",
+	"test",
+	"timers",
+	"tls",
+	"trace_events",
+	"tty",
+	"url",
+	"util",
+	"v8",
+	"vm",
+	"wasi",
+	"worker_threads",
+	"zlib",
+]);
+
+function isNodeBuiltinModule(specifier: string) {
+	const normalized = normalizeModuleSpecifier(specifier);
+	const base = normalized.split("/")[0];
+	return nodeModuleNames.has(base);
+}
+
+function isUnsupported(minVersion: string, apiSupport: NodeBuiltinAPISupport) {
+	const min = semver.coerce(minVersion);
+	const added = semver.coerce(apiSupport.addedIn);
+	if (!min || !added) {
+		return false;
+	}
+	return semver.lt(min, added);
+}
+
+function normalizeModuleSpecifier(specifier: string) {
+	return specifier.replace(/^node:/, "");
+}
+
+function shouldCheckModuleSpecifier(specifier: string) {
+	const normalized = normalizeModuleSpecifier(specifier);
+	return nodeBuiltinModules[normalized] !== undefined;
+}
+
+export default ruleCreator.createRule(typescriptLanguage, {
+	about: {
+		description:
+			"Disallow usage of Node.js built-in APIs not supported by the configured Node.js version.",
+		id: "unsupportedNodeAPIs",
+		presets: ["logical"],
+	},
+	messages: {
+		unsupportedAPI: {
+			primary:
+				"The `{{ apiName }}` API is not available in Node.js {{ minVersion }}.",
+			secondary: [
+				"The `{{ apiName }}` API was added in Node.js {{ addedIn }}.",
+				"Ensure all target Node.js versions support this API, or provide a polyfill.",
+			],
+			suggestions: [
+				"Update your minimum Node.js version to {{ addedIn }} or later.",
+				"Provide a polyfill or runtime check for older versions.",
+			],
+		},
+	},
+	options: {
+		minVersion: z
+			.string()
+			.default("18.0.0")
+			.describe("The minimum Node.js version the project supports."),
+	},
+	setup(context) {
+		const moduleBindings = new Map<string, string>();
+
+		function checkModuleSupport(
+			moduleKey: string,
+			node: ts.Node,
+			sourceFile: ts.SourceFile,
+			minVersion: string,
+		) {
+			const info = nodeBuiltinModules[moduleKey];
+			if (!info) {
+				return;
+			}
+
+			if (!isUnsupported(minVersion, info)) {
+				return;
+			}
+
+			context.report({
+				data: {
+					addedIn: info.addedIn,
+					apiName: moduleKey,
+					minVersion,
+				},
+				message: "unsupportedAPI",
+				range: getTSNodeRange(node, sourceFile),
+			});
+		}
+
+		function checkAPISupport(
+			apiKey: string,
+			node: ts.Node,
+			sourceFile: ts.SourceFile,
+			minVersion: string,
+		) {
+			const info = nodeBuiltinAPIs[apiKey];
+			if (!info) {
+				return;
+			}
+
+			if (!isUnsupported(minVersion, info)) {
+				return;
+			}
+
+			context.report({
+				data: {
+					addedIn: info.addedIn,
+					apiName: apiKey,
+					minVersion,
+				},
+				message: "unsupportedAPI",
+				range: getTSNodeRange(node, sourceFile),
+			});
+		}
+
+		function getPropertyAccessPath(node: ts.PropertyAccessExpression) {
+			const parts: string[] = [];
+			let current: ts.Expression = node;
+
+			while (current.kind === SyntaxKind.PropertyAccessExpression) {
+				const propertyAccess = current as ts.PropertyAccessExpression;
+				parts.unshift(propertyAccess.name.text);
+				current = propertyAccess.expression;
+			}
+
+			if (current.kind !== SyntaxKind.Identifier) {
+				return undefined;
+			}
+
+			return {
+				parts,
+				rootName: (current as ts.Identifier).text,
+			};
+		}
+
+		return {
+			visitors: {
+				CallExpression(node, { options, sourceFile }) {
+					if (
+						node.expression.kind !== SyntaxKind.Identifier ||
+						(node.expression as ts.Identifier).text !== "require" ||
+						node.arguments.length === 0
+					) {
+						return;
+					}
+
+					const arg = node.arguments[0];
+					if (arg.kind !== SyntaxKind.StringLiteral) {
+						return;
+					}
+
+					const specifier = (arg as ts.StringLiteral).text;
+					if (!isNodeBuiltinModule(specifier)) {
+						return;
+					}
+
+					const normalized = normalizeModuleSpecifier(specifier);
+
+					if (shouldCheckModuleSpecifier(specifier)) {
+						checkModuleSupport(normalized, arg, sourceFile, options.minVersion);
+					}
+
+					const parent = node.parent;
+					if (
+						parent.kind === SyntaxKind.VariableDeclaration &&
+						(parent as ts.VariableDeclaration).name.kind ===
+							SyntaxKind.Identifier
+					) {
+						const binding = (parent as ts.VariableDeclaration)
+							.name as ts.Identifier;
+						moduleBindings.set(binding.text, normalized);
+					}
+				},
+
+				Identifier(node, { options, sourceFile, typeChecker }) {
+					if (
+						node.parent.kind === SyntaxKind.PropertyAccessExpression &&
+						(node.parent as ts.PropertyAccessExpression).name === node
+					) {
+						return;
+					}
+
+					if (node.parent.kind === SyntaxKind.ImportSpecifier) {
+						return;
+					}
+
+					if (node.parent.kind === SyntaxKind.ImportClause) {
+						return;
+					}
+
+					if (node.parent.kind === SyntaxKind.NamespaceImport) {
+						return;
+					}
+
+					if (
+						node.parent.kind === SyntaxKind.VariableDeclaration &&
+						(node.parent as ts.VariableDeclaration).name === node
+					) {
+						return;
+					}
+
+					if (node.parent.kind === SyntaxKind.FunctionDeclaration) {
+						return;
+					}
+
+					if (node.parent.kind === SyntaxKind.Parameter) {
+						return;
+					}
+
+					const name = node.text;
+					if (nodeBuiltinAPIs[name] && isGlobalVariable(node, typeChecker)) {
+						checkAPISupport(name, node, sourceFile, options.minVersion);
+					}
+				},
+
+				ImportDeclaration(node, { options, sourceFile }) {
+					if (node.moduleSpecifier.kind !== SyntaxKind.StringLiteral) {
+						return;
+					}
+
+					const specifier = (node.moduleSpecifier as ts.StringLiteral).text;
+					if (!isNodeBuiltinModule(specifier)) {
+						return;
+					}
+
+					const normalized = normalizeModuleSpecifier(specifier);
+
+					if (shouldCheckModuleSpecifier(specifier)) {
+						checkModuleSupport(
+							normalized,
+							node.moduleSpecifier,
+							sourceFile,
+							options.minVersion,
+						);
+					}
+
+					if (node.importClause?.namedBindings) {
+						const bindings = node.importClause.namedBindings;
+						if (bindings.kind === SyntaxKind.NamespaceImport) {
+							moduleBindings.set(bindings.name.text, normalized);
+						}
+					}
+
+					if (node.importClause?.name) {
+						moduleBindings.set(node.importClause.name.text, normalized);
+					}
+				},
+
+				PropertyAccessExpression(node, { options, sourceFile }) {
+					const pathInfo = getPropertyAccessPath(node);
+					if (!pathInfo) {
+						return;
+					}
+
+					const { parts, rootName } = pathInfo;
+					const moduleSpec = moduleBindings.get(rootName);
+
+					if (moduleSpec) {
+						const apiPath = [moduleSpec, ...parts].join(".");
+						checkAPISupport(apiPath, node, sourceFile, options.minVersion);
+						return;
+					}
+
+					const globalPath = [rootName, ...parts].join(".");
+					if (nodeBuiltinAPIs[globalPath]) {
+						checkAPISupport(globalPath, node, sourceFile, options.minVersion);
+					}
+				},
+			},
+		};
+	},
+});

--- a/packages/plugin-node/src/rules/utils/nodeBuiltinsData.ts
+++ b/packages/plugin-node/src/rules/utils/nodeBuiltinsData.ts
@@ -1,0 +1,179 @@
+/**
+ * Version support data for Node.js built-in APIs.
+ *
+ * This curated dataset covers high-impact APIs that are commonly used but
+ * weren't available in older Node.js versions. Keys are dotted paths:
+ * - Module specifiers: "fs/promises", "timers/promises"
+ * - Properties on modules: "fs.promises", "fs.rm", "crypto.webcrypto"
+ * - Global identifiers: "globalThis", "Blob", "fetch"
+ *
+ * To add new APIs, add entries here with their first supported version.
+ */
+
+export interface NodeBuiltinAPISupport {
+	addedIn: string;
+	removedIn?: string;
+}
+
+/**
+ * Module specifiers (import/require paths) that were added in specific Node.js versions.
+ * Only includes modules that are NOT available in all Node.js versions.
+ */
+export const nodeBuiltinModules: Record<string, NodeBuiltinAPISupport> = {
+	// Subpath imports
+	"assert/strict": { addedIn: "15.0.0" },
+	"dns/promises": { addedIn: "10.6.0" },
+	"fs/promises": { addedIn: "10.0.0" },
+	"inspector/promises": { addedIn: "19.0.0" },
+	"readline/promises": { addedIn: "17.0.0" },
+	"stream/consumers": { addedIn: "16.7.0" },
+	"stream/promises": { addedIn: "15.0.0" },
+	"stream/web": { addedIn: "16.5.0" },
+	"timers/promises": { addedIn: "15.0.0" },
+	"util/types": { addedIn: "10.0.0" },
+	// New top-level modules
+	sea: { addedIn: "21.7.0" },
+	sqlite: { addedIn: "22.5.0" },
+	test: { addedIn: "18.0.0" },
+};
+
+export const nodeBuiltinAPIs: Record<string, NodeBuiltinAPISupport> = {
+	// fs module APIs
+	"fs.cp": { addedIn: "16.7.0" },
+	"fs.cpSync": { addedIn: "16.7.0" },
+	"fs.glob": { addedIn: "22.0.0" },
+	"fs.globSync": { addedIn: "22.0.0" },
+	"fs.openAsBlob": { addedIn: "19.8.0" },
+	"fs.promises": { addedIn: "10.0.0" },
+	"fs.promises.cp": { addedIn: "16.7.0" },
+	"fs.promises.glob": { addedIn: "22.0.0" },
+	"fs.promises.rm": { addedIn: "14.14.0" },
+	"fs.promises.watch": { addedIn: "15.9.0" },
+	"fs.rm": { addedIn: "14.14.0" },
+	"fs.rmSync": { addedIn: "14.14.0" },
+
+	// crypto module APIs
+	"crypto.diffieHellman": { addedIn: "13.9.0" },
+	"crypto.generateKey": { addedIn: "15.0.0" },
+	"crypto.generateKeyPair": { addedIn: "10.12.0" },
+	"crypto.generateKeyPairSync": { addedIn: "10.12.0" },
+	"crypto.generateKeySync": { addedIn: "15.0.0" },
+	"crypto.generatePrime": { addedIn: "15.8.0" },
+	"crypto.generatePrimeSync": { addedIn: "15.8.0" },
+	"crypto.getRandomValues": { addedIn: "17.4.0" },
+	"crypto.hash": { addedIn: "21.7.0" },
+	"crypto.hkdf": { addedIn: "15.0.0" },
+	"crypto.hkdfSync": { addedIn: "15.0.0" },
+	"crypto.randomUUID": { addedIn: "15.6.0" },
+	"crypto.secureHeapUsed": { addedIn: "15.6.0" },
+	"crypto.subtle": { addedIn: "15.0.0" },
+	"crypto.webcrypto": { addedIn: "15.0.0" },
+
+	// stream module APIs
+	"stream.addAbortSignal": { addedIn: "15.4.0" },
+	"stream.compose": { addedIn: "16.9.0" },
+	"stream.consumers": { addedIn: "16.7.0" },
+	"stream.getDefaultHighWaterMark": { addedIn: "19.9.0" },
+	"stream.promises": { addedIn: "15.0.0" },
+	"stream.Readable.from": { addedIn: "12.3.0" },
+	"stream.Readable.fromWeb": { addedIn: "17.0.0" },
+	"stream.Readable.toWeb": { addedIn: "17.0.0" },
+	"stream.setDefaultHighWaterMark": { addedIn: "19.9.0" },
+	"stream.Writable.fromWeb": { addedIn: "17.0.0" },
+	"stream.Writable.toWeb": { addedIn: "17.0.0" },
+
+	// timers module APIs
+	"timers.promises": { addedIn: "15.0.0" },
+
+	// util module APIs
+	"util.aborted": { addedIn: "19.7.0" },
+	"util.getSystemErrorMap": { addedIn: "16.0.0" },
+	"util.getSystemErrorName": { addedIn: "9.7.0" },
+	"util.MIMEParams": { addedIn: "19.1.0" },
+	"util.MIMEType": { addedIn: "19.1.0" },
+	"util.parseArgs": { addedIn: "18.3.0" },
+	"util.parseEnv": { addedIn: "21.7.0" },
+	"util.stripVTControlCharacters": { addedIn: "16.11.0" },
+	"util.styleText": { addedIn: "21.7.0" },
+	"util.toUSVString": { addedIn: "16.8.0" },
+	"util.transferableAbortController": { addedIn: "18.11.0" },
+	"util.transferableAbortSignal": { addedIn: "18.11.0" },
+	"util.types": { addedIn: "10.0.0" },
+
+	// buffer module APIs
+	"buffer.atob": { addedIn: "15.13.0" },
+	"buffer.Blob": { addedIn: "15.7.0" },
+	"buffer.btoa": { addedIn: "15.13.0" },
+	"buffer.File": { addedIn: "19.2.0" },
+	"buffer.isAscii": { addedIn: "19.6.0" },
+	"buffer.isUtf8": { addedIn: "19.4.0" },
+	"buffer.resolveObjectURL": { addedIn: "16.7.0" },
+	"buffer.transcode": { addedIn: "7.1.0" },
+
+	// process module APIs
+	"process.abort": { addedIn: "0.7.0" },
+	"process.availableMemory": { addedIn: "22.0.0" },
+	"process.constrainedMemory": { addedIn: "19.6.0" },
+	"process.finalization": { addedIn: "22.5.0" },
+	"process.getActiveResourcesInfo": { addedIn: "17.3.0" },
+	"process.getBuiltinModule": { addedIn: "22.3.0" },
+	"process.loadEnvFile": { addedIn: "21.7.0" },
+	"process.permission": { addedIn: "20.0.0" },
+	"process.sourceMapsEnabled": { addedIn: "20.7.0" },
+
+	// Global identifiers
+	atob: { addedIn: "16.0.0" },
+	Blob: { addedIn: "15.7.0" },
+	BroadcastChannel: { addedIn: "15.4.0" },
+	btoa: { addedIn: "16.0.0" },
+	ByteLengthQueuingStrategy: { addedIn: "18.0.0" },
+	CloseEvent: { addedIn: "23.0.0" },
+	CompressionStream: { addedIn: "18.0.0" },
+	CountQueuingStrategy: { addedIn: "18.0.0" },
+	Crypto: { addedIn: "17.6.0" },
+	crypto: { addedIn: "17.6.0" },
+	CryptoKey: { addedIn: "15.0.0" },
+	CustomEvent: { addedIn: "18.7.0" },
+	DecompressionStream: { addedIn: "18.0.0" },
+	DOMException: { addedIn: "17.0.0" },
+	Event: { addedIn: "15.0.0" },
+	EventTarget: { addedIn: "15.0.0" },
+	fetch: { addedIn: "18.0.0" },
+	File: { addedIn: "20.0.0" },
+	FormData: { addedIn: "18.0.0" },
+	globalThis: { addedIn: "12.0.0" },
+	Headers: { addedIn: "18.0.0" },
+	Iterator: { addedIn: "23.0.0" },
+	MessageChannel: { addedIn: "15.0.0" },
+	MessageEvent: { addedIn: "15.0.0" },
+	MessagePort: { addedIn: "15.0.0" },
+	Navigator: { addedIn: "21.0.0" },
+	navigator: { addedIn: "21.0.0" },
+	performance: { addedIn: "16.0.0" },
+	PerformanceEntry: { addedIn: "19.0.0" },
+	PerformanceMark: { addedIn: "19.0.0" },
+	PerformanceMeasure: { addedIn: "19.0.0" },
+	PerformanceObserver: { addedIn: "19.0.0" },
+	PerformanceObserverEntryList: { addedIn: "19.0.0" },
+	PerformanceResourceTiming: { addedIn: "18.2.0" },
+	ReadableByteStreamController: { addedIn: "18.0.0" },
+	ReadableStream: { addedIn: "18.0.0" },
+	ReadableStreamBYOBReader: { addedIn: "18.0.0" },
+	ReadableStreamBYOBRequest: { addedIn: "18.0.0" },
+	ReadableStreamDefaultController: { addedIn: "18.0.0" },
+	ReadableStreamDefaultReader: { addedIn: "18.0.0" },
+	Request: { addedIn: "18.0.0" },
+	Response: { addedIn: "18.0.0" },
+	structuredClone: { addedIn: "17.0.0" },
+	SubtleCrypto: { addedIn: "15.0.0" },
+	TextDecoderStream: { addedIn: "18.0.0" },
+	TextEncoderStream: { addedIn: "18.0.0" },
+	TransformStream: { addedIn: "18.0.0" },
+	TransformStreamDefaultController: { addedIn: "18.0.0" },
+	URL: { addedIn: "10.0.0" },
+	URLSearchParams: { addedIn: "10.0.0" },
+	WebSocket: { addedIn: "22.4.0" },
+	WritableStream: { addedIn: "18.0.0" },
+	WritableStreamDefaultController: { addedIn: "18.0.0" },
+	WritableStreamDefaultWriter: { addedIn: "18.0.0" },
+};

--- a/packages/site/src/content/docs/rules/node/unsupportedNodeAPIs.mdx
+++ b/packages/site/src/content/docs/rules/node/unsupportedNodeAPIs.mdx
@@ -1,0 +1,104 @@
+---
+description: "Disallow usage of Node.js built-in APIs not supported by the configured Node.js version."
+title: "unsupportedNodeAPIs"
+topic: "rules"
+---
+
+import { Tabs, TabItem } from "@astrojs/starlight/components";
+
+import { RuleEquivalents } from "~/components/RuleEquivalents";
+import RuleSummary from "~/components/RuleSummary.astro";
+
+<RuleSummary plugin="node" rule="unsupportedNodeAPIs" />
+
+Node.js continuously adds new built-in APIs with each release.
+Using APIs that aren't available in your target Node.js version causes runtime errors when deployed to environments running older versions.
+
+This rule reports usage of Node.js built-in APIs that were added after the configured minimum Node.js version.
+
+## Examples
+
+With `minVersion` set to `"14.0.0"`:
+
+<Tabs>
+<TabItem label="❌ Incorrect">
+
+```ts
+import * as fs from "fs";
+
+await fs.promises.rm("file.txt");
+```
+
+```ts
+import * as test from "node:test";
+```
+
+```ts
+const data = await fetch("https://api.example.com/data");
+```
+
+```ts
+const clone = structuredClone({ value: 1 });
+```
+
+```ts
+crypto.randomUUID();
+```
+
+</TabItem>
+<TabItem label="✅ Correct">
+
+```ts
+import * as fs from "fs";
+
+await fs.promises.unlink("file.txt");
+```
+
+```ts
+import * as crypto from "crypto";
+
+crypto.randomBytes(16);
+```
+
+```ts
+import { request } from "https";
+```
+
+```ts
+const clone = JSON.parse(JSON.stringify({ value: 1 }));
+```
+
+</TabItem>
+</Tabs>
+
+## Options
+
+### `minVersion`
+
+The minimum Node.js version the project supports.
+Defaults to `"18.0.0"`.
+
+APIs added after this version will be reported as errors.
+
+```json
+{
+	"rules": {
+		"node/unsupportedNodeAPIs": ["error", { "minVersion": "16.0.0" }]
+	}
+}
+```
+
+## When Not To Use It
+
+If you use a transpiler or bundler that provides polyfills for newer Node.js APIs, you may not need this rule.
+You may also disable this rule if your project only targets the latest Node.js versions.
+
+## Further Reading
+
+- [Node.js: Releases](https://nodejs.org/en/about/previous-releases)
+- [Node.js: API Documentation](https://nodejs.org/api/)
+- [node.green: Node.js ES compatibility tables](https://node.green/)
+
+## Equivalents in Other Linters
+
+<RuleEquivalents pluginId="node" ruleId="unsupportedNodeAPIs" />

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -433,13 +433,22 @@ importers:
       '@flint.fyi/utils':
         specifier: workspace:^
         version: link:../utils
+      semver:
+        specifier: ^7.7.3
+        version: 7.7.3
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
+      zod:
+        specifier: ^4.2.1
+        version: 4.2.1
     devDependencies:
       '@flint.fyi/rule-tester':
         specifier: workspace:^
         version: link:../rule-tester
+      '@types/semver':
+        specifier: ^7.7.0
+        version: 7.7.1
       tsdown:
         specifier: 0.19.0-beta.2
         version: 0.19.0-beta.2(@arethetypeswrong/core@0.18.2)(oxc-resolver@11.15.0)(synckit@0.11.11)(typescript@5.9.3)
@@ -2167,6 +2176,9 @@ packages:
 
   '@types/sax@1.2.7':
     resolution: {integrity: sha512-rO73L89PJxeYM3s3pPPjiPgVVcymqU490g0YO5n5By0k2Erzj6tay/4lr1CHAAU4JyOWd1rpQ8bCf6cZfHU96A==}
+
+  '@types/semver@7.7.1':
+    resolution: {integrity: sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==}
 
   '@types/unist@2.0.11':
     resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
@@ -6817,6 +6829,8 @@ snapshots:
   '@types/sax@1.2.7':
     dependencies:
       '@types/node': 24.10.1
+
+  '@types/semver@7.7.1': {}
 
   '@types/unist@2.0.11': {}
 


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #932
- [x] That issue was marked as [`status: accepting prs`](https://github.com/flint-fyi/flint/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/flint-fyi/flint/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Implements the `unsupportedNodeAPIs` rule for the Node.js plugin.

This rule detects usage of Node.js built-in APIs that are not supported by the configured minimum Node.js version:
- Module imports (e.g., `fs/promises`, `node:test`, `timers/promises`)
- Property access on imported modules (e.g., `fs.promises.rm`, `crypto.webcrypto`)
- Global identifiers (e.g., `fetch`, `globalThis`, `Blob`)

This is a first implementation covering the most commonly used APIs. The data model is designed to be easily extensible for adding more API coverage later.