### PR TITLE
feat(jsx): add file selectors

### DIFF
--- a/.changeset/cold-moments-sit.md
+++ b/.changeset/cold-moments-sit.md
@@ -1,0 +1,11 @@
+---
+"@flint.fyi/jsx": minor
+"@flint.fyi/site": patch
+---
+
+Add file selectors.
+The plugin now includes the following selectors:
+
+- `all`: `**/*.{jsx,tsx}`
+- `javascript`: `**/*.jsx`
+- `typescript`: `**/*.tsx`

--- a/packages/jsx/src/plugin.ts
+++ b/packages/jsx/src/plugin.ts
@@ -45,7 +45,15 @@ import tabIndexPositiveValues from "./rules/tabIndexPositiveValues.ts";
 import unescapedEntities from "./rules/unescapedEntities.ts";
 import unnecessaryFragments from "./rules/unnecessaryFragments.ts";
 
+const jsFiles = ["**/*.jsx"];
+const tsFiles = ["**/*.tsx"];
+
 export const jsx = createPlugin({
+	files: {
+		all: [...jsFiles, ...tsFiles],
+		javascript: jsFiles,
+		typescript: tsFiles,
+	},
 	name: "JSX",
 	rules: [
 		accessKeys,

--- a/packages/site/src/content/docs/rules/jsx.mdx
+++ b/packages/site/src/content/docs/rules/jsx.mdx
@@ -117,6 +117,8 @@ export default defineConfig({
 
 ## Selectors
 
-Flint's JSX plugin provides the following file selector:
+Flint's JSX plugin provides the following file selectors:
 
 - `all`: `**/*.{jsx,tsx}`
+- `javascript`: `**/*.jsx`
+- `typescript`: `**/*.tsx`


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to flint! ❤️‍🔥
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #2173
- [x] That issue was marked as [`status: accepting prs`](https://github.com/flint-fyi/flint/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/flint-fyi/flint/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

This change adds selectors to the jsx plugin.  Interestingly, despite it being in the documentation, the plugin didn't even have the `all` selector yet.
