### PR TITLE
feat: implement shadows for TypeScript plugin

### DIFF
--- a/packages/comparisons/src/data.json
+++ b/packages/comparisons/src/data.json
@@ -16425,7 +16425,8 @@
 		"flint": {
 			"name": "shadows",
 			"plugin": "ts",
-			"preset": "stylistic"
+			"preset": "logical",
+			"status": "implemented"
 		}
 	},
 	{

--- a/packages/site/src/content/docs/rules/ts/shadows.mdx
+++ b/packages/site/src/content/docs/rules/ts/shadows.mdx
@@ -1,0 +1,104 @@
+---
+description: "Avoid declaring variables that shadow variables in outer scopes."
+title: "shadows"
+topic: "rules"
+---
+
+import { Tabs, TabItem } from "@astrojs/starlight/components";
+import { RuleEquivalents } from "~/components/RuleEquivalents";
+import RuleSummary from "~/components/RuleSummary.astro";
+
+<RuleSummary plugin="ts" rule="shadows" />
+
+When a variable in an inner scope has the same name as a variable in an outer scope, it "shadows" the outer variable.
+This can lead to confusion about which variable is being referenced and may cause subtle bugs.
+
+## Examples
+
+<Tabs>
+<TabItem label="❌ Incorrect">
+
+```ts
+const value = 3;
+function example() {
+	const value = 10; // shadows outer 'value'
+	return value;
+}
+
+let count = 1;
+function increment(count) {
+	// parameter shadows outer 'count'
+	return count + 1;
+}
+
+let name = "outer";
+{
+	let name = "inner"; // shadows outer 'name'
+}
+```
+
+</TabItem>
+<TabItem label="✅ Correct">
+
+```ts
+const outerValue = 3;
+function example() {
+	const innerValue = 10;
+	return innerValue;
+}
+
+let totalCount = 1;
+function increment(amount) {
+	return totalCount + amount;
+}
+
+let outerName = "outer";
+{
+	let innerName = "inner";
+}
+```
+
+</TabItem>
+</Tabs>
+
+## Allowed Patterns
+
+This rule allows some common patterns that would otherwise be flagged:
+
+### Function/Class Expression Names
+
+When a function or class expression has the same name as the variable it's assigned to, this is not reported:
+
+```ts
+const compute = function compute() {}; // allowed
+const Widget = class Widget {}; // allowed
+```
+
+### Type Shadowing Value
+
+TypeScript types and interfaces exist in a separate namespace from values, so a value can have the same name as a type without shadowing:
+
+```ts
+type Value = number;
+function example() {
+	const Value = 1; // allowed - type vs value
+}
+```
+
+## Options
+
+This rule is not configurable.
+
+## When Not To Use It
+
+If your codebase frequently uses the same variable names in different scopes intentionally (such as callback parameters that match outer variables), you may find this rule too noisy.
+You might consider using [Flint disable comments](/directives) for specific situations instead of completely disabling this rule.
+
+## Further Reading
+
+- [MDN: Variable scope](https://developer.mozilla.org/en-US/docs/Glossary/Scope)
+- [ESLint: no-shadow](https://eslint.org/docs/latest/rules/no-shadow)
+
+## Equivalents in Other Linters
+
+<RuleEquivalents pluginId="ts" ruleId="shadows" />

--- a/packages/ts/src/plugin.ts
+++ b/packages/ts/src/plugin.ts
@@ -221,6 +221,7 @@ import selfAssignments from "./rules/selfAssignments.ts";
 import selfComparisons from "./rules/selfComparisons.ts";
 import sequences from "./rules/sequences.ts";
 import shadowedRestrictedNames from "./rules/shadowedRestrictedNames.ts";
+import shadows from "./rules/shadows.ts";
 import sparseArrays from "./rules/sparseArrays.ts";
 import symbolDescriptions from "./rules/symbolDescriptions.ts";
 import typeofComparisons from "./rules/typeofComparisons.ts";
@@ -463,6 +464,7 @@ export const ts = createPlugin({
 		selfComparisons,
 		sequences,
 		shadowedRestrictedNames,
+		shadows,
 		sparseArrays,
 		symbolDescriptions,
 		typeofComparisons,

--- a/packages/ts/src/rules/shadows.test.ts
+++ b/packages/ts/src/rules/shadows.test.ts
@@ -1,0 +1,297 @@
+import { ruleTester } from "./ruleTester.ts";
+import rule from "./shadows.ts";
+
+ruleTester.describe(rule, {
+	invalid: [
+		{
+			code: `
+const value = 3;
+function example() {
+    const value = 10;
+}
+`,
+			snapshot: `
+const value = 3;
+function example() {
+    const value = 10;
+          ~~~~~
+          Variable 'value' shadows a variable in an outer scope.
+}
+`,
+		},
+		{
+			code: `
+let count = 1;
+function increment(count) {
+    return count + 1;
+}
+`,
+			snapshot: `
+let count = 1;
+function increment(count) {
+                   ~~~~~
+                   Variable 'count' shadows a variable in an outer scope.
+    return count + 1;
+}
+`,
+		},
+		{
+			code: `
+let name = 'outer';
+{
+    let name = 'inner';
+}
+`,
+			snapshot: `
+let name = 'outer';
+{
+    let name = 'inner';
+        ~~~~
+        Variable 'name' shadows a variable in an outer scope.
+}
+`,
+		},
+		{
+			code: `
+function outer(item) {
+    function inner() {
+        let item = 5;
+    }
+}
+`,
+			snapshot: `
+function outer(item) {
+    function inner() {
+        let item = 5;
+            ~~~~
+            Variable 'item' shadows a variable in an outer scope.
+    }
+}
+`,
+		},
+		{
+			code: `
+const data = [1, 2, 3];
+const result = data.map((data) => data * 2);
+`,
+			snapshot: `
+const data = [1, 2, 3];
+const result = data.map((data) => data * 2);
+                         ~~~~
+                         Variable 'data' shadows a variable in an outer scope.
+`,
+		},
+		{
+			code: `
+let value = 1;
+for (let value = 0; value < 10; value++) {
+    console.log(value);
+}
+`,
+			snapshot: `
+let value = 1;
+for (let value = 0; value < 10; value++) {
+         ~~~~~
+         Variable 'value' shadows a variable in an outer scope.
+    console.log(value);
+}
+`,
+		},
+		{
+			code: `
+const index = 0;
+for (const index of [1, 2, 3]) {
+    console.log(index);
+}
+`,
+			snapshot: `
+const index = 0;
+for (const index of [1, 2, 3]) {
+           ~~~~~
+           Variable 'index' shadows a variable in an outer scope.
+    console.log(index);
+}
+`,
+		},
+		{
+			code: `
+const key = 'outer';
+for (const key in { a: 1 }) {
+    console.log(key);
+}
+`,
+			snapshot: `
+const key = 'outer';
+for (const key in { a: 1 }) {
+           ~~~
+           Variable 'key' shadows a variable in an outer scope.
+    console.log(key);
+}
+`,
+		},
+		{
+			code: `
+const error = new Error();
+try {
+    throw new Error();
+} catch (error) {
+    console.log(error);
+}
+`,
+			snapshot: `
+const error = new Error();
+try {
+    throw new Error();
+} catch (error) {
+         ~~~~~
+         Variable 'error' shadows a variable in an outer scope.
+    console.log(error);
+}
+`,
+		},
+		{
+			code: `
+class Widget {
+    process(value) {
+        const value = 10;
+    }
+}
+`,
+			snapshot: `
+class Widget {
+    process(value) {
+        const value = 10;
+              ~~~~~
+              Variable 'value' shadows a variable in an outer scope.
+    }
+}
+`,
+		},
+		{
+			code: `
+const { item } = obj;
+function process({ item }) {
+    return item;
+}
+`,
+			snapshot: `
+const { item } = obj;
+function process({ item }) {
+                   ~~~~
+                   Variable 'item' shadows a variable in an outer scope.
+    return item;
+}
+`,
+		},
+		{
+			code: `
+const [first] = array;
+const processItem = ([first]) => first;
+`,
+			snapshot: `
+const [first] = array;
+const processItem = ([first]) => first;
+                      ~~~~~
+                      Variable 'first' shadows a variable in an outer scope.
+`,
+		},
+		{
+			code: `
+function outer() {
+    const value = 1;
+    function inner() {
+        const value = 2;
+    }
+}
+`,
+			snapshot: `
+function outer() {
+    const value = 1;
+    function inner() {
+        const value = 2;
+              ~~~~~
+              Variable 'value' shadows a variable in an outer scope.
+    }
+}
+`,
+		},
+		{
+			code: `
+class Outer {}
+function createClass() {
+    class Outer {}
+}
+`,
+			snapshot: `
+class Outer {}
+function createClass() {
+    class Outer {}
+          ~~~~~
+          Variable 'Outer' shadows a variable in an outer scope.
+}
+`,
+		},
+		{
+			code: `
+function outer() {}
+function createFunction() {
+    function outer() {}
+}
+`,
+			snapshot: `
+function outer() {}
+function createFunction() {
+    function outer() {}
+             ~~~~~
+             Variable 'outer' shadows a variable in an outer scope.
+}
+`,
+		},
+	],
+	valid: [
+		`const value = 1;
+function example() {
+    const otherValue = 2;
+}`,
+		`const compute = function compute() {};`,
+		`const Widget = class Widget {};`,
+		`type Value = number;
+function example() {
+    const Value = 1;
+}`,
+		`interface Config {
+    value: number;
+}
+function example() {
+    const Config = {};
+}`,
+		`function example(value) {
+    return value * 2;
+}`,
+		`const outer = 1;
+function example() {
+    const inner = 2;
+    return inner;
+}`,
+		`class Widget {
+    value = 1;
+    getValue() {
+        return this.value;
+    }
+}`,
+		`const items = [1, 2, 3];
+const results = items.map((item) => item * 2);`,
+		`function process({ first, second }) {
+    return first + second;
+}`,
+		`const [first, second] = [1, 2];`,
+		`for (let index = 0; index < 10; index++) {
+    console.log(index);
+}`,
+		`try {
+    throw new Error();
+} catch (error) {
+    console.log(error);
+}`,
+	],
+});

--- a/packages/ts/src/rules/shadows.ts
+++ b/packages/ts/src/rules/shadows.ts
@@ -1,0 +1,300 @@
+import {
+	type AST,
+	getTSNodeRange,
+	typescriptLanguage,
+} from "@flint.fyi/typescript-language";
+import ts from "typescript";
+
+import { ruleCreator } from "./ruleCreator.ts";
+
+interface Scope {
+	names: Set<string>;
+	node: ts.Node;
+}
+
+function isFunctionExpressionNameMatchingVariable(
+	node: AST.ClassExpression | AST.FunctionExpression,
+) {
+	if (!node.name) {
+		return false;
+	}
+
+	const parent = node.parent;
+	if (!ts.isVariableDeclaration(parent)) {
+		return false;
+	}
+
+	if (!ts.isIdentifier(parent.name)) {
+		return false;
+	}
+
+	return parent.name.text === node.name.text;
+}
+
+export default ruleCreator.createRule(typescriptLanguage, {
+	about: {
+		description: "Reports variables that shadow variables in outer scopes.",
+		id: "shadows",
+		presets: ["logical"],
+	},
+	messages: {
+		shadow: {
+			primary: "Variable '{{ name }}' shadows a variable in an outer scope.",
+			secondary: [
+				"Shadowing can lead to confusion about which variable is being referenced.",
+				"This may cause bugs if the wrong variable is accidentally accessed.",
+			],
+			suggestions: ["Rename the variable to avoid shadowing."],
+		},
+	},
+	setup(context) {
+		const scopeStack: Scope[] = [];
+
+		function isShadowing(name: string): boolean {
+			for (let index = scopeStack.length - 2; index >= 0; index--) {
+				if (scopeStack[index].names.has(name)) {
+					return true;
+				}
+			}
+			return false;
+		}
+
+		function pushScope(node: ts.Node): void {
+			scopeStack.push({ names: new Set(), node });
+		}
+
+		function popScope(): void {
+			scopeStack.pop();
+		}
+
+		function getCurrentScope(): Scope | undefined {
+			return scopeStack[scopeStack.length - 1];
+		}
+
+		function addToCurrentScope(name: string): void {
+			const scope = getCurrentScope();
+			if (scope) {
+				scope.names.add(name);
+			}
+		}
+
+		function checkAndReportShadow(
+			name: string,
+			node: ts.Node,
+			sourceFile: AST.SourceFile,
+		): void {
+			if (isShadowing(name)) {
+				context.report({
+					data: { name },
+					message: "shadow",
+					range: getTSNodeRange(node, sourceFile),
+				});
+			}
+			addToCurrentScope(name);
+		}
+
+		function checkBindingName(
+			bindingName: AST.BindingName,
+			sourceFile: AST.SourceFile,
+		): void {
+			if (ts.isIdentifier(bindingName)) {
+				checkAndReportShadow(bindingName.text, bindingName, sourceFile);
+			} else if (ts.isObjectBindingPattern(bindingName)) {
+				for (const element of bindingName.elements) {
+					checkBindingName(element.name, sourceFile);
+				}
+			} else if (ts.isArrayBindingPattern(bindingName)) {
+				for (const element of bindingName.elements) {
+					if (!ts.isOmittedExpression(element)) {
+						checkBindingName(element.name, sourceFile);
+					}
+				}
+			}
+		}
+
+		function checkParameters(
+			parameters: ts.NodeArray<AST.ParameterDeclaration>,
+			sourceFile: AST.SourceFile,
+		): void {
+			for (const parameter of parameters) {
+				checkBindingName(parameter.name, sourceFile);
+			}
+		}
+
+		function visitNode(node: ts.Node, sourceFile: AST.SourceFile): void {
+			switch (node.kind) {
+				case ts.SyntaxKind.ArrowFunction: {
+					const arrowNode = node as AST.ArrowFunction;
+					pushScope(node);
+					checkParameters(arrowNode.parameters, sourceFile);
+					if (ts.isBlock(arrowNode.body)) {
+						ts.forEachChild(arrowNode.body, (child) => {
+							visitNode(child, sourceFile);
+						});
+					} else {
+						visitNode(arrowNode.body, sourceFile);
+					}
+					popScope();
+					return;
+				}
+
+				case ts.SyntaxKind.Block: {
+					pushScope(node);
+					ts.forEachChild(node, (child) => {
+						visitNode(child, sourceFile);
+					});
+					popScope();
+					return;
+				}
+
+				case ts.SyntaxKind.CatchClause: {
+					const catchNode = node as AST.CatchClause;
+					pushScope(node);
+					if (catchNode.variableDeclaration) {
+						checkBindingName(catchNode.variableDeclaration.name, sourceFile);
+					}
+					ts.forEachChild(catchNode.block, (child) => {
+						visitNode(child, sourceFile);
+					});
+					popScope();
+					return;
+				}
+
+				case ts.SyntaxKind.ClassDeclaration: {
+					const classNode = node as AST.ClassDeclaration;
+					if (classNode.name) {
+						checkAndReportShadow(
+							classNode.name.text,
+							classNode.name,
+							sourceFile,
+						);
+					}
+					pushScope(node);
+					ts.forEachChild(node, (child) => {
+						visitNode(child, sourceFile);
+					});
+					popScope();
+					return;
+				}
+
+				case ts.SyntaxKind.ClassExpression: {
+					const classNode = node as AST.ClassExpression;
+					pushScope(node);
+					if (
+						classNode.name &&
+						!isFunctionExpressionNameMatchingVariable(classNode)
+					) {
+						checkAndReportShadow(
+							classNode.name.text,
+							classNode.name,
+							sourceFile,
+						);
+					} else if (classNode.name) {
+						addToCurrentScope(classNode.name.text);
+					}
+					ts.forEachChild(node, (child) => {
+						visitNode(child, sourceFile);
+					});
+					popScope();
+					return;
+				}
+
+				case ts.SyntaxKind.Constructor:
+				case ts.SyntaxKind.GetAccessor:
+				case ts.SyntaxKind.MethodDeclaration:
+				case ts.SyntaxKind.SetAccessor: {
+					const methodNode = node as
+						| AST.ConstructorDeclaration
+						| AST.GetAccessorDeclaration
+						| AST.MethodDeclaration
+						| AST.SetAccessorDeclaration;
+					pushScope(node);
+					checkParameters(methodNode.parameters, sourceFile);
+					if (methodNode.body) {
+						visitNode(methodNode.body, sourceFile);
+					}
+					popScope();
+					return;
+				}
+				case ts.SyntaxKind.ForInStatement:
+				case ts.SyntaxKind.ForOfStatement:
+				case ts.SyntaxKind.ForStatement: {
+					pushScope(node);
+					ts.forEachChild(node, (child) => {
+						visitNode(child, sourceFile);
+					});
+					popScope();
+					return;
+				}
+				case ts.SyntaxKind.FunctionDeclaration: {
+					const functionNode = node as AST.FunctionDeclaration;
+					if (functionNode.name) {
+						checkAndReportShadow(
+							functionNode.name.text,
+							functionNode.name,
+							sourceFile,
+						);
+					}
+					pushScope(node);
+					checkParameters(functionNode.parameters, sourceFile);
+					if (functionNode.body) {
+						visitNode(functionNode.body, sourceFile);
+					}
+					popScope();
+					return;
+				}
+				case ts.SyntaxKind.FunctionExpression: {
+					const functionNode = node as AST.FunctionExpression;
+					pushScope(node);
+					if (
+						functionNode.name &&
+						!isFunctionExpressionNameMatchingVariable(functionNode)
+					) {
+						checkAndReportShadow(
+							functionNode.name.text,
+							functionNode.name,
+							sourceFile,
+						);
+					} else if (functionNode.name) {
+						addToCurrentScope(functionNode.name.text);
+					}
+					checkParameters(functionNode.parameters, sourceFile);
+					visitNode(functionNode.body, sourceFile);
+					popScope();
+					return;
+				}
+
+				case ts.SyntaxKind.SourceFile:
+					pushScope(node);
+					ts.forEachChild(node, (child) => {
+						visitNode(child, sourceFile);
+					});
+					popScope();
+					return;
+
+				case ts.SyntaxKind.VariableDeclaration: {
+					const varNode = node as AST.VariableDeclaration;
+					checkBindingName(varNode.name, sourceFile);
+					if (varNode.initializer) {
+						visitNode(varNode.initializer, sourceFile);
+					}
+					return;
+				}
+
+				default:
+					ts.forEachChild(node, (child) => {
+						visitNode(child, sourceFile);
+					});
+			}
+		}
+
+		return {
+			visitors: {
+				SourceFile: (sourceFile) => {
+					scopeStack.length = 0;
+					visitNode(sourceFile, sourceFile);
+				},
+			},
+		};
+	},
+});


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #2007
- [x] That issue was marked as [`status: accepting prs`](https://github.com/flint-fyi/flint/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/flint-fyi/flint/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Implements the `shadows` rule which reports variables that shadow variables in outer scopes. Shadowing can lead to confusion about which variable is being referenced.

Equivalent to ESLint's `no-shadow` / `@typescript-eslint/no-shadow`.