### PR TITLE
docs: add Netlify logo to homepage footer

### DIFF
--- a/packages/site/src/components/Footer.astro
+++ b/packages/site/src/components/Footer.astro
@@ -18,22 +18,27 @@ export type Props = StarlightRouteData;
 		>.
 	</div>
 
-	<a href="https://www.netlify.com">
-		<img
-			alt="Deploys by Netlify"
-			class="dark"
-			src="https://www.netlify.com/assets/badges/netlify-badge-color-accent.svg"
-		/>
-		<img
-			alt="Deploys by Netlify"
-			class="light"
-			src="https://www.netlify.com/assets/badges/netlify-badge-color-bg.svg"
-		/>
-	</a>
+	{
+		Astro.url.pathname === "/" && (
+			<a href="https://www.netlify.com">
+				<img
+					alt="Deploys by Netlify"
+					class="dark"
+					src="https://www.netlify.com/assets/badges/netlify-badge-color-accent.svg"
+				/>
+				<img
+					alt="Deploys by Netlify"
+					class="light"
+					src="https://www.netlify.com/assets/badges/netlify-badge-color-bg.svg"
+				/>
+			</a>
+		)
+	}
 </footer>
 
 <style>
 	footer {
+		align-items: center;
 		display: flex;
 		flex-direction: column;
 		text-align: center;
@@ -50,6 +55,7 @@ export type Props = StarlightRouteData;
 	.credits a {
 		color: var(--sl-color-gray-2);
 	}
+
 	:global(html[data-theme="dark"]) .light,
 	:global(html[data-theme="light"]) .dark {
 		display: none;

--- a/packages/site/src/components/Footer.astro
+++ b/packages/site/src/components/Footer.astro
@@ -5,28 +5,53 @@ import Default from "@astrojs/starlight/components/Footer.astro";
 export type Props = StarlightRouteData;
 ---
 
-<Default {...Astro.props}>
-	<slot />
-</Default>
+<footer>
+	<Default {...Astro.props}>
+		<slot />
+	</Default>
 
-<div class="credits">
-	Made with ❤️‍🔥 around the world by
-	<a href="/team">the Flint team</a> and <a
-		href="http://github.com/flint-fyi/flint/contributors"
-		target="_blank">contributors</a
-	>.
-</div>
+	<div class="credits">
+		Made with ❤️‍🔥 around the world by
+		<a href="/team">the Flint team</a> and <a
+			href="http://github.com/flint-fyi/flint/contributors"
+			target="_blank">contributors</a
+		>.
+	</div>
+
+	<a href="https://www.netlify.com">
+		<img
+			alt="Deploys by Netlify"
+			class="dark"
+			src="https://www.netlify.com/assets/badges/netlify-badge-color-accent.svg"
+		/>
+		<img
+			alt="Deploys by Netlify"
+			class="light"
+			src="https://www.netlify.com/assets/badges/netlify-badge-color-bg.svg"
+		/>
+	</a>
+</footer>
 
 <style>
+	footer {
+		display: flex;
+		flex-direction: column;
+		text-align: center;
+	}
+
 	.credits {
 		border-top: 1px solid var(--sl-color-gray-6);
 		color: var(--sl-color-gray-3);
 		margin-top: clamp(2rem, calc(0.25rem + 6vw), 5rem);
-		padding-top: clamp(1rem, calc(0.125rem + 3vw), 2.5rem);
+		padding: clamp(1rem, calc(0.125rem + 3vw), 2.5rem) 0 2rem;
 		text-align: center;
 	}
 
 	.credits a {
 		color: var(--sl-color-gray-2);
+	}
+	:global(html[data-theme="dark"]) .light,
+	:global(html[data-theme="light"]) .dark {
+		display: none;
 	}
 </style>


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #2640 
- [x] That issue was marked as [`status: accepting prs`](https://github.com/flint-fyi/flint/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/flint-fyi/flint/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

<table>
<thead>
<tr>
<th>Light</th>
<th>Dark</th>
</tr>
</thead>
<tbody>
<tr>
<td>
<img width="741" height="215" alt="Screenshot of the footer wth the standard 'built with Netlify' light color image centered below it" src="https://github.com/user-attachments/assets/1fb6ccce-d34b-4c69-af35-371c3bffe6e2" />
</td>
<td>
<img width="741" height="215" alt="Screenshot of the footer wth the standard 'built with Netlify' dark color image centered below it" src="https://github.com/user-attachments/assets/887f16ab-2678-4610-b738-b30c2da9714c" />
</td>
</tr>
</tbody>
</table>

❤️‍🔥