### PR TITLE
fix(site): add descriptions to blog entries

### DIFF
--- a/packages/site/src/content/docs/blog/introducing-flint.mdx
+++ b/packages/site/src/content/docs/blog/introducing-flint.mdx
@@ -1,5 +1,8 @@
 ---
 date: 2025-12-30T14:59:23Z
+description: Flint is a new "hybrid" linter for the web.
+  Why do we need yet another linter, and why is Flint implemented the way it is?
+  Let's talk about it!
 excerpt: ESLint has been the leading web ecosystem linter for a decade.
   Its dominance is being challenged by new native speed linters such as Biome and Oxlint that implement blazing fast linting using native speed languages.
   Even TypeScript's source is being ported from TypeScript to Go.

--- a/packages/site/src/content/docs/blog/what-flint-does-differently.mdx
+++ b/packages/site/src/content/docs/blog/what-flint-does-differently.mdx
@@ -1,5 +1,7 @@
 ---
 date: 2026-01-02T14:59:23Z
+description: Flint is an experimental linter.
+  It intentionally revisits many of the core design decisions from other popular web linters.
 excerpt: Flint is an experimental linter.
   It intentionally revisits many of the core design decisions from other popular web linters.
   This post covers the categories of changes and each high-level change's hypothesis.


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #1780
- [x] That issue was marked as [`status: accepting prs`](https://github.com/flint-fyi/flint/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/flint-fyi/flint/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

I'd tried out adding a fallback to the `OGImageRoute` description of the page's `excerpt`. But the excerpts are quite longer than typical descriptions and don't fit in the preview image.

Example `http://localhost:4321/og/blog/what-flint-does-differently.webp`:

<img width="1200" height="630" alt="OG image for 'What Flint Does Differently' with the description: 'Flint is an experimental linter. It intentionally revisits many of the core design decisions from other popular web linters.'" src="https://github.com/user-attachments/assets/8e5f9328-6298-445f-bda6-910d5b693cc0" />


❤️‍🔥