### PR TITLE
fix(yaml): [emptyMappingKeys] fill in suggestions TODO yaml

### DIFF
--- a/packages/yaml/src/rules/emptyMappingKeys.ts
+++ b/packages/yaml/src/rules/emptyMappingKeys.ts
@@ -15,7 +15,10 @@ export default ruleCreator.createRule(yamlLanguage, {
 				"Empty keys are invalid in YAML and may cause parsers to reject the document or misinterpret its structure.",
 				"Even if allowed by a parser, empty keys can be confusing for developers and lead to accidental mistakes in code.",
 			],
-			suggestions: ["TODO"],
+			suggestions: [
+				"Remove the mapping entry if it is not needed.",
+				"Add a key name to the mapping.",
+			],
 		},
 	},
 	setup(context) {


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to flint! ❤️‍🔥
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #1282
- [x] That issue was marked as [`status: accepting prs`](https://github.com/flint-fyi/flint/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/flint-fyi/flint/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Filled in the TODO for suggestions data in the `yaml.emptyMappingKeys` rule. The suggestions now provide actionable guidance to users on how to resolve empty mapping key issues in YAML files, following the pattern established by similar rules in the codebase.

**The code in this pull request was generated by GitHub Copilot with the Claude Sonnet 4.5 model.**