### PR TITLE
test(vue): add DOM to lib and enable JSX in tests tsconfig

### DIFF
--- a/packages/vue/src/rules/ruleTester.ts
+++ b/packages/vue/src/rules/ruleTester.ts
@@ -5,7 +5,11 @@ import { describe, it } from "vitest";
 export const ruleTester = new RuleTester({
 	defaults: {
 		fileName: "file.vue",
-		files: createRuleTesterTSConfig(),
+		files: createRuleTesterTSConfig({
+			jsx: "preserve",
+			jsxImportSource: "vue",
+			lib: ["dom", "esnext"],
+		}),
 	},
 	describe,
 	diskBackedFSRoot: import.meta.dirname,


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to flint! ❤️‍🔥
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [`status: accepting prs`](https://github.com/flint-fyi/flint/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/flint-fyi/flint/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Haven't noticed this earlier because we don't collect semantic TS diagnostics in rule tests
