### PR TITLE
refactor: ban bare zods

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -119,6 +119,15 @@ export default defineConfig(
 			// https://github.com/eslint-community/eslint-plugin-n/issues/472
 			"n/no-unpublished-bin": "off",
 
+			// Restrict imports
+			"@typescript-eslint/no-restricted-imports": [
+				"error",
+				{
+					message: "Use zod/v4 for the modern v4 API instead.",
+					name: "zod",
+				},
+			],
+			// Use no-restricted-syntax to target e.g. `type Foo = typeof import('foo.js')` as well.
 			"no-restricted-syntax": ["error", ...banJsImportExtension()],
 
 			"perfectionist/sort-imports": [
@@ -148,6 +157,25 @@ export default defineConfig(
 				],
 			},
 			perfectionist: { partitionByComment: true, type: "natural" },
+		},
+	},
+	{
+		files: ["packages/core/**/*.ts"],
+		ignores: ["packages/core/**/*.test.ts"],
+		rules: {
+			"@typescript-eslint/no-restricted-imports": [
+				"error",
+				{
+					message:
+						"Use Standard Schema for abstractions or Zod Core for parsing.",
+					name: "zod",
+				},
+				{
+					message:
+						"Use Standard Schema for abstractions or Zod Core for parsing.",
+					name: "zod/v4",
+				},
+			],
 		},
 	},
 	{

--- a/packages/core/src/cache/cacheSchema.test.ts
+++ b/packages/core/src/cache/cacheSchema.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import z from "zod";
+import z from "zod/v4";
 
 import type { CacheStorage } from "../types/cache.ts";
 import { cacheStorageSchema } from "./cacheSchema.ts";

--- a/packages/core/src/cache/cacheSchema.ts
+++ b/packages/core/src/cache/cacheSchema.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line @typescript-eslint/no-restricted-imports -- TODO: Use Zod Mini in core package
 import z from "zod/v4";
 
 import type { SuggestionForFile } from "../types/changes.ts";

--- a/packages/core/src/cache/readFromCache.ts
+++ b/packages/core/src/cache/readFromCache.ts
@@ -1,7 +1,6 @@
 import { nullThrows } from "@flint.fyi/utils";
 import { CachedFactory } from "cached-factory";
 import { debugForFile } from "debug-for-file";
-import z from "zod";
 
 import { readFileSafe } from "../running/readFileSafe.ts";
 import type { FileCacheStorage } from "../types/cache.ts";
@@ -22,7 +21,7 @@ export async function readFromCache(
 		return undefined;
 	}
 
-	const decodeResult = z.safeDecode(cacheStorageSchema, rawCacheString);
+	const decodeResult = cacheStorageSchema.safeDecode(rawCacheString);
 	if (!decodeResult.success) {
 		log(
 			"Linting all %d file path(s) due to invalid cache data: %s",

--- a/packages/core/src/cache/writeToCache.ts
+++ b/packages/core/src/cache/writeToCache.ts
@@ -2,7 +2,6 @@ import { CachedFactory } from "cached-factory";
 import { debugForFile } from "debug-for-file";
 import * as fs from "node:fs/promises";
 import omitEmpty from "omit-empty";
-import z from "zod";
 
 import type { CacheStorage } from "../types/cache.ts";
 import type { LintResults } from "../types/linting.ts";
@@ -55,7 +54,7 @@ export async function writeToCache(
 
 	await fs.mkdir(cacheFileDirectory, { recursive: true });
 
-	const encoded = z.safeEncode(cacheStorageSchema, storage);
+	const encoded = cacheStorageSchema.safeEncode(storage);
 	if (!encoded.success) {
 		log("Failed to encode cache data: %s", encoded.error.message);
 		return;

--- a/packages/core/src/plugins/createPlugin.test.ts
+++ b/packages/core/src/plugins/createPlugin.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import z from "zod";
+import z from "zod/v4";
 
 import { createLanguage } from "../languages/createLanguage.ts";
 import { createPlugin } from "./createPlugin.ts";

--- a/packages/core/src/utils/codecs.ts
+++ b/packages/core/src/utils/codecs.ts
@@ -1,7 +1,7 @@
 /**
  * https://zod.dev/codecs#useful-codecs
  */
-
+// eslint-disable-next-line @typescript-eslint/no-restricted-imports -- TODO: Use Zod Mini in core package
 import z from "zod/v4";
 
 export const jsonCodec = <T extends z.core.$ZodType>(schema: T) =>

--- a/packages/json/src/rules/keyDuplicates.ts
+++ b/packages/json/src/rules/keyDuplicates.ts
@@ -1,6 +1,6 @@
 import { jsonLanguage } from "@flint.fyi/json-language";
 import ts from "typescript";
-import z from "zod";
+import z from "zod/v4";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/json/src/rules/keyNormalization.ts
+++ b/packages/json/src/rules/keyNormalization.ts
@@ -1,6 +1,6 @@
 import { jsonLanguage } from "@flint.fyi/json-language";
 import ts from "typescript";
-import z from "zod";
+import z from "zod/v4";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/ts/src/rules/arrayTypes.ts
+++ b/packages/ts/src/rules/arrayTypes.ts
@@ -5,7 +5,7 @@ import {
 	typescriptLanguage,
 } from "@flint.fyi/typescript-language";
 import * as ts from "typescript";
-import { z } from "zod";
+import { z } from "zod/v4";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/ts/src/rules/classMethodsThis.ts
+++ b/packages/ts/src/rules/classMethodsThis.ts
@@ -1,6 +1,6 @@
 import { type AST, typescriptLanguage } from "@flint.fyi/typescript-language";
 import ts from "typescript";
-import { z } from "zod";
+import { z } from "zod/v4";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/ts/src/rules/constructorGenericCalls.ts
+++ b/packages/ts/src/rules/constructorGenericCalls.ts
@@ -4,7 +4,7 @@ import {
 	typescriptLanguage,
 } from "@flint.fyi/typescript-language";
 import ts from "typescript";
-import { z } from "zod";
+import { z } from "zod/v4";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/ts/src/rules/extraneousClasses.ts
+++ b/packages/ts/src/rules/extraneousClasses.ts
@@ -4,7 +4,7 @@ import {
 	typescriptLanguage,
 } from "@flint.fyi/typescript-language";
 import ts from "typescript";
-import { z } from "zod";
+import { z } from "zod/v4";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/ts/src/rules/functionDeclarationStyles.ts
+++ b/packages/ts/src/rules/functionDeclarationStyles.ts
@@ -4,7 +4,7 @@ import {
 	typescriptLanguage,
 } from "@flint.fyi/typescript-language";
 import ts from "typescript";
-import { z } from "zod";
+import { z } from "zod/v4";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/ts/src/rules/indexedObjectTypes.ts
+++ b/packages/ts/src/rules/indexedObjectTypes.ts
@@ -5,7 +5,7 @@ import {
 	typescriptLanguage,
 } from "@flint.fyi/typescript-language";
 import * as ts from "typescript";
-import { z } from "zod";
+import { z } from "zod/v4";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/ts/src/rules/irregularWhitespaces.ts
+++ b/packages/ts/src/rules/irregularWhitespaces.ts
@@ -1,6 +1,6 @@
 import { typescriptLanguage } from "@flint.fyi/typescript-language";
 import * as ts from "typescript";
-import { z } from "zod";
+import { z } from "zod/v4";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/ts/src/rules/namespaceDeclarations.ts
+++ b/packages/ts/src/rules/namespaceDeclarations.ts
@@ -4,7 +4,7 @@ import {
 } from "@flint.fyi/typescript-language";
 import * as tsutils from "ts-api-utils";
 import ts, { SyntaxKind } from "typescript";
-import { z } from "zod";
+import { z } from "zod/v4";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/ts/src/rules/nullishCoalescingOperators.ts
+++ b/packages/ts/src/rules/nullishCoalescingOperators.ts
@@ -8,7 +8,7 @@ import {
 } from "@flint.fyi/typescript-language";
 import * as tsutils from "ts-api-utils";
 import ts from "typescript";
-import { z } from "zod";
+import { z } from "zod/v4";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/ts/src/rules/propertyAccessNotation.ts
+++ b/packages/ts/src/rules/propertyAccessNotation.ts
@@ -5,7 +5,7 @@ import {
 	typescriptLanguage,
 } from "@flint.fyi/typescript-language";
 import ts from "typescript";
-import { z } from "zod";
+import { z } from "zod/v4";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/ts/src/rules/sizeComparisonOperators.ts
+++ b/packages/ts/src/rules/sizeComparisonOperators.ts
@@ -4,7 +4,7 @@ import {
 	typescriptLanguage,
 } from "@flint.fyi/typescript-language";
 import * as ts from "typescript";
-import { z } from "zod";
+import { z } from "zod/v4";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/ts/src/rules/tsComments.ts
+++ b/packages/ts/src/rules/tsComments.ts
@@ -4,7 +4,7 @@ import type {
 } from "@flint.fyi/core";
 import { typescriptLanguage } from "@flint.fyi/typescript-language";
 import * as tsutils from "ts-api-utils";
-import { z } from "zod";
+import { z } from "zod/v4";
 
 import { ruleCreator } from "./ruleCreator.ts";
 


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to flint! ❤️‍🔥
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [`status: accepting prs`](https://github.com/flint-fyi/flint/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [ ] Steps in [CONTRIBUTING.md](https://github.com/flint-fyi/flint/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->
We're like 50/50 `zod/v4`/`zod`, we should just use one import path. (IMO we should switch to Zod mini as well, but that's a different PR for sure)

Noticed in, and thus blocked on #1855.