### PR TITLE
fix: normalize file dependencies to ensure cache hits

### DIFF
--- a/.changeset/tender-spoons-sin.md
+++ b/.changeset/tender-spoons-sin.md
@@ -1,0 +1,5 @@
+---
+"@flint.fyi/core": patch
+---
+
+Normalize file dependencies to ensure cache hits.

--- a/packages/core/src/running/finalizeFileResults.ts
+++ b/packages/core/src/running/finalizeFileResults.ts
@@ -1,7 +1,10 @@
 import { debugForFile } from "debug-for-file";
+import { resolve } from "node:path";
 
 import { DirectivesFilterer } from "../directives/DirectivesFilterer.ts";
 import { directiveReports } from "../directives/reports/directiveReports.ts";
+import { normalizePath } from "../host/normalizePath.ts";
+import type { LinterHost } from "../types/host.ts";
 import type { LanguageFileDiagnostic } from "../types/languages.ts";
 import type { FileReport } from "../types/reports.ts";
 import type { LanguageAndFile } from "./types.ts";
@@ -19,6 +22,7 @@ export function finalizeFileResults(
 	filePath: string,
 	languageAndFiles: LanguageAndFile[],
 	reports: FileReport[],
+	host: LinterHost,
 	skipDiagnostics?: boolean,
 ) {
 	const directivesFilterer = new DirectivesFilterer();
@@ -35,9 +39,13 @@ export function finalizeFileResults(
 
 		if (cache?.dependencies) {
 			for (const dependency of cache.dependencies) {
-				if (!fileDependencies.has(dependency)) {
-					log("Adding file dependency %s for file %s", dependency, filePath);
-					fileDependencies.add(dependency);
+				const normalized = normalizePath(
+					resolve(dependency),
+					host.isCaseSensitiveFS(),
+				);
+				if (!fileDependencies.has(normalized)) {
+					log("Adding file dependency %s for file %s", normalized, filePath);
+					fileDependencies.add(normalized);
 				}
 			}
 		}

--- a/packages/core/src/running/runConfig.ts
+++ b/packages/core/src/running/runConfig.ts
@@ -57,6 +57,7 @@ export async function runConfig(
 				filePath,
 				languageAndFiles,
 				reportsByFilePath.get(filePath).flat(),
+				host,
 				skipDiagnostics,
 			),
 		]),


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to flint! ❤️‍🔥
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [`status: accepting prs`](https://github.com/flint-fyi/flint/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/flint-fyi/flint/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

`allFilePaths` is generated by `computeUseDefinitions()`. And in `computeUseDefinitions`, the path has been normalized.
But in `finalizeFileResults.ts`, we didn't normalize file dependencies. So the files alway marked as uncached that is a big problem.

```ts
// readFromCache.ts
for (const filePath of allFilePaths) {
	const fileCached = cached.get(filePath);
	if (!fileCached) {
		log("No cache available for: %s", filePath);
		markAsUncached(filePath);
		continue;
	}
```
