### PR TITLE
feat: implement regexLegacyFeatures rule for TypeScript plugin

### DIFF
--- a/packages/comparisons/src/data.json
+++ b/packages/comparisons/src/data.json
@@ -15134,7 +15134,8 @@
 		"flint": {
 			"name": "regexLegacyFeatures",
 			"plugin": "ts",
-			"preset": "logical"
+			"preset": "logical",
+			"status": "implemented"
 		}
 	},
 	{

--- a/packages/site/src/content/docs/rules/ts/regexLegacyFeatures.mdx
+++ b/packages/site/src/content/docs/rules/ts/regexLegacyFeatures.mdx
@@ -1,0 +1,93 @@
+---
+description: "Reports usage of legacy RegExp static properties and prototype methods."
+title: "regexLegacyFeatures"
+topic: "rules"
+---
+
+import { Tabs, TabItem } from "@astrojs/starlight/components";
+import { RuleEquivalents } from "~/components/RuleEquivalents";
+import RuleSummary from "~/components/RuleSummary.astro";
+
+<RuleSummary plugin="ts" rule="regexLegacyFeatures" />
+
+JavaScript's `RegExp` constructor has several static properties (like `RegExp.$1`, `RegExp.input`, and `RegExp.lastMatch`) and prototype methods (like `RegExp.prototype.compile`) that are legacy features from earlier JavaScript versions.
+These properties and methods exist only for backwards compatibility and should not be used in modern code.
+
+Legacy static properties are problematic because they are global state that changes whenever any regex executes, which can cause hard-to-debug issues in concurrent or modular code.
+The `compile` method is deprecated because it allows mutating an existing regex, which leads to confusing behavior.
+
+## Examples
+
+<Tabs>
+<TabItem label="❌ Incorrect">
+
+```ts
+RegExp.input;
+```
+
+```ts
+RegExp.$_;
+```
+
+```ts
+RegExp.lastMatch;
+```
+
+```ts
+RegExp["$&"];
+```
+
+```ts
+RegExp.$1;
+```
+
+```ts
+const regex = /pattern/;
+regex.compile("newPattern", "g");
+```
+
+</TabItem>
+<TabItem label="✅ Correct">
+
+```ts
+const regex = /pattern/;
+const result = regex.exec("test");
+if (result) {
+	console.log(result[1]);
+}
+```
+
+```ts
+const regex = /pattern/;
+regex.test("value");
+```
+
+```ts
+const matches = "test".match(/pattern/g);
+```
+
+```ts
+const newRegex = new RegExp("newPattern", "g");
+```
+
+</TabItem>
+</Tabs>
+
+## Options
+
+This rule is not configurable.
+
+## When Not To Use It
+
+If you are maintaining legacy code that relies on these features and cannot be refactored, you may need to disable this rule for those specific files.
+Some older testing frameworks or polyfills may also depend on these features.
+
+## Further Reading
+
+- [MDN: RegExp static properties](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp#static_properties)
+- [TC39: Legacy RegExp features in JavaScript](https://github.com/tc39/proposal-regexp-legacy-features)
+- [MDN: RegExp.prototype.compile()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/compile)
+
+## Equivalents in Other Linters
+
+<RuleEquivalents pluginId="ts" ruleId="regexLegacyFeatures" />

--- a/packages/ts/src/plugin.ts
+++ b/packages/ts/src/plugin.ts
@@ -194,6 +194,7 @@ import regexGraphemeStringLiterals from "./rules/regexGraphemeStringLiterals.ts"
 import regexHexadecimalEscapes from "./rules/regexHexadecimalEscapes.ts";
 import regexIgnoreCaseFlags from "./rules/regexIgnoreCaseFlags.ts";
 import regexInvisibleCharacters from "./rules/regexInvisibleCharacters.ts";
+import regexLegacyFeatures from "./rules/regexLegacyFeatures.ts";
 import returnAssignments from "./rules/returnAssignments.ts";
 import selfAssignments from "./rules/selfAssignments.ts";
 import selfComparisons from "./rules/selfComparisons.ts";
@@ -414,6 +415,7 @@ export const ts = createPlugin({
 		regexGraphemeStringLiterals,
 		regexHexadecimalEscapes,
 		regexIgnoreCaseFlags,
+		regexLegacyFeatures,
 		returnAssignments,
 		selfAssignments,
 		selfComparisons,

--- a/packages/ts/src/rules/regexLegacyFeatures.test.ts
+++ b/packages/ts/src/rules/regexLegacyFeatures.test.ts
@@ -1,0 +1,235 @@
+import rule from "./regexLegacyFeatures.ts";
+import { ruleTester } from "./ruleTester.ts";
+
+ruleTester.describe(rule, {
+	invalid: [
+		{
+			code: `
+RegExp.input;
+`,
+			snapshot: `
+RegExp.input;
+~~~~~~~~~~~~
+The 'RegExp.input' static property is deprecated.
+`,
+		},
+		{
+			code: `
+RegExp.$_;
+`,
+			snapshot: `
+RegExp.$_;
+~~~~~~~~~
+The 'RegExp.$_' static property is deprecated.
+`,
+		},
+		{
+			code: `
+RegExp.lastMatch;
+`,
+			snapshot: `
+RegExp.lastMatch;
+~~~~~~~~~~~~~~~~
+The 'RegExp.lastMatch' static property is deprecated.
+`,
+		},
+		{
+			code: `
+RegExp["$&"];
+`,
+			snapshot: `
+RegExp["$&"];
+~~~~~~~~~~~~
+The 'RegExp.$&' static property is deprecated.
+`,
+		},
+		{
+			code: `
+RegExp.lastParen;
+`,
+			snapshot: `
+RegExp.lastParen;
+~~~~~~~~~~~~~~~~
+The 'RegExp.lastParen' static property is deprecated.
+`,
+		},
+		{
+			code: `
+RegExp["$+"];
+`,
+			snapshot: `
+RegExp["$+"];
+~~~~~~~~~~~~
+The 'RegExp.$+' static property is deprecated.
+`,
+		},
+		{
+			code: `
+RegExp.leftContext;
+`,
+			snapshot: `
+RegExp.leftContext;
+~~~~~~~~~~~~~~~~~~
+The 'RegExp.leftContext' static property is deprecated.
+`,
+		},
+		{
+			code: `
+RegExp["$\`"];
+`,
+			snapshot: `
+RegExp["$\`"];
+~~~~~~~~~~~~
+The 'RegExp.$\`' static property is deprecated.
+`,
+		},
+		{
+			code: `
+RegExp.rightContext;
+`,
+			snapshot: `
+RegExp.rightContext;
+~~~~~~~~~~~~~~~~~~~
+The 'RegExp.rightContext' static property is deprecated.
+`,
+		},
+		{
+			code: `
+RegExp["$'"];
+`,
+			snapshot: `
+RegExp["$'"];
+~~~~~~~~~~~~
+The 'RegExp.$'' static property is deprecated.
+`,
+		},
+		{
+			code: `
+RegExp.$1;
+`,
+			snapshot: `
+RegExp.$1;
+~~~~~~~~~
+The 'RegExp.$1' static property is deprecated.
+`,
+		},
+		{
+			code: `
+RegExp["$2"];
+`,
+			snapshot: `
+RegExp["$2"];
+~~~~~~~~~~~~
+The 'RegExp.$2' static property is deprecated.
+`,
+		},
+		{
+			code: `
+RegExp.$3;
+`,
+			snapshot: `
+RegExp.$3;
+~~~~~~~~~
+The 'RegExp.$3' static property is deprecated.
+`,
+		},
+		{
+			code: `
+RegExp.$4;
+`,
+			snapshot: `
+RegExp.$4;
+~~~~~~~~~
+The 'RegExp.$4' static property is deprecated.
+`,
+		},
+		{
+			code: `
+RegExp.$5;
+`,
+			snapshot: `
+RegExp.$5;
+~~~~~~~~~
+The 'RegExp.$5' static property is deprecated.
+`,
+		},
+		{
+			code: `
+RegExp.$6;
+`,
+			snapshot: `
+RegExp.$6;
+~~~~~~~~~
+The 'RegExp.$6' static property is deprecated.
+`,
+		},
+		{
+			code: `
+RegExp.$7;
+`,
+			snapshot: `
+RegExp.$7;
+~~~~~~~~~
+The 'RegExp.$7' static property is deprecated.
+`,
+		},
+		{
+			code: `
+RegExp.$8;
+`,
+			snapshot: `
+RegExp.$8;
+~~~~~~~~~
+The 'RegExp.$8' static property is deprecated.
+`,
+		},
+		{
+			code: `
+RegExp.$9;
+`,
+			snapshot: `
+RegExp.$9;
+~~~~~~~~~
+The 'RegExp.$9' static property is deprecated.
+`,
+		},
+		{
+			code: `
+const regex = new RegExp('pattern', 'gi');
+regex.compile;
+`,
+			snapshot: `
+const regex = new RegExp('pattern', 'gi');
+regex.compile;
+~~~~~~~~~~~~~
+The 'RegExp.prototype.compile' method is deprecated.
+`,
+		},
+		{
+			code: `
+const regex = /pattern/;
+regex.compile('new pattern', 'g');
+`,
+			snapshot: `
+const regex = /pattern/;
+regex.compile('new pattern', 'g');
+~~~~~~~~~~~~~
+The 'RegExp.prototype.compile' method is deprecated.
+`,
+		},
+	],
+	valid: [
+		`RegExp;`,
+		`new RegExp();`,
+		`RegExp.unknown;`,
+		`RegExp.test;`,
+		`RegExp.exec;`,
+		`RegExp.prototype;`,
+		`/pattern/.test('value');`,
+		`/pattern/.exec('value');`,
+		`const regex = /pattern/; regex.test('value');`,
+		`const regex = new RegExp('pattern'); regex.exec('value');`,
+		`const Custom = { $1: 1 }; Custom.$1;`,
+		`const obj = { compile: () => {} }; obj.compile();`,
+	],
+});

--- a/packages/ts/src/rules/regexLegacyFeatures.ts
+++ b/packages/ts/src/rules/regexLegacyFeatures.ts
@@ -1,0 +1,146 @@
+import {
+	getTSNodeRange,
+	isGlobalDeclarationOfName,
+	typescriptLanguage,
+} from "@flint.fyi/typescript-language";
+import ts from "typescript";
+
+import { ruleCreator } from "./ruleCreator.ts";
+import { isBuiltinSymbolLike } from "./utils/isBuiltinSymbolLike.ts";
+
+const LEGACY_STATIC_PROPERTIES = new Set([
+	"$1",
+	"$2",
+	"$3",
+	"$4",
+	"$5",
+	"$6",
+	"$7",
+	"$8",
+	"$9",
+	"$&",
+	"$'",
+	"$+",
+	"$_",
+	"$`",
+	"input",
+	"lastMatch",
+	"lastParen",
+	"leftContext",
+	"rightContext",
+]);
+
+const LEGACY_PROTOTYPE_METHODS = new Set(["compile"]);
+
+export default ruleCreator.createRule(typescriptLanguage, {
+	about: {
+		description:
+			"Reports usage of legacy RegExp static properties and prototype methods.",
+		id: "regexLegacyFeatures",
+		presets: ["logical"],
+	},
+	messages: {
+		forbiddenPrototypeMethod: {
+			primary: "The 'RegExp.prototype.{{ name }}' method is deprecated.",
+			secondary: [
+				"This method is a legacy feature and should not be used in modern code.",
+				"It exists only for backwards compatibility with older scripts.",
+			],
+			suggestions: [
+				"Create a new RegExp instance instead of recompiling an existing one.",
+			],
+		},
+		forbiddenStaticProperty: {
+			primary: "The 'RegExp.{{ name }}' static property is deprecated.",
+			secondary: [
+				"This property is a legacy feature and should not be used in modern code.",
+				"It exists only for backwards compatibility with older scripts.",
+			],
+			suggestions: [
+				"Capture the needed values from the match result instead of using global properties.",
+			],
+		},
+	},
+	setup(context) {
+		return {
+			visitors: {
+				ElementAccessExpression: (node, { sourceFile, typeChecker }) => {
+					if (
+						!ts.isIdentifier(node.expression) ||
+						node.expression.text !== "RegExp" ||
+						!ts.isStringLiteral(node.argumentExpression)
+					) {
+						return;
+					}
+
+					const propertyName = node.argumentExpression.text;
+					if (!LEGACY_STATIC_PROPERTIES.has(propertyName)) {
+						return;
+					}
+
+					if (
+						!isGlobalDeclarationOfName(node.expression, "RegExp", typeChecker)
+					) {
+						return;
+					}
+
+					context.report({
+						data: { name: propertyName },
+						message: "forbiddenStaticProperty",
+						range: getTSNodeRange(node, sourceFile),
+					});
+				},
+				PropertyAccessExpression: (
+					node,
+					{ program, sourceFile, typeChecker },
+				) => {
+					if (ts.isPrivateIdentifier(node.name)) {
+						return;
+					}
+
+					const propertyName = node.name.text;
+
+					if (ts.isIdentifier(node.expression)) {
+						if (node.expression.text === "RegExp") {
+							if (!LEGACY_STATIC_PROPERTIES.has(propertyName)) {
+								return;
+							}
+
+							if (
+								!isGlobalDeclarationOfName(
+									node.expression,
+									"RegExp",
+									typeChecker,
+								)
+							) {
+								return;
+							}
+
+							context.report({
+								data: { name: propertyName },
+								message: "forbiddenStaticProperty",
+								range: getTSNodeRange(node, sourceFile),
+							});
+							return;
+						}
+					}
+
+					if (!LEGACY_PROTOTYPE_METHODS.has(propertyName)) {
+						return;
+					}
+
+					const objectType = typeChecker.getTypeAtLocation(node.expression);
+					if (!isBuiltinSymbolLike(program, objectType, "RegExp")) {
+						return;
+					}
+
+					context.report({
+						data: { name: propertyName },
+						message: "forbiddenPrototypeMethod",
+						range: getTSNodeRange(node, sourceFile),
+					});
+				},
+			},
+		};
+	},
+});


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #1929
- [x] That issue was marked as [`status: accepting prs`](https://github.com/flint-fyi/flint/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/flint-fyi/flint/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Implements the `regexLegacyFeatures` rule which reports usage of:
- Legacy RegExp static properties (like `RegExp.$1`, `RegExp.input`, `RegExp.lastMatch`, etc.)
- Legacy prototype methods (like `regex.compile()`)

❤️‍🔥