### PR TITLE
feat(ts): add `javascript` and `typescript` file selectors

### DIFF
--- a/.changeset/grumpy-dots-greet.md
+++ b/.changeset/grumpy-dots-greet.md
@@ -1,0 +1,6 @@
+---
+"@flint.fyi/ts": minor
+"@flint.fyi/site": patch
+---
+
+add `javascript` and `typescript` file selectors, and add missing `cts` and `mts` extensions to `all`

--- a/packages/site/src/content/docs/rules/ts.mdx
+++ b/packages/site/src/content/docs/rules/ts.mdx
@@ -138,7 +138,7 @@ import { defineConfig, ts } from "flint";
 export default defineConfig({
 	use: [
 		{
-			files: ts.files.all,
+			files: ts.files.javascript,
 			rules: ts.presets.untyped,
 		},
 	],
@@ -154,6 +154,8 @@ For long-lived projects, Flint recommends using this only as a stopgap measure p
 
 ## Selectors
 
-Flint's TypeScript plugin provides the following file selector:
+Flint's TypeScript plugin provides the following file selectors:
 
-- `all`: `**/*.{cjs,js,jsx,mjs,ts,tsx}`
+- `all`: `**/*.{cjs,cts,js,jsx,mjs,mts,ts,tsx}`
+- `javascript`: `**/*.{cjs,js,jsx,mjs}`
+- `typescript`: `**/*.{cts,mts,ts,tsx}`

--- a/packages/ts/src/plugin.ts
+++ b/packages/ts/src/plugin.ts
@@ -294,9 +294,14 @@ import voidOperator from "./rules/voidOperator.ts";
 import withStatements from "./rules/withStatements.ts";
 import wrapperObjects from "./rules/wrapperObjects.ts";
 
+const jsFiles = ["**/*.{cjs,js,jsx,mjs}"];
+const tsFiles = ["**/*.{cts,mts,ts,tsx}"];
+
 export const ts = createPlugin({
 	files: {
-		all: ["**/*.{cjs,js,jsx,mjs,ts,tsx}"],
+		all: [...jsFiles, ...tsFiles],
+		javascript: jsFiles,
+		typescript: tsFiles,
 	},
 	name: "TypeScript",
 	rules: [


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to flint! ❤️‍🔥
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #2170
- [x] That issue was marked as [`status: accepting prs`](https://github.com/flint-fyi/flint/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/flint-fyi/flint/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

This change adds new file selectors to the `ts` plugin for `javascript` and `typescript` files.  I also added the missing `cts` and `mts` extensions to `all`.
