### PR TITLE
feat: implement stringTrimMethods for TypeScript plugin

### DIFF
--- a/packages/comparisons/src/data.json
+++ b/packages/comparisons/src/data.json
@@ -16798,6 +16798,7 @@
 			"name": "stringTrimMethods",
 			"plugin": "ts",
 			"preset": "stylistic",
+			"status": "implemented",
 			"strictness": "strict"
 		},
 		"oxlint": [

--- a/packages/site/src/content/docs/rules/ts/stringTrimMethods.mdx
+++ b/packages/site/src/content/docs/rules/ts/stringTrimMethods.mdx
@@ -1,0 +1,78 @@
+---
+description: "Reports usage of trimLeft and trimRight instead of trimStart and trimEnd."
+title: "stringTrimMethods"
+topic: "rules"
+---
+
+import { Tabs, TabItem } from "@astrojs/starlight/components";
+import { RuleEquivalents } from "~/components/RuleEquivalents";
+import RuleSummary from "~/components/RuleSummary.astro";
+
+<RuleSummary plugin="ts" rule="stringTrimMethods" />
+
+JavaScript provides `trimStart()` and `trimEnd()` as the standard methods for trimming whitespace from the beginning or end of a string.
+The older `trimLeft()` and `trimRight()` methods are deprecated aliases that use directional terminology.
+
+Using `trimStart()` and `trimEnd()` is preferred because:
+
+- They are the standard method names in the ECMAScript specification
+- They use direction-independent terminology, which is better for internationalization
+- The terms "start" and "end" are more accurate for strings in right-to-left languages
+
+## Examples
+
+### trimLeft to trimStart
+
+<Tabs>
+<TabItem label="❌ Incorrect">
+
+```ts
+const result = text.trimLeft();
+```
+
+</TabItem>
+<TabItem label="✅ Correct">
+
+```ts
+const result = text.trimStart();
+```
+
+</TabItem>
+</Tabs>
+
+### trimRight to trimEnd
+
+<Tabs>
+<TabItem label="❌ Incorrect">
+
+```ts
+const result = text.trimRight();
+```
+
+</TabItem>
+<TabItem label="✅ Correct">
+
+```ts
+const result = text.trimEnd();
+```
+
+</TabItem>
+</Tabs>
+
+## Options
+
+This rule is not configurable.
+
+## When Not To Use It
+
+If you need to support very old JavaScript environments that don't have `trimStart` and `trimEnd`, you may need to disable this rule.
+However, these methods are widely supported in all modern environments.
+
+## Further Reading
+
+- [MDN: String.prototype.trimStart()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/trimStart)
+- [MDN: String.prototype.trimEnd()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/trimEnd)
+
+## Equivalents in Other Linters
+
+<RuleEquivalents pluginId="ts" ruleId="stringTrimMethods" />

--- a/packages/ts/src/plugin.ts
+++ b/packages/ts/src/plugin.ts
@@ -222,6 +222,7 @@ import selfComparisons from "./rules/selfComparisons.ts";
 import sequences from "./rules/sequences.ts";
 import shadowedRestrictedNames from "./rules/shadowedRestrictedNames.ts";
 import sparseArrays from "./rules/sparseArrays.ts";
+import stringTrimMethods from "./rules/stringTrimMethods.ts";
 import symbolDescriptions from "./rules/symbolDescriptions.ts";
 import typeofComparisons from "./rules/typeofComparisons.ts";
 import unassignedVariables from "./rules/unassignedVariables.ts";
@@ -464,6 +465,7 @@ export const ts = createPlugin({
 		sequences,
 		shadowedRestrictedNames,
 		sparseArrays,
+		stringTrimMethods,
 		symbolDescriptions,
 		typeofComparisons,
 		unassignedVariables,

--- a/packages/ts/src/rules/stringTrimMethods.test.ts
+++ b/packages/ts/src/rules/stringTrimMethods.test.ts
@@ -1,0 +1,82 @@
+import rule from "./stringTrimMethods.ts";
+import { ruleTester } from "./ruleTester.ts";
+
+ruleTester.describe(rule, {
+	invalid: [
+		{
+			code: `
+const result = str.trimLeft();
+`,
+			snapshot: `
+const result = str.trimLeft();
+                   ~~~~~~~~
+                   Prefer \`trimStart()\` over \`trimLeft()\`.
+`,
+		},
+		{
+			code: `
+const result = str.trimRight();
+`,
+			snapshot: `
+const result = str.trimRight();
+                   ~~~~~~~~~
+                   Prefer \`trimEnd()\` over \`trimRight()\`.
+`,
+		},
+		{
+			code: `
+const result = "  hello  ".trimLeft();
+`,
+			snapshot: `
+const result = "  hello  ".trimLeft();
+                           ~~~~~~~~
+                           Prefer \`trimStart()\` over \`trimLeft()\`.
+`,
+		},
+		{
+			code: `
+const result = "  hello  ".trimRight();
+`,
+			snapshot: `
+const result = "  hello  ".trimRight();
+                           ~~~~~~~~~
+                           Prefer \`trimEnd()\` over \`trimRight()\`.
+`,
+		},
+		{
+			code: `
+function clean(input: string) {
+    return input.trimLeft().trimRight();
+}
+`,
+			snapshot: `
+function clean(input: string) {
+    return input.trimLeft().trimRight();
+                            ~~~~~~~~~
+                            Prefer \`trimEnd()\` over \`trimRight()\`.
+                 ~~~~~~~~
+                 Prefer \`trimStart()\` over \`trimLeft()\`.
+}
+`,
+		},
+		{
+			code: `
+const result = text?.trimLeft();
+`,
+			snapshot: `
+const result = text?.trimLeft();
+                     ~~~~~~~~
+                     Prefer \`trimStart()\` over \`trimLeft()\`.
+`,
+		},
+	],
+	valid: [
+		`const result = str.trimStart();`,
+		`const result = str.trimEnd();`,
+		`const result = str.trim();`,
+		`const result = str.trimLeft;`,
+		`const result = str.trimRight;`,
+		`const result = trimLeft();`,
+		`const result = str["trimLeft"]();`,
+	],
+});

--- a/packages/ts/src/rules/stringTrimMethods.ts
+++ b/packages/ts/src/rules/stringTrimMethods.ts
@@ -1,0 +1,63 @@
+import { type AST, typescriptLanguage } from "@flint.fyi/typescript-language";
+import * as ts from "typescript";
+
+import { ruleCreator } from "./ruleCreator.ts";
+
+export default ruleCreator.createRule(typescriptLanguage, {
+	about: {
+		description:
+			"Reports usage of trimLeft and trimRight instead of trimStart and trimEnd.",
+		id: "stringTrimMethods",
+		presets: ["logical"],
+	},
+	messages: {
+		preferTrimStart: {
+			primary: "Prefer `trimStart()` over `trimLeft()`.",
+			secondary: [
+				"trimLeft is a deprecated alias for trimStart.",
+				"trimStart uses direction-independent terminology.",
+			],
+			suggestions: ["Replace with trimStart()."],
+		},
+		preferTrimEnd: {
+			primary: "Prefer `trimEnd()` over `trimRight()`.",
+			secondary: [
+				"trimRight is a deprecated alias for trimEnd.",
+				"trimEnd uses direction-independent terminology.",
+			],
+			suggestions: ["Replace with trimEnd()."],
+		},
+	},
+	setup(context) {
+		return {
+			visitors: {
+				CallExpression(node: AST.CallExpression, { sourceFile }) {
+					if (!ts.isPropertyAccessExpression(node.expression)) {
+						return;
+					}
+
+					const methodName = node.expression.name.text;
+
+					if (methodName !== "trimLeft" && methodName !== "trimRight") {
+						return;
+					}
+
+					if (node.arguments.length !== 0) {
+						return;
+					}
+
+					const message =
+						methodName === "trimLeft" ? "preferTrimStart" : "preferTrimEnd";
+
+					context.report({
+						message,
+						range: {
+							begin: node.expression.name.getStart(sourceFile),
+							end: node.expression.name.getEnd(),
+						},
+					});
+				},
+			},
+		};
+	},
+});


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #2064
- [x] That issue was marked as [`status: accepting prs`](https://github.com/flint-fyi/flint/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/flint-fyi/flint/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Implements the `stringTrimMethods` rule that suggests using modern `trimStart()`/`trimEnd()` methods instead of deprecated `trimLeft()`/`trimRight()` aliases. Equivalent to ESLint unicorn/prefer-string-trim-start-end.