### PR TITLE
chore: clean up urls

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ It also brings in several improvements over traditional linter paradigms:
 
 For deep dives into Flint, see:
 
-- **[Introducing Flint](https://www.flint.fyi/blog/introducing-flint)**: the core hypotheses Flint is testing out, with why we hope they succeed.
-- **[What Flint Does Differently](https://www.flint.fyi/blog/what-flint-does-differently)**: a full list of the core, developer, and end-user design differences in Flint compared to other linters.
+- **[Introducing Flint](https://flint.fyi/blog/introducing-flint)**: the core hypotheses Flint is testing out, with why we hope they succeed.
+- **[What Flint Does Differently](https://flint.fyi/blog/what-flint-does-differently)**: a full list of the core, developer, and end-user design differences in Flint compared to other linters.
 
 ## Usage
 

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -2,7 +2,7 @@
 	"name": "@flint.fyi/browser",
 	"version": "0.2.2",
 	"description": "[Experimental] A Flint plugin for browser code.",
-	"homepage": "https://www.flint.fyi/rules/browser",
+	"homepage": "https://flint.fyi/rules/browser",
 	"repository": {
 		"type": "git",
 		"url": "git+https://github.com/flint-fyi/flint.git",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -2,7 +2,7 @@
 	"name": "@flint.fyi/cli",
 	"version": "0.19.0",
 	"description": "[Experimental] Command-line interface for Flint.",
-	"homepage": "https://www.flint.fyi/cli",
+	"homepage": "https://flint.fyi/cli",
 	"repository": {
 		"type": "git",
 		"url": "git+https://github.com/flint-fyi/flint.git",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -2,7 +2,7 @@
 	"name": "@flint.fyi/cli",
 	"version": "0.19.0",
 	"description": "[Experimental] Command-line interface for Flint.",
-	"homepage": "https://flint.fyi",
+	"homepage": "https://www.flint.fyi/cli",
 	"repository": {
 		"type": "git",
 		"url": "git+https://github.com/flint-fyi/flint.git",

--- a/packages/json/package.json
+++ b/packages/json/package.json
@@ -2,7 +2,7 @@
 	"name": "@flint.fyi/json",
 	"version": "0.16.2",
 	"description": "[Experimental] JSON plugin for Flint.",
-	"homepage": "https://www.flint.fyi/rules/json",
+	"homepage": "https://flint.fyi/rules/json",
 	"repository": {
 		"type": "git",
 		"url": "git+https://github.com/flint-fyi/flint.git",

--- a/packages/jsx/package.json
+++ b/packages/jsx/package.json
@@ -2,7 +2,7 @@
 	"name": "@flint.fyi/jsx",
 	"version": "0.3.1",
 	"description": "[Experimental] A Flint plugin for JSX code.",
-	"homepage": "https://www.flint.fyi/rules/jsx",
+	"homepage": "https://flint.fyi/rules/jsx",
 	"repository": {
 		"type": "git",
 		"url": "git+https://github.com/flint-fyi/flint.git",

--- a/packages/md/package.json
+++ b/packages/md/package.json
@@ -2,7 +2,7 @@
 	"name": "@flint.fyi/md",
 	"version": "0.15.2",
 	"description": "[Experimental] Markdown plugin for Flint.",
-	"homepage": "https://www.flint.fyi/rules/md",
+	"homepage": "https://flint.fyi/rules/md",
 	"repository": {
 		"type": "git",
 		"url": "git+https://github.com/flint-fyi/flint.git",

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -2,7 +2,7 @@
 	"name": "@flint.fyi/next",
 	"version": "0.2.2",
 	"description": "[Experimental] A Flint plugin for Next.js code.",
-	"homepage": "https://www.flint.fyi/rules/next",
+	"homepage": "https://flint.fyi/rules/next",
 	"repository": {
 		"type": "git",
 		"url": "git+https://github.com/flint-fyi/flint.git",

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -2,7 +2,7 @@
 	"name": "@flint.fyi/node",
 	"version": "0.2.2",
 	"description": "[Experimental] A Flint plugin for Node.js code.",
-	"homepage": "https://www.flint.fyi/rules/node",
+	"homepage": "https://flint.fyi/rules/node",
 	"repository": {
 		"type": "git",
 		"url": "git+https://github.com/flint-fyi/flint.git",

--- a/packages/nuxt/package.json
+++ b/packages/nuxt/package.json
@@ -2,7 +2,7 @@
 	"name": "@flint.fyi/nuxt",
 	"version": "0.1.5",
 	"description": "[Experimental] A Flint plugin for Nuxt code.",
-	"homepage": "https://www.flint.fyi/rules/nuxt",
+	"homepage": "https://flint.fyi/rules/nuxt",
 	"repository": {
 		"type": "git",
 		"url": "git+https://github.com/flint-fyi/flint.git",

--- a/packages/package-json/package.json
+++ b/packages/package-json/package.json
@@ -2,7 +2,7 @@
 	"name": "@flint.fyi/package-json",
 	"version": "0.17.0",
 	"description": "[Experimental] package.json plugin for Flint.",
-	"homepage": "https://www.flint.fyi/rules/package-json",
+	"homepage": "https://flint.fyi/rules/package-json",
 	"repository": {
 		"type": "git",
 		"url": "git+https://github.com/flint-fyi/flint.git",

--- a/packages/performance/package.json
+++ b/packages/performance/package.json
@@ -2,7 +2,7 @@
 	"name": "@flint.fyi/performance",
 	"version": "0.2.2",
 	"description": "[Experimental] A Flint plugin for performant code.",
-	"homepage": "https://www.flint.fyi/rules/performance",
+	"homepage": "https://flint.fyi/rules/performance",
 	"repository": {
 		"type": "git",
 		"url": "git+https://github.com/flint-fyi/flint.git",

--- a/packages/plugin-flint/package.json
+++ b/packages/plugin-flint/package.json
@@ -2,7 +2,7 @@
 	"name": "@flint.fyi/plugin-flint",
 	"version": "0.5.0",
 	"description": "[Experimental] A Flint plugin for linting Flint plugins.",
-	"homepage": "https://www.flint.fyi/rules/flint",
+	"homepage": "https://flint.fyi/rules/flint",
 	"repository": {
 		"type": "git",
 		"url": "git+https://github.com/flint-fyi/flint.git",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -2,7 +2,7 @@
 	"name": "@flint.fyi/react",
 	"version": "0.1.5",
 	"description": "[Experimental] A Flint plugin for React code.",
-	"homepage": "https://www.flint.fyi/rules/react",
+	"homepage": "https://flint.fyi/rules/react",
 	"repository": {
 		"type": "git",
 		"url": "git+https://github.com/flint-fyi/flint.git",

--- a/packages/site/src/content/docs/cli.mdx
+++ b/packages/site/src/content/docs/cli.mdx
@@ -28,7 +28,7 @@ You can open this file in an editor to see which files are cached, as well as de
 :::tip
 This value can also be set in your Flint configuration.
 Values applied on the command line will override any value defined in the config file.
-See [Configuration > cacheLocation](https://www.flint.fyi/configuration#cacheLocation) for more.
+See [Configuration > cacheLocation](https://flint.fyi/configuration#cacheLocation) for more.
 :::
 
 ## `--fix`

--- a/packages/site/src/content/docs/configuration.mdx
+++ b/packages/site/src/content/docs/configuration.mdx
@@ -37,7 +37,7 @@ You can open this file in an editor to see which files are cached, as well as de
 
 :::tip
 You can also override the value in this config using the `--cache-location` CLI flag.
-See [CLI > --cache-location](https://www.flint.fyi/cli#--cache-location) for more.
+See [CLI > --cache-location](https://flint.fyi/cli#--cache-location) for more.
 :::
 
 ### `ignore`

--- a/packages/solid/package.json
+++ b/packages/solid/package.json
@@ -2,7 +2,7 @@
 	"name": "@flint.fyi/solid",
 	"version": "0.1.5",
 	"description": "[Experimental] A Flint plugin for SolidJS code.",
-	"homepage": "https://www.flint.fyi/rules/solid",
+	"homepage": "https://flint.fyi/rules/solid",
 	"repository": {
 		"type": "git",
 		"url": "git+https://github.com/flint-fyi/flint.git",

--- a/packages/spelling/package.json
+++ b/packages/spelling/package.json
@@ -2,7 +2,7 @@
 	"name": "@flint.fyi/spelling",
 	"version": "0.2.2",
 	"description": "[Experimental] A spell-checker plugin for Flint powered by CSpell.",
-	"homepage": "https://www.flint.fyi/rules/spelling",
+	"homepage": "https://flint.fyi/rules/spelling",
 	"repository": {
 		"type": "git",
 		"url": "git+https://github.com/flint-fyi/flint.git",

--- a/packages/ts/package.json
+++ b/packages/ts/package.json
@@ -2,7 +2,7 @@
 	"name": "@flint.fyi/ts",
 	"version": "0.18.0",
 	"description": "[Experimental] TypeScript language plugin for Flint.",
-	"homepage": "https://www.flint.fyi/rules/ts",
+	"homepage": "https://flint.fyi/rules/ts",
 	"repository": {
 		"type": "git",
 		"url": "git+https://github.com/flint-fyi/flint.git",

--- a/packages/vitest/package.json
+++ b/packages/vitest/package.json
@@ -2,7 +2,7 @@
 	"name": "@flint.fyi/vitest",
 	"version": "0.1.0",
 	"description": "[Experimental] A Flint plugin for Vitest.",
-	"homepage": "https://www.flint.fyi/rules/vitest",
+	"homepage": "https://flint.fyi/rules/vitest",
 	"repository": {
 		"type": "git",
 		"url": "git+https://github.com/flint-fyi/flint.git",

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -2,7 +2,7 @@
 	"name": "@flint.fyi/vue",
 	"version": "0.1.0",
 	"description": "[Experimental] Vue.js language plugin for Flint.",
-	"homepage": "https://www.flint.fyi/rules/vue",
+	"homepage": "https://flint.fyi/rules/vue",
 	"repository": {
 		"type": "git",
 		"url": "git+https://github.com/flint-fyi/flint.git",

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -2,7 +2,7 @@
 	"name": "@flint.fyi/vue",
 	"version": "0.1.0",
 	"description": "[Experimental] Vue.js language plugin for Flint.",
-	"homepage": "https://flint.fyi",
+	"homepage": "https://www.flint.fyi/rules/vue",
 	"repository": {
 		"type": "git",
 		"url": "git+https://github.com/flint-fyi/flint.git",

--- a/packages/yaml/package.json
+++ b/packages/yaml/package.json
@@ -2,7 +2,7 @@
 	"name": "@flint.fyi/yaml",
 	"version": "0.15.2",
 	"description": "[Experimental] YAML language plugin for Flint.",
-	"homepage": "https://www.flint.fyi/rules/yaml",
+	"homepage": "https://flint.fyi/rules/yaml",
 	"repository": {
 		"type": "git",
 		"url": "git+https://github.com/flint-fyi/flint.git",


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to flint! ❤️‍🔥
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [`status: accepting prs`](https://github.com/flint-fyi/flint/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [ ] Steps in [CONTRIBUTING.md](https://github.com/flint-fyi/flint/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->
Fixed the Vue & CLI homepages, at which point I realized ~2/3s of the URLs were missing the www. In the name of consistency I added it to the rest as well.