### PR TITLE
docs: contributing typo fix

### DIFF
--- a/packages/site/src/content/docs/project/contributing.mdx
+++ b/packages/site/src/content/docs/project/contributing.mdx
@@ -26,7 +26,7 @@ There are two steps involved:
 
 With the exception of very small typos, all changes to this repository generally need to correspond to an [unassigned open issue marked as `status: accepting prs` and not `ai assigned` on the issue tracker](https://github.com/flint-fyi/flint/issues?q=is%3Aissue%20is%3Aopen%20label%3A%22status%3A%20accepting%20prs%22%20-label%3A%22ai%20assigned%22%20no%3Aassignee).
 If this is your first time contributing, consider searching for [unassigned issues that also have the `good first issue` label](https://github.com/flint-fyi/flint/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22+label%3A%22status%3A+accepting+prs%22+no%3Aassignee+).
-If the issue you'd like to fix isn't found on the issue, see [Reporting Issues](#reporting-issues) for filing your own (please do!).
+If the issue you'd like to fix isn't found on the [issue tracker](https://github.com/flint-fyi/flint/issues), see [Reporting Issues](#reporting-issues) for filing your own (please do!).
 
 #### Issue Claiming
 
@@ -47,7 +47,7 @@ Don't worry if you get this wrong: you can always change the PR title after send
 Check [previously merged PRs](https://github.com/flint-fyi/flint/pulls?q=is%3Apr+is%3Amerged+-label%3Adependencies+) for reference.
 
 Finally, if your PR includes any user-facing changes, run `pnpm changeset` to [add a proper changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
-This should _not_ use traditional conventional commit syntax, and should instead reflect what you would want the user to see in the changelog.  
+This should _not_ use traditional conventional commit syntax, and should instead reflect what you would want the user to see in the changelog.
 For example, everything _after_ the initial colon in a commit title would be sufficient.
 This will allow our release automation to version packages appropriately when the next release happens.
 


### PR DESCRIPTION
## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [`status: accepting prs`](https://github.com/flint-fyi/flint/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [ ] Steps in [CONTRIBUTING.md](https://github.com/flint-fyi/flint/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Just merged a fix for this typo in https://github.com/JoshuaKGoldberg/emoji-blast/pull/1548 so wanted to "leave the campsite cleaner than I found it"  🙂

🩵
