### PR TITLE
fix(options): change "skip-language-reports" type to boolean

### DIFF
--- a/packages/cli/src/options.ts
+++ b/packages/cli/src/options.ts
@@ -24,8 +24,7 @@ export const options = {
 		type: "string",
 	},
 	"skip-language-reports": {
-		multiple: true,
-		type: "string",
+		type: "boolean",
 	},
 	version: {
 		type: "boolean",

--- a/packages/cli/src/runCliOnce.ts
+++ b/packages/cli/src/runCliOnce.ts
@@ -53,9 +53,9 @@ export async function runCliOnce(
 		...config.definition,
 		filePath: configFileName,
 	};
-	const ignoreCache = !!values["cache-ignore"];
+	const ignoreCache = values["cache-ignore"] ?? false;
 
-	const skipLanguageReports = !!values["skip-language-reports"];
+	const skipLanguageReports = values["skip-language-reports"] ?? false;
 
 	const lintResults = await (values.fix
 		? runConfigFixing(configDefinition, host, {


### PR DESCRIPTION


<!-- 👋 Hi, thanks for sending a PR to flint! ❤️‍🔥
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [`status: accepting prs`](https://github.com/flint-fyi/flint/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [ ] Steps in [CONTRIBUTING.md](https://github.com/flint-fyi/flint/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->
I let Amp have a go at comparing TSESLint's loading compared to Flint's loading for #1320, and I don't think SWE is quite over if it decided to obsess over this for a bit (though it eventually took its ADHD pills and did what I asked, really funny thinking block tbh)

Amp-Thread-ID: https://ampcode.com/threads/T-019d7570-19bb-7407-9947-d9afb2d88c5a