### PR TITLE
refactor: makeDisposable cleanup + e2e package bin invocation

### DIFF
--- a/packages/core/src/languages/makeDisposable.ts
+++ b/packages/core/src/languages/makeDisposable.ts
@@ -1,6 +1,6 @@
 export function makeDisposable<T extends object>(obj: T): Disposable & T {
 	return {
-		[Symbol.dispose]: () => () => {
+		[Symbol.dispose]: () => {
 			// Intentionally empty to satisfy the Disposable interface.
 		},
 		...obj,

--- a/packages/e2e/tests/utils.ts
+++ b/packages/e2e/tests/utils.ts
@@ -1,5 +1,6 @@
 import { normalizePath } from "@flint.fyi/utils";
 import { execa } from "execa";
+import path from "node:path";
 
 declare global {
 	// TODO[typescript>=6.0]: Remove this declaration.
@@ -33,6 +34,11 @@ export function normalizeOutput(stdout: string, cwd: string): string {
 		.replace(/Finished in \S+/g, "Finished in <time>");
 }
 
+const flintBinPath = path.resolve(
+	import.meta.dirname,
+	"../../flint/bin/index.js",
+);
+
 /**
  * Runs the flint CLI with color output enabled.
  */
@@ -41,5 +47,5 @@ export function runFlint(cwd: string, args: string[] = []) {
 		cwd,
 		env: { FORCE_COLOR: "1" },
 		reject: false,
-	})`npx flint ${args}`;
+	})`node ${flintBinPath} ${args}`;
 }

--- a/packages/e2e/tests/utils.ts
+++ b/packages/e2e/tests/utils.ts
@@ -1,6 +1,5 @@
 import { normalizePath } from "@flint.fyi/utils";
 import { execa } from "execa";
-import path from "node:path";
 
 declare global {
 	// TODO[typescript>=6.0]: Remove this declaration.
@@ -34,11 +33,6 @@ export function normalizeOutput(stdout: string, cwd: string): string {
 		.replace(/Finished in \S+/g, "Finished in <time>");
 }
 
-const flintBinPath = path.resolve(
-	import.meta.dirname,
-	"../../flint/bin/index.js",
-);
-
 /**
  * Runs the flint CLI with color output enabled.
  */
@@ -47,5 +41,5 @@ export function runFlint(cwd: string, args: string[] = []) {
 		cwd,
 		env: { FORCE_COLOR: "1" },
 		reject: false,
-	})`node ${flintBinPath} ${args}`;
+	})`flint ${args}`;
 }


### PR DESCRIPTION
## Stack

Small refactors split out from #2537 per review:

1. **#2765 (this PR)** - small refactors (no behavior change, independent)
2. #2766 - `LintSession`, watch mode rewrite, mandatory `LanguageReport.source`
3. #2537 - `@flint.fyi/lsp` package, stacks on #2766

This PR is independent of #2766 and #2537 - can merge in any order.

## Overview

- Drop the redundant outer arrow in `makeDisposable` `[Symbol.dispose]: () => () => {}`. The wrapper returned a function (which the runtime discarded), so disposal was already a no-op. This is purely a code-smell cleanup, not a behavior change.
- Run e2e `flint` invocations through the package-manager-provided `flint` bin instead of reaching into `packages/flint/bin/index.js`, so the tests still cover the package `bin` entry without relying on `npx`.

## PR Checklist

- [x] Addresses an existing open issue: fixes #2462 (split from #2537)
- [ ] That issue was marked as [`status: accepting prs`](https://github.com/flint-fyi/flint/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/flint-fyi/flint/blob/main/.github/CONTRIBUTING.md) were taken
