### PR TITLE
docs: nullishCheckStyle supersedes no-eq-null

### DIFF
--- a/packages/comparisons/src/data.json
+++ b/packages/comparisons/src/data.json
@@ -10275,7 +10275,7 @@
 			"preset": "logical",
 			"status": "implemented"
 		},
-		"notes": "Default ESLint's \"smart\" to true",
+		"notes": "Default similar to ESLint's \"{ \"null\": \"ignore\" }\" to true",
 		"oxlint": [
 			{
 				"name": "eslint/eqeqeq",
@@ -13764,9 +13764,9 @@
 			}
 		],
 		"flint": {
-			"name": "nullComparisons",
+			"name": "nullishCheckStyle",
 			"plugin": "ts",
-			"status": "skipped"
+			"status": "implemented"
 		},
 		"oxlint": [
 			{
@@ -13774,14 +13774,6 @@
 				"url": "https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-eql-null.html"
 			}
 		]
-	},
-	{
-		"flint": {
-			"name": "nullishCheckStyle",
-			"plugin": "ts",
-			"preset": "logical",
-			"status": "implemented"
-		}
 	},
 	{
 		"eslint": [


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to flint! ❤️‍🔥
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [`status: accepting prs`](https://github.com/flint-fyi/flint/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/flint-fyi/flint/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

TIL that [no-eq-null](https://eslint.org/docs/latest/rules/no-eq-null) exists. The flint rule does that and more.