### PR TITLE
feat(ts): implement invalidThis rule

### DIFF
--- a/packages/comparisons/src/data.json
+++ b/packages/comparisons/src/data.json
@@ -11387,7 +11387,8 @@
 		"flint": {
 			"name": "invalidThis",
 			"plugin": "ts",
-			"preset": "untyped"
+			"preset": "untyped",
+			"status": "implemented"
 		}
 	},
 	{

--- a/packages/site/src/content/docs/rules/ts/invalidThis.mdx
+++ b/packages/site/src/content/docs/rules/ts/invalidThis.mdx
@@ -1,0 +1,146 @@
+---
+description: "Reports usage of `this` in contexts where its value is `undefined`."
+title: "invalidThis"
+topic: "rules"
+---
+
+import { Tabs, TabItem } from "@astrojs/starlight/components";
+import { RuleEquivalents } from "~/components/RuleEquivalents";
+import RuleSummary from "~/components/RuleSummary.astro";
+
+<RuleSummary plugin="ts" rule="invalidThis" />
+
+In strict mode, `this` is `undefined` in functions that are not methods, constructors, or bound to an object.
+Using `this` in such contexts typically indicates a bug or misunderstanding of how `this` works in JavaScript.
+
+This rule flags usage of `this` in contexts where its value would be `undefined`.
+
+## Examples
+
+<Tabs>
+<TabItem label="❌ Incorrect">
+
+```ts
+function getValue() {
+	return this.value;
+}
+```
+
+```ts
+const getValue = function () {
+	return this.value;
+};
+```
+
+```ts
+(function () {
+	console.log(this);
+})();
+```
+
+```ts
+const obj = {
+	method() {
+		return function () {
+			return this.value;
+		};
+	},
+};
+```
+
+```ts
+items.forEach(function (item) {
+	this.process(item);
+});
+```
+
+</TabItem>
+<TabItem label="✅ Correct">
+
+```ts
+class Example {
+	method() {
+		return this.value;
+	}
+}
+```
+
+```ts
+const obj = {
+	method() {
+		return this.value;
+	},
+};
+```
+
+```ts
+const obj = {
+	handler: function () {
+		return this.value;
+	},
+};
+```
+
+```ts
+function Foo() {
+	this.value = 0;
+}
+```
+
+```ts
+const bar = function () {
+	this.value = 0;
+}.bind(obj);
+```
+
+```ts
+items.forEach(function (item) {
+	this.process(item);
+}, thisArg);
+```
+
+```ts
+obj.method = function () {
+	return this.value;
+};
+```
+
+</TabItem>
+</Tabs>
+
+## Options
+
+### `capIsConstructor`
+
+Type: `boolean`
+Default: `true`
+
+Whether to assume functions starting with an uppercase letter are constructors.
+
+When `true` (default), functions with names starting with uppercase are treated as constructors, allowing `this` usage:
+
+```ts
+function Foo() {
+	this.value = 0;
+}
+
+const Handler = function () {
+	this.active = true;
+};
+```
+
+When `false`, these functions are treated as regular functions and `this` usage is flagged.
+
+## When Not To Use It
+
+If your codebase uses `this` in non-strict mode scripts where `this` refers to the global object, you may disable this rule.
+TypeScript with `strict` or `noImplicitThis` enabled will catch these issues at compile time, making this rule redundant.
+
+## Further Reading
+
+- [MDN: this](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/this)
+- [MDN: Strict mode](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode)
+
+## Equivalents in Other Linters
+
+<RuleEquivalents pluginId="ts" ruleId="invalidThis" />

--- a/packages/ts/src/plugin.ts
+++ b/packages/ts/src/plugin.ts
@@ -108,6 +108,7 @@ import impliedEvals from "./rules/impliedEvals.ts";
 import importEmptyBlocks from "./rules/importEmptyBlocks.ts";
 import importTypeSideEffects from "./rules/importTypeSideEffects.ts";
 import instanceOfArrays from "./rules/instanceOfArrays.ts";
+import invalidThis from "./rules/invalidThis.ts";
 import isNaNComparisons from "./rules/isNaNComparisons.ts";
 import mathMethods from "./rules/mathMethods.ts";
 import meaninglessVoidOperators from "./rules/meaninglessVoidOperators.ts";
@@ -260,6 +261,7 @@ export const ts = createPlugin({
 		importEmptyBlocks,
 		importTypeSideEffects,
 		instanceOfArrays,
+		invalidThis,
 		isNaNComparisons,
 		mathMethods,
 		meaninglessVoidOperators,

--- a/packages/ts/src/rules/invalidThis.test.ts
+++ b/packages/ts/src/rules/invalidThis.test.ts
@@ -1,0 +1,188 @@
+import rule from "./invalidThis.ts";
+import { ruleTester } from "./ruleTester.ts";
+
+ruleTester.describe(rule, {
+	invalid: [
+		{
+			code: `
+function getValue() {
+    return this.value;
+}
+`,
+			snapshot: `
+function getValue() {
+    return this.value;
+           ~~~~
+           Unexpected \`this\` in a context where its value is \`undefined\`.
+}
+`,
+		},
+		{
+			code: `
+const getValue = function() {
+    return this.value;
+};
+`,
+			snapshot: `
+const getValue = function() {
+    return this.value;
+           ~~~~
+           Unexpected \`this\` in a context where its value is \`undefined\`.
+};
+`,
+		},
+		{
+			code: `
+(function() {
+    console.log(this);
+})();
+`,
+			snapshot: `
+(function() {
+    console.log(this);
+                ~~~~
+                Unexpected \`this\` in a context where its value is \`undefined\`.
+})();
+`,
+		},
+		{
+			code: `
+function outer() {
+    return function inner() {
+        return this.value;
+    };
+}
+`,
+			snapshot: `
+function outer() {
+    return function inner() {
+        return this.value;
+               ~~~~
+               Unexpected \`this\` in a context where its value is \`undefined\`.
+    };
+}
+`,
+		},
+		{
+			code: `
+const obj = {
+    method() {
+        return function() {
+            return this.value;
+        };
+    }
+};
+`,
+			snapshot: `
+const obj = {
+    method() {
+        return function() {
+            return this.value;
+                   ~~~~
+                   Unexpected \`this\` in a context where its value is \`undefined\`.
+        };
+    }
+};
+`,
+		},
+		{
+			code: `
+function getValue() {
+    const arrow = () => this.value;
+    return arrow();
+}
+`,
+			snapshot: `
+function getValue() {
+    const arrow = () => this.value;
+                        ~~~~
+                        Unexpected \`this\` in a context where its value is \`undefined\`.
+    return arrow();
+}
+`,
+		},
+		{
+			code: `
+items.forEach(function(item: unknown) {
+    this.process(item);
+});
+`,
+			snapshot: `
+items.forEach(function(item: unknown) {
+    this.process(item);
+    ~~~~
+    Unexpected \`this\` in a context where its value is \`undefined\`.
+});
+`,
+		},
+		{
+			code: `
+function Foo() {
+    this.value = 1;
+}
+`,
+			options: { capIsConstructor: false },
+			snapshot: `
+function Foo() {
+    this.value = 1;
+    ~~~~
+    Unexpected \`this\` in a context where its value is \`undefined\`.
+}
+`,
+		},
+		{
+			code: `
+const Handler = function() {
+    this.active = true;
+};
+`,
+			options: { capIsConstructor: false },
+			snapshot: `
+const Handler = function() {
+    this.active = true;
+    ~~~~
+    Unexpected \`this\` in a context where its value is \`undefined\`.
+};
+`,
+		},
+	],
+	valid: [
+		`class Example { method() { return this.value; } }`,
+		`class Example { get value() { return this._value; } }`,
+		`class Example { set value(v: number) { this._value = v; } }`,
+		`class Example { constructor() { this.value = 0; } }`,
+		`class Example { static method() { return this.name; } }`,
+		`class Example { static { this.initialized = true; } }`,
+		`class Example { value = this.compute(); }`,
+		`class Example { static value = this.compute(); }`,
+		`class Example { handler = () => this.value; }`,
+		`class Example { method() { return () => this.value; } }`,
+		`const obj = { method() { return this.value; } };`,
+		`const obj = { get value() { return this._value; } };`,
+		`const obj = { set value(v: number) { this._value = v; } };`,
+		`const obj = { handler: function() { return this.value; } };`,
+		`const obj = { nested: { method() { return this.value; } } };`,
+		`function Foo() { this.value = 0; }`,
+		`const Handler = function() { this.active = true; };`,
+		`const bar = (function() { this.value = 0; }).bind(obj);`,
+		`getValue.call(obj);`,
+		`getValue.apply(obj, []);`,
+		`items.forEach(function(item: unknown) { this.process(item); }, thisArg);`,
+		`items.map(function(item: unknown) { return this.transform(item); }, context);`,
+		`items.filter(function(item: unknown) { return this.matches(item); }, predicate);`,
+		`items.find(function(item: unknown) { return this.equals(item); }, target);`,
+		`items.some(function(item: unknown) { return this.contains(item); }, checker);`,
+		`items.every(function(item: unknown) { return this.validates(item); }, validator);`,
+		`obj.method = function() { return this.value; };`,
+		`Foo.prototype.getValue = function() { return this.value; };`,
+		`this.value = 0;`,
+		{
+			code: `function Foo() { this.value = 0; }`,
+			options: { capIsConstructor: true },
+		},
+		{
+			code: `const Handler = function() { this.active = true; };`,
+			options: { capIsConstructor: true },
+		},
+	],
+});

--- a/packages/ts/src/rules/invalidThis.ts
+++ b/packages/ts/src/rules/invalidThis.ts
@@ -1,0 +1,420 @@
+import {
+	type AST,
+	getTSNodeRange,
+	typescriptLanguage,
+} from "@flint.fyi/typescript-language";
+import * as ts from "typescript";
+import { z } from "zod";
+
+import { ruleCreator } from "./ruleCreator.ts";
+
+type FunctionLike =
+	| AST.ArrowFunction
+	| AST.FunctionDeclaration
+	| AST.FunctionExpression
+	| AST.GetAccessorDeclaration
+	| AST.MethodDeclaration
+	| AST.SetAccessorDeclaration;
+
+function getAssignedVariableName(node: FunctionLike): string | undefined {
+	const parent = node.parent;
+
+	if (ts.isVariableDeclaration(parent) && ts.isIdentifier(parent.name)) {
+		return parent.name.text;
+	}
+
+	if (ts.isPropertyAssignment(parent) && ts.isIdentifier(parent.name)) {
+		return parent.name.text;
+	}
+
+	return undefined;
+}
+
+function getEnclosingFunction(
+	node: AST.ThisExpression,
+): FunctionLike | undefined {
+	let current: ts.Node | undefined = node.parent;
+
+	while (current) {
+		switch (current.kind) {
+			case ts.SyntaxKind.ArrowFunction:
+			case ts.SyntaxKind.FunctionDeclaration:
+			case ts.SyntaxKind.FunctionExpression:
+			case ts.SyntaxKind.GetAccessor:
+			case ts.SyntaxKind.MethodDeclaration:
+			case ts.SyntaxKind.SetAccessor:
+				return current as FunctionLike;
+			case ts.SyntaxKind.ClassDeclaration:
+			case ts.SyntaxKind.ClassExpression:
+			case ts.SyntaxKind.ClassStaticBlockDeclaration:
+				return undefined;
+		}
+		current = current.parent as ts.Node | undefined;
+	}
+
+	return undefined;
+}
+
+function getFunctionName(node: FunctionLike): string | undefined {
+	if (ts.isFunctionDeclaration(node) || ts.isFunctionExpression(node)) {
+		return node.name?.text;
+	}
+
+	return undefined;
+}
+
+function isArrayMethodWithThisArg(node: FunctionLike): boolean {
+	const parent = node.parent;
+
+	if (!ts.isCallExpression(parent)) {
+		return false;
+	}
+
+	const callee = parent.expression;
+	if (!ts.isPropertyAccessExpression(callee)) {
+		return false;
+	}
+
+	const arrayMethods = new Set([
+		"every",
+		"filter",
+		"find",
+		"findIndex",
+		"findLast",
+		"findLastIndex",
+		"flatMap",
+		"forEach",
+		"map",
+		"some",
+	]);
+
+	const methodName = callee.name.text;
+	if (!arrayMethods.has(methodName)) {
+		return false;
+	}
+
+	const callbackIndex = parent.arguments.findIndex((arg) => arg === node);
+	if (callbackIndex === -1) {
+		return false;
+	}
+
+	return parent.arguments.length > callbackIndex + 1;
+}
+
+function isBindCallApply(node: FunctionLike): boolean {
+	let current: ts.Node = node;
+
+	while (ts.isParenthesizedExpression(current.parent)) {
+		current = current.parent;
+	}
+
+	const parent = current.parent;
+
+	if (!ts.isPropertyAccessExpression(parent)) {
+		return false;
+	}
+
+	const grandParent = parent.parent;
+	if (!ts.isCallExpression(grandParent) || grandParent.expression !== parent) {
+		return false;
+	}
+
+	const methodName = parent.name.text;
+	return (
+		methodName === "bind" || methodName === "call" || methodName === "apply"
+	);
+}
+
+function isClassMember(node: FunctionLike): boolean {
+	switch (node.kind) {
+		case ts.SyntaxKind.GetAccessor:
+		case ts.SyntaxKind.MethodDeclaration:
+		case ts.SyntaxKind.SetAccessor:
+			return (
+				ts.isClassDeclaration(node.parent) || ts.isClassExpression(node.parent)
+			);
+		default:
+			return false;
+	}
+}
+
+function isClassPropertyInitializer(node: FunctionLike): boolean {
+	const parent = node.parent;
+	return (
+		ts.isPropertyDeclaration(parent) &&
+		parent.initializer === node &&
+		(ts.isClassDeclaration(parent.parent) ||
+			ts.isClassExpression(parent.parent))
+	);
+}
+
+function isConstructor(node: FunctionLike, capIsConstructor: boolean): boolean {
+	if (!capIsConstructor) {
+		return false;
+	}
+
+	const functionName = getFunctionName(node);
+	if (functionName && /^[A-Z]/.test(functionName)) {
+		return true;
+	}
+
+	const assignedName = getAssignedVariableName(node);
+	if (assignedName && /^[A-Z]/.test(assignedName)) {
+		return true;
+	}
+
+	return false;
+}
+
+function isInClassFieldInitializer(node: AST.ThisExpression): boolean {
+	let current: ts.Node | undefined = node.parent;
+
+	while (current) {
+		if (ts.isPropertyDeclaration(current)) {
+			return (
+				ts.isClassDeclaration(current.parent) ||
+				ts.isClassExpression(current.parent)
+			);
+		}
+
+		if (
+			ts.isFunctionDeclaration(current) ||
+			ts.isFunctionExpression(current) ||
+			ts.isClassStaticBlockDeclaration(current)
+		) {
+			return false;
+		}
+
+		current = current.parent as ts.Node | undefined;
+	}
+
+	return false;
+}
+
+function isInClassStaticBlock(node: AST.ThisExpression): boolean {
+	let current: ts.Node | undefined = node.parent;
+
+	while (current) {
+		if (ts.isClassStaticBlockDeclaration(current)) {
+			return true;
+		}
+
+		if (
+			ts.isFunctionDeclaration(current) ||
+			ts.isFunctionExpression(current) ||
+			ts.isArrowFunction(current)
+		) {
+			return false;
+		}
+
+		current = current.parent as ts.Node | undefined;
+	}
+
+	return false;
+}
+
+function isObjectMethod(node: FunctionLike): boolean {
+	const parent = node.parent;
+
+	if (
+		ts.isPropertyAssignment(parent) &&
+		ts.isObjectLiteralExpression(parent.parent)
+	) {
+		return true;
+	}
+
+	if (
+		(node.kind === ts.SyntaxKind.MethodDeclaration ||
+			node.kind === ts.SyntaxKind.GetAccessor ||
+			node.kind === ts.SyntaxKind.SetAccessor) &&
+		ts.isObjectLiteralExpression(node.parent)
+	) {
+		return true;
+	}
+
+	return false;
+}
+
+function isPropertyAssignment(node: FunctionLike): boolean {
+	const parent = node.parent;
+
+	if (
+		ts.isBinaryExpression(parent) &&
+		parent.operatorToken.kind === ts.SyntaxKind.EqualsToken &&
+		parent.right === node
+	) {
+		const left = parent.left;
+		return (
+			ts.isPropertyAccessExpression(left) || ts.isElementAccessExpression(left)
+		);
+	}
+
+	return false;
+}
+
+function isValidThisContext(
+	thisNode: AST.ThisExpression,
+	capIsConstructor: boolean,
+): boolean {
+	if (isInClassFieldInitializer(thisNode)) {
+		return true;
+	}
+
+	if (isInClassStaticBlock(thisNode)) {
+		return true;
+	}
+
+	const enclosingFunction = getEnclosingFunction(thisNode);
+
+	if (!enclosingFunction) {
+		return true;
+	}
+
+	if (enclosingFunction.kind === ts.SyntaxKind.ArrowFunction) {
+		return isValidThisContextForArrow(enclosingFunction, capIsConstructor);
+	}
+
+	if (isClassMember(enclosingFunction)) {
+		return true;
+	}
+
+	if (isClassPropertyInitializer(enclosingFunction)) {
+		return true;
+	}
+
+	if (isConstructor(enclosingFunction, capIsConstructor)) {
+		return true;
+	}
+
+	if (isObjectMethod(enclosingFunction)) {
+		return true;
+	}
+
+	if (isPropertyAssignment(enclosingFunction)) {
+		return true;
+	}
+
+	if (isBindCallApply(enclosingFunction)) {
+		return true;
+	}
+
+	if (isArrayMethodWithThisArg(enclosingFunction)) {
+		return true;
+	}
+
+	return false;
+}
+
+function isValidThisContextForArrow(
+	arrow: AST.ArrowFunction,
+	capIsConstructor: boolean,
+): boolean {
+	let current: ts.Node | undefined = arrow.parent;
+
+	while (current) {
+		switch (current.kind) {
+			case ts.SyntaxKind.ArrowFunction:
+				break;
+			case ts.SyntaxKind.ClassDeclaration:
+			case ts.SyntaxKind.ClassExpression:
+			case ts.SyntaxKind.ClassStaticBlockDeclaration:
+				return true;
+			case ts.SyntaxKind.FunctionDeclaration:
+			case ts.SyntaxKind.FunctionExpression:
+			case ts.SyntaxKind.GetAccessor:
+			case ts.SyntaxKind.MethodDeclaration:
+			case ts.SyntaxKind.SetAccessor: {
+				const functionNode = current as FunctionLike;
+
+				if (isClassMember(functionNode)) {
+					return true;
+				}
+
+				if (isClassPropertyInitializer(functionNode)) {
+					return true;
+				}
+
+				if (isConstructor(functionNode, capIsConstructor)) {
+					return true;
+				}
+
+				if (isObjectMethod(functionNode)) {
+					return true;
+				}
+
+				if (isPropertyAssignment(functionNode)) {
+					return true;
+				}
+
+				if (isBindCallApply(functionNode)) {
+					return true;
+				}
+
+				if (isArrayMethodWithThisArg(functionNode)) {
+					return true;
+				}
+
+				return false;
+			}
+			case ts.SyntaxKind.PropertyDeclaration:
+				if (
+					ts.isClassDeclaration(current.parent) ||
+					ts.isClassExpression(current.parent)
+				) {
+					return true;
+				}
+				break;
+		}
+
+		current = current.parent as ts.Node | undefined;
+	}
+
+	return false;
+}
+
+export default ruleCreator.createRule(typescriptLanguage, {
+	about: {
+		description:
+			"Reports usage of `this` in contexts where its value is `undefined`.",
+		id: "invalidThis",
+		presets: ["untyped"],
+	},
+	messages: {
+		invalidThis: {
+			primary: "Unexpected `this` in a context where its value is `undefined`.",
+			secondary: [
+				"In strict mode, `this` is `undefined` in functions that are not methods, constructors, or bound to an object.",
+				"Using `this` in such contexts typically indicates a bug or misunderstanding of how `this` works in JavaScript.",
+			],
+			suggestions: [
+				"Convert to a method on an object or class.",
+				"Use `.bind()`, `.call()`, or `.apply()` to explicitly set the `this` value.",
+				"Use an arrow function if you need to capture `this` from an enclosing scope.",
+			],
+		},
+	},
+	options: {
+		capIsConstructor: z
+			.boolean()
+			.default(true)
+			.describe(
+				"Whether to assume functions starting with an uppercase letter are constructors.",
+			),
+	},
+	setup(context) {
+		return {
+			visitors: {
+				ThisKeyword: (node, { options, sourceFile }) => {
+					if (isValidThisContext(node, options.capIsConstructor)) {
+						return;
+					}
+
+					context.report({
+						message: "invalidThis",
+						range: getTSNodeRange(node, sourceFile),
+					});
+				},
+			},
+		};
+	},
+});


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #1481.
- [x] That issue was marked as [`status: accepting prs`](https://github.com/flint-fyi/flint/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [`.github/DEVELOPMENT.md`](https://github.com/flint-fyi/flint/blob/main/.github/DEVELOPMENT.md) were taken

## Overview

Implements the `invalidThis` rule for the TypeScript plugin, equivalent to ESLint's `no-invalid-this` rule.

This rule flags usage of `this` in contexts where its value would be `undefined` in strict mode:
- Standalone functions (not methods)
- Arrow functions whose enclosing context is not a valid `this` context
- Callback functions without a `thisArg` parameter

The rule recognizes valid `this` contexts including:
- Class members and constructors
- Object literal methods and getters/setters
- Functions assigned to properties
- Functions starting with uppercase (treated as constructors when `capIsConstructor: true`)
- Array method callbacks with `thisArg`
- Functions called with `.bind()`, `.call()`, or `.apply()`
