### PR TITLE
fix(comparison): remove `yamlKeys` from the preset of the sorting plugin

### DIFF
--- a/.changeset/salty-parks-sleep.md
+++ b/.changeset/salty-parks-sleep.md
@@ -1,0 +1,5 @@
+---
+"@flint.fyi/comparisons": patch
+---
+
+Remove `yamlKeys` from the Sorting plugin presets.

--- a/packages/comparisons/src/data.json
+++ b/packages/comparisons/src/data.json
@@ -7252,8 +7252,7 @@
 		],
 		"flint": {
 			"name": "yamlKeys",
-			"plugin": "sorting",
-			"preset": "stylistic"
+			"plugin": "sorting"
 		}
 	},
 	{


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to flint! ❤️‍🔥
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #2174
- [x] That issue was marked as [`status: accepting prs`](https://github.com/flint-fyi/flint/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/flint-fyi/flint/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->
