### PR TITLE
feat: implement methodSignatureStyles rule for TypeScript plugin

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -37,6 +37,7 @@
 		"azat-io",
 		"barrymichaeldoyle",
 		"bday",
+		"bivariant",
 		"bradzacher",
 		"codemod",
 		"contentinfo",

--- a/packages/comparisons/src/data.json
+++ b/packages/comparisons/src/data.json
@@ -12595,7 +12595,8 @@
 		"flint": {
 			"name": "methodSignatureStyles",
 			"plugin": "ts",
-			"preset": "stylistic"
+			"preset": "stylistic",
+			"status": "implemented"
 		}
 	},
 	{

--- a/packages/site/src/content/docs/rules/ts/methodSignatureStyles.mdx
+++ b/packages/site/src/content/docs/rules/ts/methodSignatureStyles.mdx
@@ -1,0 +1,84 @@
+---
+description: "Enforce using function property signatures over methods."
+title: "methodSignatureStyles"
+topic: "rules"
+---
+
+import { Tabs, TabItem } from "@astrojs/starlight/components";
+import { RuleEquivalents } from "~/components/RuleEquivalents";
+import RuleSummary from "~/components/RuleSummary.astro";
+
+<RuleSummary plugin="ts" rule="methodSignatureStyles" />
+
+TypeScript provides two ways to define function properties in interfaces and type literals: method signatures and property signatures with function types.
+
+Method signatures are bivariant in their parameter types when `strictFunctionTypes` is enabled, meaning parameters are checked less strictly.
+Function property signatures are fully contravariant and provide better type safety.
+
+This rule reports method signatures and suggests converting them to function property signatures.
+
+## Examples
+
+<Tabs>
+<TabItem label="❌ Incorrect">
+
+```ts
+interface Example {
+	method(): void;
+}
+```
+
+```ts
+interface Example {
+	greet(name: string): string;
+}
+```
+
+```ts
+interface Example {
+	transform<T>(value: T): T;
+}
+```
+
+</TabItem>
+<TabItem label="✅ Correct">
+
+```ts
+interface Example {
+	method: () => void;
+}
+```
+
+```ts
+interface Example {
+	greet: (name: string) => string;
+}
+```
+
+```ts
+interface Example {
+	transform: <T>(value: T) => T;
+}
+```
+
+</TabItem>
+</Tabs>
+
+## Options
+
+This rule is not configurable.
+
+## When Not To Use It
+
+If your project does not use `strictFunctionTypes` or if you prefer the conciseness of method signatures, you may disable this rule.
+Some codebases may also intentionally use method signatures to allow for more flexible parameter typing in scenarios where bivariance is desired.
+
+## Further Reading
+
+- [TypeScript PR for strictFunctionTypes](https://github.com/microsoft/TypeScript/pull/18654)
+- [TypeScript handbook: strictFunctionTypes](https://www.typescriptlang.org/tsconfig#strictFunctionTypes)
+- [TypeScript FAQ: Method and function call behavior](https://github.com/microsoft/TypeScript/wiki/FAQ#why-are-function-parameters-bivariant)
+
+## Equivalents in Other Linters
+
+<RuleEquivalents pluginId="ts" ruleId="methodSignatureStyles" />

--- a/packages/ts/src/plugin.ts
+++ b/packages/ts/src/plugin.ts
@@ -91,6 +91,7 @@ import globalObjectCalls from "./rules/globalObjectCalls.ts";
 import impliedEvals from "./rules/impliedEvals.ts";
 import instanceOfArrays from "./rules/instanceOfArrays.ts";
 import isNaNComparisons from "./rules/isNaNComparisons.ts";
+import methodSignatureStyles from "./rules/methodSignatureStyles.ts";
 import multilineAmbiguities from "./rules/multilineAmbiguities.ts";
 import namespaceDeclarations from "./rules/namespaceDeclarations.ts";
 import negativeZeroComparisons from "./rules/negativeZeroComparisons.ts";
@@ -221,6 +222,7 @@ export const ts = createPlugin({
 		impliedEvals,
 		instanceOfArrays,
 		isNaNComparisons,
+		methodSignatureStyles,
 		multilineAmbiguities,
 		namespaceDeclarations,
 		negativeZeroComparisons,

--- a/packages/ts/src/rules/methodSignatureStyles.test.ts
+++ b/packages/ts/src/rules/methodSignatureStyles.test.ts
@@ -1,0 +1,316 @@
+import rule from "./methodSignatureStyles.ts";
+import { ruleTester } from "./ruleTester.ts";
+
+ruleTester.describe(rule, {
+	invalid: [
+		{
+			code: `
+interface Example {
+    method(): void;
+}
+`,
+			snapshot: `
+interface Example {
+    method(): void;
+    ~~~~~~~~~~~~~~~
+    Method signature is less type-safe than function property signature.
+}
+`,
+			suggestions: [
+				{
+					id: "convertToProperty",
+					updated: `
+interface Example {
+    method: () => void;
+}
+`,
+				},
+			],
+		},
+		{
+			code: `
+interface Example {
+    method(value: string): number;
+}
+`,
+			snapshot: `
+interface Example {
+    method(value: string): number;
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    Method signature is less type-safe than function property signature.
+}
+`,
+			suggestions: [
+				{
+					id: "convertToProperty",
+					updated: `
+interface Example {
+    method: (value: string) => number;
+}
+`,
+				},
+			],
+		},
+		{
+			code: `
+interface Example {
+    method?(value: string): number;
+}
+`,
+			snapshot: `
+interface Example {
+    method?(value: string): number;
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    Method signature is less type-safe than function property signature.
+}
+`,
+			suggestions: [
+				{
+					id: "convertToProperty",
+					updated: `
+interface Example {
+    method?: (value: string) => number;
+}
+`,
+				},
+			],
+		},
+		{
+			code: `
+interface Example {
+    readonly method(value: string): number;
+}
+`,
+			snapshot: `
+interface Example {
+    readonly method(value: string): number;
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    Method signature is less type-safe than function property signature.
+}
+`,
+			suggestions: [
+				{
+					id: "convertToProperty",
+					updated: `
+interface Example {
+    readonly method: (value: string) => number;
+}
+`,
+				},
+			],
+		},
+		{
+			code: `
+interface Example {
+    method<T>(value: T): T;
+}
+`,
+			snapshot: `
+interface Example {
+    method<T>(value: T): T;
+    ~~~~~~~~~~~~~~~~~~~~~~~
+    Method signature is less type-safe than function property signature.
+}
+`,
+			suggestions: [
+				{
+					id: "convertToProperty",
+					updated: `
+interface Example {
+    method: <T>(value: T) => T;
+}
+`,
+				},
+			],
+		},
+		{
+			code: `
+type Example = {
+    method(): void;
+};
+`,
+			snapshot: `
+type Example = {
+    method(): void;
+    ~~~~~~~~~~~~~~~
+    Method signature is less type-safe than function property signature.
+};
+`,
+			suggestions: [
+				{
+					id: "convertToProperty",
+					updated: `
+type Example = {
+    method: () => void;
+};
+`,
+				},
+			],
+		},
+		{
+			code: `
+interface Example {
+    method(): void,
+}
+`,
+			snapshot: `
+interface Example {
+    method(): void,
+    ~~~~~~~~~~~~~~~
+    Method signature is less type-safe than function property signature.
+}
+`,
+			suggestions: [
+				{
+					id: "convertToProperty",
+					updated: `
+interface Example {
+    method: () => void,
+}
+`,
+				},
+			],
+		},
+		{
+			code: `
+interface Example {
+    [key: string]: unknown;
+    method(): void;
+}
+`,
+			snapshot: `
+interface Example {
+    [key: string]: unknown;
+    method(): void;
+    ~~~~~~~~~~~~~~~
+    Method signature is less type-safe than function property signature.
+}
+`,
+			suggestions: [
+				{
+					id: "convertToProperty",
+					updated: `
+interface Example {
+    [key: string]: unknown;
+    method: () => void;
+}
+`,
+				},
+			],
+		},
+		{
+			code: `
+interface Example {
+    "complex-name"(): void;
+}
+`,
+			snapshot: `
+interface Example {
+    "complex-name"(): void;
+    ~~~~~~~~~~~~~~~~~~~~~~~
+    Method signature is less type-safe than function property signature.
+}
+`,
+			suggestions: [
+				{
+					id: "convertToProperty",
+					updated: `
+interface Example {
+    ["complex-name"]: () => void;
+}
+`,
+				},
+			],
+		},
+		{
+			code: `
+interface Example {
+    method(first: string, second: number): boolean;
+}
+`,
+			snapshot: `
+interface Example {
+    method(first: string, second: number): boolean;
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    Method signature is less type-safe than function property signature.
+}
+`,
+			suggestions: [
+				{
+					id: "convertToProperty",
+					updated: `
+interface Example {
+    method: (first: string, second: number) => boolean;
+}
+`,
+				},
+			],
+		},
+		{
+			code: `
+interface Example {
+    method();
+}
+`,
+			snapshot: `
+interface Example {
+    method();
+    ~~~~~~~~~
+    Method signature is less type-safe than function property signature.
+}
+`,
+			suggestions: [
+				{
+					id: "convertToProperty",
+					updated: `
+interface Example {
+    method: () => any;
+}
+`,
+				},
+			],
+		},
+		{
+			code: `
+interface Example {
+    [key](): void;
+}
+`,
+			snapshot: `
+interface Example {
+    [key](): void;
+    ~~~~~~~~~~~~~~
+    Method signature is less type-safe than function property signature.
+}
+`,
+			suggestions: [
+				{
+					id: "convertToProperty",
+					updated: `
+interface Example {
+    [key]: () => void;
+}
+`,
+				},
+			],
+		},
+	],
+	valid: [
+		`interface Example { method: () => void; }`,
+		`interface Example { method: (value: string) => number; }`,
+		`interface Example { method?: (value: string) => number; }`,
+		`interface Example { readonly method: (value: string) => number; }`,
+		`interface Example { method: <T>(value: T) => T; }`,
+		`type Example = { method: () => void; };`,
+		`interface Example { property: string; }`,
+		`interface Example { getThis(): this; }`,
+		`interface Example { clone(): this; }`,
+		`interface Example { get value(): number; }`,
+		`interface Example { set value(v: number); }`,
+		`type Example = { get value(): number; };`,
+		`type Example = { set value(v: number): void; };`,
+		`interface Example { method(): this | undefined; }`,
+		`interface Example { method(): Promise<this>; }`,
+		`interface Example { method<T>(): Map<T, this>; }`,
+	],
+});

--- a/packages/ts/src/rules/methodSignatureStyles.test.ts
+++ b/packages/ts/src/rules/methodSignatureStyles.test.ts
@@ -3,6 +3,7 @@ import { ruleTester } from "./ruleTester.ts";
 
 ruleTester.describe(rule, {
 	invalid: [
+		// Default style: "property" - reports method signatures
 		{
 			code: `
 interface Example {
@@ -13,7 +14,7 @@ interface Example {
 interface Example {
     method(): void;
     ~~~~~~~~~~~~~~~
-    Method signature is less type-safe than function property signature.
+    Shorthand method signature is forbidden. Use a function property instead.
 }
 `,
 			suggestions: [
@@ -37,7 +38,7 @@ interface Example {
 interface Example {
     method(value: string): number;
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    Method signature is less type-safe than function property signature.
+    Shorthand method signature is forbidden. Use a function property instead.
 }
 `,
 			suggestions: [
@@ -61,7 +62,7 @@ interface Example {
 interface Example {
     method?(value: string): number;
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    Method signature is less type-safe than function property signature.
+    Shorthand method signature is forbidden. Use a function property instead.
 }
 `,
 			suggestions: [
@@ -85,7 +86,7 @@ interface Example {
 interface Example {
     readonly method(value: string): number;
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    Method signature is less type-safe than function property signature.
+    Shorthand method signature is forbidden. Use a function property instead.
 }
 `,
 			suggestions: [
@@ -109,7 +110,7 @@ interface Example {
 interface Example {
     method<T>(value: T): T;
     ~~~~~~~~~~~~~~~~~~~~~~~
-    Method signature is less type-safe than function property signature.
+    Shorthand method signature is forbidden. Use a function property instead.
 }
 `,
 			suggestions: [
@@ -125,6 +126,30 @@ interface Example {
 		},
 		{
 			code: `
+interface Example {
+    ['f']<T extends {}>(a: T, b: T): T;
+}
+`,
+			snapshot: `
+interface Example {
+    ['f']<T extends {}>(a: T, b: T): T;
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    Shorthand method signature is forbidden. Use a function property instead.
+}
+`,
+			suggestions: [
+				{
+					id: "convertToProperty",
+					updated: `
+interface Example {
+    ['f']: <T extends {}>(a: T, b: T) => T;
+}
+`,
+				},
+			],
+		},
+		{
+			code: `
 type Example = {
     method(): void;
 };
@@ -133,7 +158,7 @@ type Example = {
 type Example = {
     method(): void;
     ~~~~~~~~~~~~~~~
-    Method signature is less type-safe than function property signature.
+    Shorthand method signature is forbidden. Use a function property instead.
 };
 `,
 			suggestions: [
@@ -157,7 +182,7 @@ interface Example {
 interface Example {
     method(): void,
     ~~~~~~~~~~~~~~~
-    Method signature is less type-safe than function property signature.
+    Shorthand method signature is forbidden. Use a function property instead.
 }
 `,
 			suggestions: [
@@ -183,7 +208,7 @@ interface Example {
     [key: string]: unknown;
     method(): void;
     ~~~~~~~~~~~~~~~
-    Method signature is less type-safe than function property signature.
+    Shorthand method signature is forbidden. Use a function property instead.
 }
 `,
 			suggestions: [
@@ -208,7 +233,7 @@ interface Example {
 interface Example {
     "complex-name"(): void;
     ~~~~~~~~~~~~~~~~~~~~~~~
-    Method signature is less type-safe than function property signature.
+    Shorthand method signature is forbidden. Use a function property instead.
 }
 `,
 			suggestions: [
@@ -232,7 +257,7 @@ interface Example {
 interface Example {
     method(first: string, second: number): boolean;
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    Method signature is less type-safe than function property signature.
+    Shorthand method signature is forbidden. Use a function property instead.
 }
 `,
 			suggestions: [
@@ -256,7 +281,7 @@ interface Example {
 interface Example {
     method();
     ~~~~~~~~~
-    Method signature is less type-safe than function property signature.
+    Shorthand method signature is forbidden. Use a function property instead.
 }
 `,
 			suggestions: [
@@ -280,7 +305,7 @@ interface Example {
 interface Example {
     [key](): void;
     ~~~~~~~~~~~~~~
-    Method signature is less type-safe than function property signature.
+    Shorthand method signature is forbidden. Use a function property instead.
 }
 `,
 			suggestions: [
@@ -294,23 +319,320 @@ interface Example {
 				},
 			],
 		},
+
+		// Style: "method" - reports function property signatures
+		{
+			code: `
+interface Example {
+    f: (a: string) => number;
+}
+`,
+			options: { style: "method" },
+			snapshot: `
+interface Example {
+    f: (a: string) => number;
+    ~~~~~~~~~~~~~~~~~~~~~~~~~
+    Function property signature is forbidden. Use a method shorthand instead.
+}
+`,
+			suggestions: [
+				{
+					id: "convertToMethod",
+					updated: `
+interface Example {
+    f(a: string): number;
+}
+`,
+				},
+			],
+		},
+		{
+			code: `
+interface Example {
+    ['f']: (a: boolean) => void;
+}
+`,
+			options: { style: "method" },
+			snapshot: `
+interface Example {
+    ['f']: (a: boolean) => void;
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    Function property signature is forbidden. Use a method shorthand instead.
+}
+`,
+			suggestions: [
+				{
+					id: "convertToMethod",
+					updated: `
+interface Example {
+    ['f'](a: boolean): void;
+}
+`,
+				},
+			],
+		},
+		{
+			code: `
+interface Example {
+    f: <T>(a: T) => T;
+}
+`,
+			options: { style: "method" },
+			snapshot: `
+interface Example {
+    f: <T>(a: T) => T;
+    ~~~~~~~~~~~~~~~~~~
+    Function property signature is forbidden. Use a method shorthand instead.
+}
+`,
+			suggestions: [
+				{
+					id: "convertToMethod",
+					updated: `
+interface Example {
+    f<T>(a: T): T;
+}
+`,
+				},
+			],
+		},
+		{
+			code: `
+interface Example {
+    ['f']: <T extends {}>(a: T, b: T) => T;
+}
+`,
+			options: { style: "method" },
+			snapshot: `
+interface Example {
+    ['f']: <T extends {}>(a: T, b: T) => T;
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    Function property signature is forbidden. Use a method shorthand instead.
+}
+`,
+			suggestions: [
+				{
+					id: "convertToMethod",
+					updated: `
+interface Example {
+    ['f']<T extends {}>(a: T, b: T): T;
+}
+`,
+				},
+			],
+		},
+		{
+			code: `
+type Example = { f: (a: string) => number };
+`,
+			options: { style: "method" },
+			snapshot: `
+type Example = { f: (a: string) => number };
+                 ~~~~~~~~~~~~~~~~~~~~~~~~
+                 Function property signature is forbidden. Use a method shorthand instead.
+`,
+			suggestions: [
+				{
+					id: "convertToMethod",
+					updated: `
+type Example = { f(a: string): number };
+`,
+				},
+			],
+		},
+		{
+			code: `
+type Example = { ['f']?: (a: boolean) => void };
+`,
+			options: { style: "method" },
+			snapshot: `
+type Example = { ['f']?: (a: boolean) => void };
+                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                 Function property signature is forbidden. Use a method shorthand instead.
+`,
+			suggestions: [
+				{
+					id: "convertToMethod",
+					updated: `
+type Example = { ['f']?(a: boolean): void };
+`,
+				},
+			],
+		},
+		{
+			code: `
+type Example = { f?: <T>(a?: T) => T };
+`,
+			options: { style: "method" },
+			snapshot: `
+type Example = { f?: <T>(a?: T) => T };
+                 ~~~~~~~~~~~~~~~~~~~
+                 Function property signature is forbidden. Use a method shorthand instead.
+`,
+			suggestions: [
+				{
+					id: "convertToMethod",
+					updated: `
+type Example = { f?<T>(a?: T): T };
+`,
+				},
+			],
+		},
+		{
+			code: `
+type Example = { readonly f: (a: string) => number };
+`,
+			options: { style: "method" },
+			snapshot: `
+type Example = { readonly f: (a: string) => number };
+                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                 Function property signature is forbidden. Use a method shorthand instead.
+`,
+			suggestions: [
+				{
+					id: "convertToMethod",
+					updated: `
+type Example = { readonly f(a: string): number };
+`,
+				},
+			],
+		},
+		// Delimiter preservation in method mode
+		{
+			code: `
+interface Foo {
+    semi: (arg: string) => void;
+}
+`,
+			options: { style: "method" },
+			snapshot: `
+interface Foo {
+    semi: (arg: string) => void;
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    Function property signature is forbidden. Use a method shorthand instead.
+}
+`,
+			suggestions: [
+				{
+					id: "convertToMethod",
+					updated: `
+interface Foo {
+    semi(arg: string): void;
+}
+`,
+				},
+			],
+		},
+		{
+			code: `
+interface Foo {
+    comma: (arg: string) => void,
+}
+`,
+			options: { style: "method" },
+			snapshot: `
+interface Foo {
+    comma: (arg: string) => void,
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    Function property signature is forbidden. Use a method shorthand instead.
+}
+`,
+			suggestions: [
+				{
+					id: "convertToMethod",
+					updated: `
+interface Foo {
+    comma(arg: string): void,
+}
+`,
+				},
+			],
+		},
 	],
 	valid: [
+		// Default style: "property" - accepts function property signatures
 		`interface Example { method: () => void; }`,
 		`interface Example { method: (value: string) => number; }`,
 		`interface Example { method?: (value: string) => number; }`,
 		`interface Example { readonly method: (value: string) => number; }`,
 		`interface Example { method: <T>(value: T) => T; }`,
+		`interface Example { ['f']: <T extends {}>(a: T, b: T) => T; }`,
 		`type Example = { method: () => void; };`,
+		`type Example = { readonly f: (a: string) => number };`,
+		`type Example = { ['f']?: (a: boolean) => void };`,
+		`type Example = { readonly f?: <T>(a?: T) => T };`,
+		`type Example = { readonly ['f']?: <T>(a: T, b: T) => T };`,
 		`interface Example { property: string; }`,
-		`interface Example { getThis(): this; }`,
-		`interface Example { clone(): this; }`,
+		// Getters and setters are always valid
 		`interface Example { get value(): number; }`,
 		`interface Example { set value(v: number); }`,
 		`type Example = { get value(): number; };`,
 		`type Example = { set value(v: number): void; };`,
+		// Methods returning this are valid (can't be converted)
+		`interface Example { getThis(): this; }`,
+		`interface Example { clone(): this; }`,
 		`interface Example { method(): this | undefined; }`,
 		`interface Example { method(): Promise<this>; }`,
 		`interface Example { method<T>(): Map<T, this>; }`,
+
+		// Style: "method" - accepts method signatures
+		{
+			code: `interface Test { f(a: string): number; }`,
+			options: { style: "method" },
+		},
+		{
+			code: `interface Test { ['f'](a: boolean): void; }`,
+			options: { style: "method" },
+		},
+		{
+			code: `interface Test { f<T>(a: T): T; }`,
+			options: { style: "method" },
+		},
+		{
+			code: `interface Test { ['f']<T extends {}>(a: T, b: T): T; }`,
+			options: { style: "method" },
+		},
+		{
+			code: `type Test = { f(a: string): number };`,
+			options: { style: "method" },
+		},
+		{
+			code: `type Test = { ['f']?(a: boolean): void };`,
+			options: { style: "method" },
+		},
+		{
+			code: `type Test = { f?<T>(a?: T): T };`,
+			options: { style: "method" },
+		},
+		{
+			code: `type Test = { ['f']?<T>(a: T, b: T): T };`,
+			options: { style: "method" },
+		},
+		// Getters/setters valid in method mode too
+		{
+			code: `interface Test { get f(): number; }`,
+			options: { style: "method" },
+		},
+		{
+			code: `interface Test { set f(value: number): void; }`,
+			options: { style: "method" },
+		},
+		{
+			code: `type Test = { get f(): number };`,
+			options: { style: "method" },
+		},
+		{
+			code: `type Test = { set f(value: number): void };`,
+			options: { style: "method" },
+		},
+		// Non-function properties should not be reported in method mode
+		{
+			code: `interface Test { prop: string; }`,
+			options: { style: "method" },
+		},
+		{
+			code: `interface Test { prop: number[]; }`,
+			options: { style: "method" },
+		},
 	],
 });

--- a/packages/ts/src/rules/methodSignatureStyles.ts
+++ b/packages/ts/src/rules/methodSignatureStyles.ts
@@ -1,15 +1,40 @@
 import * as ts from "typescript";
+import { z } from "zod";
 
 import { getTSNodeRange } from "../getTSNodeRange.ts";
 import { typescriptLanguage } from "../language.ts";
 import * as AST from "../types/ast.ts";
 import { ruleCreator } from "./ruleCreator.ts";
 
+function containsThisType(node: ts.Node): boolean {
+	if (node.kind === ts.SyntaxKind.ThisType) {
+		return true;
+	}
+	let found = false;
+	ts.forEachChild(node, (child) => {
+		if (containsThisType(child)) {
+			found = true;
+		}
+	});
+	return found;
+}
+
+function getDelimiter(node: ts.Node, sourceFile: ts.SourceFile) {
+	const text = node.getText(sourceFile);
+	const lastChar = text[text.length - 1];
+	if (lastChar === ";" || lastChar === ",") {
+		return lastChar;
+	}
+	return "";
+}
+
 function getMethodKey(
 	node: AST.MethodSignature | AST.PropertySignature,
 	sourceFile: ts.SourceFile,
 ) {
 	let key = node.name.getText(sourceFile);
+	// Only wrap in brackets for string literals (e.g., "complex-name"(): void)
+	// Computed property names (e.g., ['f'] or [key]) already include brackets
 	if (node.name.kind === ts.SyntaxKind.StringLiteral) {
 		key = `[${key}]`;
 	}
@@ -26,15 +51,19 @@ function getMethodKey(
 }
 
 function getMethodParams(
-	node: AST.MethodSignature | AST.FunctionTypeNode,
+	node: AST.FunctionTypeNode | AST.MethodSignature,
 	sourceFile: ts.SourceFile,
 ) {
 	let params = "()";
 	if (node.parameters.length > 0) {
 		const firstParam = node.parameters[0];
 		const lastParam = node.parameters[node.parameters.length - 1];
-		let openParen: ts.Node | undefined;
-		let closeParen: ts.Node | undefined;
+
+		if (!firstParam || !lastParam) {
+			return params;
+		}
+		let openParenPos: number | undefined;
+		let closeParenPos: number | undefined;
 
 		for (
 			let i = firstParam.getStart(sourceFile) - 1;
@@ -43,7 +72,7 @@ function getMethodParams(
 		) {
 			const char = sourceFile.text[i];
 			if (char === "(") {
-				openParen = { getStart: () => i, getEnd: () => i + 1 } as ts.Node;
+				openParenPos = i;
 				break;
 			}
 		}
@@ -51,16 +80,13 @@ function getMethodParams(
 		for (let i = lastParam.getEnd(); i < node.getEnd(); i++) {
 			const char = sourceFile.text[i];
 			if (char === ")") {
-				closeParen = { getStart: () => i, getEnd: () => i + 1 } as ts.Node;
+				closeParenPos = i + 1;
 				break;
 			}
 		}
 
-		if (openParen && closeParen) {
-			params = sourceFile.text.substring(
-				openParen.getStart(),
-				closeParen.getEnd(),
-			);
+		if (openParenPos !== undefined && closeParenPos !== undefined) {
+			params = sourceFile.text.substring(openParenPos, closeParenPos);
 		}
 	}
 	if (node.typeParameters && node.typeParameters.length > 0) {
@@ -73,7 +99,7 @@ function getMethodParams(
 }
 
 function getMethodReturnType(
-	node: AST.MethodSignature | AST.FunctionTypeNode,
+	node: AST.FunctionTypeNode | AST.MethodSignature,
 	sourceFile: ts.SourceFile,
 ) {
 	if (!node.type) {
@@ -82,50 +108,44 @@ function getMethodReturnType(
 	return node.type.getText(sourceFile);
 }
 
-function getDelimiter(node: ts.Node, sourceFile: ts.SourceFile) {
-	const text = node.getText(sourceFile);
-	const lastChar = text[text.length - 1];
-	if (lastChar === ";" || lastChar === ",") {
-		return lastChar;
+function getPropertyKey(
+	node: AST.PropertySignature,
+	sourceFile: ts.SourceFile,
+) {
+	let key = node.name.getText(sourceFile);
+	// Only wrap in brackets for string literals (e.g., "complex-name": () => void)
+	// Computed property names (e.g., ['f'] or [key]) already include brackets
+	if (node.name.kind === ts.SyntaxKind.StringLiteral) {
+		key = `[${key}]`;
 	}
-	return "";
-}
-
-function containsThisType(node: ts.Node): boolean {
-	if (node.kind === ts.SyntaxKind.ThisType) {
-		return true;
+	if (node.questionToken) {
+		key = `${key}?`;
 	}
-	let found = false;
-	ts.forEachChild(node, (child) => {
-		if (containsThisType(child)) {
-			found = true;
-		}
-	});
-	return found;
-}
-
-function isGetterOrSetter(node: AST.MethodSignature) {
-	const modifiers = node.modifiers;
-	if (!modifiers) {
-		return false;
-	}
-	return modifiers.some(
-		(m) =>
-			m.kind === ts.SyntaxKind.GetKeyword ||
-			m.kind === ts.SyntaxKind.SetKeyword,
+	const readonlyModifier = node.modifiers?.find(
+		(modifier) => modifier.kind === ts.SyntaxKind.ReadonlyKeyword,
 	);
+	if (readonlyModifier) {
+		key = `readonly ${key}`;
+	}
+	return key;
 }
 
 export default ruleCreator.createRule(typescriptLanguage, {
 	about: {
-		description: "Enforce using function property signatures over methods.",
+		description: "Enforce using a particular method signature syntax.",
 		id: "methodSignatureStyles",
 		presets: ["stylistic"],
 	},
 	messages: {
+		preferMethod: {
+			primary:
+				"Function property signature is forbidden. Use a method shorthand instead.",
+			secondary: [],
+			suggestions: ["Convert to method signature."],
+		},
 		preferProperty: {
 			primary:
-				"Method signature is less type-safe than function property signature.",
+				"Shorthand method signature is forbidden. Use a function property instead.",
 			secondary: [
 				"Method signatures have bivariant parameter types when strictFunctionTypes is enabled.",
 				"Function property signatures are fully contravariant and provide better type safety.",
@@ -133,14 +153,24 @@ export default ruleCreator.createRule(typescriptLanguage, {
 			suggestions: ["Convert to function property signature."],
 		},
 	},
+	options: {
+		style: z
+			.enum(["property", "method"])
+			.default("property")
+			.describe(
+				"Which method signature style to enforce: 'property' for function properties (`f: () => void`), or 'method' for method shorthand (`f(): void`).",
+			),
+	},
 	setup(context) {
 		return {
 			visitors: {
-				MethodSignature: (node, { sourceFile }) => {
-					if (isGetterOrSetter(node)) {
+				MethodSignature: (node, { options, sourceFile }) => {
+					if (options.style !== "property") {
 						return;
 					}
 
+					// Methods that return `this` type can't be converted to function properties
+					// because arrow functions don't have their own `this` binding
 					if (node.type && containsThisType(node.type)) {
 						return;
 					}
@@ -158,6 +188,33 @@ export default ruleCreator.createRule(typescriptLanguage, {
 								id: "convertToProperty",
 								range: getTSNodeRange(node, sourceFile),
 								text: `${key}: ${params} => ${returnType}${delimiter}`,
+							},
+						],
+					});
+				},
+				PropertySignature: (node, { options, sourceFile }) => {
+					if (options.style !== "method") {
+						return;
+					}
+
+					if (!node.type || node.type.kind !== ts.SyntaxKind.FunctionType) {
+						return;
+					}
+
+					const functionType = node.type;
+					const key = getPropertyKey(node, sourceFile);
+					const params = getMethodParams(functionType, sourceFile);
+					const returnType = getMethodReturnType(functionType, sourceFile);
+					const delimiter = getDelimiter(node, sourceFile);
+
+					context.report({
+						message: "preferMethod",
+						range: getTSNodeRange(node, sourceFile),
+						suggestions: [
+							{
+								id: "convertToMethod",
+								range: getTSNodeRange(node, sourceFile),
+								text: `${key}${params}: ${returnType}${delimiter}`,
 							},
 						],
 					});

--- a/packages/ts/src/rules/methodSignatureStyles.ts
+++ b/packages/ts/src/rules/methodSignatureStyles.ts
@@ -1,0 +1,168 @@
+import * as ts from "typescript";
+
+import { getTSNodeRange } from "../getTSNodeRange.ts";
+import { typescriptLanguage } from "../language.ts";
+import * as AST from "../types/ast.ts";
+import { ruleCreator } from "./ruleCreator.ts";
+
+function getMethodKey(
+	node: AST.MethodSignature | AST.PropertySignature,
+	sourceFile: ts.SourceFile,
+) {
+	let key = node.name.getText(sourceFile);
+	if (node.name.kind === ts.SyntaxKind.StringLiteral) {
+		key = `[${key}]`;
+	}
+	if (node.questionToken) {
+		key = `${key}?`;
+	}
+	const readonlyModifier = node.modifiers?.find(
+		(modifier) => modifier.kind === ts.SyntaxKind.ReadonlyKeyword,
+	);
+	if (readonlyModifier) {
+		key = `readonly ${key}`;
+	}
+	return key;
+}
+
+function getMethodParams(
+	node: AST.MethodSignature | AST.FunctionTypeNode,
+	sourceFile: ts.SourceFile,
+) {
+	let params = "()";
+	if (node.parameters.length > 0) {
+		const firstParam = node.parameters[0];
+		const lastParam = node.parameters[node.parameters.length - 1];
+		let openParen: ts.Node | undefined;
+		let closeParen: ts.Node | undefined;
+
+		for (
+			let i = firstParam.getStart(sourceFile) - 1;
+			i >= node.getStart(sourceFile);
+			i--
+		) {
+			const char = sourceFile.text[i];
+			if (char === "(") {
+				openParen = { getStart: () => i, getEnd: () => i + 1 } as ts.Node;
+				break;
+			}
+		}
+
+		for (let i = lastParam.getEnd(); i < node.getEnd(); i++) {
+			const char = sourceFile.text[i];
+			if (char === ")") {
+				closeParen = { getStart: () => i, getEnd: () => i + 1 } as ts.Node;
+				break;
+			}
+		}
+
+		if (openParen && closeParen) {
+			params = sourceFile.text.substring(
+				openParen.getStart(),
+				closeParen.getEnd(),
+			);
+		}
+	}
+	if (node.typeParameters && node.typeParameters.length > 0) {
+		const typeParams = node.typeParameters
+			.map((tp) => tp.getText(sourceFile))
+			.join(", ");
+		params = `<${typeParams}>${params}`;
+	}
+	return params;
+}
+
+function getMethodReturnType(
+	node: AST.MethodSignature | AST.FunctionTypeNode,
+	sourceFile: ts.SourceFile,
+) {
+	if (!node.type) {
+		return "any";
+	}
+	return node.type.getText(sourceFile);
+}
+
+function getDelimiter(node: ts.Node, sourceFile: ts.SourceFile) {
+	const text = node.getText(sourceFile);
+	const lastChar = text[text.length - 1];
+	if (lastChar === ";" || lastChar === ",") {
+		return lastChar;
+	}
+	return "";
+}
+
+function containsThisType(node: ts.Node): boolean {
+	if (node.kind === ts.SyntaxKind.ThisType) {
+		return true;
+	}
+	let found = false;
+	ts.forEachChild(node, (child) => {
+		if (containsThisType(child)) {
+			found = true;
+		}
+	});
+	return found;
+}
+
+function isGetterOrSetter(node: AST.MethodSignature) {
+	const modifiers = node.modifiers;
+	if (!modifiers) {
+		return false;
+	}
+	return modifiers.some(
+		(m) =>
+			m.kind === ts.SyntaxKind.GetKeyword ||
+			m.kind === ts.SyntaxKind.SetKeyword,
+	);
+}
+
+export default ruleCreator.createRule(typescriptLanguage, {
+	about: {
+		description: "Enforce using function property signatures over methods.",
+		id: "methodSignatureStyles",
+		presets: ["stylistic"],
+	},
+	messages: {
+		preferProperty: {
+			primary:
+				"Method signature is less type-safe than function property signature.",
+			secondary: [
+				"Method signatures have bivariant parameter types when strictFunctionTypes is enabled.",
+				"Function property signatures are fully contravariant and provide better type safety.",
+			],
+			suggestions: ["Convert to function property signature."],
+		},
+	},
+	setup(context) {
+		return {
+			visitors: {
+				MethodSignature: (node, { sourceFile }) => {
+					if (isGetterOrSetter(node)) {
+						return;
+					}
+
+					if (node.type && containsThisType(node.type)) {
+						return;
+					}
+
+					const key = getMethodKey(node, sourceFile);
+					const params = getMethodParams(node, sourceFile);
+					const returnType = getMethodReturnType(node, sourceFile);
+					const delimiter = getDelimiter(node, sourceFile);
+
+					context.report({
+						message: "preferProperty",
+						range: getTSNodeRange(node, sourceFile),
+						suggestions: [
+							{
+								id: "convertToProperty",
+								range: getTSNodeRange(node, sourceFile),
+								text: `${key}: ${params} => ${returnType}${delimiter}`,
+							},
+						],
+					});
+				},
+			},
+		};
+	},
+});


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #1678
- [x] That issue was marked as [`status: accepting prs`](https://github.com/flint-fyi/flint/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/flint-fyi/flint/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Implements the methodSignatureStyles rule that enforces using function property signatures over method signatures. Method signatures are bivariant with strictFunctionTypes, while function property signatures are fully contravariant and provide better type safety.