### PR TITLE
feat(plugin-flint): add fixer for `testShorthands`

### DIFF
--- a/.changeset/smooth-chefs-like.md
+++ b/.changeset/smooth-chefs-like.md
@@ -1,0 +1,6 @@
+---
+"@flint.fyi/plugin-flint": patch
+---
+
+Added a fixer for the `flint/testShorthands` rule.
+It will now replace the test case object with the string equivalent.

--- a/packages/plugin-flint/src/rules/testShorthands.test.ts
+++ b/packages/plugin-flint/src/rules/testShorthands.test.ts
@@ -6,19 +6,26 @@ ruleTester.describe(rule, {
 		{
 			code: `
                 ruleTester.describe(rule, {
-                    valid: ['a', { code: 'a' }],
+                    valid: ['a', { code: 'b' }],
                     invalid: []
                 });
-            
+
+`,
+			output: `
+                ruleTester.describe(rule, {
+                    valid: ['a', 'b'],
+                    invalid: []
+                });
+
 `,
 			snapshot: `
                 ruleTester.describe(rule, {
-                    valid: ['a', { code: 'a' }],
+                    valid: ['a', { code: 'b' }],
                                    ~~~~~~~~~
                                    Use string shorthand for test cases with only a code property.
                     invalid: []
                 });
-            
+
 `,
 		},
 		{
@@ -27,26 +34,36 @@ ruleTester.describe(rule, {
                     valid: [
                         'a',
                         {
-                          code: 'a'
+                          code: 'b'
                         }
                     ],
                     invalid: []
                 });
-            
+
+`,
+			output: `
+                ruleTester.describe(rule, {
+                    valid: [
+                        'a',
+                        'b'
+                    ],
+                    invalid: []
+                });
+
 `,
 			snapshot: `
                 ruleTester.describe(rule, {
                     valid: [
                         'a',
                         {
-                          code: 'a'
+                          code: 'b'
                           ~~~~~~~~~
                           Use string shorthand for test cases with only a code property.
                         }
                     ],
                     invalid: []
                 });
-            
+
 `,
 		},
 	],

--- a/packages/plugin-flint/src/rules/testShorthands.ts
+++ b/packages/plugin-flint/src/rules/testShorthands.ts
@@ -42,7 +42,15 @@ export default ruleCreator.createRule(typescriptLanguage, {
 							ts.isIdentifier(caseNode.properties[0].name) &&
 							caseNode.properties[0].name.text === "code"
 						) {
+							let fix;
+							if (ts.isPropertyAssignment(caseNode.properties[0])) {
+								fix = {
+									range: getTSNodeRange(caseNode, sourceFile),
+									text: caseNode.properties[0].initializer.getText(sourceFile),
+								};
+							}
 							context.report({
+								fix,
 								message: "testShorthands",
 								range: getTSNodeRange(caseNode.properties[0], sourceFile),
 							});

--- a/packages/plugin-flint/src/rules/testShorthands.ts
+++ b/packages/plugin-flint/src/rules/testShorthands.ts
@@ -1,3 +1,4 @@
+import type { FileChange } from "@flint.fyi/core";
 import {
 	getTSNodeRange,
 	typescriptLanguage,
@@ -6,7 +7,6 @@ import ts from "typescript";
 
 import { getRuleTesterDescribedCases } from "../utils/getRuleTesterDescribedCases.ts";
 import { ruleCreator } from "./ruleCreator.ts";
-import type { FileChange } from "@flint.fyi/core";
 
 export default ruleCreator.createRule(typescriptLanguage, {
 	about: {

--- a/packages/plugin-flint/src/rules/testShorthands.ts
+++ b/packages/plugin-flint/src/rules/testShorthands.ts
@@ -6,6 +6,7 @@ import ts from "typescript";
 
 import { getRuleTesterDescribedCases } from "../utils/getRuleTesterDescribedCases.ts";
 import { ruleCreator } from "./ruleCreator.ts";
+import type { FileChange } from "@flint.fyi/core";
 
 export default ruleCreator.createRule(typescriptLanguage, {
 	about: {
@@ -42,7 +43,7 @@ export default ruleCreator.createRule(typescriptLanguage, {
 							ts.isIdentifier(caseNode.properties[0].name) &&
 							caseNode.properties[0].name.text === "code"
 						) {
-							let fix;
+							let fix: FileChange | undefined;
 							if (ts.isPropertyAssignment(caseNode.properties[0])) {
 								fix = {
 									range: getTSNodeRange(caseNode, sourceFile),

--- a/packages/site/src/content/docs/rules/flint/testShorthands.mdx
+++ b/packages/site/src/content/docs/rules/flint/testShorthands.mdx
@@ -20,7 +20,7 @@ without any additional configuration (like `options`, `errors`, etc.), it can be
 
 ```ts
 ruleTester.describe(rule, {
-	valid: ["a", { code: "a" }],
+	valid: ["a", { code: "b" }],
 	invalid: [],
 });
 ```
@@ -30,7 +30,7 @@ ruleTester.describe(rule, {
 
 ```ts
 ruleTester.describe(rule, {
-	valid: ["a", "a"],
+	valid: ["a", "b"],
 	invalid: [],
 });
 ```


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to flint! ❤️‍🔥
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #2563
- [x] That issue was marked as [`status: accepting prs`](https://github.com/flint-fyi/flint/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/flint-fyi/flint/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

This change adds a fixer for `flint/testShorthands`, replacing the long-form object test case with the string equivalent.
