### PR TITLE
feat(vitest): [testCasesWithinDescribes] add rule

### DIFF
--- a/.changeset/plain-parrots-eat.md
+++ b/.changeset/plain-parrots-eat.md
@@ -1,0 +1,6 @@
+---
+"@flint.fyi/comparisons": patch
+"@flint.fyi/vitest": patch
+---
+
+Added testCasesWithinDescribes rule.

--- a/packages/comparisons/src/data.json
+++ b/packages/comparisons/src/data.json
@@ -21260,6 +21260,19 @@
 	{
 		"eslint": [
 			{
+				"name": "require-top-level-describe",
+				"url": "https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/require-top-level-describe.md"
+			}
+		],
+		"flint": {
+			"name": "maxiumumDescribesPerFile",
+			"plugin": "vitest",
+			"status": "skipped"
+		}
+	},
+	{
+		"eslint": [
+			{
 				"name": "max-expects",
 				"url": "https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/max-expects.md"
 			}

--- a/packages/site/src/content/docs/rules/vitest/testCasesWithinDescribes.mdx
+++ b/packages/site/src/content/docs/rules/vitest/testCasesWithinDescribes.mdx
@@ -1,0 +1,68 @@
+---
+description: "Reports importing from `node:test`."
+title: "testCasesWithinDescribes"
+topic: "rules"
+---
+
+import { Tabs, TabItem } from "@astrojs/starlight/components";
+
+import { RuleEquivalents } from "~/components/RuleEquivalents";
+import RuleSummary from "~/components/RuleSummary.astro";
+
+<RuleSummary plugin="vitest" rule="testCasesWithinDescribes" />
+
+Vitest allows declaring standalone hooks and tests: those not in a parent `describe()` block.
+Some repositories prefer to always include those in a `describe()` for consistent test case grouping.
+
+This rule reports on any hook or test declaration not in a parent `describe()` block.
+
+## Examples
+
+<Tabs>
+<TabItem label="❌ Incorrect">
+
+```ts
+beforeEach(() => {
+	// ...
+});
+
+test("...", () => {
+	// ...
+});
+```
+
+</TabItem>
+<TabItem label="✅ Correct">
+
+```ts
+describe("...", () => {
+	beforeEach(() => {
+		// ...
+	});
+
+	test("...", () => {
+		// ...
+	});
+});
+```
+
+</TabItem>
+</Tabs>
+
+## Options
+
+This rule is not configurable.
+
+## When Not To Use It
+
+If you don't want to have all hooks and tests declared in `describe()` blocks, this rule might not be for you.
+For example, smaller and/or tightly-organized repositories often have one test file per component or function under test, and so are organized into groups that way already.
+
+## Further Reading
+
+- [Vitest API: Describe](https://vitest.dev/api/describe)
+- [Vitest API: Test](https://vitest.dev/api/test)
+
+## Equivalents in Other Linters
+
+<RuleEquivalents pluginId="vitest" ruleId="testCasesWithinDescribes" />

--- a/packages/vitest/src/plugin.ts
+++ b/packages/vitest/src/plugin.ts
@@ -10,6 +10,7 @@ import describePaddingLines from "./rules/describePaddingLines.ts";
 import expectGroupPaddingLines from "./rules/expectGroupPaddingLines.ts";
 import nodeTestImports from "./rules/nodeTestImports.ts";
 import testCasePaddingLines from "./rules/testCasePaddingLines.ts";
+import testCasesWithinDescribes from "./rules/testCasesWithinDescribes.ts";
 
 export const vitest = createPlugin({
 	files: {
@@ -26,5 +27,6 @@ export const vitest = createPlugin({
 		expectGroupPaddingLines,
 		nodeTestImports,
 		testCasePaddingLines,
+		testCasesWithinDescribes,
 	],
 });

--- a/packages/vitest/src/rules/testCasesWithinDescribes.test.ts
+++ b/packages/vitest/src/rules/testCasesWithinDescribes.test.ts
@@ -1,0 +1,162 @@
+import { ruleTester } from "../ruleTester.ts";
+import rule from "./testCasesWithinDescribes.ts";
+
+ruleTester.describe(rule, {
+	invalid: [
+		{
+			code: `
+beforeEach("my test", () => {})
+`,
+			snapshot: `
+beforeEach("my test", () => {})
+~~~~~~~~~~
+Prefer wrapping \`beforeEach()\` hooks in a \`describe()\` block.
+`,
+		},
+		{
+			code: `
+test("my test", () => {})
+describe("test suite", () => {});
+`,
+			snapshot: `
+test("my test", () => {})
+~~~~
+Prefer wrapping \`test()\` tests in a \`describe()\` block.
+describe("test suite", () => {});
+`,
+		},
+		{
+			code: `
+test("my test", () => {})
+describe("test suite", () => {
+	it("test", () => {})
+});
+`,
+			snapshot: `
+test("my test", () => {})
+~~~~
+Prefer wrapping \`test()\` tests in a \`describe()\` block.
+describe("test suite", () => {
+	it("test", () => {})
+});
+`,
+		},
+		{
+			code: `
+describe("test suite", () => {});
+afterAll("my test", () => {})
+`,
+			snapshot: `
+describe("test suite", () => {});
+afterAll("my test", () => {})
+~~~~~~~~
+Prefer wrapping \`afterAll()\` hooks in a \`describe()\` block.
+`,
+		},
+		{
+			code: `
+it.skip("test", () => {});
+`,
+			snapshot: `
+it.skip("test", () => {});
+~~~~~~~
+Prefer wrapping \`it()\` tests in a \`describe()\` block.
+`,
+		},
+		{
+			code: `
+it.each([1, 2, 3])("%n", () => {});
+`,
+			snapshot: `
+it.each([1, 2, 3])("%n", () => {});
+~~~~~~~
+Prefer wrapping \`it()\` tests in a \`describe()\` block.
+`,
+		},
+		{
+			code: `
+it.skip.each([1, 2, 3])("%n", () => {});
+`,
+			snapshot: `
+it.skip.each([1, 2, 3])("%n", () => {});
+~~~~~~~~~~~~
+Prefer wrapping \`it()\` tests in a \`describe()\` block.
+`,
+		},
+		{
+			code: `
+it.skip.each\`\`("%n", () => {});
+`,
+			snapshot: `
+it.skip.each\`\`("%n", () => {});
+~~~~~~~~~~~~
+Prefer wrapping \`it()\` tests in a \`describe()\` block.
+`,
+		},
+		{
+			code: `
+it.each\`\`("%n", () => {});
+`,
+			snapshot: `
+it.each\`\`("%n", () => {});
+~~~~~~~
+Prefer wrapping \`it()\` tests in a \`describe()\` block.
+`,
+		},
+	],
+	valid: [
+		"it.each()",
+		`
+import { it } from "vitest";
+it.extend()
+`,
+		`describe("test suite", () => { test("my test") });`,
+		`describe("test suite", () => { it("my test") });`,
+		`
+describe("test suite", () => {
+	beforeEach("a", () => {});
+	describe("b", () => {});
+	test("c", () => {})
+});
+`,
+		`describe("test suite", () => { beforeAll("my beforeAll") });`,
+		`describe("test suite", () => { afterEach("my afterEach") });`,
+		`describe("test suite", () => { afterAll("my afterAll") });`,
+		`
+describe("test suite", () => {
+	it("my test", () => {})
+	describe("another test suite", () => {
+	});
+	test("my other test", () => {})
+});
+`,
+		"foo()",
+		`describe.each([1, true])("trues", value => { it("an it", () => expect(value).toBe(true) ); });`,
+		`
+describe("%s", () => {
+	it("is fine", () => {
+		//
+	});
+});
+
+describe.each("world")("%s", () => {
+	it.each([1, 2, 3])("%n", () => {
+		//
+	});
+});
+`,
+		`
+describe.each("hello")("%s", () => {
+	it("is fine", () => {
+		//
+	});
+});
+
+describe.each("world")("%s", () => {
+	it.each([1, 2, 3])("%n", () => {
+		//
+	});
+});
+`,
+	],
+});

--- a/packages/vitest/src/rules/testCasesWithinDescribes.ts
+++ b/packages/vitest/src/rules/testCasesWithinDescribes.ts
@@ -1,0 +1,82 @@
+import {
+	getTSNodeRange,
+	typescriptLanguage,
+} from "@flint.fyi/typescript-language";
+
+import { ruleCreator } from "../ruleCreator.ts";
+import { parseVitestFunctionCall } from "../utils/parseVitestFunctionCall.ts";
+
+export default ruleCreator.createRule(typescriptLanguage, {
+	about: {
+		description: "Reports importing from `node:test`.",
+		id: "testCasesWithinDescribes",
+		presets: ["stylisticStrict"],
+	},
+	messages: {
+		standalone: {
+			primary:
+				"Prefer wrapping `{{ name }}()` {{ type }}s in a `describe()` block.",
+			secondary: [
+				"Vitest allows declaring standalone {{ type }}: those not in a parent `describe()` block.",
+				"This repository prefers adding a parent to consistently group test cases.",
+			],
+			suggestions: ["Add a describe() parent to this `{{ name }}`."],
+		},
+	},
+	setup(context) {
+		let insideDescribeStack = 0;
+
+		return {
+			visitors: {
+				CallExpression: (node, { sourceFile }) => {
+					const functionCall = parseVitestFunctionCall(node);
+
+					switch (functionCall?.name) {
+						case "afterAll":
+						case "afterEach":
+						case "beforeAll":
+						case "beforeEach":
+							if (!insideDescribeStack) {
+								context.report({
+									data: { name: functionCall.name, type: "hook" },
+									message: "standalone",
+									range: getTSNodeRange(functionCall.targetNode, sourceFile),
+								});
+							}
+							break;
+
+						case "describe":
+						case "xdescribe":
+							insideDescribeStack += 1;
+							break;
+
+						case "fit":
+						case "it":
+						case "test":
+						case "xit":
+						case "xtest":
+							if (!insideDescribeStack) {
+								context.report({
+									data: { name: functionCall.name, type: "test" },
+									message: "standalone",
+									range: getTSNodeRange(functionCall.targetNode, sourceFile),
+								});
+							}
+					}
+				},
+				"CallExpression:exit": (node) => {
+					// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+					switch (parseVitestFunctionCall(node!)?.name) {
+						case "describe":
+						case "xdescribe":
+							insideDescribeStack -= 1;
+							break;
+					}
+				},
+				"SourceFile:exit": () => {
+					insideDescribeStack = 0;
+				},
+			},
+		};
+	},
+});

--- a/packages/vitest/src/utils/parseVitestFunctionCall.ts
+++ b/packages/vitest/src/utils/parseVitestFunctionCall.ts
@@ -1,0 +1,96 @@
+import type { AST } from "@flint.fyi/typescript-language";
+import ts from "typescript";
+
+const knownVitestFunctionNames = [
+	"afterAll",
+	"afterEach",
+	"beforeAll",
+	"beforeEach",
+	"describe",
+	"fit",
+	"it",
+	"test",
+	"xdescribe",
+	"xit",
+	"xit",
+	"xtest",
+] as const;
+
+const knownBlockNamesSet = new Set<string>(knownVitestFunctionNames);
+
+const knownVitestFunctionModifiersSet = new Set([
+	"concurrent",
+	"fails",
+	"only",
+	"runIf",
+	"sequential",
+	"skip",
+	"skipIf",
+	"todo",
+]);
+
+interface VitestCallee {
+	name: string;
+	segments: string[];
+	targetNode: AST.AnyNode;
+}
+
+export function parseVitestFunctionCall(node: AST.CallExpression) {
+	const parsedCallee = parseVitestCallee(node.expression);
+
+	if (!parsedCallee || !knownBlockNamesSet.has(parsedCallee.name)) {
+		return undefined;
+	}
+
+	switch (node.expression.kind) {
+		case ts.SyntaxKind.CallExpression:
+		case ts.SyntaxKind.TaggedTemplateExpression:
+			return parsedCallee.segments
+				.slice(0, -1)
+				.every((segment) => knownVitestFunctionModifiersSet.has(segment))
+				? parsedCallee
+				: undefined;
+
+		case ts.SyntaxKind.Identifier:
+			return parsedCallee;
+
+		case ts.SyntaxKind.PropertyAccessExpression:
+			return parsedCallee.segments.every((segment) =>
+				knownVitestFunctionModifiersSet.has(segment),
+			)
+				? parsedCallee
+				: undefined;
+	}
+}
+
+function parseVitestCallee(
+	node: AST.AnyNode,
+	targetNode?: AST.AnyNode,
+): undefined | VitestCallee {
+	switch (node.kind) {
+		case ts.SyntaxKind.CallExpression:
+			return parseVitestCallee(node.expression, targetNode);
+
+		case ts.SyntaxKind.Identifier:
+			return {
+				name: node.text,
+				segments: [],
+				targetNode: targetNode ?? node,
+			};
+
+		case ts.SyntaxKind.PropertyAccessExpression: {
+			const parsedExpression = parseVitestCallee(node.expression, node);
+
+			return (
+				parsedExpression && {
+					...parsedExpression,
+					segments: [...parsedExpression.segments, node.name.text],
+					targetNode: node,
+				}
+			);
+		}
+
+		case ts.SyntaxKind.TaggedTemplateExpression:
+			return parseVitestCallee(node.tag, targetNode);
+	}
+}


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #2691 
- [x] That issue was marked as [`status: accepting prs`](https://github.com/flint-fyi/flint/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/flint-fyi/flint/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

The ESLint rule equivalent has a `maxNumberOfTopLevelDescribes` option not implemented here. That strikes me as a separate rule. I moved it to a skipped `vitest/maxiumumDescribesPerFile` rule.

❤️‍🔥