### PR TITLE
feat(ts): implement numericLiteralCasing rule

### DIFF
--- a/packages/comparisons/src/data.json
+++ b/packages/comparisons/src/data.json
@@ -13573,6 +13573,7 @@
 			"name": "numericLiteralCasing",
 			"plugin": "ts",
 			"preset": "stylistic",
+			"status": "implemented",
 			"strictness": "strict"
 		},
 		"oxlint": [

--- a/packages/site/src/content/docs/rules/ts/numericLiteralCasing.mdx
+++ b/packages/site/src/content/docs/rules/ts/numericLiteralCasing.mdx
@@ -1,0 +1,97 @@
+---
+description: "Reports numeric literals with inconsistent casing in prefixes and exponents."
+title: "numericLiteralCasing"
+topic: "rules"
+---
+
+import { Tabs, TabItem } from "@astrojs/starlight/components";
+import { RuleEquivalents } from "~/components/RuleEquivalents";
+import RuleSummary from "~/components/RuleSummary.astro";
+
+<RuleSummary plugin="ts" rule="numericLiteralCasing" />
+
+This rule enforces consistent casing for numeric literal prefixes and exponents.
+
+The convention is:
+
+- Lowercase prefixes: `0x`, `0o`, `0b`
+- Lowercase exponent notation: `e`
+- Uppercase hexadecimal digits: `0xABCDEF`
+
+This improves readability by clearly distinguishing prefixes from values and making hexadecimal letters visually distinct from lowercase characters.
+
+## Examples
+
+<Tabs>
+<TabItem label="❌ Incorrect">
+
+```ts
+const value = 0xff;
+```
+
+```ts
+const value = 0xff;
+```
+
+```ts
+const value = 0o77;
+```
+
+```ts
+const value = 0b1010;
+```
+
+```ts
+const value = 1e10;
+```
+
+```ts
+const value = 0xffn;
+```
+
+</TabItem>
+<TabItem label="✅ Correct">
+
+```ts
+const value = 0xff;
+```
+
+```ts
+const value = 0xabcd;
+```
+
+```ts
+const value = 0o77;
+```
+
+```ts
+const value = 0b1010;
+```
+
+```ts
+const value = 1e10;
+```
+
+```ts
+const value = 0xffn;
+```
+
+</TabItem>
+</Tabs>
+
+## Options
+
+This rule is not configurable.
+
+## When Not To Use It
+
+If you have a codebase with a different established convention for numeric literal casing, or if you prefer a different style, you may want to disable this rule.
+
+## Further Reading
+
+- [MDN: Lexical grammar - Numeric literals](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#numeric_literals)
+- [MDN: BigInt](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt)
+
+## Equivalents in Other Linters
+
+<RuleEquivalents pluginId="ts" ruleId="numericLiteralCasing" />

--- a/packages/ts/src/plugin.ts
+++ b/packages/ts/src/plugin.ts
@@ -143,6 +143,7 @@ import nonNullAssertedOptionalChains from "./rules/nonNullAssertedOptionalChains
 import nonNullAssertionPlacement from "./rules/nonNullAssertionPlacement.ts";
 import nonOctalDecimalEscapes from "./rules/nonOctalDecimalEscapes.ts";
 import numberMethodRanges from "./rules/numberMethodRanges.ts";
+import numericLiteralCasing from "./rules/numericLiteralCasing.ts";
 import numericLiteralParsing from "./rules/numericLiteralParsing.ts";
 import objectCalls from "./rules/objectCalls.ts";
 import objectHasOwns from "./rules/objectHasOwns.ts";
@@ -321,6 +322,7 @@ export const ts = createPlugin({
 		nonNullAssertionPlacement,
 		nonOctalDecimalEscapes,
 		numberMethodRanges,
+		numericLiteralCasing,
 		numericLiteralParsing,
 		objectCalls,
 		objectHasOwns,

--- a/packages/ts/src/rules/numericLiteralCasing.test.ts
+++ b/packages/ts/src/rules/numericLiteralCasing.test.ts
@@ -1,0 +1,142 @@
+import rule from "./numericLiteralCasing.ts";
+import { ruleTester } from "./ruleTester.ts";
+
+ruleTester.describe(rule, {
+	invalid: [
+		{
+			code: `
+const value = 0XFF;
+`,
+			snapshot: `
+const value = 0XFF;
+              ~~~~
+              Use lowercase for the \`0x\` prefix and exponent notation.
+`,
+		},
+		{
+			code: `
+const value = 0xff;
+`,
+			snapshot: `
+const value = 0xff;
+              ~~~~
+              Use lowercase for the \`0x\` prefix and exponent notation.
+`,
+		},
+		{
+			code: `
+const value = 0Xff;
+`,
+			snapshot: `
+const value = 0Xff;
+              ~~~~
+              Use lowercase for the \`0x\` prefix and exponent notation.
+`,
+		},
+		{
+			code: `
+const value = 0O77;
+`,
+			snapshot: `
+const value = 0O77;
+              ~~~~
+              Use lowercase for the \`0o\` prefix and exponent notation.
+`,
+		},
+		{
+			code: `
+const value = 0B1010;
+`,
+			snapshot: `
+const value = 0B1010;
+              ~~~~~~
+              Use lowercase for the \`0b\` prefix and exponent notation.
+`,
+		},
+		{
+			code: `
+const value = 1E10;
+`,
+			snapshot: `
+const value = 1E10;
+              ~~~~
+              Use lowercase for the \`e\` prefix and exponent notation.
+`,
+		},
+		{
+			code: `
+const value = 1.5E10;
+`,
+			snapshot: `
+const value = 1.5E10;
+              ~~~~~~
+              Use lowercase for the \`e\` prefix and exponent notation.
+`,
+		},
+		{
+			code: `
+const value = 0XFFn;
+`,
+			snapshot: `
+const value = 0XFFn;
+              ~~~~~
+              Use lowercase for the \`0x\` prefix and exponent notation.
+`,
+		},
+		{
+			code: `
+const value = 0xffn;
+`,
+			snapshot: `
+const value = 0xffn;
+              ~~~~~
+              Use lowercase for the \`0x\` prefix and exponent notation.
+`,
+		},
+		{
+			code: `
+const value = 0O77n;
+`,
+			snapshot: `
+const value = 0O77n;
+              ~~~~~
+              Use lowercase for the \`0o\` prefix and exponent notation.
+`,
+		},
+		{
+			code: `
+const value = 0B1010n;
+`,
+			snapshot: `
+const value = 0B1010n;
+              ~~~~~~~
+              Use lowercase for the \`0b\` prefix and exponent notation.
+`,
+		},
+		{
+			code: `
+const value = 0XFFFFn;
+`,
+			snapshot: `
+const value = 0XFFFFn;
+              ~~~~~~~
+              Use lowercase for the \`0x\` prefix and exponent notation.
+`,
+		},
+	],
+	valid: [
+		`const value = 0xFF;`,
+		`const value = 0xABCD;`,
+		`const value = 0o77;`,
+		`const value = 0b1010;`,
+		`const value = 1e10;`,
+		`const value = 1.5e10;`,
+		`const value = 1e-5;`,
+		`const value = 0xFFn;`,
+		`const value = 0o77n;`,
+		`const value = 0b1010n;`,
+		`const value = 123;`,
+		`const value = 123n;`,
+		`const value = 1.5;`,
+	],
+});

--- a/packages/ts/src/rules/numericLiteralCasing.test.ts
+++ b/packages/ts/src/rules/numericLiteralCasing.test.ts
@@ -10,7 +10,7 @@ const value = 0XFF;
 			snapshot: `
 const value = 0XFF;
               ~~~~
-              Use lowercase for the \`0x\` prefix and exponent notation.
+              Prefer lowercase for the \`0x\` prefix and exponent notation.
 `,
 		},
 		{
@@ -20,7 +20,7 @@ const value = 0xff;
 			snapshot: `
 const value = 0xff;
               ~~~~
-              Use lowercase for the \`0x\` prefix and exponent notation.
+              Prefer lowercase for the \`0x\` prefix and exponent notation.
 `,
 		},
 		{
@@ -30,7 +30,7 @@ const value = 0Xff;
 			snapshot: `
 const value = 0Xff;
               ~~~~
-              Use lowercase for the \`0x\` prefix and exponent notation.
+              Prefer lowercase for the \`0x\` prefix and exponent notation.
 `,
 		},
 		{
@@ -40,7 +40,7 @@ const value = 0O77;
 			snapshot: `
 const value = 0O77;
               ~~~~
-              Use lowercase for the \`0o\` prefix and exponent notation.
+              Prefer lowercase for the \`0o\` prefix and exponent notation.
 `,
 		},
 		{
@@ -50,7 +50,7 @@ const value = 0B1010;
 			snapshot: `
 const value = 0B1010;
               ~~~~~~
-              Use lowercase for the \`0b\` prefix and exponent notation.
+              Prefer lowercase for the \`0b\` prefix and exponent notation.
 `,
 		},
 		{
@@ -60,7 +60,7 @@ const value = 1E10;
 			snapshot: `
 const value = 1E10;
               ~~~~
-              Use lowercase for the \`e\` prefix and exponent notation.
+              Prefer lowercase for the \`e\` prefix and exponent notation.
 `,
 		},
 		{
@@ -70,7 +70,7 @@ const value = 1.5E10;
 			snapshot: `
 const value = 1.5E10;
               ~~~~~~
-              Use lowercase for the \`e\` prefix and exponent notation.
+              Prefer lowercase for the \`e\` prefix and exponent notation.
 `,
 		},
 		{
@@ -80,7 +80,7 @@ const value = 0XFFn;
 			snapshot: `
 const value = 0XFFn;
               ~~~~~
-              Use lowercase for the \`0x\` prefix and exponent notation.
+              Prefer lowercase for the \`0x\` prefix and exponent notation.
 `,
 		},
 		{
@@ -90,7 +90,7 @@ const value = 0xffn;
 			snapshot: `
 const value = 0xffn;
               ~~~~~
-              Use lowercase for the \`0x\` prefix and exponent notation.
+              Prefer lowercase for the \`0x\` prefix and exponent notation.
 `,
 		},
 		{
@@ -100,7 +100,7 @@ const value = 0O77n;
 			snapshot: `
 const value = 0O77n;
               ~~~~~
-              Use lowercase for the \`0o\` prefix and exponent notation.
+              Prefer lowercase for the \`0o\` prefix and exponent notation.
 `,
 		},
 		{
@@ -110,7 +110,7 @@ const value = 0B1010n;
 			snapshot: `
 const value = 0B1010n;
               ~~~~~~~
-              Use lowercase for the \`0b\` prefix and exponent notation.
+              Prefer lowercase for the \`0b\` prefix and exponent notation.
 `,
 		},
 		{
@@ -120,7 +120,7 @@ const value = 0XFFFFn;
 			snapshot: `
 const value = 0XFFFFn;
               ~~~~~~~
-              Use lowercase for the \`0x\` prefix and exponent notation.
+              Prefer lowercase for the \`0x\` prefix and exponent notation.
 `,
 		},
 	],

--- a/packages/ts/src/rules/numericLiteralCasing.ts
+++ b/packages/ts/src/rules/numericLiteralCasing.ts
@@ -1,0 +1,92 @@
+import {
+	getTSNodeRange,
+	typescriptLanguage,
+} from "@flint.fyi/typescript-language";
+
+import { ruleCreator } from "./ruleCreator.ts";
+
+function fixBigIntLiteral(raw: string) {
+	return fixNumericLiteral(raw.slice(0, -1)) + "n";
+}
+
+function fixNumericLiteral(raw: string) {
+	let fixed = raw.toLowerCase();
+
+	if (fixed.startsWith("0x")) {
+		fixed = "0x" + fixed.slice(2).toUpperCase();
+	}
+
+	return fixed;
+}
+
+export default ruleCreator.createRule(typescriptLanguage, {
+	about: {
+		description:
+			"Reports numeric literals with inconsistent casing in prefixes and exponents.",
+		id: "numericLiteralCasing",
+		presets: ["stylisticStrict"],
+	},
+	messages: {
+		invalidCasing: {
+			primary:
+				"Use lowercase for the `{{ prefix }}` prefix and exponent notation.",
+			secondary: [
+				"Lowercase prefixes (`0x`, `0o`, `0b`) and exponents (`e`) are more readable.",
+				"Hexadecimal digits should be uppercase for better distinction from lowercase letters.",
+			],
+		},
+	},
+	setup(context) {
+		return {
+			visitors: {
+				BigIntLiteral: (node, { sourceFile }) => {
+					const raw = node.getText(sourceFile);
+					const fixed = fixBigIntLiteral(raw);
+
+					if (raw !== fixed) {
+						const prefix = getPrefix(raw);
+						context.report({
+							data: { prefix },
+							message: "invalidCasing",
+							range: getTSNodeRange(node, sourceFile),
+						});
+					}
+				},
+				NumericLiteral: (node, { sourceFile }) => {
+					const raw = node.getText(sourceFile);
+					const fixed = fixNumericLiteral(raw);
+
+					if (raw !== fixed) {
+						const prefix = getPrefix(raw);
+						context.report({
+							data: { prefix },
+							message: "invalidCasing",
+							range: getTSNodeRange(node, sourceFile),
+						});
+					}
+				},
+			},
+		};
+	},
+});
+
+function getPrefix(raw: string) {
+	const lowerRaw = raw.toLowerCase();
+	if (lowerRaw.startsWith("0x")) {
+		return "0x";
+	}
+
+	if (lowerRaw.startsWith("0o")) {
+		return "0o";
+	}
+
+	if (lowerRaw.startsWith("0b")) {
+		return "0b";
+	}
+
+	if (lowerRaw.includes("e")) {
+		return "e";
+	}
+
+	return "";
+}

--- a/packages/ts/src/rules/numericLiteralCasing.ts
+++ b/packages/ts/src/rules/numericLiteralCasing.ts
@@ -1,4 +1,5 @@
 import {
+	type AST,
 	getTSNodeRange,
 	typescriptLanguage,
 } from "@flint.fyi/typescript-language";
@@ -10,13 +11,25 @@ function fixBigIntLiteral(raw: string) {
 }
 
 function fixNumericLiteral(raw: string) {
-	let fixed = raw.toLowerCase();
+	const fixed = raw.toLowerCase();
 
-	if (fixed.startsWith("0x")) {
-		fixed = "0x" + fixed.slice(2).toUpperCase();
+	return fixed.startsWith("0x") ? "0x" + fixed.slice(2).toUpperCase() : fixed;
+}
+
+function getPrefix(raw: string) {
+	const lowerRaw = raw.toLowerCase();
+
+	for (const prefix of ["0x", "0o", "0b"]) {
+		if (lowerRaw.startsWith(prefix)) {
+			return prefix;
+		}
 	}
 
-	return fixed;
+	if (lowerRaw.includes("e")) {
+		return "e";
+	}
+
+	return "";
 }
 
 export default ruleCreator.createRule(typescriptLanguage, {
@@ -28,65 +41,54 @@ export default ruleCreator.createRule(typescriptLanguage, {
 	},
 	messages: {
 		invalidCasing: {
-			primary:
-				"Use lowercase for the `{{ prefix }}` prefix and exponent notation.",
+			primary: "Prefer lowercase for the exponent notation.",
 			secondary: [
 				"Lowercase prefixes (`0x`, `0o`, `0b`) and exponents (`e`) are more readable.",
 				"Hexadecimal digits should be uppercase for better distinction from lowercase letters.",
 			],
+			suggestions: ["Switch the numeric literal to the suggested case."],
+		},
+		invalidCasingPrefix: {
+			primary:
+				"Prefer lowercase for the `{{ prefix }}` prefix and exponent notation.",
+			secondary: [
+				"Lowercase prefixes (`0x`, `0o`, `0b`) and exponents (`e`) are more readable.",
+				"Hexadecimal digits should be uppercase for better distinction from lowercase letters.",
+			],
+			suggestions: ["Switch the numeric literal to the suggested case."],
 		},
 	},
 	setup(context) {
+		function checkNode(
+			node: AST.BigIntLiteral | AST.NumericLiteral,
+			fixer: (raw: string) => string,
+			sourceFile: AST.SourceFile,
+		) {
+			const raw = node.getText(sourceFile);
+			const fixed = fixer(raw);
+
+			if (raw === fixed) {
+				return;
+			}
+
+			const prefix = getPrefix(raw);
+
+			context.report({
+				data: { prefix },
+				message: prefix ? "invalidCasingPrefix" : "invalidCasing",
+				range: getTSNodeRange(node, sourceFile),
+			});
+		}
+
 		return {
 			visitors: {
 				BigIntLiteral: (node, { sourceFile }) => {
-					const raw = node.getText(sourceFile);
-					const fixed = fixBigIntLiteral(raw);
-
-					if (raw !== fixed) {
-						const prefix = getPrefix(raw);
-						context.report({
-							data: { prefix },
-							message: "invalidCasing",
-							range: getTSNodeRange(node, sourceFile),
-						});
-					}
+					checkNode(node, fixBigIntLiteral, sourceFile);
 				},
 				NumericLiteral: (node, { sourceFile }) => {
-					const raw = node.getText(sourceFile);
-					const fixed = fixNumericLiteral(raw);
-
-					if (raw !== fixed) {
-						const prefix = getPrefix(raw);
-						context.report({
-							data: { prefix },
-							message: "invalidCasing",
-							range: getTSNodeRange(node, sourceFile),
-						});
-					}
+					checkNode(node, fixNumericLiteral, sourceFile);
 				},
 			},
 		};
 	},
 });
-
-function getPrefix(raw: string) {
-	const lowerRaw = raw.toLowerCase();
-	if (lowerRaw.startsWith("0x")) {
-		return "0x";
-	}
-
-	if (lowerRaw.startsWith("0o")) {
-		return "0o";
-	}
-
-	if (lowerRaw.startsWith("0b")) {
-		return "0b";
-	}
-
-	if (lowerRaw.includes("e")) {
-		return "e";
-	}
-
-	return "";
-}


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #1803
- [x] That issue was marked as [`status: accepting prs`](https://github.com/flint-fyi/flint/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/flint-fyi/flint/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Implements the `numericLiteralCasing` rule that enforces consistent casing for numeric literal prefixes and exponents:
- Lowercase prefixes: `0x`, `0o`, `0b`
- Lowercase exponent notation: `e`
- Uppercase hexadecimal digits: `0xABCDEF`

Also handles BigInt literals with the same conventions.