### PR TITLE
chore: Add helix config

### DIFF
--- a/.helix/config.toml
+++ b/.helix/config.toml
@@ -1,0 +1,2 @@
+[editor]
+rulers = [80]

--- a/.helix/config.toml
+++ b/.helix/config.toml
@@ -1,2 +1,3 @@
 [editor]
+auto-format = true
 rulers = [80]

--- a/.helix/config.toml
+++ b/.helix/config.toml
@@ -1,3 +1,0 @@
-[editor]
-auto-format = true
-rulers = [80]

--- a/.helix/languages.toml
+++ b/.helix/languages.toml
@@ -1,30 +1,38 @@
-# Only formatter is set so each contributor's global language-server
-# config is preserved. auto-format is enabled in config.toml.
+# Prettier as the project formatter, matching .vscode/settings.json.
+# Only formatter and auto-format are set so each contributor's
+# global language-server config is preserved.
 
 [[language]]
 name = "javascript"
+auto-format = true
 formatter = { command = "npx", args = ["prettier", "--parser", "babel"] }
 
 [[language]]
 name = "jsx"
+auto-format = true
 formatter = { command = "npx", args = ["prettier", "--parser", "babel"] }
 
 [[language]]
 name = "typescript"
+auto-format = true
 formatter = { command = "npx", args = ["prettier", "--parser", "typescript"] }
 
 [[language]]
 name = "tsx"
+auto-format = true
 formatter = { command = "npx", args = ["prettier", "--parser", "typescript"] }
 
 [[language]]
 name = "json"
+auto-format = true
 formatter = { command = "npx", args = ["prettier", "--parser", "json"] }
 
 [[language]]
 name = "markdown"
+auto-format = true
 formatter = { command = "npx", args = ["prettier", "--parser", "markdown"] }
 
 [[language]]
 name = "yaml"
+auto-format = true
 formatter = { command = "npx", args = ["prettier", "--parser", "yaml"] }

--- a/.helix/languages.toml
+++ b/.helix/languages.toml
@@ -1,37 +1,30 @@
-# Only formatter and auto-format are set so each contributor's
-# global language-server config is preserved.
+# Only formatter is set so each contributor's global language-server
+# config is preserved. auto-format is enabled in config.toml.
 
 [[language]]
 name = "javascript"
 formatter = { command = "npx", args = ["prettier", "--parser", "babel"] }
-auto-format = true
 
 [[language]]
 name = "jsx"
 formatter = { command = "npx", args = ["prettier", "--parser", "babel"] }
-auto-format = true
 
 [[language]]
 name = "typescript"
 formatter = { command = "npx", args = ["prettier", "--parser", "typescript"] }
-auto-format = true
 
 [[language]]
 name = "tsx"
 formatter = { command = "npx", args = ["prettier", "--parser", "typescript"] }
-auto-format = true
 
 [[language]]
 name = "json"
 formatter = { command = "npx", args = ["prettier", "--parser", "json"] }
-auto-format = true
 
 [[language]]
 name = "markdown"
 formatter = { command = "npx", args = ["prettier", "--parser", "markdown"] }
-auto-format = true
 
 [[language]]
 name = "yaml"
 formatter = { command = "npx", args = ["prettier", "--parser", "yaml"] }
-auto-format = true

--- a/.helix/languages.toml
+++ b/.helix/languages.toml
@@ -1,0 +1,37 @@
+# Only formatter and auto-format are set so each contributor's
+# global language-server config is preserved.
+
+[[language]]
+name = "javascript"
+formatter = { command = "npx", args = ["prettier", "--parser", "babel"] }
+auto-format = true
+
+[[language]]
+name = "jsx"
+formatter = { command = "npx", args = ["prettier", "--parser", "babel"] }
+auto-format = true
+
+[[language]]
+name = "typescript"
+formatter = { command = "npx", args = ["prettier", "--parser", "typescript"] }
+auto-format = true
+
+[[language]]
+name = "tsx"
+formatter = { command = "npx", args = ["prettier", "--parser", "typescript"] }
+auto-format = true
+
+[[language]]
+name = "json"
+formatter = { command = "npx", args = ["prettier", "--parser", "json"] }
+auto-format = true
+
+[[language]]
+name = "markdown"
+formatter = { command = "npx", args = ["prettier", "--parser", "markdown"] }
+auto-format = true
+
+[[language]]
+name = "yaml"
+formatter = { command = "npx", args = ["prettier", "--parser", "yaml"] }
+auto-format = true


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to flint! ❤️‍🔥
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [`status: accepting prs`](https://github.com/flint-fyi/flint/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/flint-fyi/flint/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

I use Helix, not VSCode. I kept ending up with unformatted code. So, I added settings to mirror `.vscode/settings.json` so that Helix users will automatically use `prettier` and autoformat on save.
