### PR TITLE
ci(split-test): split tests so that vitest --changed doesn't apply to e2e

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -77,7 +77,6 @@ jobs:
         run: pnpm run test --project='!e2e'
   test_e2e:
     name: Test E2E
-    needs: typecheck
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -55,7 +55,6 @@ jobs:
       - run: pnpm exec tsc -b
   test:
     name: Test
-    needs: typecheck
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -72,7 +72,7 @@ jobs:
         if: ${{ github.event_name == 'pull_request' }}
         name: Run affected tests except e2e
         run: pnpm run test --changed origin/${{ github.base_ref }} --project='!e2e'
-      - # On main, run the full non-e2e test suite w/ type checking.
+      - # On main, run the full non-e2e test suite.
         if: ${{ github.ref == 'refs/heads/main' }}
         name: Run full test suite except e2e
         run: pnpm run test --project='!e2e'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -46,8 +46,16 @@ jobs:
       - uses: ./.github/actions/prepare
       - run: pnpm run build # Knip requires all exports to be generated.
       - run: pnpm run lint:knip
+  typecheck:
+    name: Typecheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: ./.github/actions/prepare
+      - run: pnpm exec tsc -b
   test:
     name: Test
+    needs: typecheck
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -60,7 +68,6 @@ jobs:
         with:
           key: vite-cache-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
           path: node_modules/.vite
-      - run: pnpm exec tsc -b # For types tests
       - # Run partial test pass on PRs (only changed files), excluding e2e.
         if: ${{ github.event_name == 'pull_request' }}
         name: Run affected tests except e2e
@@ -71,11 +78,11 @@ jobs:
         run: pnpm run test --project='!e2e'
   test_e2e:
     name: Test E2E
+    needs: typecheck
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          fetch-depth: 0
           filter: "tree:0"
       - uses: ./.github/actions/prepare
       - name: Cache Vite cache
@@ -83,8 +90,5 @@ jobs:
         with:
           key: vite-cache-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
           path: node_modules/.vite
-      - run: pnpm exec tsc -b # For types tests
-      - # On PRs and main, always run e2e regardless of changed files.
-        if: ${{ github.event_name == 'pull_request' || github.ref == 'refs/heads/main' }}
-        name: Run e2e test suite
+      - name: Run e2e test suite
         run: pnpm run test --project e2e

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -61,11 +61,30 @@ jobs:
           key: vite-cache-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
           path: node_modules/.vite
       - run: pnpm exec tsc -b # For types tests
-      - # Run partial test pass on PRs (only changed files)
+      - # Run partial test pass on PRs (only changed files), excluding e2e.
         if: ${{ github.event_name == 'pull_request' }}
-        name: Run affected tests
-        run: pnpm run test --changed origin/${{ github.base_ref }}
-      - # On main, run the full test suite w/ type checking
+        name: Run affected tests except e2e
+        run: pnpm run test --changed origin/${{ github.base_ref }} --project='!e2e'
+      - # On main, run the full non-e2e test suite w/ type checking.
         if: ${{ github.ref == 'refs/heads/main' }}
-        name: Run full test suite
-        run: pnpm run test
+        name: Run full test suite except e2e
+        run: pnpm run test --project='!e2e'
+  test_e2e:
+    name: Test E2E
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          filter: "tree:0"
+      - uses: ./.github/actions/prepare
+      - name: Cache Vite cache
+        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+        with:
+          key: vite-cache-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          path: node_modules/.vite
+      - run: pnpm exec tsc -b # For types tests
+      - # On PRs and main, always run e2e regardless of changed files.
+        if: ${{ github.event_name == 'pull_request' || github.ref == 'refs/heads/main' }}
+        name: Run e2e test suite
+        run: pnpm run test --project e2e


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #2423
- [x] That issue was marked as [`status: accepting prs`](https://github.com/flint-fyi/flint/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/flint-fyi/flint/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Split e2e tests out into a separate job without the `--changed` flag.

I've also split the typecheck out to its own ci step since both jobs depend on that.

🚀 🔥 🫶 
