### PR TITLE
fix: jsx/autoFocusProps no longer double reports ts issue

### DIFF
--- a/.changeset/thick-socks-whisper.md
+++ b/.changeset/thick-socks-whisper.md
@@ -1,0 +1,5 @@
+---
+"@flint.fyi/jsx": patch
+---
+
+fix: jsx/autoFocusProps no longer double reports ts issue

--- a/.changeset/thick-socks-whisper.md
+++ b/.changeset/thick-socks-whisper.md
@@ -2,4 +2,4 @@
 "@flint.fyi/jsx": patch
 ---
 
-fix: jsx/autoFocusProps no longer double reports ts issue
+Prevent `jsx/autoFocusProps` from double reporting ts issues.

--- a/packages/jsx/src/rules/autoFocusProps.test.ts
+++ b/packages/jsx/src/rules/autoFocusProps.test.ts
@@ -15,16 +15,6 @@ ruleTester.describe(rule, {
 		},
 		{
 			code: `
-<div autoFocus="true" />
-`,
-			snapshot: `
-<div autoFocus="true" />
-     ~~~~~~~~~~~~~~~~
-     The \`autoFocus\` prop disruptively forces unintuitive focus behavior.
-`,
-		},
-		{
-			code: `
 <div autoFocus={true} />
 `,
 			snapshot: `
@@ -47,6 +37,8 @@ ruleTester.describe(rule, {
 	valid: [
 		`<div />`,
 		`<div autoFocus="false" />`,
+		// String literals are already caught by TypeScript as a type error, no need to double-report.
+		`<div autoFocus="true" />`,
 		`<div autoFocus={false} />`,
 		`<input type="text" />`,
 	],

--- a/packages/jsx/src/rules/autoFocusProps.ts
+++ b/packages/jsx/src/rules/autoFocusProps.ts
@@ -36,7 +36,9 @@ export default ruleCreator.createRule(typescriptLanguage, {
 			}
 
 			if (property.initializer.kind === SyntaxKind.StringLiteral) {
-				return property.initializer.text === "false";
+				// Any string value is already a TypeScript type error for boolean props,
+				// so we don't need to report on them here.
+				return true;
 			}
 
 			if (property.initializer.kind === SyntaxKind.JsxExpression) {


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #2547
- [x] That issue was marked as [`status: accepting prs`](https://github.com/flint-fyi/flint/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/flint-fyi/flint/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

The rule was reporting on `autoFocus="true"` and other string literal values, but since `autoFocus` is a boolean prop, passing a string is already a TypeScript type error. This was causing Flint to double-report issues that TypeScript already covers.

The fix treats any string literal initializer as "skip reporting". The rule now only flags cases where autoFocus is intentionally enabled as a boolean: bare `autoFocus`, `autoFocus={true}`, or `autoFocus={undefined}`.

😁 🫶 🔥 🔥 🔥 