### PR TITLE
chore: update issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/01-rule-bug.yaml
+++ b/.github/ISSUE_TEMPLATE/01-rule-bug.yaml
@@ -1,5 +1,14 @@
+name: 🐛 Lint Rule Bug
+description: Report a bug specific to a lint rule provided by Flint
+
+title: "🐛 Bug: [plugin.ruleName] <short description of the bug>"
+
+labels:
+  - "type: bug"
+
 body:
-  - attributes:
+  - type: checkboxes
+    attributes:
       description: If any of these required steps are not taken, we may not be able to review your issue. Help us to help you!
       label: Bug Report Checklist
       options:
@@ -7,36 +16,53 @@ body:
           required: true
         - label: I have [searched for related issues](https://github.com/flint-fyi/flint/issues?q=is%3Aissue) and found none that matched my issue.
           required: true
-    type: checkboxes
-  - attributes:
+  - type: dropdown
+    id: plugin
+    attributes:
+      label: Plugin
+      description: What plugin does the rule belong to?
+      options:
+        - Astro
+        - Browser
+        - Flint
+        - JSON
+        - JSX
+        - Markdown
+        - Next
+        - Node
+        - Nuxt
+        - PackageJSON
+        - Performance
+        - React
+        - SolidJS
+        - Sorting
+        - Spelling
+        - TypeScript
+        - Vitest
+        - Vue
+        - YAML
+    validations:
+      required: true
+  - type: textarea
+    attributes:
       description: A minimal code sample which demonstrates the issue
       label: Reproduction
       render: TypeScript
-    type: textarea
     validations:
       required: true
-  - attributes:
+  - type: textarea
+    attributes:
       description: What did you expect to happen?
       label: Expected
-    type: textarea
     validations:
       required: true
-  - attributes:
+  - type: textarea
+    attributes:
       description: What happened instead?
       label: Actual
-    type: textarea
     validations:
       required: true
-  - attributes:
+  - type: textarea
+    attributes:
       description: Any additional info you'd like to provide.
       label: Additional Info
-    type: textarea
-
-description: Report a bug specific to a lint rule provided by Flint
-
-labels:
-  - "type: bug"
-
-name: 🐛 Lint Rule Bug
-
-title: "🐛 Bug: [plugin.ruleName] <short description of the bug>"

--- a/.github/ISSUE_TEMPLATE/02-rule-feature.yaml
+++ b/.github/ISSUE_TEMPLATE/02-rule-feature.yaml
@@ -1,5 +1,14 @@
+name: 🚀 Lint Rule Feature
+description: Request a feature be added to a lint rule provided by Flint
+
+title: "🚀 Feature: [plugin.ruleName] <short description of the feature>"
+
+labels:
+  - "type: feature"
+
 body:
-  - attributes:
+  - type: checkboxes
+    attributes:
       description: If any of these required steps are not taken, we may not be able to review your issue. Help us to help you!
       label: Feature Request Checklist
       options:
@@ -7,23 +16,40 @@ body:
           required: true
         - label: I have [searched for related issues](https://github.com/flint-fyi/flint/issues?q=is%3Aissue) and found none that matched my issue.
           required: true
-    type: checkboxes
-  - attributes:
-      description: What did you expect to be able to do?
-      label: Overview
-    type: textarea
+  - type: dropdown
+    id: plugin
+    attributes:
+      label: Plugin
+      description: What plugin does the rule belong to?
+      options:
+        - Astro
+        - Browser
+        - Flint
+        - JSON
+        - JSX
+        - Markdown
+        - Next
+        - Node
+        - Nuxt
+        - PackageJSON
+        - Performance
+        - React
+        - SolidJS
+        - Sorting
+        - Spelling
+        - TypeScript
+        - Vitest
+        - Vue
+        - YAML
     validations:
       required: true
-  - attributes:
+  - type: textarea
+    attributes:
+      description: What did you expect to be able to do?
+      label: Overview
+    validations:
+      required: true
+  - type: textarea
+    attributes:
       description: Any additional info you'd like to provide.
       label: Additional Info
-    type: textarea
-
-description: Request a feature be added to a lint rule provided by Flint
-
-labels:
-  - "type: feature"
-
-name: 🚀 Lint Rule Feature
-
-title: "🚀 Feature: [plugin.ruleName] <short description of the feature>"

--- a/.github/ISSUE_TEMPLATE/03-general-bug.yaml
+++ b/.github/ISSUE_TEMPLATE/03-general-bug.yaml
@@ -1,3 +1,11 @@
+name: 🐛 General Bug
+description: Report a non-rule-specific bug with Flint, its integrations, or its plugins
+
+title: "🐛 Bug: <short description of the bug>"
+
+labels:
+  - "type: bug"
+
 body:
   - attributes:
       description: If any of these required steps are not taken, we may not be able to review your issue. Help us to help you!
@@ -26,12 +34,3 @@ body:
       label: Additional Info
     id: additional_info
     type: textarea
-
-description: Report a non-rule-specific bug with Flint, its integrations, or its plugins
-
-labels:
-  - "type: bug"
-
-name: 🐛 General Bug
-
-title: "🐛 Bug: <short description of the bug>"

--- a/.github/ISSUE_TEMPLATE/04-general-feature.yaml
+++ b/.github/ISSUE_TEMPLATE/04-general-feature.yaml
@@ -1,3 +1,11 @@
+name: 🚀 General Feature
+description: Request that a new non-rule-specific feature be added or an existing feature improved to Flint, its integrations, or its plugins
+
+title: "🚀 Feature: <short description of the feature>"
+
+labels:
+  - "type: feature"
+
 body:
   - attributes:
       description: If any of these required steps are not taken, we may not be able to review your issue. Help us to help you!
@@ -18,12 +26,3 @@ body:
       description: Any additional info you'd like to provide.
       label: Additional Info
     type: textarea
-
-description: Request that a new non-rule-specific feature be added or an existing feature improved to Flint, its integrations, or its plugins
-
-labels:
-  - "type: feature"
-
-name: 🚀 General Feature
-
-title: "🚀 Feature: <short description of the feature>"

--- a/.github/ISSUE_TEMPLATE/05-documentation.yaml
+++ b/.github/ISSUE_TEMPLATE/05-documentation.yaml
@@ -1,9 +1,17 @@
+name: 📝 Documentation
+description: Report a typo or missing area of documentation
+
+title: "📝 Documentation: <short description of the request>"
+
+labels:
+  - "area: documentation"
+
 body:
   - attributes:
       description: If any of these required steps are not taken, we may not be able to review your issue. Help us to help you!
       label: Documentation Report Checklist
       options:
-        - label: I am using the latest published version of all Flint packages.
+        - label: I have checked the latest `main` branch of the repository.
           required: true
         - label: I have [searched for related issues](https://github.com/flint-fyi/flint/issues?q=is%3Aissue) and found none that matched my issue.
           required: true
@@ -18,12 +26,3 @@ body:
       description: Any additional info you'd like to provide.
       label: Additional Info
     type: textarea
-
-description: Report a typo or missing area of documentation
-
-labels:
-  - "area: documentation"
-
-name: 📝 Documentation
-
-title: "📝 Documentation: <short description of the request>"

--- a/.github/ISSUE_TEMPLATE/06-tooling.yaml
+++ b/.github/ISSUE_TEMPLATE/06-tooling.yaml
@@ -1,15 +1,25 @@
+name: 🛠 Tooling
+description: Report a bug or request an enhancement in repository tooling
+
+title: "🛠 Tooling: <short description of the change>"
+
+labels:
+  - "area: tooling"
+
 body:
   - attributes:
       description: If any of these required steps are not taken, we may not be able to review your issue. Help us to help you!
       label: Tooling Report Checklist
       options:
-        - label: I am using the latest published version of all Flint packages.
+        - label: I have tried restarting my IDE and the issue persists.
+          required: true
+        - label: I have pulled the latest `main` branch of the repository.
           required: true
         - label: I have [searched for related issues](https://github.com/flint-fyi/flint/issues?q=is%3Aissue) and found none that matched my issue.
           required: true
     type: checkboxes
   - attributes:
-      description: What did you expect to be able to do?
+      description: What tooling changes would you like to make?
       label: Overview
     type: textarea
     validations:
@@ -18,12 +28,3 @@ body:
       description: Any additional info you'd like to provide.
       label: Additional Info
     type: textarea
-
-description: Report a bug or request an enhancement in repository tooling
-
-labels:
-  - "area: tooling"
-
-name: 🛠 Tooling
-
-title: "🛠 Tooling: <short description of the change>"


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to flint! ❤️‍🔥
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #1826
- [x] That issue was marked as [`status: accepting prs`](https://github.com/flint-fyi/flint/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/flint-fyi/flint/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

This change adds a plugin dropdown to the rule-style bug and feature templates, and improves a few of the others (e.g. tooling)

Top-level ordering referenced from https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#creating-issue-forms

As a follow-up we could explore using something like `advanced-issue-labeler` to automatically apply the appropriate plugin label based on what was selected.  e.g. https://sourcegraph.com/github.com/SeleniumHQ/selenium/-/blob/.github/workflows/issue-labeler.yml