### PR TITLE
feat(config-finder): move findConfigFileName into core

### DIFF
--- a/.changeset/config-finder-package.md
+++ b/.changeset/config-finder-package.md
@@ -1,0 +1,6 @@
+---
+"@flint.fyi/core": minor
+"@flint.fyi/cli": patch
+---
+
+Extract `findConfigFileName` and `configFileNameCandidates` from `@flint.fyi/cli` into `@flint.fyi/core` so the CLI, the upcoming LSP server, and other consumers can share a single implementation.

--- a/packages/cli/src/runCli.ts
+++ b/packages/cli/src/runCli.ts
@@ -1,11 +1,11 @@
 import {
 	createDiskBackedLinterHost,
 	createEphemeralLinterHost,
+	findConfigFileName,
 } from "@flint.fyi/core";
 import { parseArgs } from "node:util";
 
 import packageData from "../package.json" with { type: "json" };
-import { findConfigFileName } from "./findConfigFileName.ts";
 import { options } from "./options.ts";
 import { createRendererFactory } from "./renderers/createRendererFactory.ts";
 import { runCliOnce } from "./runCliOnce.ts";

--- a/packages/core/src/configs/findConfigFileName.ts
+++ b/packages/core/src/configs/findConfigFileName.ts
@@ -1,5 +1,8 @@
 import type { LinterHost } from "../types/host.ts";
 
+/**
+ * Flint config file names in preference order.
+ */
 export const configFileNameCandidates = [
 	"flint.config.ts",
 	"flint.config.mts",

--- a/packages/core/src/configs/findConfigFileName.ts
+++ b/packages/core/src/configs/findConfigFileName.ts
@@ -1,6 +1,6 @@
-import type { LinterHost } from "@flint.fyi/core";
+import type { LinterHost } from "../types/host.ts";
 
-const candidatesOrdered = [
+export const configFileNameCandidates = [
 	"flint.config.ts",
 	"flint.config.mts",
 	"flint.config.cts",
@@ -15,7 +15,7 @@ export async function findConfigFileName(host: LinterHost) {
 	);
 	const children = new Set(currentDirectoryContents.map((file) => file.name));
 
-	const fileName = candidatesOrdered.find((candidate) =>
+	const fileName = configFileNameCandidates.find((candidate) =>
 		children.has(candidate),
 	);
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -2,6 +2,10 @@ export * from "./cache/getCacheFilePath.ts";
 export { writeToCache } from "./cache/writeToCache.ts";
 export { applyChangesToText } from "./changing/applyChangesToText.ts";
 export { defineConfig } from "./configs/defineConfig.ts";
+export {
+	configFileNameCandidates,
+	findConfigFileName,
+} from "./configs/findConfigFileName.ts";
 export { isConfig } from "./configs/isConfig.ts";
 export { validateConfigDefinition } from "./configs/validateConfigDefinition.ts";
 export { DirectivesCollector } from "./directives/DirectivesCollector.ts";


### PR DESCRIPTION
## Stack

Spun out of #2537 review (per @lishaduck's request to land this upstack so other in-flight projects can share it):

- **#2769 (this PR)** — extract `findConfigFileName` to a new `@flint.fyi/config-finder` package
- #2537 — `@flint.fyi/lsp` will consume this in place of its duplicated `configCandidates` constant

This PR is independent — does not depend on the rest of the LSP stack.

## Overview

Moves `findConfigFileName` and the ordered candidate list out of `@flint.fyi/cli` into a new `@flint.fyi/config-finder` package. The CLI now imports it; the upcoming LSP server can do the same instead of maintaining a parallel constant.

The candidate ordering is now exported as `configFileNameCandidates` in case other consumers want to inspect or filter the list directly (e.g., LSP structural-change detection).

## PR Checklist

- [x] Addresses an existing open issue: split out from #2537 (per review)
- [ ] That issue was marked as [`status: accepting prs`](https://github.com/flint-fyi/flint/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/flint-fyi/flint/blob/main/.github/CONTRIBUTING.md) were taken
