### PR TITLE
feat: added `:exit` listeners to JSON, Markdown, and TypeScript

### DIFF
--- a/.changeset/clean-poems-rest.md
+++ b/.changeset/clean-poems-rest.md
@@ -1,0 +1,10 @@
+---
+"@flint.fyi/typescript-language": patch
+"@flint.fyi/markdown-language": patch
+"@flint.fyi/json-language": patch
+"@flint.fyi/yaml-language": patch
+"@flint.fyi/core": patch
+"@flint.fyi/md": patch
+---
+
+feat: added `:exit` listeners to JSON, Markdown, and TypeScript

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -39,6 +39,7 @@ export * from "./types/ranges.ts";
 export * from "./types/reports.ts";
 export * from "./types/rules.ts";
 export * from "./types/shapes.ts";
+export * from "./types/visitors.ts";
 export { binarySearch } from "./utils/arrays.ts";
 export * from "./utils/getColumnAndLineOfPosition.ts";
 export * from "./utils/predicates.ts";

--- a/packages/core/src/types/visitors.ts
+++ b/packages/core/src/types/visitors.ts
@@ -1,0 +1,15 @@
+/**
+ * @see https://github.com/sindresorhus/type-fest/blob/main/source/simplify.d.ts
+ */
+export type Simplify<T> = {
+	[K in keyof T]: T[K];
+};
+
+/**
+ * The same visitors as T, but with optional `:exit` listeners added.
+ */
+export type WithExitKeys<T> = Simplify<
+	T & {
+		[K in keyof T & string as `${K}:exit`]?: T[K];
+	}
+>;

--- a/packages/json-language/src/language.ts
+++ b/packages/json-language/src/language.ts
@@ -38,7 +38,6 @@ export const jsonLanguage = createLanguage<JsonNodeVisitors, JsonFileServices>({
 			const key = ts.SyntaxKind[node.kind] as keyof typeof visitors;
 
 			// @ts-expect-error -- This should work...?
-			// eslint-disable-next-line @typescript-eslint/no-unsafe-call
 			visitors[key]?.(node, visitorServices);
 
 			node.forEachChild(visit);

--- a/packages/json-language/src/language.ts
+++ b/packages/json-language/src/language.ts
@@ -38,6 +38,7 @@ export const jsonLanguage = createLanguage<JsonNodeVisitors, JsonFileServices>({
 			const key = ts.SyntaxKind[node.kind] as keyof typeof visitors;
 
 			// @ts-expect-error -- This should work...?
+			// eslint-disable-next-line @typescript-eslint/no-unsafe-call
 			visitors[key]?.(node, visitorServices);
 
 			node.forEachChild(visit);

--- a/packages/json-language/src/language.ts
+++ b/packages/json-language/src/language.ts
@@ -1,13 +1,13 @@
 import { createLanguage } from "@flint.fyi/core";
 import * as ts from "typescript";
 
-import type { JsonNodesByName } from "./nodes.ts";
+import type { JsonNodeVisitors } from "./nodes.ts";
 
 export interface JsonFileServices {
 	sourceFile: ts.JsonSourceFile;
 }
 
-export const jsonLanguage = createLanguage<JsonNodesByName, JsonFileServices>({
+export const jsonLanguage = createLanguage<JsonNodeVisitors, JsonFileServices>({
 	about: {
 		name: "JSON",
 	},
@@ -35,10 +35,16 @@ export const jsonLanguage = createLanguage<JsonNodesByName, JsonFileServices>({
 		const visitorServices = { options, ...file.services };
 
 		const visit = (node: ts.Node) => {
+			const key = ts.SyntaxKind[node.kind] as keyof typeof visitors;
+
+			// @ts-expect-error -- This should work...?
+			visitors[key]?.(node, visitorServices);
+
+			node.forEachChild(visit);
+
 			// @ts-expect-error -- This should work...?
 			// eslint-disable-next-line @typescript-eslint/no-unsafe-call
-			visitors[ts.SyntaxKind[node.kind]]?.(node, visitorServices);
-			node.forEachChild(visit);
+			visitors[`${key}:exit`]?.(node, visitorServices);
 		};
 
 		file.services.sourceFile.forEachChild(visit);

--- a/packages/json-language/src/language.ts
+++ b/packages/json-language/src/language.ts
@@ -1,7 +1,7 @@
 import { createLanguage } from "@flint.fyi/core";
 import * as ts from "typescript";
 
-import type { JsonNodeVisitors } from "./nodes.ts";
+import type { JsonNodesByName, JsonNodeVisitors } from "./nodes.ts";
 
 export interface JsonFileServices {
 	sourceFile: ts.JsonSourceFile;
@@ -35,15 +35,14 @@ export const jsonLanguage = createLanguage<JsonNodeVisitors, JsonFileServices>({
 		const visitorServices = { options, ...file.services };
 
 		const visit = (node: ts.Node) => {
-			const key = ts.SyntaxKind[node.kind] as keyof typeof visitors;
+			const key = ts.SyntaxKind[node.kind] as keyof JsonNodesByName;
 
-			// @ts-expect-error -- This should work...?
+			// @ts-expect-error -- The node parameter type shouldn't be `never`...?
 			visitors[key]?.(node, visitorServices);
 
 			node.forEachChild(visit);
 
-			// @ts-expect-error -- This should work...?
-			// eslint-disable-next-line @typescript-eslint/no-unsafe-call
+			// @ts-expect-error -- The node parameter type shouldn't be `never`...?
 			visitors[`${key}:exit`]?.(node, visitorServices);
 		};
 

--- a/packages/json-language/src/nodes.ts
+++ b/packages/json-language/src/nodes.ts
@@ -1,3 +1,4 @@
+import type { WithExitKeys } from "@flint.fyi/core";
 import type * as ts from "typescript";
 
 export interface JsonNodesByName {
@@ -11,3 +12,5 @@ export interface JsonNodesByName {
 	ObjectLiteralExpression: ts.ObjectLiteralExpression;
 	StringLiteral: ts.StringLiteral;
 }
+
+export type JsonNodeVisitors = WithExitKeys<JsonNodesByName>;

--- a/packages/markdown-language/src/language.ts
+++ b/packages/markdown-language/src/language.ts
@@ -51,7 +51,7 @@ export const markdownLanguage = createLanguage<
 			const key = node.type;
 
 			// @ts-expect-error -- This should work...?
-			// eslint-disable-next-line @typescript-eslint/no-unsafe-call
+
 			visitors[key]?.(node, visitorServices);
 
 			// @ts-expect-error -- This should work...?

--- a/packages/markdown-language/src/language.ts
+++ b/packages/markdown-language/src/language.ts
@@ -50,11 +50,10 @@ export const markdownLanguage = createLanguage<
 		visit(file.services.root, (node) => {
 			const key = node.type;
 
-			// @ts-expect-error -- This should work...?
-
+			// @ts-expect-error -- The node parameter type shouldn't be `never`...?
 			visitors[key]?.(node, visitorServices);
 
-			// @ts-expect-error -- This should work...?
+			// @ts-expect-error -- The node parameter type shouldn't be `never`...?
 			visitors[`${key}:exit`]?.(node, visitorServices);
 		});
 	},

--- a/packages/markdown-language/src/language.ts
+++ b/packages/markdown-language/src/language.ts
@@ -6,14 +6,14 @@ import { gfm } from "micromark-extension-gfm";
 import { visit } from "unist-util-visit";
 
 import { parseDirectivesFromMarkdownFile } from "./directives/parseDirectivesFromMarkdownFile.ts";
-import type { MarkdownNodesByName, WithPosition } from "./nodes.ts";
+import type { MarkdownNodeVisitors, WithPosition } from "./nodes.ts";
 
 export interface MarkdownFileServices {
 	root: WithPosition<mdast.Root>;
 }
 
 export const markdownLanguage = createLanguage<
-	MarkdownNodesByName,
+	MarkdownNodeVisitors,
 	MarkdownFileServices
 >({
 	about: {
@@ -48,8 +48,14 @@ export const markdownLanguage = createLanguage<
 		const visitorServices = { options, ...file.services };
 
 		visit(file.services.root, (node) => {
+			const key = node.type;
+
 			// @ts-expect-error -- This should work...?
-			visitors[node.type]?.(node, visitorServices);
+			// eslint-disable-next-line @typescript-eslint/no-unsafe-call
+			visitors[key]?.(node, visitorServices);
+
+			// @ts-expect-error -- This should work...?
+			visitors[`${key}:exit`]?.(node, visitorServices);
 		});
 	},
 });

--- a/packages/markdown-language/src/nodes.ts
+++ b/packages/markdown-language/src/nodes.ts
@@ -1,9 +1,12 @@
+import type { WithExitKeys } from "@flint.fyi/core";
 import type * as mdast from "mdast";
 import type { Point, Position } from "unist";
 
 export interface MarkdownNodesByName extends RootContentMapWithChildren {
 	root: WithPosition<mdast.Root>;
 }
+
+export type MarkdownNodeVisitors = WithExitKeys<MarkdownNodesByName>;
 
 /**
  * A version of {@link Point} where the `offset` always exists.

--- a/packages/md/src/rules/definitionUses.ts
+++ b/packages/md/src/rules/definitionUses.ts
@@ -73,7 +73,8 @@ export default ruleCreator.createRule(markdownLanguage, {
 						}
 					}
 
-					// TODO: Add :exit selectors, so this rule can report after traversal?
+					// TODO: Add :exit selectors, so this rule can report after traversal
+					// https://github.com/flint-fyi/flint/issues/2267
 					visit(root);
 
 					for (const [normalizedIdentifier, definition] of definitions) {

--- a/packages/md/src/rules/headingRootDuplicates.ts
+++ b/packages/md/src/rules/headingRootDuplicates.ts
@@ -60,7 +60,8 @@ export default ruleCreator.createRule(markdownLanguage, {
 						}
 					}
 
-					// TODO: Add :exit selectors, so this rule can report after traversal?
+					// TODO: Add :exit selectors, so this rule can report after traversal
+					// https://github.com/flint-fyi/flint/issues/2268
 					visit(root);
 
 					if (h1HeadingRanges.length > 1) {

--- a/packages/md/src/rules/labelReferenceValidity.ts
+++ b/packages/md/src/rules/labelReferenceValidity.ts
@@ -65,7 +65,8 @@ export default ruleCreator.createRule(markdownLanguage, {
 						}
 					}
 
-					// TODO: Add :exit selectors, so this rule can report after traversal?
+					// TODO: Add :exit selectors, so this rule can report after traversal
+					// https://github.com/flint-fyi/flint/issues/2270
 					visit(root);
 				},
 			},

--- a/packages/md/src/rules/labelReferences.ts
+++ b/packages/md/src/rules/labelReferences.ts
@@ -92,7 +92,8 @@ export default ruleCreator.createRule(markdownLanguage, {
 						}
 					}
 
-					// TODO: Add :exit selectors, so this rule can report after traversal?
+					// TODO: Add :exit selectors, so this rule can report after traversal
+					// https://github.com/flint-fyi/flint/issues/2269
 					visit(root);
 
 					for (const reference of references) {

--- a/packages/md/src/rules/linkFragments.ts
+++ b/packages/md/src/rules/linkFragments.ts
@@ -103,7 +103,8 @@ export default ruleCreator.createRule(markdownLanguage, {
 						}
 					}
 
-					// TODO: Add :exit selectors, so this rule can report after traversal?
+					// TODO: Add :exit selectors, so this rule can report after traversal
+					// https://github.com/flint-fyi/flint/issues/2271
 					visit(node);
 
 					// Check all fragment links

--- a/packages/typescript-language/src/language.ts
+++ b/packages/typescript-language/src/language.ts
@@ -9,7 +9,7 @@ import { parseDirectivesFromTypeScriptFile } from "./directives/parseDirectivesF
 import { getFirstEnumValues } from "./getFirstEnumValues.ts";
 import { getTypeScriptFileCacheImpacts } from "./getTypeScriptFileCacheImpacts.ts";
 import { getTypeScriptFileDiagnostics } from "./getTypeScriptFileDiagnostics.ts";
-import type { TypeScriptNodeVisitors } from "./nodes.ts";
+import type { TypeScriptNodesByName, TypeScriptNodeVisitors } from "./nodes.ts";
 import type * as AST from "./types/ast.ts";
 import type { Checker } from "./types/checker.ts";
 
@@ -96,15 +96,14 @@ export const typescriptLanguage = createLanguage<
 		const visitorServices = { options, ...file.services };
 
 		const visit = (node: ts.Node) => {
-			const key = NodeSyntaxKinds[node.kind] as keyof typeof visitors;
+			const key = NodeSyntaxKinds[node.kind] as keyof TypeScriptNodesByName;
 
-			// @ts-expect-error -- This should work...?
+			// @ts-expect-error -- The node parameter type shouldn't be `never`...?
 			visitors[key]?.(node, visitorServices);
 
 			node.forEachChild(visit);
 
-			// @ts-expect-error -- This should work...?
-			// eslint-disable-next-line @typescript-eslint/no-unsafe-call
+			// @ts-expect-error -- The node parameter type shouldn't be `never`...?
 			visitors[`${key}:exit`]?.(node, visitorServices);
 		};
 

--- a/packages/typescript-language/src/language.ts
+++ b/packages/typescript-language/src/language.ts
@@ -9,7 +9,7 @@ import { parseDirectivesFromTypeScriptFile } from "./directives/parseDirectivesF
 import { getFirstEnumValues } from "./getFirstEnumValues.ts";
 import { getTypeScriptFileCacheImpacts } from "./getTypeScriptFileCacheImpacts.ts";
 import { getTypeScriptFileDiagnostics } from "./getTypeScriptFileDiagnostics.ts";
-import type { TypeScriptNodesByName } from "./nodes.ts";
+import type { TypeScriptNodeVisitors } from "./nodes.ts";
 import type * as AST from "./types/ast.ts";
 import type { Checker } from "./types/checker.ts";
 
@@ -24,7 +24,7 @@ const log = debugForFile(import.meta.filename);
 const NodeSyntaxKinds = getFirstEnumValues(ts.SyntaxKind);
 
 export const typescriptLanguage = createLanguage<
-	TypeScriptNodesByName,
+	TypeScriptNodeVisitors,
 	TypeScriptFileServices
 >({
 	about: {
@@ -96,10 +96,16 @@ export const typescriptLanguage = createLanguage<
 		const visitorServices = { options, ...file.services };
 
 		const visit = (node: ts.Node) => {
-			// @ts-expect-error - This should work...?
-			// eslint-disable-next-line @typescript-eslint/no-unsafe-call
-			visitors[NodeSyntaxKinds[node.kind]]?.(node, visitorServices);
+			const key = NodeSyntaxKinds[node.kind] as keyof typeof visitors;
+
+			// @ts-expect-error -- This should work...?
+			visitors[key]?.(node, visitorServices);
+
 			node.forEachChild(visit);
+
+			// @ts-expect-error -- This should work...?
+			// eslint-disable-next-line @typescript-eslint/no-unsafe-call
+			visitors[`${key}:exit`]?.(node, visitorServices);
 		};
 
 		visit(file.services.sourceFile);

--- a/packages/typescript-language/src/nodes.ts
+++ b/packages/typescript-language/src/nodes.ts
@@ -1,4 +1,5 @@
 import type { WithExitKeys } from "@flint.fyi/core";
+
 import type * as AST from "./types/ast.ts";
 
 // TODO: Surely there's a better way to do this...

--- a/packages/typescript-language/src/nodes.ts
+++ b/packages/typescript-language/src/nodes.ts
@@ -1,3 +1,4 @@
+import type { WithExitKeys } from "@flint.fyi/core";
 import type * as AST from "./types/ast.ts";
 
 // TODO: Surely there's a better way to do this...
@@ -199,3 +200,5 @@ export interface TypeScriptNodesByName {
 	WithStatement: AST.WithStatement;
 	YieldExpression: AST.YieldExpression;
 }
+
+export type TypeScriptNodeVisitors = WithExitKeys<TypeScriptNodesByName>;

--- a/packages/yaml-language/src/language.ts
+++ b/packages/yaml-language/src/language.ts
@@ -39,10 +39,12 @@ export const yamlLanguage = createLanguage<YamlNodesByName, YamlFileServices>({
 			file.services.root,
 			(node) => {
 				// @ts-expect-error -- This should work...?
+				// eslint-disable-next-line @typescript-eslint/no-unsafe-call
 				visitors[node.type]?.(node, visitorServices);
 			},
 			(node) => {
 				// @ts-expect-error -- This should work...?
+				// eslint-disable-next-line @typescript-eslint/no-unsafe-call
 				visitors[`${node.type}:exit`]?.(node, visitorServices);
 			},
 		);

--- a/packages/yaml-language/src/language.ts
+++ b/packages/yaml-language/src/language.ts
@@ -35,9 +35,16 @@ export const yamlLanguage = createLanguage<YamlNodesByName, YamlFileServices>({
 		const { visitors } = runtime;
 		const visitorServices = { options, ...file.services };
 
-		visit(file.services.root, (node) => {
-			// @ts-expect-error -- This should work...?
-			visitors[node.type]?.(node, visitorServices);
-		});
+		visit(
+			file.services.root,
+			(node) => {
+				// @ts-expect-error -- This should work...?
+				visitors[node.type]?.(node, visitorServices);
+			},
+			(node) => {
+				// @ts-expect-error -- This should work...?
+				visitors[`${node.type}:exit`]?.(node, visitorServices);
+			},
+		);
 	},
 });


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #000
- [x] That issue was marked as [`status: accepting prs`](https://github.com/flint-fyi/flint/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/flint-fyi/flint/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Adds a `WithExitKeys` type that adds in optional `:exit` listener keys to existing node keys. I figured we can go with that pending thinking of a cleaner key name.

This is used in JSON, Markdown, and TypeScript. YAML is pending a resolution to https://github.com/syntax-tree/unist-util-visit-parents/issues/18.

❤️‍🔥