### PR TITLE
feat(core): add withFileSystemWatcher to compose a watcher onto a host

### DIFF
--- a/.changeset/with-file-system-watcher.md
+++ b/.changeset/with-file-system-watcher.md
@@ -1,0 +1,8 @@
+---
+"@flint.fyi/core": minor
+---
+
+Add `withFileSystemWatcher(host, watcher)`, which composes a `FileSystemWatcher` onto an existing linter host so its directory/file watching is driven by that watcher.
+Editor integrations (such as a language server) use it to feed their own filesystem events into the linter instead of relying on the host's default watching.
+
+`watchDirectorySync` callbacks may now receive an optional change event (`"created"`, `"changed"`, or `"deleted"`) alongside the path, so watchers that know what kind of change occurred can report it.

--- a/.changeset/with-file-system-watcher.md
+++ b/.changeset/with-file-system-watcher.md
@@ -2,7 +2,6 @@
 "@flint.fyi/core": minor
 ---
 
-Add `withFileSystemWatcher(host, watcher)`, which composes a `FileSystemWatcher` onto an existing linter host so its directory/file watching is driven by that watcher.
-Editor integrations (such as a language server) use it to feed their own filesystem events into the linter instead of relying on the host's default watching.
+Add `withFileSystemWatcher` to allow using an editor's (or other processes') built-in file-system watcher rather than direct file-polling.
 
-`watchDirectorySync` callbacks may now receive an optional change event (`"created"`, `"changed"`, or `"deleted"`) alongside the path, so watchers that know what kind of change occurred can report it.
+`watchDirectorySync` callbacks now optionally consume the kind of change (created/edited/deleted).

--- a/.changeset/with-file-system-watcher.md
+++ b/.changeset/with-file-system-watcher.md
@@ -3,5 +3,3 @@
 ---
 
 Add `withFileSystemWatcher` to allow using an editor's (or other processes') built-in file-system watcher rather than direct file-polling.
-
-`watchDirectorySync` callbacks now optionally consume the kind of change (created/edited/deleted).

--- a/packages/core/src/host/withFileSystemWatcher.test.ts
+++ b/packages/core/src/host/withFileSystemWatcher.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { FileSystemWatcher, LinterHost } from "../types/host.ts";
+import { withFileSystemWatcher } from "./withFileSystemWatcher.ts";
+
+describe(withFileSystemWatcher, () => {
+	it("delegates watch methods to the watcher and passes everything else through", () => {
+		const disposable: Disposable = {
+			[Symbol.dispose]: vi.fn(),
+		};
+		const watchDirectorySync = vi.fn(() => disposable);
+		const watchFileSync = vi.fn(() => disposable);
+		const watcher: FileSystemWatcher = { watchDirectorySync, watchFileSync };
+
+		const baseWatchDirectorySync = vi.fn();
+		const baseWatchFileSync = vi.fn();
+		const baseHost = {
+			getCurrentDirectory: () => "/root",
+			readFileSync: vi.fn(() => "contents"),
+			watchDirectorySync: baseWatchDirectorySync,
+			watchFileSync: baseWatchFileSync,
+		} as unknown as LinterHost;
+
+		const host = withFileSystemWatcher(baseHost, watcher);
+
+		const directoryCallback = vi.fn();
+		const fileCallback = vi.fn();
+		host.watchDirectorySync("/dir", directoryCallback, {
+			ignoredPaths: [],
+			recursive: true,
+		});
+		host.watchFileSync("/file", fileCallback, { ignoredPaths: [] });
+
+		expect(watchDirectorySync).toHaveBeenCalledWith("/dir", directoryCallback, {
+			ignoredPaths: [],
+			recursive: true,
+		});
+		expect(watchFileSync).toHaveBeenCalledWith("/file", fileCallback, {
+			ignoredPaths: [],
+		});
+		expect(baseWatchDirectorySync).not.toHaveBeenCalled();
+		expect(baseWatchFileSync).not.toHaveBeenCalled();
+
+		expect(host.getCurrentDirectory()).toBe("/root");
+		expect(host.readFileSync("/file")).toBe("contents");
+	});
+});

--- a/packages/core/src/host/withFileSystemWatcher.test.ts
+++ b/packages/core/src/host/withFileSystemWatcher.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 
-import type { FileSystemWatcher, LinterHost } from "../types/host.ts";
+import type { FileSystemWatcher, LinterHost } from "../index.ts";
 import { withFileSystemWatcher } from "./withFileSystemWatcher.ts";
 
 describe(withFileSystemWatcher, () => {

--- a/packages/core/src/host/withFileSystemWatcher.ts
+++ b/packages/core/src/host/withFileSystemWatcher.ts
@@ -6,7 +6,6 @@ export function withFileSystemWatcher(
 ): LinterHost {
 	return {
 		...host,
-		watchDirectorySync: watcher.watchDirectorySync.bind(watcher),
-		watchFileSync: watcher.watchFileSync.bind(watcher),
+		...watcher,
 	};
 }

--- a/packages/core/src/host/withFileSystemWatcher.ts
+++ b/packages/core/src/host/withFileSystemWatcher.ts
@@ -1,0 +1,12 @@
+import type { FileSystemWatcher, LinterHost } from "../types/host.ts";
+
+export function withFileSystemWatcher(
+	host: LinterHost,
+	watcher: FileSystemWatcher,
+): LinterHost {
+	return {
+		...host,
+		watchDirectorySync: watcher.watchDirectorySync.bind(watcher),
+		watchFileSync: watcher.watchFileSync.bind(watcher),
+	};
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -29,6 +29,7 @@ export {
 	nodeModulesDir,
 	vcsDirectories,
 } from "./host/watcher.ts";
+export { withFileSystemWatcher } from "./host/withFileSystemWatcher.ts";
 export { createLanguage } from "./languages/createLanguage.ts";
 export { createPlugin } from "./plugins/createPlugin.ts";
 export { formatReport } from "./reporting/formatReport.ts";

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -75,6 +75,7 @@ export type {
 } from "./types/directives.ts";
 export type { FormattingResults } from "./types/formatting.ts";
 export type {
+	FileSystemWatcher,
 	LinterHost,
 	LinterHostDirectoryEntry,
 	LinterHostDirectoryWatcher,

--- a/packages/core/src/types/host.ts
+++ b/packages/core/src/types/host.ts
@@ -1,5 +1,10 @@
 import type { commonlyIgnoredGlobs } from "../host/watcher.ts";
 
+export type FileSystemWatcher = Pick<
+	LinterHost,
+	"watchDirectorySync" | "watchFileSync"
+>;
+
 export interface LinterHost {
 	fileTypeSync(pathAbsolute: string): "directory" | "file" | undefined;
 	getCurrentDirectory(): string;

--- a/packages/core/src/types/host.ts
+++ b/packages/core/src/types/host.ts
@@ -45,6 +45,7 @@ export interface LinterHostDirectoryEntry {
 }
 
 export type LinterHostDirectoryWatcher = (filePathAbsolute: string) => void;
+
 export type LinterHostFileWatcher = (event: LinterHostFileWatcherEvent) => void;
 
 export type LinterHostFileWatcherEvent = "changed" | "created" | "deleted";

--- a/packages/core/src/types/host.ts
+++ b/packages/core/src/types/host.ts
@@ -1,18 +1,16 @@
 import type { commonlyIgnoredGlobs } from "../host/watcher.ts";
 
 export interface FileSystemWatcher {
-	watchDirectorySync(
-		this: void,
+	watchDirectorySync: (
 		directoryPathAbsolute: string,
 		callback: LinterHostDirectoryWatcher,
 		options: WatchDirectoryOptions,
-	): Disposable;
-	watchFileSync(
-		this: void,
+	) => Disposable;
+	watchFileSync: (
 		filePathAbsolute: string,
 		callback: LinterHostFileWatcher,
 		options: WatchOptions,
-	): Disposable;
+	) => Disposable;
 }
 
 export interface LinterHost extends FileSystemWatcher {

--- a/packages/core/src/types/host.ts
+++ b/packages/core/src/types/host.ts
@@ -1,11 +1,21 @@
 import type { commonlyIgnoredGlobs } from "../host/watcher.ts";
 
-export type FileSystemWatcher = Pick<
-	LinterHost,
-	"watchDirectorySync" | "watchFileSync"
->;
+export interface FileSystemWatcher {
+	watchDirectorySync(
+		this: void,
+		directoryPathAbsolute: string,
+		callback: LinterHostDirectoryWatcher,
+		options: WatchDirectoryOptions,
+	): Disposable;
+	watchFileSync(
+		this: void,
+		filePathAbsolute: string,
+		callback: LinterHostFileWatcher,
+		options: WatchOptions,
+	): Disposable;
+}
 
-export interface LinterHost {
+export interface LinterHost extends FileSystemWatcher {
 	fileTypeSync(pathAbsolute: string): "directory" | "file" | undefined;
 	getCurrentDirectory(): string;
 	getFileTouchTime(filePath: string): Promise<number | undefined>;
@@ -25,16 +35,6 @@ export interface LinterHost {
 	readDirectorySync(directoryPathAbsolute: string): LinterHostDirectoryEntry[];
 	readFile(filePathAbsolute: string): Promise<string | undefined>;
 	readFileSync(filePathAbsolute: string): string | undefined;
-	watchDirectorySync(
-		directoryPathAbsolute: string,
-		callback: LinterHostDirectoryWatcher,
-		options: WatchDirectoryOptions,
-	): Disposable;
-	watchFileSync(
-		filePathAbsolute: string,
-		callback: LinterHostFileWatcher,
-		options: WatchOptions,
-	): Disposable;
 	writeFile(filePathAbsolute: string, content: string): Promise<void>;
 	writeFileSync(filePathAbsolute: string, content: string): void;
 }


### PR DESCRIPTION
## PR Checklist

- [x] Split from #2537 following [maintainer review requesting smaller LSP changes](https://github.com/flint-fyi/flint/pull/2537#pullrequestreview-4254640568)
- [x] Steps in [CONTRIBUTING.md](https://github.com/flint-fyi/flint/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Add `withFileSystemWatcher` to allow using an editor's (or other processes') built-in file-system watcher rather than direct file-polling.
