### PR TITLE
ci: remove ignored packages from changesets

### DIFF
--- a/.changeset/cold-moments-sit.md
+++ b/.changeset/cold-moments-sit.md
@@ -1,6 +1,5 @@
 ---
 "@flint.fyi/jsx": minor
-"@flint.fyi/site": patch
 ---
 
 Add file selectors.

--- a/.changeset/grumpy-clouds-love.md
+++ b/.changeset/grumpy-clouds-love.md
@@ -1,6 +1,5 @@
 ---
 "@flint.fyi/core": minor
-"@flint.fyi/site": minor
 "@flint.fyi/cli": minor
 ---
 

--- a/.changeset/grumpy-dots-greet.md
+++ b/.changeset/grumpy-dots-greet.md
@@ -1,6 +1,5 @@
 ---
 "@flint.fyi/ts": minor
-"@flint.fyi/site": patch
 ---
 
 Add `javascript` and `typescript` file selectors, and add missing `cts` and `mts` extensions to `all`.

--- a/.changeset/polite-kings-cut.md
+++ b/.changeset/polite-kings-cut.md
@@ -1,7 +1,6 @@
 ---
 "@flint.fyi/ts": minor
 "@flint.fyi/comparisons": patch
-"@flint.fyi/site": patch
 ---
 
 Change `untyped` preset name to `javascript`.

--- a/.changeset/strict-kiwis-sell.md
+++ b/.changeset/strict-kiwis-sell.md
@@ -1,5 +1,0 @@
----
-"@flint.fyi/site": patch
----
-
-Correct arg attribute to args.


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to flint! ❤️‍🔥
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [`status: accepting prs`](https://github.com/flint-fyi/flint/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/flint-fyi/flint/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

In #2322 we enabled the setting to ignore private packages, but didn't remove references from existing changesets for the @flint.fyi/site package (which is private and now ignored)

https://github.com/flint-fyi/flint/actions/runs/22117321148/job/63928646333
