### PR TITLE
fix(cli): properly use `report about.url` for URLs

### DIFF
--- a/packages/cli/src/presenters/detailed/createDetailedReport.ts
+++ b/packages/cli/src/presenters/detailed/createDetailedReport.ts
@@ -12,9 +12,6 @@ export async function* createDetailedReport(
 	sourceFileText: string,
 	width: number,
 ) {
-	const urlFriendly = `flint.fyi/rules/${report.about.id}`;
-	const url = `https://${urlFriendly}`;
-
 	yield indenter;
 	yield wrapIfNeeded(
 		chalk.hex(ColorCodes.primaryMessage),
@@ -22,7 +19,11 @@ export async function* createDetailedReport(
 			chalk.hex(ColorCodes.ruleBracket)("["),
 			chalk
 				.hex(ColorCodes.reportAboutId)
-				.bold(`\u001B]8;;${url}\u0007${report.about.id}\u001B]8;;\u0007`),
+				.bold(
+					report.about.url
+						? formatUrl(report.about.url, report.about.id)
+						: report.about.id,
+				),
 			chalk.hex(ColorCodes.ruleBracket)("]"),
 			" ",
 			formatReport(report.data, report.message.primary),
@@ -68,8 +69,16 @@ export async function* createDetailedReport(
 		yield "\n";
 	}
 
-	yield `${indenter} `;
-	yield chalk
-		.hex(ColorCodes.ruleUrl)
-		.italic(`→ \u001B]8;;${url}\u0007${urlFriendly}\u001B]8;;\u0007`);
+	if (report.about.url) {
+		yield `${indenter} `;
+		yield chalk
+			.hex(ColorCodes.ruleUrl)
+			.italic(
+				`→ ${formatUrl(report.about.url, report.about.url.replace(/^https:\/\//, ""))}`,
+			);
+	}
+}
+
+function formatUrl(url: string, text: string) {
+	return `\u001B]8;;${url}\u0007${text}\u001B]8;;\u0007`;
 }

--- a/packages/core/src/types/reports.ts
+++ b/packages/core/src/types/reports.ts
@@ -6,7 +6,14 @@ export interface FileReport extends NormalizedReport {
 	/**
 	 * Metadata on the rule or other system that created this report.
 	 */
-	about: BaseAbout;
+	about: FileReportAbout;
+}
+
+export interface FileReportAbout extends BaseAbout {
+	/**
+	 * URL to point users to documentation for the report, if one exists.
+	 */
+	url?: string;
 }
 
 export interface FileReportWithFix extends FileReport {


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to flint! 
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #1206
- [x] That issue was marked as [`status: accepting prs`](https://github.com/flint-fyi/flint/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/flint-fyi/flint/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

`RuleCreator`-created rules were already passing in `about.url` in rules, and reports were already setting their `about` to the `rule.about`. So the only logic that needed to change was detailed reports using `report.about.url` rather than `report.about.id` + string concatenation to build URLs.

<img width="776" height="344" alt="Screenshot of a terminal CLI in detailed mode showing flint.fyi/rules/ts/forinarrays as the proper suggestion URL for a report" src="https://github.com/user-attachments/assets/1b955477-82ac-4835-9a34-4e6cffe9c684" />


❤️‍🔥