### PR TITLE
feat: implement constVariables for TypeScript plugin

### DIFF
--- a/packages/comparisons/src/data.json
+++ b/packages/comparisons/src/data.json
@@ -8943,7 +8943,8 @@
 		"flint": {
 			"name": "constVariables",
 			"plugin": "ts",
-			"preset": "logical"
+			"preset": "logical",
+			"status": "implemented"
 		}
 	},
 	{

--- a/packages/site/src/content/docs/rules/ts/constVariables.mdx
+++ b/packages/site/src/content/docs/rules/ts/constVariables.mdx
@@ -1,0 +1,91 @@
+---
+description: "Reports variables declared with `let` that are never reassigned and could be `const`."
+title: "constVariables"
+topic: "rules"
+---
+
+import { Tabs, TabItem } from "@astrojs/starlight/components";
+import { RuleEquivalents } from "~/components/RuleEquivalents";
+import RuleSummary from "~/components/RuleSummary.astro";
+
+<RuleSummary plugin="ts" rule="constVariables" />
+
+Using `const` for variables that are never reassigned signals to readers that the variable's binding will not change.
+This reduces cognitive load and makes code easier to understand and maintain.
+
+## Examples
+
+<Tabs>
+<TabItem label="❌ Incorrect">
+
+```ts
+let value = 1;
+console.log(value);
+```
+
+```ts
+let name = "hello";
+```
+
+```ts
+let obj = { key: "value" };
+obj.key = "updated";
+```
+
+```ts
+let arr = [1, 2, 3];
+arr.push(4);
+```
+
+</TabItem>
+<TabItem label="✅ Correct">
+
+```ts
+const value = 1;
+console.log(value);
+```
+
+```ts
+const name = "hello";
+```
+
+```ts
+let count = 0;
+count++;
+```
+
+```ts
+let value = 1;
+value = 2;
+```
+
+```ts
+const obj = { key: "value" };
+obj.key = "updated";
+```
+
+```ts
+const arr = [1, 2, 3];
+arr.push(4);
+```
+
+</TabItem>
+</Tabs>
+
+## Options
+
+This rule is not configurable.
+
+## When Not To Use It
+
+If you are working in a codebase where `let` is preferred for stylistic consistency regardless of reassignment, you may want to disable this rule.
+Some developers prefer using `let` for all mutable data structures even when the binding itself is not reassigned.
+
+## Further Reading
+
+- [MDN: const](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/const)
+- [MDN: let](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/let)
+
+## Equivalents in Other Linters
+
+<RuleEquivalents pluginId="ts" ruleId="constVariables" />

--- a/packages/ts/src/plugin.ts
+++ b/packages/ts/src/plugin.ts
@@ -52,6 +52,7 @@ import combinedPushes from "./rules/combinedPushes.ts";
 import consecutiveNonNullAssertions from "./rules/consecutiveNonNullAssertions.ts";
 import constantAssignments from "./rules/constantAssignments.ts";
 import constructorReturns from "./rules/constructorReturns.ts";
+import constVariables from "./rules/constVariables.ts";
 import dateConstructorClones from "./rules/dateConstructorClones.ts";
 import dateNowTimestamps from "./rules/dateNowTimestamps.ts";
 import debuggerStatements from "./rules/debuggerStatements.ts";
@@ -176,6 +177,7 @@ export const ts = createPlugin({
 		consecutiveNonNullAssertions,
 		constantAssignments,
 		constructorReturns,
+		constVariables,
 		dateConstructorClones,
 		dateNowTimestamps,
 		debuggerStatements,

--- a/packages/ts/src/rules/constVariables.test.ts
+++ b/packages/ts/src/rules/constVariables.test.ts
@@ -1,0 +1,111 @@
+import rule from "./constVariables.ts";
+import { ruleTester } from "./ruleTester.ts";
+
+ruleTester.describe(rule, {
+	invalid: [
+		{
+			code: `
+let value = 1;
+console.log(value);
+`,
+			snapshot: `
+let value = 1;
+    ~~~~~
+    'value' is never reassigned. Use \`const\` instead of \`let\`.
+console.log(value);
+`,
+		},
+		{
+			code: `
+let name = "hello";
+`,
+			snapshot: `
+let name = "hello";
+    ~~~~
+    'name' is never reassigned. Use \`const\` instead of \`let\`.
+`,
+		},
+		{
+			code: `
+let obj = { key: "value" };
+obj.key = "updated";
+`,
+			snapshot: `
+let obj = { key: "value" };
+    ~~~
+    'obj' is never reassigned. Use \`const\` instead of \`let\`.
+obj.key = "updated";
+`,
+		},
+		{
+			code: `
+let arr = [1, 2, 3];
+arr.push(4);
+`,
+			snapshot: `
+let arr = [1, 2, 3];
+    ~~~
+    'arr' is never reassigned. Use \`const\` instead of \`let\`.
+arr.push(4);
+`,
+		},
+		{
+			code: `
+let { a, b } = getValues();
+console.log(a, b);
+`,
+			snapshot: `
+let { a, b } = getValues();
+      ~
+      'a' is never reassigned. Use \`const\` instead of \`let\`.
+console.log(a, b);
+`,
+		},
+		{
+			code: `
+let [first, second] = getArray();
+console.log(first, second);
+`,
+			snapshot: `
+let [first, second] = getArray();
+     ~~~~~
+     'first' is never reassigned. Use \`const\` instead of \`let\`.
+console.log(first, second);
+`,
+		},
+		{
+			code: `
+function example() {
+    let inner = 42;
+    return inner;
+}
+`,
+			snapshot: `
+function example() {
+    let inner = 42;
+        ~~~~~
+        'inner' is never reassigned. Use \`const\` instead of \`let\`.
+    return inner;
+}
+`,
+		},
+	],
+	valid: [
+		`const value = 1;`,
+		`let value = 1; value = 2;`,
+		`let count = 0; count++;`,
+		`let num = 10; num--;`,
+		`let sum = 0; sum += 5;`,
+		`let diff = 10; diff -= 3;`,
+		`let product = 1; product *= 2;`,
+		`let quotient = 10; quotient /= 2;`,
+		`let value; value = 1;`,
+		`let a = 1, b = 2; a = 3;`,
+		`let { x, y } = point; x = 10;`,
+		`let [first, second] = arr; first = "new";`,
+		`for (let i = 0; i < 10; i++) { console.log(i); }`,
+		`for (let item of items) { console.log(item); }`,
+		`for (let key in obj) { console.log(key); }`,
+		`var value = 1;`,
+	],
+});

--- a/packages/ts/src/rules/constVariables.ts
+++ b/packages/ts/src/rules/constVariables.ts
@@ -1,0 +1,114 @@
+import ts, { SyntaxKind } from "typescript";
+
+import { typescriptLanguage } from "../language.ts";
+import type * as AST from "../types/ast.ts";
+import { getModifyingReferences } from "../utils/getModifyingReferences.ts";
+import { ruleCreator } from "./ruleCreator.ts";
+
+function collectBindingIdentifiers(name: AST.BindingName): AST.Identifier[] {
+	if (name.kind === SyntaxKind.Identifier) {
+		return [name];
+	}
+
+	const identifiers: AST.Identifier[] = [];
+
+	for (const element of name.elements) {
+		if (element.kind === SyntaxKind.BindingElement) {
+			identifiers.push(...collectBindingIdentifiers(element.name));
+		}
+	}
+
+	return identifiers;
+}
+
+export default ruleCreator.createRule(typescriptLanguage, {
+	about: {
+		description:
+			"Reports variables declared with `let` that are never reassigned and could be `const`.",
+		id: "constVariables",
+		presets: ["logical"],
+	},
+	messages: {
+		preferConst: {
+			primary:
+				"'{{ name }}' is never reassigned. Use `const` instead of `let`.",
+			secondary: [
+				"`const` declarations signal to readers that the variable will never be reassigned.",
+				"This reduces cognitive load and makes code easier to understand.",
+			],
+			suggestions: [
+				"Change `let` to `const` for this declaration.",
+				"If you intend to reassign this variable later, keep `let`.",
+			],
+		},
+	},
+	setup(context) {
+		return {
+			visitors: {
+				VariableDeclarationList: (node, { sourceFile, typeChecker }) => {
+					if (
+						node.flags & ts.NodeFlags.Const ||
+						node.declarations.length === 0
+					) {
+						return;
+					}
+
+					const letKeyword = node
+						.getChildren(sourceFile)
+						.find((child) => child.kind === SyntaxKind.LetKeyword);
+
+					if (!letKeyword) {
+						return;
+					}
+
+					for (const declaration of node.declarations) {
+						if (!declaration.initializer) {
+							return;
+						}
+
+						const identifiers = collectBindingIdentifiers(declaration.name);
+
+						for (const identifier of identifiers) {
+							const modifyingReferences = getModifyingReferences(
+								identifier,
+								sourceFile,
+								typeChecker,
+							);
+
+							if (modifyingReferences.length > 0) {
+								return;
+							}
+						}
+					}
+
+					for (const declaration of node.declarations) {
+						const identifiers = collectBindingIdentifiers(declaration.name);
+						const firstIdentifier = identifiers[0];
+
+						if (!firstIdentifier) {
+							continue;
+						}
+
+						context.report({
+							data: {
+								name: firstIdentifier.text,
+							},
+							fix: {
+								range: {
+									begin: letKeyword.getStart(sourceFile),
+									end: letKeyword.getEnd(),
+								},
+								text: "const",
+							},
+							message: "preferConst",
+							range: {
+								begin: firstIdentifier.getStart(sourceFile),
+								end: firstIdentifier.getEnd(),
+							},
+						});
+					}
+				},
+			},
+		};
+	},
+});


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #1420
- [x] That issue was marked as [`status: accepting prs`](https://github.com/flint-fyi/flint/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/flint-fyi/flint/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Implements the `constVariables` rule for the TypeScript plugin. This rule reports variables declared with `let` that are never reassigned and could use `const` instead.

The rule:
- Only applies to `let` declarations (not `var`)
- Checks all identifiers in destructuring patterns
- Requires an initializer (uninitialized `let` cannot become `const`)
- Provides an auto-fix to change `let` to `const`