### PR TITLE
feat: implement regexUnnecessaryBackreferences for TypeScript plugin

### DIFF
--- a/packages/comparisons/src/data.json
+++ b/packages/comparisons/src/data.json
@@ -15655,7 +15655,8 @@
 		"flint": {
 			"name": "regexUnnecessaryBackreferences",
 			"plugin": "ts",
-			"preset": "logical"
+			"preset": "logical",
+			"status": "implemented"
 		},
 		"oxlint": [
 			{

--- a/packages/site/src/content/docs/rules/ts/regexUnnecessaryBackreferences.mdx
+++ b/packages/site/src/content/docs/rules/ts/regexUnnecessaryBackreferences.mdx
@@ -1,0 +1,117 @@
+---
+description: "Reports backreferences in regular expressions that are always empty or never match."
+title: "regexUnnecessaryBackreferences"
+topic: "rules"
+---
+
+import { Tabs, TabItem } from "@astrojs/starlight/components";
+import { RuleEquivalents } from "~/components/RuleEquivalents";
+import RuleSummary from "~/components/RuleSummary.astro";
+
+<RuleSummary plugin="ts" rule="regexUnnecessaryBackreferences" />
+
+Reports backreferences in regular expressions that will always match an empty string or will never participate in the match.
+This can indicate a bug in the regex pattern.
+
+## Examples
+
+### Nested Backreference
+
+When a backreference is inside the group it references, it always matches an empty string because the group hasn't completed yet.
+
+<Tabs>
+<TabItem label="❌ Incorrect">
+
+```ts
+const pattern = /(a\1)/;
+```
+
+</TabItem>
+<TabItem label="✅ Correct">
+
+```ts
+const pattern = /(a)\1/;
+```
+
+</TabItem>
+</Tabs>
+
+### Forward Backreference
+
+When a backreference appears before its capturing group is defined, it always matches an empty string.
+
+<Tabs>
+<TabItem label="❌ Incorrect">
+
+```ts
+const pattern = /\1(a)/;
+```
+
+</TabItem>
+<TabItem label="✅ Correct">
+
+```ts
+const pattern = /(a)\1/;
+```
+
+</TabItem>
+</Tabs>
+
+### Disjunctive Backreference
+
+When a backreference and its capturing group are in different alternation branches, the backreference never matches because when one branch is taken, the other is not.
+
+<Tabs>
+<TabItem label="❌ Incorrect">
+
+```ts
+const pattern = /(a)|\1b/;
+```
+
+</TabItem>
+<TabItem label="✅ Correct">
+
+```ts
+const pattern = /(a)\1|b/;
+```
+
+</TabItem>
+</Tabs>
+
+### RegExp Constructor
+
+The rule also checks regex patterns in `RegExp` constructor calls.
+
+<Tabs>
+<TabItem label="❌ Incorrect">
+
+```ts
+const pattern = new RegExp("(a\\1)");
+```
+
+</TabItem>
+<TabItem label="✅ Correct">
+
+```ts
+const pattern = new RegExp("(a)\\1");
+```
+
+</TabItem>
+</Tabs>
+
+## Options
+
+This rule is not configurable.
+
+## When Not To Use It
+
+If you intentionally use backreferences that match empty strings for specific regex logic, or if you're working with dynamically constructed regex patterns, you may disable this rule.
+
+## Further Reading
+
+- [MDN: Backreferences](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_expressions/Groups_and_backreferences)
+- [MDN: Groups and backreferences](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Backreference)
+
+## Equivalents in Other Linters
+
+<RuleEquivalents pluginId="ts" ruleId="regexUnnecessaryBackreferences" />

--- a/packages/ts/src/plugin.ts
+++ b/packages/ts/src/plugin.ts
@@ -216,6 +216,7 @@ import regexTestMethods from "./rules/regexTestMethods.ts";
 import regexUnicodeCodepointEscapes from "./rules/regexUnicodeCodepointEscapes.ts";
 import regexUnicodeEscapes from "./rules/regexUnicodeEscapes.ts";
 import regexUnicodeFlag from "./rules/regexUnicodeFlag.ts";
+import regexUnnecessaryBackreferences from "./rules/regexUnnecessaryBackreferences.ts";
 import returnAssignments from "./rules/returnAssignments.ts";
 import selfAssignments from "./rules/selfAssignments.ts";
 import selfComparisons from "./rules/selfComparisons.ts";
@@ -455,6 +456,7 @@ export const ts = createPlugin({
 		regexSuperLinearBacktracking,
 		regexSuperLinearMoves,
 		regexTestMethods,
+		regexUnnecessaryBackreferences,
 		regexUnicodeCodepointEscapes,
 		regexUnicodeEscapes,
 		regexUnicodeFlag,

--- a/packages/ts/src/rules/regexUnnecessaryBackreferences.test.ts
+++ b/packages/ts/src/rules/regexUnnecessaryBackreferences.test.ts
@@ -1,0 +1,109 @@
+import rule from "./regexUnnecessaryBackreferences.ts";
+import { ruleTester } from "./ruleTester.ts";
+
+ruleTester.describe(rule, {
+	invalid: [
+		{
+			code: `
+/(a\\1)/;
+`,
+			snapshot: `
+/(a\\1)/;
+   ~~
+   Backreference '\\1' is inside the group it references and always matches empty.
+`,
+		},
+		{
+			code: `
+/(\\1)/;
+`,
+			snapshot: `
+/(\\1)/;
+  ~~
+  Backreference '\\1' is inside the group it references and always matches empty.
+`,
+		},
+		{
+			code: `
+/\\1(a)/;
+`,
+			snapshot: `
+/\\1(a)/;
+ ~~
+ Backreference '\\1' appears before its capturing group is defined.
+`,
+		},
+		{
+			code: `
+/(a)\\2(b)/;
+`,
+			snapshot: `
+/(a)\\2(b)/;
+    ~~
+    Backreference '\\2' appears before its capturing group is defined.
+`,
+		},
+		{
+			code: `
+/(a)|\\1b/;
+`,
+			snapshot: `
+/(a)|\\1b/;
+     ~~
+     Backreference '\\1' and its capturing group are in different alternation branches.
+`,
+		},
+		{
+			code: `
+new RegExp("(a\\\\1)");
+`,
+			snapshot: `
+new RegExp("(a\\\\1)");
+              ~~~
+              Backreference '\\\\1' is inside the group it references and always matches empty.
+`,
+		},
+		{
+			code: `
+RegExp("\\\\1(a)");
+`,
+			snapshot: `
+RegExp("\\\\1(a)");
+        ~~~
+        Backreference '\\\\1' appears before its capturing group is defined.
+`,
+		},
+		{
+			code: `
+/(a)|\\1(b)/;
+`,
+			snapshot: `
+/(a)|\\1(b)/;
+     ~~
+     Backreference '\\1' and its capturing group are in different alternation branches.
+`,
+		},
+
+		{
+			code: `
+/(?:(a)|\\1)+/;
+`,
+			snapshot: `
+/(?:(a)|\\1)+/;
+        ~~
+        Backreference '\\1' and its capturing group are in different alternation branches.
+`,
+		},
+	],
+	valid: [
+		`/(a)\\1/;`,
+		`/(a|b)\\1/;`,
+		`/(?:a|(b))\\1/;`,
+		`/\\1/;`,
+		`/[\\1]/;`,
+		`new RegExp(variable);`,
+		`/(a)(b)\\1\\2/;`,
+		`/(?<name>a)\\k<name>/;`,
+		`/((a)\\2)/;`,
+	],
+});

--- a/packages/ts/src/rules/regexUnnecessaryBackreferences.ts
+++ b/packages/ts/src/rules/regexUnnecessaryBackreferences.ts
@@ -1,0 +1,397 @@
+import {
+	type AST,
+	type TypeScriptFileServices,
+	typescriptLanguage,
+} from "@flint.fyi/typescript-language";
+
+import { ruleCreator } from "./ruleCreator.ts";
+import { getRegExpConstruction } from "./utils/getRegExpConstruction.ts";
+import { getRegExpLiteralDetails } from "./utils/getRegExpLiteralDetails.ts";
+
+interface BackReferenceInfo {
+	end: number;
+	groupCountSoFar: number;
+	nestedIn: number[];
+	path: PathFrame[];
+	raw: string;
+	reference: number;
+	start: number;
+}
+
+interface GroupInfo {
+	end: number;
+	number: number;
+	path: PathFrame[];
+	start: number;
+}
+
+interface Issue {
+	end: number;
+	kind: IssueKind;
+	raw: string;
+	start: number;
+}
+
+type IssueKind = "disjunctive" | "forward" | "nested";
+
+interface PathFrame {
+	alternative: number;
+	disjunctionId: number;
+}
+
+function analyzePattern(pattern: string, doubleEscaped: boolean) {
+	const groups = new Map<number, GroupInfo>();
+	const backReferences: BackReferenceInfo[] = [];
+
+	let captureCount = 0;
+	let disjunctionIdCounter = 0;
+
+	const groupStack: {
+		capturingNumber: number | undefined;
+		pathAtOpen: PathFrame[];
+		start: number;
+	}[] = [];
+
+	const disjunctionStack: PathFrame[] = [
+		{ alternative: 0, disjunctionId: disjunctionIdCounter++ },
+	];
+
+	let i = 0;
+
+	function getCurrentPath() {
+		return disjunctionStack.map((f) => ({ ...f }));
+	}
+
+	function getOpenCapturingNumbers() {
+		const result: number[] = [];
+		for (const g of groupStack) {
+			if (g.capturingNumber !== undefined) {
+				result.push(g.capturingNumber);
+			}
+		}
+		return result;
+	}
+
+	while (i < pattern.length) {
+		const char = pattern[i];
+
+		if (char === "\\") {
+			const escLen = doubleEscaped ? 2 : 1;
+			if (
+				doubleEscaped &&
+				pattern[i + 1] === "\\" &&
+				i + escLen < pattern.length
+			) {
+				const nextChar = pattern[i + escLen];
+				if (nextChar && nextChar >= "1" && nextChar <= "9") {
+					let refStr = nextChar;
+					let endIdx = i + escLen + 1;
+					while (endIdx < pattern.length) {
+						const digit = pattern[endIdx];
+						if (digit === undefined || digit < "0" || digit > "9") {
+							break;
+						}
+						refStr += digit;
+						endIdx++;
+					}
+					const ref = parseInt(refStr, 10);
+					backReferences.push({
+						end: endIdx,
+						groupCountSoFar: captureCount,
+						nestedIn: getOpenCapturingNumbers(),
+						path: getCurrentPath(),
+						raw: pattern.slice(i, endIdx),
+						reference: ref,
+						start: i,
+					});
+					i = endIdx;
+					continue;
+				}
+				i += escLen + 1;
+				continue;
+			}
+			if (!doubleEscaped && i + 1 < pattern.length) {
+				const nextChar = pattern[i + 1];
+				if (nextChar && nextChar >= "1" && nextChar <= "9") {
+					let refStr = nextChar;
+					let endIdx = i + 2;
+					while (endIdx < pattern.length) {
+						const digit = pattern[endIdx];
+						if (digit === undefined || digit < "0" || digit > "9") {
+							break;
+						}
+						refStr += digit;
+						endIdx++;
+					}
+					const ref = parseInt(refStr, 10);
+					backReferences.push({
+						end: endIdx,
+						groupCountSoFar: captureCount,
+						nestedIn: getOpenCapturingNumbers(),
+						path: getCurrentPath(),
+						raw: pattern.slice(i, endIdx),
+						reference: ref,
+						start: i,
+					});
+					i = endIdx;
+					continue;
+				}
+				i += 2;
+				continue;
+			}
+			i++;
+			continue;
+		}
+
+		if (char === "[") {
+			let j = i + 1;
+			if (j < pattern.length && pattern[j] === "^") {
+				j++;
+			}
+			if (j < pattern.length && pattern[j] === "]") {
+				j++;
+			}
+			while (j < pattern.length && pattern[j] !== "]") {
+				if (pattern[j] === "\\") {
+					j += doubleEscaped ? 3 : 2;
+				} else {
+					j++;
+				}
+			}
+			i = j + 1;
+			continue;
+		}
+
+		if (char === "(") {
+			const groupStart = i;
+			let isCapturing = true;
+
+			if (pattern[i + 1] === "?") {
+				const afterQuestion = pattern[i + 2];
+				if (
+					afterQuestion === ":" ||
+					afterQuestion === "=" ||
+					afterQuestion === "!"
+				) {
+					isCapturing = false;
+				} else if (afterQuestion === "<") {
+					const afterLt = pattern[i + 3];
+					if (afterLt === "=" || afterLt === "!") {
+						isCapturing = false;
+					}
+				}
+			}
+
+			let capturingNumber: number | undefined;
+			if (isCapturing) {
+				captureCount++;
+				capturingNumber = captureCount;
+			}
+
+			const pathAtOpen = getCurrentPath();
+			const newDisjunctionId = disjunctionIdCounter++;
+			disjunctionStack.push({
+				alternative: 0,
+				disjunctionId: newDisjunctionId,
+			});
+			groupStack.push({
+				capturingNumber,
+				pathAtOpen,
+				start: groupStart,
+			});
+
+			i++;
+			continue;
+		}
+
+		if (char === ")") {
+			disjunctionStack.pop();
+			const groupFrame = groupStack.pop();
+			if (groupFrame?.capturingNumber !== undefined) {
+				groups.set(groupFrame.capturingNumber, {
+					end: i + 1,
+					number: groupFrame.capturingNumber,
+					path: groupFrame.pathAtOpen,
+					start: groupFrame.start,
+				});
+			}
+			i++;
+			continue;
+		}
+
+		if (char === "|") {
+			const currentFrame = disjunctionStack.at(-1);
+			if (currentFrame) {
+				currentFrame.alternative++;
+			}
+			i++;
+			continue;
+		}
+
+		i++;
+	}
+
+	return { backReferences, groups, totalCaptures: captureCount };
+}
+
+function divergesByAlternation(
+	groupPath: PathFrame[],
+	backrefPath: PathFrame[],
+) {
+	const minLen = Math.min(groupPath.length, backrefPath.length);
+	for (let i = 0; i < minLen; i++) {
+		const gFrame = groupPath[i];
+		const bFrame = backrefPath[i];
+		if (!gFrame || !bFrame) {
+			return false;
+		}
+		if (gFrame.disjunctionId !== bFrame.disjunctionId) {
+			return false;
+		}
+		if (gFrame.alternative !== bFrame.alternative) {
+			return true;
+		}
+	}
+	return false;
+}
+
+function findIssues(pattern: string, doubleEscaped: boolean): Issue[] {
+	const { backReferences, groups, totalCaptures } = analyzePattern(
+		pattern,
+		doubleEscaped,
+	);
+	const issues: Issue[] = [];
+
+	for (const backReference of backReferences) {
+		if (backReference.reference > totalCaptures) {
+			continue;
+		}
+
+		if (backReference.nestedIn.includes(backReference.reference)) {
+			issues.push({
+				end: backReference.end,
+				kind: "nested",
+				raw: backReference.raw,
+				start: backReference.start,
+			});
+			continue;
+		}
+
+		const group = groups.get(backReference.reference);
+		if (group && divergesByAlternation(group.path, backReference.path)) {
+			issues.push({
+				end: backReference.end,
+				kind: "disjunctive",
+				raw: backReference.raw,
+				start: backReference.start,
+			});
+			continue;
+		}
+
+		if (backReference.reference > backReference.groupCountSoFar) {
+			issues.push({
+				end: backReference.end,
+				kind: "forward",
+				raw: backReference.raw,
+				start: backReference.start,
+			});
+		}
+	}
+
+	return issues;
+}
+
+export default ruleCreator.createRule(typescriptLanguage, {
+	about: {
+		description:
+			"Reports backreferences in regular expressions that are always empty or never match.",
+		id: "regexUnnecessaryBackreferences",
+		presets: ["logical"],
+	},
+	messages: {
+		disjunctive: {
+			primary:
+				"Backreference '{{ reference }}' and its capturing group are in different alternation branches.",
+			secondary: [
+				"When the capturing group is matched, this backreference is not evaluated.",
+				"When this backreference is evaluated, the capturing group has not participated.",
+			],
+			suggestions: [
+				"Move the backreference to the same branch as the capturing group.",
+			],
+		},
+		forward: {
+			primary:
+				"Backreference '{{ reference }}' appears before its capturing group is defined.",
+			secondary: [
+				"At this point in the pattern, the capturing group has not yet been matched.",
+				"This backreference will always match an empty string.",
+			],
+			suggestions: ["Move the backreference after the capturing group."],
+		},
+		nested: {
+			primary:
+				"Backreference '{{ reference }}' is inside the group it references and always matches empty.",
+			secondary: [
+				"The capturing group has not finished matching when the backreference is evaluated.",
+				"This backreference will always match an empty string.",
+			],
+			suggestions: ["Move the backreference outside the capturing group."],
+		},
+	},
+	setup(context) {
+		function checkRegexLiteral(
+			node: AST.RegularExpressionLiteral,
+			services: TypeScriptFileServices,
+		) {
+			const { pattern, start } = getRegExpLiteralDetails(node, services);
+			const issues = findIssues(pattern, false);
+
+			for (const issue of issues) {
+				context.report({
+					data: {
+						reference: issue.raw,
+					},
+					message: issue.kind,
+					range: {
+						begin: start + issue.start,
+						end: start + issue.end,
+					},
+				});
+			}
+		}
+
+		function checkRegExpConstructor(
+			node: AST.CallExpression | AST.NewExpression,
+			services: TypeScriptFileServices,
+		) {
+			const construction = getRegExpConstruction(node, services);
+			if (!construction) {
+				return;
+			}
+
+			const issues = findIssues(construction.pattern, true);
+
+			for (const issue of issues) {
+				context.report({
+					data: {
+						reference: issue.raw,
+					},
+					message: issue.kind,
+					range: {
+						begin: construction.start + 1 + issue.start,
+						end: construction.start + 1 + issue.end,
+					},
+				});
+			}
+		}
+
+		return {
+			visitors: {
+				CallExpression: checkRegExpConstructor,
+				NewExpression: checkRegExpConstructor,
+				RegularExpressionLiteral: checkRegexLiteral,
+			},
+		};
+	},
+});


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #1972
- [x] That issue was marked as [`status: accepting prs`](https://github.com/flint-fyi/flint/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/flint-fyi/flint/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Implements the `regexUnnecessaryBackreferences` rule that detects backreferences in regular expressions that are always empty or never match:

- **Nested**: Backreference inside the group it references (e.g., `/(a\1)/`)
- **Forward**: Backreference before its group is defined (e.g., `/\1(a)/`)
- **Disjunctive**: Group and backreference in different alternation branches (e.g., `/(a)|\1b/`)

Equivalent to ESLint's `no-useless-backreference` and `regexp/no-useless-backreference`.