### PR TITLE
fix: jsx/imageAltTexts should not report on known non-string values

### DIFF
--- a/.changeset/tiny-readers-doubt.md
+++ b/.changeset/tiny-readers-doubt.md
@@ -2,4 +2,4 @@
 "@flint.fyi/jsx": patch
 ---
 
-fix: jsx/imageAltTexts should not report on known non-string values
+`imageAltTexts` should not report on known non-string values.

--- a/.changeset/tiny-readers-doubt.md
+++ b/.changeset/tiny-readers-doubt.md
@@ -1,0 +1,5 @@
+---
+"@flint.fyi/jsx": patch
+---
+
+fix: jsx/imageAltTexts should not report on known non-string values

--- a/packages/jsx/src/rules/altTexts.test.ts
+++ b/packages/jsx/src/rules/altTexts.test.ts
@@ -15,16 +15,6 @@ ruleTester.describe(rule, {
 		},
 		{
 			code: `
-<img src="foo.jpg" alt />
-`,
-			snapshot: `
-<img src="foo.jpg" alt />
- ~~~
- img element is missing alt text for non-visual users.
-`,
-		},
-		{
-			code: `
 <img src="foo.jpg" alt={undefined} />
 `,
 			snapshot: `
@@ -75,5 +65,10 @@ ruleTester.describe(rule, {
 		`<object aria-label="Video" />`,
 		`<object title="Movie" />`,
 		`<div>Not an image element</div>`,
+		// Known non-string values are covered by TypeScript — no need to double-report
+		`<img src="foo.jpg" alt />`,
+		`<img src="foo.jpg" alt={[]} />`,
+		`<img src="foo.jpg" alt={{}} />`,
+		`<img src="foo.jpg" alt={123} />`,
 	],
 });

--- a/packages/jsx/src/rules/altTexts.ts
+++ b/packages/jsx/src/rules/altTexts.ts
@@ -88,25 +88,20 @@ export default ruleCreator.createRule(typescriptLanguage, {
 				return;
 			}
 
-			if (properties.kind === SyntaxKind.JsxAttribute) {
-				if (!properties.initializer) {
+			if (
+				properties.kind === SyntaxKind.JsxAttribute &&
+				properties.initializer?.kind === SyntaxKind.JsxExpression
+			) {
+				const { expression } = properties.initializer;
+				if (
+					expression?.kind === SyntaxKind.Identifier &&
+					expression.text === "undefined"
+				) {
 					context.report({
 						data: { element: elementName },
 						message: "missingAlt",
 						range: getTSNodeRange(tagName, sourceFile),
 					});
-				} else if (properties.initializer.kind === SyntaxKind.JsxExpression) {
-					const { expression } = properties.initializer;
-					if (
-						expression?.kind === SyntaxKind.Identifier &&
-						expression.text === "undefined"
-					) {
-						context.report({
-							data: { element: elementName },
-							message: "missingAlt",
-							range: getTSNodeRange(tagName, sourceFile),
-						});
-					}
 				}
 			}
 		}


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #2546
- [x] That issue was marked as [`status: accepting prs`](https://github.com/flint-fyi/flint/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/flint-fyi/flint/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Stops `jsx/altTexts` from reporting on `<img alt />` and other known non-string alt values (e.g. `alt={[]}`, `alt={123}`) since TypeScript already flags these as type errors. The rule now only reports when `alt` is entirely absent or explicitly set to `undefined` which are the two cases TypeScript won't catch. 

🔥 🫶 🚀 😁 