### PR TITLE
chore: switch from . to / in rule template issue titles

### DIFF
--- a/.github/ISSUE_TEMPLATE/01-rule-bug.yaml
+++ b/.github/ISSUE_TEMPLATE/01-rule-bug.yaml
@@ -1,7 +1,7 @@
 name: 🐛 Lint Rule Bug
 description: Report a bug specific to a lint rule provided by Flint
 
-title: "🐛 Bug: [plugin.ruleName] <short description of the bug>"
+title: "🐛 Bug: [plugin/ruleName] <short description of the bug>"
 
 labels:
   - "type: bug"

--- a/.github/ISSUE_TEMPLATE/02-rule-feature.yaml
+++ b/.github/ISSUE_TEMPLATE/02-rule-feature.yaml
@@ -1,7 +1,7 @@
 name: 🚀 Lint Rule Feature
 description: Request a feature be added to a lint rule provided by Flint
 
-title: "🚀 Feature: [plugin.ruleName] <short description of the feature>"
+title: "🚀 Feature: [plugin/ruleName] <short description of the feature>"
 
 labels:
   - "type: feature"


### PR DESCRIPTION
I just noticed this. We've been using `/` as the delimiter.