### PR TITLE
fix: ignore more in watcher

### DIFF
--- a/packages/cli/src/runCliWatch.ts
+++ b/packages/cli/src/runCliWatch.ts
@@ -50,7 +50,12 @@ export async function runCliWatch(
 		currentRenderer = startNewTask();
 
 		const rerun = debounce((fileName: string) => {
-			if (fileName.startsWith("node_modules/.cache")) {
+			if (
+				fileName.startsWith("node_modules/.cache") ||
+				fileName.startsWith(".git") ||
+				fileName.startsWith(".jj") ||
+				fileName.startsWith(".turbo")
+			) {
 				log(
 					"Skipping re-running watch mode for ignored change to: %s",
 					fileName,


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to flint! ❤️‍🔥
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [`status: accepting prs`](https://github.com/flint-fyi/flint/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/flint-fyi/flint/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->
It does annoy me that this is effectively a duplicate of https://github.com/flint-fyi/flint/blob/abc2bb98bb67a0b032d1cab44ce81fd23f654e17/packages/core/src/host/createDiskBackedLinterHost.ts#L12. Speaking of which, we should probably make this customizable [like Vite](https://vite.dev/config/server-options#server-watch) at some point.