### PR TITLE
chore(volar-language): switch tsdown's devExports away from @flint.fyi/source

### DIFF
--- a/packages/volar-language/tsdown.config.ts
+++ b/packages/volar-language/tsdown.config.ts
@@ -9,7 +9,7 @@ export default defineConfig({
 	dts: { build: true, incremental: true },
 	entry: ["src/index.ts"],
 	exports: {
-		devExports: "@flint.fyi/source",
+		devExports: true,
 		packageJson: false,
 	},
 	failOnWarn: true,


### PR DESCRIPTION

## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [`status: accepting prs`](https://github.com/flint-fyi/flint/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/flint-fyi/flint/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

I missed this in https://github.com/flint-fyi/flint/pull/2315

I'll self-merge this since it's trivial, and I don't want build-related things to be broken on `main`