### PR TITLE
style: prefer nullThrows a bit more

### DIFF
--- a/packages/typescript-language/src/language.ts
+++ b/packages/typescript-language/src/language.ts
@@ -8,7 +8,7 @@ import {
 	type LanguageFileDefinition,
 	type RuleRuntime,
 } from "@flint.fyi/core";
-import { assert } from "@flint.fyi/utils";
+import { assert, nullThrows } from "@flint.fyi/utils";
 import { createProjectService } from "@typescript-eslint/project-service";
 import { debugForFile } from "debug-for-file";
 import path from "node:path";
@@ -96,30 +96,23 @@ export const typescriptLanguage = createLanguage<
 			service.openClientFile(data.filePathAbsolute);
 
 			log("Retrieving client services:", data.filePathAbsolute);
-			const scriptInfo = service.getScriptInfo(data.filePathAbsolute);
-			assert(
-				scriptInfo != null,
+			const scriptInfo = nullThrows(
+				service.getScriptInfo(data.filePathAbsolute),
 				`Could not find script info for file: ${data.filePathAbsolute}`,
 			);
 
-			const defaultProject = service.getDefaultProjectForFile(
-				scriptInfo.fileName,
-				true,
-			);
-			assert(
-				defaultProject != null,
+			const defaultProject = nullThrows(
+				service.getDefaultProjectForFile(scriptInfo.fileName, true),
 				`Could not find default project for file: ${data.filePathAbsolute}`,
 			);
 
-			const program = defaultProject.getLanguageService(true).getProgram();
-			assert(
-				program != null,
+			const program = nullThrows(
+				defaultProject.getLanguageService(true).getProgram(),
 				`Could not retrieve program for file: ${data.filePathAbsolute}`,
 			);
 
-			const sourceFile = program.getSourceFile(data.filePathAbsolute);
-			assert(
-				sourceFile != null,
+			const sourceFile = nullThrows(
+				program.getSourceFile(data.filePathAbsolute),
 				`Could not retrieve source file for: ${data.filePathAbsolute}`,
 			);
 

--- a/packages/volar-language/src/language.ts
+++ b/packages/volar-language/src/language.ts
@@ -114,7 +114,7 @@ setTSProgramCreationProxy(
 				/* for apply */
 			} as unknown as typeof createProgram,
 			{
-				apply(target, thisArg, args: unknown[]) {
+				apply(_, thisArg, args: unknown[]) {
 					let volarLanguage = null as null | VolarLanguage<string>;
 					const createProgramProxy = new Proxy(createProgram, {
 						apply(target, thisArg, [options]: [ts.CreateProgramOptions]) {


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to flint! ❤️‍🔥
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [`status: accepting prs`](https://github.com/flint-fyi/flint/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/flint-fyi/flint/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->
Was looking over the #2315 diff and noticed a few more `nullThrows`-ables lying around.
I think these look better this way but I'm not tied to it, especially if it conflicts with #2316 (it doesn't, yet). ❤️‍🔥