### PR TITLE
feat(core): add optional range to LanguageReport

### DIFF
--- a/.changeset/hot-teeth-rhyme.md
+++ b/.changeset/hot-teeth-rhyme.md
@@ -1,0 +1,6 @@
+---
+"@flint.fyi/typescript-language": minor
+"@flint.fyi/core": minor
+---
+
+Add optional character range to language reports.

--- a/packages/core/src/types/languages.ts
+++ b/packages/core/src/types/languages.ts
@@ -1,7 +1,6 @@
 import type { CommentDirective } from "./directives.ts";
 import type { LinterHost } from "./host.ts";
 import type { CharacterReportRange } from "./ranges.ts";
-import type { NormalizedReportRangeObject } from "./reports.ts";
 import type { FileReport } from "./reports.ts";
 import type { Rule, RuleAbout, RuleDefinition, RuleRuntime } from "./rules.ts";
 import type { AnyOptionalSchema, InferredOutputObject } from "./shapes.ts";
@@ -87,7 +86,7 @@ export interface LanguageAbout {
 
 export interface LanguageReport {
 	code?: string;
-	range?: NormalizedReportRangeObject;
+	range?: CharacterReportRange;
 	text: string;
 }
 

--- a/packages/core/src/types/languages.ts
+++ b/packages/core/src/types/languages.ts
@@ -1,6 +1,7 @@
 import type { CommentDirective } from "./directives.ts";
 import type { LinterHost } from "./host.ts";
 import type { CharacterReportRange } from "./ranges.ts";
+import type { NormalizedReportRangeObject } from "./reports.ts";
 import type { FileReport } from "./reports.ts";
 import type { Rule, RuleAbout, RuleDefinition, RuleRuntime } from "./rules.ts";
 import type { AnyOptionalSchema, InferredOutputObject } from "./shapes.ts";
@@ -86,6 +87,7 @@ export interface LanguageAbout {
 
 export interface LanguageReport {
 	code?: string;
+	range?: NormalizedReportRangeObject;
 	text: string;
 }
 

--- a/packages/typescript-language/src/convertTypeScriptDiagnosticToLanguageReport.ts
+++ b/packages/typescript-language/src/convertTypeScriptDiagnosticToLanguageReport.ts
@@ -32,11 +32,8 @@ export function convertTypeScriptDiagnosticToLanguageReport(
 		...(diagnostic.file !== undefined &&
 			diagnostic.start !== undefined && {
 				range: {
-					begin: getColumnAndLineOfPosition(diagnostic.file, diagnostic.start),
-					end: getColumnAndLineOfPosition(
-						diagnostic.file,
-						diagnostic.start + (diagnostic.length ?? 0),
-					),
+					begin: diagnostic.start,
+					end: diagnostic.start + (diagnostic.length ?? 0),
 				},
 			}),
 	};

--- a/packages/typescript-language/src/convertTypeScriptDiagnosticToLanguageReport.ts
+++ b/packages/typescript-language/src/convertTypeScriptDiagnosticToLanguageReport.ts
@@ -29,6 +29,16 @@ export function convertTypeScriptDiagnosticToLanguageReport(
 	return {
 		code: `TS${diagnostic.code}`,
 		text: formatReport(diagnostic),
+		...(diagnostic.file !== undefined &&
+			diagnostic.start !== undefined && {
+				range: {
+					begin: getColumnAndLineOfPosition(diagnostic.file, diagnostic.start),
+					end: getColumnAndLineOfPosition(
+						diagnostic.file,
+						diagnostic.start + (diagnostic.length ?? 0),
+					),
+				},
+			}),
 	};
 }
 


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #2460
- [x] That issue was marked as [`status: accepting prs`](https://github.com/flint-fyi/flint/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/flint-fyi/flint/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

I only added it to TypeScript diagnostics, since that was where it surfaced during my experiments with an LSP. I assume we would eventually want to use it in every type of diagnostic.

We might also want to define different types of diagnostics for line-level and file-level so that it's always required for the relevant type of diagnostic, but that is out-of-scope for this PR/issue.