### PR TITLE
fix(comparisons): add returnVoidSafety instead of promiseFinallyReturns

### DIFF
--- a/packages/comparisons/src/data.json
+++ b/packages/comparisons/src/data.json
@@ -14336,8 +14336,10 @@
 		"flint": {
 			"name": "promiseFinallyReturns",
 			"plugin": "ts",
-			"preset": "logical"
+			"preset": "logical",
+			"status": "skipped"
 		},
+		"notes": "Largely covered by returnVoidSafety.",
 		"oxlint": [
 			{
 				"name": "promise/no-return-in-finally",
@@ -16247,6 +16249,19 @@
 				"url": "https://oxc.rs/docs/guide/usage/linter/rules/typescript/prefer-return-this-type.html"
 			}
 		]
+	},
+	{
+		"eslint": [
+			{
+				"name": "@typescript-eslint/strict-void-returns",
+				"url": "https://typescript-eslint.io/rules/strict-void-returns"
+			}
+		],
+		"flint": {
+			"name": "returnVoidSafety",
+			"plugin": "ts",
+			"preset": "logicalStrict"
+		}
 	},
 	{
 		"biome": [


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #1819
- [x] That issue was marked as [`status: accepting prs`](https://github.com/flint-fyi/flint/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/flint-fyi/flint/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Kirk mentioned strict-void-return, which was added to typescript-eslint after this comparisons data was formed.

❤️‍🔥