### PR TITLE
docs(ts): [namespaceDeclarations] improve test coverage and fix docs

### DIFF
--- a/packages/site/src/content/docs/rules/ts/namespaceDeclarations.mdx
+++ b/packages/site/src/content/docs/rules/ts/namespaceDeclarations.mdx
@@ -1,5 +1,5 @@
 ---
-description: "Consecutive non-null assertion operators are unnecessary."
+description: "Reports using legacy `namespace` declarations."
 title: "namespaceDeclarations"
 topic: "rules"
 ---

--- a/packages/ts/src/rules/namespaceDeclarations.test.ts
+++ b/packages/ts/src/rules/namespaceDeclarations.test.ts
@@ -13,10 +13,85 @@ namespace name {}
 Prefer using ECMAScript modules over legacy TypeScript namespaces.
 `,
 		},
+		{
+			code: `
+module name {}
+`,
+			snapshot: `
+module name {}
+~~~~~~
+Prefer using ECMAScript modules over legacy TypeScript namespaces.
+`,
+		},
+		{
+			code: `
+export namespace name {}
+`,
+			snapshot: `
+export namespace name {}
+~~~~~~
+Prefer using ECMAScript modules over legacy TypeScript namespaces.
+`,
+		},
+		{
+			code: `
+export module name {}
+`,
+			snapshot: `
+export module name {}
+~~~~~~
+Prefer using ECMAScript modules over legacy TypeScript namespaces.
+`,
+		},
+		{
+			code: `
+declare namespace name {}
+`,
+			snapshot: `
+declare namespace name {}
+~~~~~~~
+Prefer using ECMAScript modules over legacy TypeScript namespaces.
+`,
+		},
+		{
+			code: `
+declare module name {}
+`,
+			snapshot: `
+declare module name {}
+~~~~~~~
+Prefer using ECMAScript modules over legacy TypeScript namespaces.
+`,
+		},
+		{
+			code: `
+namespace outer {
+    namespace inner {}
+}
+`,
+			snapshot: `
+namespace outer {
+~~~~~~~~~
+Prefer using ECMAScript modules over legacy TypeScript namespaces.
+    namespace inner {}
+}
+`,
+		},
+		{
+			code: `
+namespace A.B.C {}
+`,
+			snapshot: `
+namespace A.B.C {}
+~~~~~~~~~
+Prefer using ECMAScript modules over legacy TypeScript namespaces.
+`,
+		},
 	],
 	valid: [
 		`declare global {}`,
 		`declare module 'name' {}`,
+		`declare module "name" {}`,
 		{
 			code: `declare module name {}`,
 			options: { allowDeclarations: true },
@@ -33,8 +108,27 @@ declare namespace outer {
 			options: { allowDeclarations: true },
 		},
 		{
+			code: `
+declare module 'express' {
+    namespace inner {}
+}`,
+			options: { allowDeclarations: true },
+		},
+		{
+			code: `
+declare global {
+    namespace inner {}
+}`,
+			options: { allowDeclarations: true },
+		},
+		{
 			code: `namespace name {}`,
 			fileName: "file.d.ts",
+			options: { allowDefinitionFiles: true },
+		},
+		{
+			code: `module name {}`,
+			fileName: "types.d.ts",
 			options: { allowDefinitionFiles: true },
 		},
 	],


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #1690
- [x] That issue was marked as [`status: accepting prs`](https://github.com/flint-fyi/flint/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/flint-fyi/flint/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

The rule already existed in an initial mostly-done form. This PR improves the test coverage for the `namespaceDeclarations` rule and fixes an incorrect description in the docs.

**Changes:**
- Added test cases for `module` keyword (legacy syntax)
- Added test cases for `export namespace` and `export module`
- Added test cases for `declare namespace` and `declare module` (invalid when `allowDeclarations: false`)
- Added test case for nested namespaces (verifies only outer is reported)
- Added test case for dotted namespaces (`namespace A.B.C {}`)
- Added test cases for string module declarations with double quotes
- Added valid test cases for nested namespaces in `declare global` and string modules
- Fixed the description in the docs file (was incorrectly saying 'Consecutive non-null assertion operators are unnecessary')

❤️‍🔥