### PR TITLE
refactor: set ignored paths per watcher

### DIFF
--- a/packages/cli/src/runCliWatch.ts
+++ b/packages/cli/src/runCliWatch.ts
@@ -1,4 +1,9 @@
-import type { LinterHost, LintResults } from "@flint.fyi/core";
+import {
+	type LinterHost,
+	type LintResults,
+	nodeModulesCache,
+	vcsDirs,
+} from "@flint.fyi/core";
 import { pathKey } from "@flint.fyi/utils";
 import debounce from "debounce";
 import { debugForFile } from "debug-for-file";
@@ -77,7 +82,7 @@ export async function runCliWatch(
 
 		log("Watching cwd:", cwd);
 		const watcher = host.watchDirectorySync(cwd, rerun, {
-			ignoredPaths: ["/node_modules/.cache", "/.git", "/.jj"],
+			ignoredPaths: [nodeModulesCache, ...vcsDirs],
 			recursive: true,
 		});
 	});

--- a/packages/cli/src/runCliWatch.ts
+++ b/packages/cli/src/runCliWatch.ts
@@ -77,6 +77,7 @@ export async function runCliWatch(
 
 		log("Watching cwd:", cwd);
 		const watcher = host.watchDirectorySync(cwd, rerun, {
+			ignoredPaths: ["/node_modules/.cache", "/.git", "/.jj"],
 			recursive: true,
 		});
 	});

--- a/packages/cli/src/runCliWatch.ts
+++ b/packages/cli/src/runCliWatch.ts
@@ -2,7 +2,7 @@ import {
 	type LinterHost,
 	type LintResults,
 	nodeModulesCache,
-	vcsDirs,
+	vcsDirectories,
 } from "@flint.fyi/core";
 import { pathKey } from "@flint.fyi/utils";
 import debounce from "debounce";
@@ -82,7 +82,7 @@ export async function runCliWatch(
 
 		log("Watching cwd:", cwd);
 		const watcher = host.watchDirectorySync(cwd, rerun, {
-			ignoredPaths: [nodeModulesCache, ...vcsDirs],
+			ignoredPaths: [nodeModulesCache, ...vcsDirectories],
 			recursive: true,
 		});
 	});

--- a/packages/core/src/host/createDiskBackedLinterHost.test.ts
+++ b/packages/core/src/host/createDiskBackedLinterHost.test.ts
@@ -112,12 +112,13 @@ describe("createDiskBackedLinterHost", () => {
 		},
 	);
 
-	describe("watchFile", () => {
+	describe("watchFileSync", () => {
 		it("reports creation", async () => {
 			const host = createDiskBackedLinterHost(integrationRoot);
 			const filePath = path.join(integrationRoot, "watch.txt");
 			const onEvent = vi.fn();
 			using _ = host.watchFileSync(filePath, onEvent, {
+				ignoredPaths: [],
 				pollingInterval: 10,
 			});
 
@@ -134,7 +135,7 @@ describe("createDiskBackedLinterHost", () => {
 			const filePath = path.join(integrationRoot, "watch-change.txt");
 			fs.writeFileSync(filePath, "first");
 			const onEvent = vi.fn();
-			using _ = host.watchFileSync(filePath, onEvent);
+			using _ = host.watchFileSync(filePath, onEvent, { ignoredPaths: [] });
 
 			await sleep(50);
 
@@ -149,7 +150,7 @@ describe("createDiskBackedLinterHost", () => {
 			const filePath = path.join(integrationRoot, "watch-delete.txt");
 			fs.writeFileSync(filePath, "first");
 			const onEvent = vi.fn();
-			using _ = host.watchFileSync(filePath, onEvent);
+			using _ = host.watchFileSync(filePath, onEvent, { ignoredPaths: [] });
 
 			await sleep(50);
 
@@ -163,7 +164,10 @@ describe("createDiskBackedLinterHost", () => {
 			const host = createDiskBackedLinterHost(integrationRoot);
 			const filePath = path.join(integrationRoot, "watch-recreate.txt");
 			const onEvent = vi.fn();
-			using _ = host.watchFileSync(filePath, onEvent, { pollingInterval: 10 });
+			using _ = host.watchFileSync(filePath, onEvent, {
+				ignoredPaths: [],
+				pollingInterval: 10,
+			});
 
 			await sleep(50);
 
@@ -191,7 +195,10 @@ describe("createDiskBackedLinterHost", () => {
 			const secondDir = path.join(firstDir, "second");
 			const filePath = path.join(secondDir, "deep.txt");
 			const onEvent = vi.fn();
-			using _ = host.watchFileSync(filePath, onEvent, { pollingInterval: 10 });
+			using _ = host.watchFileSync(filePath, onEvent, {
+				ignoredPaths: [],
+				pollingInterval: 10,
+			});
 
 			await sleep(50);
 
@@ -239,7 +246,7 @@ describe("createDiskBackedLinterHost", () => {
 			const filePath = path.join(integrationRoot, "disposed.txt");
 			const onEvent = vi.fn();
 			{
-				using _ = host.watchFileSync(filePath, onEvent);
+				using _ = host.watchFileSync(filePath, onEvent, { ignoredPaths: [] });
 			}
 
 			fs.writeFileSync(filePath, "content");
@@ -255,6 +262,7 @@ describe("createDiskBackedLinterHost", () => {
 			const onEvent = vi.fn();
 			{
 				using _ = host.watchFileSync(filePath, onEvent, {
+					ignoredPaths: [],
 					pollingInterval: 10,
 				});
 				await sleep(50);
@@ -278,6 +286,7 @@ describe("createDiskBackedLinterHost", () => {
 			fs.writeFileSync(filePath, "first");
 			{
 				using _ = host.watchFileSync(filePath, onEvent, {
+					ignoredPaths: [],
 					pollingInterval: 10,
 				});
 				await sleep(50);
@@ -300,6 +309,7 @@ describe("createDiskBackedLinterHost", () => {
 			const otherPath = path.join(integrationRoot, "other.txt");
 			const onEvent = vi.fn();
 			using _ = host.watchFileSync(targetPath, onEvent, {
+				ignoredPaths: [],
 				pollingInterval: 10,
 			});
 
@@ -317,7 +327,10 @@ describe("createDiskBackedLinterHost", () => {
 			const dirPath = path.join(integrationRoot, "directory");
 			const onEvent = vi.fn();
 			fs.mkdirSync(dirPath, { recursive: true });
-			using _ = host.watchFileSync(dirPath, onEvent, { pollingInterval: 10 });
+			using _ = host.watchFileSync(dirPath, onEvent, {
+				ignoredPaths: [],
+				pollingInterval: 10,
+			});
 
 			await sleep(50);
 
@@ -339,7 +352,10 @@ describe("createDiskBackedLinterHost", () => {
 			const filePath = path.join(dirPath, "file.txt");
 			const onEvent = vi.fn();
 			fs.mkdirSync(dirPath, { recursive: true });
-			using _ = host.watchFileSync(dirPath, onEvent, { pollingInterval: 10 });
+			using _ = host.watchFileSync(dirPath, onEvent, {
+				ignoredPaths: [],
+				pollingInterval: 10,
+			});
 
 			await sleep(50);
 
@@ -350,7 +366,7 @@ describe("createDiskBackedLinterHost", () => {
 		});
 	});
 
-	describe("watchDirectory", () => {
+	describe("watchDirectorySync", () => {
 		it("watches directories non-recursively", async () => {
 			const host = createDiskBackedLinterHost(integrationRoot);
 			const directoryPath = path.join(integrationRoot, "dir");
@@ -359,6 +375,7 @@ describe("createDiskBackedLinterHost", () => {
 
 			const onEvent = vi.fn();
 			using _ = host.watchDirectorySync(directoryPath, onEvent, {
+				ignoredPaths: [],
 				recursive: false,
 			});
 
@@ -384,6 +401,7 @@ describe("createDiskBackedLinterHost", () => {
 			fs.writeFileSync(path.join(directoryPath, "existing.txt"), "content");
 			const onEvent = vi.fn();
 			using _ = host.watchDirectorySync(directoryPath, onEvent, {
+				ignoredPaths: [],
 				recursive: true,
 			});
 
@@ -404,7 +422,10 @@ describe("createDiskBackedLinterHost", () => {
 			const baseDir = path.join(integrationRoot, "base-git");
 			fs.mkdirSync(baseDir, { recursive: true });
 			const onEvent = vi.fn();
-			using _ = host.watchDirectorySync(baseDir, onEvent, { recursive: true });
+			using _ = host.watchDirectorySync(baseDir, onEvent, {
+				ignoredPaths: [],
+				recursive: true,
+			});
 
 			await sleep(50);
 
@@ -423,7 +444,10 @@ describe("createDiskBackedLinterHost", () => {
 			const baseDir = path.join(integrationRoot, "base-node-modules");
 			fs.mkdirSync(baseDir, { recursive: true });
 			const onEvent = vi.fn();
-			using _ = host.watchDirectorySync(baseDir, onEvent, { recursive: true });
+			using _ = host.watchDirectorySync(baseDir, onEvent, {
+				ignoredPaths: [],
+				recursive: true,
+			});
 
 			await sleep(50);
 
@@ -447,7 +471,10 @@ describe("createDiskBackedLinterHost", () => {
 			const baseDir = path.join(integrationRoot, "lookalike");
 			fs.mkdirSync(baseDir, { recursive: true });
 			const onEvent = vi.fn();
-			using _ = host.watchDirectorySync(baseDir, onEvent, { recursive: true });
+			using _ = host.watchDirectorySync(baseDir, onEvent, {
+				ignoredPaths: [],
+				recursive: true,
+			});
 
 			await sleep(50);
 
@@ -466,6 +493,7 @@ describe("createDiskBackedLinterHost", () => {
 			const normalizedDirectory = normalizePath(directoryPath);
 			const onEvent = vi.fn();
 			using _ = host.watchDirectorySync(directoryPath, onEvent, {
+				ignoredPaths: [],
 				pollingInterval: 10,
 				recursive: false,
 			});
@@ -487,6 +515,7 @@ describe("createDiskBackedLinterHost", () => {
 			fs.mkdirSync(directoryPath, { recursive: true });
 
 			using _ = host.watchDirectorySync(directoryPath, onEvent, {
+				ignoredPaths: [],
 				pollingInterval: 10,
 				recursive: false,
 			});
@@ -514,6 +543,7 @@ describe("createDiskBackedLinterHost", () => {
 			const normalizedSecond = normalizePath(secondFile);
 
 			using _ = host.watchDirectorySync(directoryPath, onEvent, {
+				ignoredPaths: [],
 				pollingInterval: 10,
 				recursive: false,
 			});
@@ -539,6 +569,7 @@ describe("createDiskBackedLinterHost", () => {
 			const onEvent = vi.fn();
 			fs.mkdirSync(directoryPath, { recursive: true });
 			using _ = host.watchDirectorySync(directoryPath, onEvent, {
+				ignoredPaths: [],
 				pollingInterval: 10,
 				recursive: false,
 			});
@@ -584,6 +615,7 @@ describe("createDiskBackedLinterHost", () => {
 			const subDirectoryPath = normalizePath(path.join(directoryPath, "dir"));
 			const onEvent = vi.fn();
 			using _ = host.watchDirectorySync(directoryPath, onEvent, {
+				ignoredPaths: [],
 				pollingInterval: 10,
 				recursive: false,
 			});

--- a/packages/core/src/host/createDiskBackedLinterHost.ts
+++ b/packages/core/src/host/createDiskBackedLinterHost.ts
@@ -9,8 +9,6 @@ import type {
 } from "../types/host.ts";
 import { isFileSystemCaseSensitive } from "./isFileSystemCaseSensitive.ts";
 
-const ignoredPaths = ["/node_modules", "/.git", "/.jj"];
-
 export function createDiskBackedLinterHost(cwd: string): LinterHost {
 	const caseSensitiveFS = isFileSystemCaseSensitive();
 	cwd = normalizePath(cwd);
@@ -268,7 +266,7 @@ export function createDiskBackedLinterHost(cwd: string): LinterHost {
 						if (changedKey.startsWith(dirKeySlash)) {
 							relative = relative.slice(directoryPathAbsolute.length);
 						}
-						for (const ignored of ignoredPaths) {
+						for (const ignored of options.ignoredPaths) {
 							if (
 								relative.endsWith(ignored) ||
 								relative.includes(ignored + "/")
@@ -287,7 +285,7 @@ export function createDiskBackedLinterHost(cwd: string): LinterHost {
 			return createWatcher(
 				filePathAbsolute,
 				false,
-				options?.pollingInterval ?? 2_000,
+				options.pollingInterval ?? 2_000,
 				(normalizedChangedFilePath, event) => {
 					if (
 						normalizedChangedFilePath != null &&

--- a/packages/core/src/host/createVFSLinterHost.test.ts
+++ b/packages/core/src/host/createVFSLinterHost.test.ts
@@ -351,7 +351,9 @@ describe(createVFSLinterHost, () => {
 			const host = createVFSLinterHost({ caseSensitive: true, cwd: "/root" });
 			const onEvent = vi.fn();
 
-			using _ = host.watchFileSync("/root/file.txt", onEvent);
+			using _ = host.watchFileSync("/root/file.txt", onEvent, {
+				ignoredPaths: [],
+			});
 
 			expect(onEvent).not.toHaveBeenCalled();
 
@@ -365,7 +367,9 @@ describe(createVFSLinterHost, () => {
 			const onEvent = vi.fn();
 
 			host.vfsUpsertFile("/root/file.txt", "content");
-			using _ = host.watchFileSync("/root/file.txt", onEvent);
+			using _ = host.watchFileSync("/root/file.txt", onEvent, {
+				ignoredPaths: [],
+			});
 
 			expect(onEvent).not.toHaveBeenCalled();
 
@@ -379,7 +383,9 @@ describe(createVFSLinterHost, () => {
 			const onEvent = vi.fn();
 
 			host.vfsUpsertFile("/root/file.txt", "content");
-			using _ = host.watchFileSync("/root/file.txt", onEvent);
+			using _ = host.watchFileSync("/root/file.txt", onEvent, {
+				ignoredPaths: [],
+			});
 
 			expect(onEvent).not.toHaveBeenCalled();
 
@@ -393,7 +399,9 @@ describe(createVFSLinterHost, () => {
 			const onEvent = vi.fn();
 
 			{
-				using _ = host.watchFileSync("/root/file.txt", onEvent);
+				using _ = host.watchFileSync("/root/file.txt", onEvent, {
+					ignoredPaths: [],
+				});
 			}
 			host.vfsUpsertFile("/root/file.txt", "content");
 
@@ -408,7 +416,9 @@ describe(createVFSLinterHost, () => {
 			const host = createVFSLinterHost({ baseHost });
 			const onEvent = vi.fn();
 
-			using _ = host.watchFileSync("/root/file.txt", onEvent);
+			using _ = host.watchFileSync("/root/file.txt", onEvent, {
+				ignoredPaths: [],
+			});
 
 			expect(onEvent).not.toHaveBeenCalled();
 
@@ -427,6 +437,7 @@ describe(createVFSLinterHost, () => {
 			const host = createVFSLinterHost({ baseHost });
 
 			using _ = host.watchFileSync("/root/file.txt", vi.fn(), {
+				ignoredPaths: [],
 				pollingInterval: 555,
 			});
 
@@ -434,6 +445,7 @@ describe(createVFSLinterHost, () => {
 				"/root/file.txt",
 				expect.any(Function),
 				{
+					ignoredPaths: [],
 					pollingInterval: 555,
 				},
 			);
@@ -448,7 +460,9 @@ describe(createVFSLinterHost, () => {
 			const host = createVFSLinterHost({ baseHost });
 
 			{
-				using _ = host.watchFileSync("/root/file.txt", vi.fn());
+				using _ = host.watchFileSync("/root/file.txt", vi.fn(), {
+					ignoredPaths: [],
+				});
 
 				expect(dispose).not.toHaveBeenCalled();
 			}
@@ -467,6 +481,7 @@ describe(createVFSLinterHost, () => {
 				const onEvent = vi.fn();
 
 				using _ = host.watchDirectorySync("/root", onEvent, {
+					ignoredPaths: [],
 					recursive: false,
 				});
 				host.vfsUpsertFile("/root/file.txt", "content");
@@ -482,6 +497,7 @@ describe(createVFSLinterHost, () => {
 				const onEvent = vi.fn();
 
 				using _ = host.watchDirectorySync("/root", onEvent, {
+					ignoredPaths: [],
 					recursive: false,
 				});
 				host.vfsUpsertFile("/root/dir/file.txt", "content");
@@ -496,7 +512,10 @@ describe(createVFSLinterHost, () => {
 				});
 				const onEvent = vi.fn();
 
-				using _ = host.watchDirectorySync("/", onEvent, { recursive: false });
+				using _ = host.watchDirectorySync("/", onEvent, {
+					ignoredPaths: [],
+					recursive: false,
+				});
 				host.vfsUpsertFile("/root/dir/file.txt", "content");
 
 				expect(onEvent).toHaveBeenCalledExactlyOnceWith("/root");
@@ -510,6 +529,7 @@ describe(createVFSLinterHost, () => {
 				const onEvent = vi.fn();
 
 				using _ = host.watchDirectorySync("C:\\", onEvent, {
+					ignoredPaths: [],
 					recursive: false,
 				});
 				host.vfsUpsertFile("C:\\file.txt", "content");
@@ -526,6 +546,7 @@ describe(createVFSLinterHost, () => {
 
 				host.vfsUpsertFile("/root/file.txt", "content");
 				using _ = host.watchDirectorySync("/root", onEvent, {
+					ignoredPaths: [],
 					recursive: false,
 				});
 
@@ -545,6 +566,7 @@ describe(createVFSLinterHost, () => {
 
 				host.vfsUpsertFile("/root/file.txt", "content");
 				using _ = host.watchDirectorySync("/root", onEvent, {
+					ignoredPaths: [],
 					recursive: false,
 				});
 
@@ -564,6 +586,7 @@ describe(createVFSLinterHost, () => {
 
 				host.vfsUpsertFile("/root/nested/file.txt", "content");
 				using _ = host.watchDirectorySync("/root", onEvent, {
+					ignoredPaths: [],
 					recursive: false,
 				});
 
@@ -584,6 +607,7 @@ describe(createVFSLinterHost, () => {
 				const onEvent = vi.fn();
 
 				using _ = host.watchDirectorySync("/root", onEvent, {
+					ignoredPaths: [],
 					recursive: true,
 				});
 
@@ -603,6 +627,7 @@ describe(createVFSLinterHost, () => {
 
 				host.vfsUpsertFile("/root/nested/file.txt", "content");
 				using _ = host.watchDirectorySync("/root", onEvent, {
+					ignoredPaths: [],
 					recursive: true,
 				});
 
@@ -624,6 +649,7 @@ describe(createVFSLinterHost, () => {
 
 				host.vfsUpsertFile("/root/nested/file.txt", "content");
 				using _ = host.watchDirectorySync("/root", onEvent, {
+					ignoredPaths: [],
 					recursive: true,
 				});
 
@@ -647,6 +673,7 @@ describe(createVFSLinterHost, () => {
 			const host = createVFSLinterHost({ baseHost });
 
 			using _ = host.watchDirectorySync("/root/file.txt", vi.fn(), {
+				ignoredPaths: [],
 				pollingInterval: 555,
 				recursive: false,
 			});
@@ -655,6 +682,7 @@ describe(createVFSLinterHost, () => {
 				"/root/file.txt",
 				expect.any(Function),
 				{
+					ignoredPaths: [],
 					pollingInterval: 555,
 					recursive: false,
 				},
@@ -671,6 +699,7 @@ describe(createVFSLinterHost, () => {
 
 			{
 				using _ = host.watchDirectorySync("/root/file.txt", vi.fn(), {
+					ignoredPaths: [],
 					recursive: false,
 				});
 

--- a/packages/core/src/host/watcher.ts
+++ b/packages/core/src/host/watcher.ts
@@ -1,0 +1,6 @@
+export const gitVcs = "/.git";
+export const jjVcs = "/.jj";
+export const vcsDirs = [gitVcs, jjVcs];
+export const nodeModulesDir = "/node_modules";
+export const nodeModulesCache = "/node_modules/.cache";
+export const commonlyIgnoredPaths = [...vcsDirs, nodeModulesDir];

--- a/packages/core/src/host/watcher.ts
+++ b/packages/core/src/host/watcher.ts
@@ -1,6 +1,6 @@
 export const gitVcs = "/.git";
 export const jjVcs = "/.jj";
-export const vcsDirs = [gitVcs, jjVcs];
+export const vcsDirectories = [gitVcs, jjVcs];
 export const nodeModulesDir = "/node_modules";
 export const nodeModulesCache = "/node_modules/.cache";
-export const commonlyIgnoredPaths = [...vcsDirs, nodeModulesDir];
+export const commonlyIgnoredPaths = [...vcsDirectories, nodeModulesDir];

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -14,6 +14,14 @@ export {
 	type CreateVFSLinterHostOpts,
 } from "./host/createVFSLinterHost.ts";
 export { isFileSystemCaseSensitive } from "./host/isFileSystemCaseSensitive.ts";
+export {
+	commonlyIgnoredPaths,
+	gitVcs,
+	jjVcs,
+	nodeModulesCache,
+	nodeModulesDir,
+	vcsDirs,
+} from "./host/watcher.ts";
 export { createLanguage } from "./languages/createLanguage.ts";
 export { createPlugin } from "./plugins/createPlugin.ts";
 export { formatReport } from "./reporting/formatReport.ts";

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -20,7 +20,7 @@ export {
 	jjVcs,
 	nodeModulesCache,
 	nodeModulesDir,
-	vcsDirs,
+	vcsDirectories,
 } from "./host/watcher.ts";
 export { createLanguage } from "./languages/createLanguage.ts";
 export { createPlugin } from "./plugins/createPlugin.ts";

--- a/packages/core/src/types/host.ts
+++ b/packages/core/src/types/host.ts
@@ -18,7 +18,7 @@ export interface LinterHost {
 	watchFileSync(
 		filePathAbsolute: string,
 		callback: LinterHostFileWatcher,
-		options?: WatchOptions,
+		options: WatchOptions,
 	): Disposable;
 	writeFile(filePathAbsolute: string, content: string): Promise<void>;
 	writeFileSync(filePathAbsolute: string, content: string): void;
@@ -45,5 +45,6 @@ export interface WatchDirectoryOptions extends WatchOptions {
 }
 
 export interface WatchOptions {
+	ignoredPaths: string[];
 	pollingInterval?: number;
 }

--- a/packages/typescript-language/src/createTypeScriptServerHost.ts
+++ b/packages/typescript-language/src/createTypeScriptServerHost.ts
@@ -116,7 +116,7 @@ export function createTypeScriptServerHost(
 				(filePathAbsolute) => {
 					callback(filePathAbsolute);
 				},
-				{ recursive },
+				{ ignoredPaths: ["/node_modules", "/.git", "/.jj"], recursive },
 			);
 			return {
 				close() {
@@ -142,6 +142,7 @@ export function createTypeScriptServerHost(
 					}
 					callback(filePath, eventKind);
 				},
+				{ ignoredPaths: ["/node_modules", "/.git", "/.jj"] },
 			);
 			return {
 				close() {

--- a/packages/typescript-language/src/createTypeScriptServerHost.ts
+++ b/packages/typescript-language/src/createTypeScriptServerHost.ts
@@ -1,4 +1,4 @@
-import type { LinterHost } from "@flint.fyi/core";
+import { commonlyIgnoredPaths, type LinterHost } from "@flint.fyi/core";
 import { assert, FlintAssertionError } from "@flint.fyi/utils";
 import fs from "node:fs";
 import path from "node:path";
@@ -116,7 +116,7 @@ export function createTypeScriptServerHost(
 				(filePathAbsolute) => {
 					callback(filePathAbsolute);
 				},
-				{ ignoredPaths: ["/node_modules", "/.git", "/.jj"], recursive },
+				{ ignoredPaths: commonlyIgnoredPaths, recursive },
 			);
 			return {
 				close() {
@@ -142,7 +142,7 @@ export function createTypeScriptServerHost(
 					}
 					callback(filePath, eventKind);
 				},
-				{ ignoredPaths: ["/node_modules", "/.git", "/.jj"] },
+				{ ignoredPaths: commonlyIgnoredPaths },
 			);
 			return {
 				close() {


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to flint! ❤️‍🔥
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #2201 
- [x] That issue was marked as [`status: accepting prs`](https://github.com/flint-fyi/flint/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/flint-fyi/flint/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->
Draft because it's stacked and I haven't wired it up to the config yet, but I'd like a review on whether forcing callsites to set ignored paths makes sense. I prefer it because every watcher should have its own set of ignores (`node_modules/` or just `node_modules/.cache`, etc), but I also see the argument that perhaps `.git` & `.jj` should always be ignored, so we're making it more painful. I don't think minimizing test size is reasonable argument though, although it is mildly annoying to me how much verbose the tests are.