### PR TITLE
feat(ts): implement regexOctalEscapes rule

### DIFF
--- a/packages/comparisons/src/data.json
+++ b/packages/comparisons/src/data.json
@@ -15341,7 +15341,8 @@
 		"flint": {
 			"name": "regexOctalEscapes",
 			"plugin": "ts",
-			"preset": "logical"
+			"preset": "logical",
+			"status": "implemented"
 		}
 	},
 	{

--- a/packages/site/src/content/docs/rules/ts/regexOctalEscapes.mdx
+++ b/packages/site/src/content/docs/rules/ts/regexOctalEscapes.mdx
@@ -1,0 +1,95 @@
+---
+description: "Reports octal escape sequences in regular expressions."
+title: "regexOctalEscapes"
+topic: "rules"
+---
+
+import { Tabs, TabItem } from "@astrojs/starlight/components";
+import { RuleEquivalents } from "~/components/RuleEquivalents";
+import RuleSummary from "~/components/RuleSummary.astro";
+
+<RuleSummary plugin="ts" rule="regexOctalEscapes" />
+
+Reports octal escape sequences in regular expressions.
+Octal escapes like `\7` or `\07` can be confused with backreferences.
+The same sequence (e.g., `\2`) may be a character or a backreference depending on the number of capturing groups in the pattern.
+
+## Examples
+
+### Octal Escape Starting with Zero
+
+<Tabs>
+<TabItem label="❌ Incorrect">
+
+```ts
+const pattern = /\07/;
+```
+
+</TabItem>
+<TabItem label="✅ Correct">
+
+```ts
+const pattern = /\x07/;
+```
+
+</TabItem>
+</Tabs>
+
+### Simple Octal Escape
+
+<Tabs>
+<TabItem label="❌ Incorrect">
+
+```ts
+const pattern = /\7/;
+```
+
+</TabItem>
+<TabItem label="✅ Correct">
+
+```ts
+const pattern = /\x07/;
+```
+
+</TabItem>
+</Tabs>
+
+### Ambiguous Octal vs Backreference
+
+<Tabs>
+<TabItem label="❌ Incorrect">
+
+```ts
+const pattern = /\1\2/;
+```
+
+</TabItem>
+<TabItem label="✅ Correct">
+
+```ts
+const pattern = /\x01\x02/;
+```
+
+</TabItem>
+</Tabs>
+
+In the incorrect example, `\1` and `\2` are octal escapes (matching characters with code 1 and 2).
+If capturing groups are added later, they could become backreferences.
+
+## Options
+
+This rule is not configurable.
+
+## When Not To Use It
+
+If you intentionally use octal escapes for specific character matching and understand the distinction from backreferences, you might want to disable this rule.
+Octal escapes inside character class ranges (e.g., `[\1-\4]`) are allowed.
+
+## Further Reading
+
+- [MDN: Character escape](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Character_escape)
+- [MDN: Backreference](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Backreference)
+
+## Equivalents in Other Linters
+
+<RuleEquivalents pluginId="ts" ruleId="regexOctalEscapes" />

--- a/packages/ts/src/plugin.ts
+++ b/packages/ts/src/plugin.ts
@@ -194,6 +194,7 @@ import regexGraphemeStringLiterals from "./rules/regexGraphemeStringLiterals.ts"
 import regexHexadecimalEscapes from "./rules/regexHexadecimalEscapes.ts";
 import regexIgnoreCaseFlags from "./rules/regexIgnoreCaseFlags.ts";
 import regexInvisibleCharacters from "./rules/regexInvisibleCharacters.ts";
+import regexOctalEscapes from "./rules/regexOctalEscapes.ts";
 import returnAssignments from "./rules/returnAssignments.ts";
 import selfAssignments from "./rules/selfAssignments.ts";
 import selfComparisons from "./rules/selfComparisons.ts";
@@ -414,6 +415,7 @@ export const ts = createPlugin({
 		regexGraphemeStringLiterals,
 		regexHexadecimalEscapes,
 		regexIgnoreCaseFlags,
+		regexOctalEscapes,
 		returnAssignments,
 		selfAssignments,
 		selfComparisons,

--- a/packages/ts/src/rules/regexOctalEscapes.test.ts
+++ b/packages/ts/src/rules/regexOctalEscapes.test.ts
@@ -1,0 +1,88 @@
+import rule from "./regexOctalEscapes.ts";
+import { ruleTester } from "./ruleTester.ts";
+
+ruleTester.describe(rule, {
+	invalid: [
+		{
+			code: String.raw`
+/\07/;
+`,
+			snapshot: String.raw`
+/\07/;
+ ~~~
+ Octal escape sequence '\07' can be confused with backreferences.
+`,
+		},
+		{
+			code: String.raw`
+/\077/;
+`,
+			snapshot: String.raw`
+/\077/;
+ ~~~~
+ Octal escape sequence '\077' can be confused with backreferences.
+`,
+		},
+		{
+			code: String.raw`
+/[\077]/;
+`,
+			snapshot: String.raw`
+/[\077]/;
+  ~~~~
+  Octal escape sequence '\077' can be confused with backreferences.
+`,
+		},
+		{
+			code: String.raw`
+/\7/;
+`,
+			snapshot: String.raw`
+/\7/;
+ ~~
+ Octal escape sequence '\7' can be confused with backreferences.
+`,
+		},
+		{
+			code: String.raw`
+/\1\2/;
+`,
+			snapshot: String.raw`
+/\1\2/;
+ ~~
+ Octal escape sequence '\1' can be confused with backreferences.
+   ~~
+   Octal escape sequence '\2' can be confused with backreferences.
+`,
+		},
+		{
+			code: String.raw`
+/()\1\2/;
+`,
+			snapshot: String.raw`
+/()\1\2/;
+     ~~
+     Octal escape sequence '\2' can be confused with backreferences.
+`,
+		},
+		{
+			code: String.raw`
+new RegExp("\\07");
+`,
+			snapshot: String.raw`
+new RegExp("\\07");
+            ~~~
+            Octal escape sequence '\07' can be confused with backreferences.
+`,
+		},
+	],
+	valid: [
+		String.raw`/\0/;`,
+		String.raw`/[\7]/;`,
+		String.raw`/[\1-\4]/;`,
+		String.raw`/()\1/;`,
+		String.raw`/()()\1\2/;`,
+		String.raw`new RegExp("\\0");`,
+		`RegExp(variable);`,
+	],
+});

--- a/packages/ts/src/rules/regexOctalEscapes.ts
+++ b/packages/ts/src/rules/regexOctalEscapes.ts
@@ -1,0 +1,167 @@
+import {
+	type AST as RegExpAST,
+	visitRegExpAST,
+} from "@eslint-community/regexpp";
+import { typescriptLanguage } from "@flint.fyi/typescript-language";
+import type { AST } from "@flint.fyi/typescript-language";
+import * as ts from "typescript";
+
+import { ruleCreator } from "./ruleCreator.ts";
+import { parseRegexpAst } from "./utils/parseRegexpAst.ts";
+
+function countCapturingGroups(pattern: RegExpAST.Pattern): number {
+	let count = 0;
+	visitRegExpAST(pattern, {
+		onCapturingGroupEnter() {
+			count++;
+		},
+	});
+	return count;
+}
+
+function isOctalEscape(raw: string): boolean {
+	return /^\\[0-7]{1,3}$/.test(raw);
+}
+
+export default ruleCreator.createRule(typescriptLanguage, {
+	about: {
+		description: "Reports octal escape sequences in regular expressions.",
+		id: "regexOctalEscapes",
+		presets: ["logical"],
+	},
+	messages: {
+		unexpected: {
+			primary:
+				"Octal escape sequence '{{ raw }}' can be confused with backreferences.",
+			secondary: [
+				"Octal escapes like \\1 can be mistaken for backreferences. The same sequence may be a character or a backreference depending on the number of capturing groups.",
+			],
+			suggestions: [
+				"Use hexadecimal escape sequences (e.g., \\x07) instead of octal escapes.",
+			],
+		},
+	},
+	setup(context) {
+		function checkPattern(
+			pattern: string,
+			patternStart: number,
+			flags: string,
+		) {
+			const regexpAst = parseRegexpAst(pattern, flags);
+			if (!regexpAst) {
+				return;
+			}
+
+			const capturingGroupCount = countCapturingGroups(regexpAst);
+
+			visitRegExpAST(regexpAst, {
+				onCharacterEnter(charNode) {
+					if (charNode.raw === "\\0") {
+						return;
+					}
+
+					if (!isOctalEscape(charNode.raw)) {
+						return;
+					}
+
+					const octalMatch = /^\\([0-7]+)$/.exec(charNode.raw);
+					if (octalMatch?.[1]) {
+						const octalValue = parseInt(octalMatch[1], 8);
+						if (
+							octalValue > 0 &&
+							octalValue <= capturingGroupCount &&
+							!charNode.raw.startsWith("\\0")
+						) {
+							return;
+						}
+					}
+
+					const shouldReport =
+						charNode.raw.startsWith("\\0") ||
+						!(
+							charNode.parent.type === "CharacterClass" ||
+							charNode.parent.type === "CharacterClassRange"
+						);
+
+					if (shouldReport) {
+						context.report({
+							data: {
+								raw: charNode.raw,
+							},
+							message: "unexpected",
+							range: {
+								begin: patternStart + charNode.start,
+								end: patternStart + charNode.end,
+							},
+						});
+					}
+				},
+			});
+		}
+
+		function checkRegexLiteral(
+			node: AST.RegularExpressionLiteral,
+			{ sourceFile }: { sourceFile: ts.SourceFile },
+		) {
+			const text = node.getText(sourceFile);
+			const match = /^\/(.*)\/([dgimsuyv]*)$/.exec(text);
+
+			if (!match) {
+				return;
+			}
+
+			const [, pattern, flags] = match;
+
+			if (!pattern) {
+				return;
+			}
+
+			const nodeStart = node.getStart(sourceFile);
+			checkPattern(pattern, nodeStart + 1, flags ?? "");
+		}
+
+		function checkRegExpConstructor(
+			node: AST.CallExpression | AST.NewExpression,
+			{ sourceFile }: { sourceFile: ts.SourceFile },
+		) {
+			if (
+				node.expression.kind !== ts.SyntaxKind.Identifier ||
+				node.expression.text !== "RegExp"
+			) {
+				return;
+			}
+
+			const args = node.arguments;
+			if (!args?.length) {
+				return;
+			}
+
+			const firstArgument = args[0];
+
+			if (
+				!firstArgument ||
+				firstArgument.kind !== ts.SyntaxKind.StringLiteral
+			) {
+				return;
+			}
+
+			const patternStart = firstArgument.getStart(sourceFile) + 1;
+
+			let flags = "";
+			const secondArgument = args[1];
+			if (secondArgument?.kind === ts.SyntaxKind.StringLiteral) {
+				flags = secondArgument.text;
+			}
+
+			checkPattern(firstArgument.text, patternStart, flags);
+		}
+
+		return {
+			visitors: {
+				CallExpression: checkRegExpConstructor,
+				NewExpression: checkRegExpConstructor,
+				RegularExpressionLiteral: checkRegexLiteral,
+			},
+		};
+	},
+});


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: Fixes #1943
- [x] Follows [DEVELOPMENT.md](https://github.com/flint-fyi/flint/blob/main/.github/DEVELOPMENT.md)'s General Guidelines

## Overview

Adds the `regexOctalEscapes` rule for the TypeScript plugin.

This rule reports octal escape sequences in regular expressions. Octal escapes like `\7` or `\07` can be confused with backreferences. The same sequence (e.g., `\2`) may be a character or a backreference depending on the number of capturing groups.

Equivalent to ESLint's [`regexp/no-octal`](https://ota-meshi.github.io/eslint-plugin-regexp/rules/no-octal.html).

❤️‍🔥