### PR TITLE
fix(comparisons): correct jsx-eslint rule doc links

### DIFF
--- a/packages/comparisons/src/data.json
+++ b/packages/comparisons/src/data.json
@@ -1396,7 +1396,7 @@
 		"eslint": [
 			{
 				"name": "jsx-a11y/no-access-key",
-				"url": "https://github.com/jsx-eslint/eslint-jsx-a11y/blob/HEAD/docs/rules/no-access-key.md"
+				"url": "https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/no-access-key.md"
 			}
 		],
 		"flint": {
@@ -1416,7 +1416,7 @@
 		"eslint": [
 			{
 				"name": "react/no-adjacent-inline-elements",
-				"url": "https://github.com/jsx-eslint/eslint-react/blob/master/docs/rules/no-adjacent-inline-elements.md"
+				"url": "https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-adjacent-inline-elements.md"
 			}
 		],
 		"flint": {
@@ -1430,7 +1430,7 @@
 		"eslint": [
 			{
 				"name": "jsx-a11y/alt-text",
-				"url": "https://github.com/jsx-eslint/eslint-jsx-a11y/blob/HEAD/docs/rules/alt-text.md"
+				"url": "https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/alt-text.md"
 			}
 		],
 		"flint": {
@@ -1450,7 +1450,7 @@
 		"eslint": [
 			{
 				"name": "jsx-a11y/anchor-ambiguous-text",
-				"url": "https://github.com/jsx-eslint/eslint-jsx-a11y/blob/HEAD/docs/rules/anchor-ambiguous-text.md"
+				"url": "https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/anchor-ambiguous-text.md"
 			}
 		],
 		"flint": {
@@ -1491,7 +1491,7 @@
 		"eslint": [
 			{
 				"name": "jsx-a11y/anchor-is-valid",
-				"url": "https://github.com/jsx-eslint/eslint-jsx-a11y/blob/HEAD/docs/rules/anchor-is-valid.md"
+				"url": "https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/anchor-is-valid.md"
 			}
 		],
 		"flint": {
@@ -1511,7 +1511,7 @@
 		"eslint": [
 			{
 				"name": "jsx-a11y/aria-activedescendant-has-tabindex",
-				"url": "https://github.com/jsx-eslint/eslint-jsx-a11y/blob/HEAD/docs/rules/aria-activedescendant-has-tabindex.md"
+				"url": "https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/aria-activedescendant-has-tabindex.md"
 			}
 		],
 		"flint": {
@@ -1531,7 +1531,7 @@
 		"eslint": [
 			{
 				"name": "jsx-a11y/no-aria-hidden-on-focusable",
-				"url": "https://github.com/jsx-eslint/eslint-jsx-a11y/blob/HEAD/docs/rules/no-aria-hidden-on-focusable.md"
+				"url": "https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/no-aria-hidden-on-focusable.md"
 			}
 		],
 		"flint": {
@@ -1552,7 +1552,7 @@
 		"eslint": [
 			{
 				"name": "jsx-a11y/aria-props",
-				"url": "https://github.com/jsx-eslint/eslint-jsx-a11y/blob/HEAD/docs/rules/aria-props.md"
+				"url": "https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/aria-props.md"
 			}
 		],
 		"flint": {
@@ -1572,7 +1572,7 @@
 		"eslint": [
 			{
 				"name": "jsx-a11y/aria-proptypes",
-				"url": "https://github.com/jsx-eslint/eslint-jsx-a11y/blob/HEAD/docs/rules/aria-proptypes.md"
+				"url": "https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/aria-proptypes.md"
 			}
 		],
 		"flint": {
@@ -1586,7 +1586,7 @@
 		"eslint": [
 			{
 				"name": "jsx-a11y/aria-role",
-				"url": "https://github.com/jsx-eslint/eslint-jsx-a11y/blob/HEAD/docs/rules/aria-role.md"
+				"url": "https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/aria-role.md"
 			}
 		],
 		"flint": {
@@ -1606,7 +1606,7 @@
 		"eslint": [
 			{
 				"name": "jsx-a11y/aria-unsupported-elements",
-				"url": "https://github.com/jsx-eslint/eslint-jsx-a11y/blob/HEAD/docs/rules/aria-unsupported-elements.md"
+				"url": "https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/aria-unsupported-elements.md"
 			}
 		],
 		"flint": {
@@ -1626,7 +1626,7 @@
 		"eslint": [
 			{
 				"name": "react/no-invalid-html-attribute",
-				"url": "https://github.com/jsx-eslint/eslint-react/blob/master/docs/rules/no-invalid-html-attribute.md"
+				"url": "https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-invalid-html-attribute.md"
 			}
 		],
 		"flint": {
@@ -1639,7 +1639,7 @@
 		"eslint": [
 			{
 				"name": "jsx-a11y/autocomplete-valid",
-				"url": "https://github.com/jsx-eslint/eslint-jsx-a11y/blob/HEAD/docs/rules/autocomplete-valid.md"
+				"url": "https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/autocomplete-valid.md"
 			}
 		],
 		"flint": {
@@ -1659,7 +1659,7 @@
 		"eslint": [
 			{
 				"name": "jsx-a11y/no-autofocus",
-				"url": "https://github.com/jsx-eslint/eslint-jsx-a11y/blob/HEAD/docs/rules/no-autofocus.md"
+				"url": "https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/no-autofocus.md"
 			}
 		],
 		"flint": {
@@ -1679,7 +1679,7 @@
 		"eslint": [
 			{
 				"name": "react/boolean-prop-naming",
-				"url": "https://github.com/jsx-eslint/eslint-react/blob/master/docs/rules/boolean-prop-naming.md"
+				"url": "https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/boolean-prop-naming.md"
 			}
 		],
 		"flint": {
@@ -1699,7 +1699,7 @@
 		"eslint": [
 			{
 				"name": "react/jsx-boolean-value",
-				"url": "https://github.com/jsx-eslint/eslint-react/blob/master/docs/rules/jsx-boolean-value.md"
+				"url": "https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-boolean-value.md"
 			}
 		],
 		"flint": {
@@ -1737,7 +1737,7 @@
 		"eslint": [
 			{
 				"name": "react/button-has-type",
-				"url": "https://github.com/jsx-eslint/eslint-react/blob/master/docs/rules/button-has-type.md"
+				"url": "https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/button-has-type.md"
 			}
 		],
 		"flint": {
@@ -1751,7 +1751,7 @@
 		"eslint": [
 			{
 				"name": "react/jsx-curly-brace-presence",
-				"url": "https://github.com/jsx-eslint/eslint-react/blob/master/docs/rules/jsx-curly-brace-presence.md"
+				"url": "https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-curly-brace-presence.md"
 			}
 		],
 		"flint": {
@@ -1771,7 +1771,7 @@
 		"eslint": [
 			{
 				"name": "react/no-children-prop",
-				"url": "https://github.com/jsx-eslint/eslint-react/blob/master/docs/rules/no-children-prop.md"
+				"url": "https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-children-prop.md"
 			}
 		],
 		"flint": {
@@ -1785,7 +1785,7 @@
 		"eslint": [
 			{
 				"name": "react/jsx-child-element-spacing",
-				"url": "https://github.com/jsx-eslint/eslint-react/blob/master/docs/rules/jsx-child-element-spacing.md"
+				"url": "https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-child-element-spacing.md"
 			}
 		],
 		"flint": {
@@ -1799,7 +1799,7 @@
 		"eslint": [
 			{
 				"name": "jsx-a11y/click-events-have-key-events",
-				"url": "https://github.com/jsx-eslint/eslint-jsx-a11y/blob/HEAD/docs/rules/click-events-have-key-events.md"
+				"url": "https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/click-events-have-key-events.md"
 			}
 		],
 		"flint": {
@@ -1819,7 +1819,7 @@
 		"eslint": [
 			{
 				"name": "react/jsx-closing-bracket-location",
-				"url": "https://github.com/jsx-eslint/eslint-react/blob/master/docs/rules/jsx-closing-bracket-location.md"
+				"url": "https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-closing-bracket-location.md"
 			}
 		],
 		"flint": {
@@ -1833,7 +1833,7 @@
 		"eslint": [
 			{
 				"name": "react/jsx-closing-tag-location",
-				"url": "https://github.com/jsx-eslint/eslint-react/blob/master/docs/rules/jsx-closing-tag-location.md"
+				"url": "https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-closing-tag-location.md"
 			}
 		],
 		"flint": {
@@ -1867,7 +1867,7 @@
 		"eslint": [
 			{
 				"name": "react/jsx-pascal-case",
-				"url": "https://github.com/jsx-eslint/eslint-react/blob/master/docs/rules/jsx-pascal-case.md"
+				"url": "https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-pascal-case.md"
 			}
 		],
 		"flint": {
@@ -1881,7 +1881,7 @@
 		"eslint": [
 			{
 				"name": "react/jsx-curly-newline",
-				"url": "https://github.com/jsx-eslint/eslint-react/blob/master/docs/rules/jsx-curly-newline.md"
+				"url": "https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-curly-newline.md"
 			}
 		],
 		"flint": {
@@ -1895,7 +1895,7 @@
 		"eslint": [
 			{
 				"name": "react/jsx-curly-spacing",
-				"url": "https://github.com/jsx-eslint/eslint-react/blob/master/docs/rules/jsx-curly-spacing.md"
+				"url": "https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-curly-spacing.md"
 			}
 		],
 		"flint": {
@@ -1909,7 +1909,7 @@
 		"eslint": [
 			{
 				"name": "react/no-object-type-as-default-prop",
-				"url": "https://github.com/jsx-eslint/eslint-react/blob/master/docs/rules/no-object-type-as-default-prop.md"
+				"url": "https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-object-type-as-default-prop.md"
 			}
 		],
 		"flint": {
@@ -1923,7 +1923,7 @@
 		"eslint": [
 			{
 				"name": "jsx-a11y/no-distracting-elements",
-				"url": "https://github.com/jsx-eslint/eslint-jsx-a11y/blob/HEAD/docs/rules/no-distracting-elements.md"
+				"url": "https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/no-distracting-elements.md"
 			}
 		],
 		"flint": {
@@ -1943,7 +1943,7 @@
 		"eslint": [
 			{
 				"name": "react/jsx-props-no-spread-multi",
-				"url": "https://github.com/jsx-eslint/eslint-react/blob/master/docs/rules/jsx-props-no-spread-multi.md"
+				"url": "https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-props-no-spread-multi.md"
 			}
 		],
 		"deno": [
@@ -1968,7 +1968,7 @@
 		"eslint": [
 			{
 				"name": "react/void-dom-elements-no-children",
-				"url": "https://github.com/jsx-eslint/eslint-react/blob/master/docs/rules/void-dom-elements-no-children.md"
+				"url": "https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/void-dom-elements-no-children.md"
 			}
 		],
 		"flint": {
@@ -1983,7 +1983,7 @@
 		"eslint": [
 			{
 				"name": "react/jsx-equals-spacing",
-				"url": "https://github.com/jsx-eslint/eslint-react/blob/master/docs/rules/jsx-equals-spacing.md"
+				"url": "https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-equals-spacing.md"
 			}
 		],
 		"flint": {
@@ -1997,7 +1997,7 @@
 		"eslint": [
 			{
 				"name": "react/jsx-one-expression-per-line",
-				"url": "https://github.com/jsx-eslint/eslint-react/blob/master/docs/rules/jsx-one-expression-per-line.md"
+				"url": "https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-one-expression-per-line.md"
 			}
 		],
 		"flint": {
@@ -2025,7 +2025,7 @@
 		"eslint": [
 			{
 				"name": "react/jsx-fragments",
-				"url": "https://github.com/jsx-eslint/eslint-react/blob/master/docs/rules/jsx-fragments.md"
+				"url": "https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-fragments.md"
 			}
 		],
 		"flint": {
@@ -2038,7 +2038,7 @@
 		"eslint": [
 			{
 				"name": "react/jsx-no-bind",
-				"url": "https://github.com/jsx-eslint/eslint-react/blob/master/docs/rules/jsx-no-bind.md"
+				"url": "https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-no-bind.md"
 			}
 		],
 		"flint": {
@@ -2052,7 +2052,7 @@
 		"eslint": [
 			{
 				"name": "react/jsx-handler-names",
-				"url": "https://github.com/jsx-eslint/eslint-react/blob/master/docs/rules/jsx-handler-names.md"
+				"url": "https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-handler-names.md"
 			}
 		],
 		"flint": {
@@ -2066,7 +2066,7 @@
 		"eslint": [
 			{
 				"name": "jsx-a11y/heading-has-content",
-				"url": "https://github.com/jsx-eslint/eslint-jsx-a11y/blob/HEAD/docs/rules/heading-has-content.md"
+				"url": "https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/heading-has-content.md"
 			}
 		],
 		"flint": {
@@ -2080,7 +2080,7 @@
 		"eslint": [
 			{
 				"name": "jsx-a11y/html-has-lang",
-				"url": "https://github.com/jsx-eslint/eslint-jsx-a11y/blob/HEAD/docs/rules/html-has-lang.md"
+				"url": "https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/html-has-lang.md"
 			}
 		],
 		"flint": {
@@ -2100,7 +2100,7 @@
 		"eslint": [
 			{
 				"name": "react/iframe-missing-sandbox",
-				"url": "https://github.com/jsx-eslint/eslint-react/blob/master/docs/rules/iframe-missing-sandbox.md"
+				"url": "https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/iframe-missing-sandbox.md"
 			}
 		],
 		"flint": {
@@ -2114,7 +2114,7 @@
 		"eslint": [
 			{
 				"name": "jsx-a11y/iframe-has-title",
-				"url": "https://github.com/jsx-eslint/eslint-jsx-a11y/blob/HEAD/docs/rules/iframe-has-title.md"
+				"url": "https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/iframe-has-title.md"
 			}
 		],
 		"flint": {
@@ -2134,7 +2134,7 @@
 		"eslint": [
 			{
 				"name": "jsx-a11y/img-redundant-alt",
-				"url": "https://github.com/jsx-eslint/eslint-jsx-a11y/blob/HEAD/docs/rules/img-redundant-alt.md"
+				"url": "https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/img-redundant-alt.md"
 			}
 		],
 		"flint": {
@@ -2153,7 +2153,7 @@
 		"eslint": [
 			{
 				"name": "react/jsx-indent",
-				"url": "https://github.com/jsx-eslint/eslint-react/blob/master/docs/rules/jsx-indent.md"
+				"url": "https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-indent.md"
 			}
 		],
 		"flint": {
@@ -2167,7 +2167,7 @@
 		"eslint": [
 			{
 				"name": "react/checked-requires-onchange-or-readonly",
-				"url": "https://github.com/jsx-eslint/eslint-react/blob/master/docs/rules/checked-requires-onchange-or-readonly.md"
+				"url": "https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/checked-requires-onchange-or-readonly.md"
 			}
 		],
 		"flint": {
@@ -2180,7 +2180,7 @@
 		"eslint": [
 			{
 				"name": "jsx-a11y/no-interactive-element-to-noninteractive-role",
-				"url": "https://github.com/jsx-eslint/eslint-jsx-a11y/blob/HEAD/docs/rules/no-interactive-element-to-noninteractive-role.md"
+				"url": "https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/no-interactive-element-to-noninteractive-role.md"
 			}
 		],
 		"flint": {
@@ -2221,7 +2221,7 @@
 		"eslint": [
 			{
 				"name": "jsx-a11y/label-has-associated-control",
-				"url": "https://github.com/jsx-eslint/eslint-jsx-a11y/blob/HEAD/docs/rules/label-has-associated-control.md"
+				"url": "https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/label-has-associated-control.md"
 			}
 		],
 		"flint": {
@@ -2241,7 +2241,7 @@
 		"eslint": [
 			{
 				"name": "jsx-a11y/lang",
-				"url": "https://github.com/jsx-eslint/eslint-jsx-a11y/blob/HEAD/docs/rules/lang.md"
+				"url": "https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/lang.md"
 			}
 		],
 		"flint": {
@@ -2276,7 +2276,7 @@
 		"eslint": [
 			{
 				"name": "react/jsx-no-literals",
-				"url": "https://github.com/jsx-eslint/eslint-react/blob/master/docs/rules/jsx-no-literals.md"
+				"url": "https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-no-literals.md"
 			}
 		],
 		"flint": {
@@ -2290,7 +2290,7 @@
 		"eslint": [
 			{
 				"name": "react/jsx-max-depth",
-				"url": "https://github.com/jsx-eslint/eslint-react/blob/master/docs/rules/jsx-max-depth.md"
+				"url": "https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-max-depth.md"
 			}
 		],
 		"flint": {
@@ -2304,7 +2304,7 @@
 		"eslint": [
 			{
 				"name": "react/jsx-max-props-per-line",
-				"url": "https://github.com/jsx-eslint/eslint-react/blob/master/docs/rules/jsx-max-props-per-line.md"
+				"url": "https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-max-props-per-line.md"
 			}
 		],
 		"flint": {
@@ -2318,7 +2318,7 @@
 		"eslint": [
 			{
 				"name": "jsx-a11y/media-has-caption",
-				"url": "https://github.com/jsx-eslint/eslint-jsx-a11y/blob/HEAD/docs/rules/media-has-caption.md"
+				"url": "https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/media-has-caption.md"
 			}
 		],
 		"flint": {
@@ -2351,7 +2351,7 @@
 		"eslint": [
 			{
 				"name": "jsx-a11y/mouse-events-have-key-events",
-				"url": "https://github.com/jsx-eslint/eslint-jsx-a11y/blob/HEAD/docs/rules/mouse-events-have-key-events.md"
+				"url": "https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/mouse-events-have-key-events.md"
 			}
 		],
 		"flint": {
@@ -2371,7 +2371,7 @@
 		"eslint": [
 			{
 				"name": "react/no-namespace",
-				"url": "https://github.com/jsx-eslint/eslint-react/blob/master/docs/rules/no-namespace.md"
+				"url": "https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-namespace.md"
 			}
 		],
 		"flint": {
@@ -2385,7 +2385,7 @@
 		"eslint": [
 			{
 				"name": "react/jsx-newline",
-				"url": "https://github.com/jsx-eslint/eslint-react/blob/master/docs/rules/jsx-newline.md"
+				"url": "https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-newline.md"
 			}
 		],
 		"flint": {
@@ -2399,7 +2399,7 @@
 		"eslint": [
 			{
 				"name": "jsx-a11y/no-noninteractive-element-interactions",
-				"url": "https://github.com/jsx-eslint/eslint-jsx-a11y/blob/HEAD/docs/rules/no-noninteractive-element-interactions.md"
+				"url": "https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/no-noninteractive-element-interactions.md"
 			}
 		],
 		"flint": {
@@ -2413,7 +2413,7 @@
 		"eslint": [
 			{
 				"name": "jsx-a11y/no-noninteractive-element-to-interactive-role",
-				"url": "https://github.com/jsx-eslint/eslint-jsx-a11y/blob/HEAD/docs/rules/no-noninteractive-element-to-interactive-role.md"
+				"url": "https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/no-noninteractive-element-to-interactive-role.md"
 			}
 		],
 		"flint": {
@@ -2427,7 +2427,7 @@
 		"eslint": [
 			{
 				"name": "jsx-a11y/no-noninteractive-tabindex",
-				"url": "https://github.com/jsx-eslint/eslint-jsx-a11y/blob/HEAD/docs/rules/no-noninteractive-tabindex.md"
+				"url": "https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/no-noninteractive-tabindex.md"
 			}
 		],
 		"flint": {
@@ -2467,7 +2467,7 @@
 		"eslint": [
 			{
 				"name": "react/jsx-indent-props",
-				"url": "https://github.com/jsx-eslint/eslint-react/blob/master/docs/rules/jsx-indent-props.md"
+				"url": "https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-indent-props.md"
 			}
 		],
 		"flint": {
@@ -2495,7 +2495,7 @@
 		"eslint": [
 			{
 				"name": "react/jsx-sort-props",
-				"url": "https://github.com/jsx-eslint/eslint-react/blob/master/docs/rules/jsx-sort-props.md"
+				"url": "https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-sort-props.md"
 			}
 		],
 		"flint": {
@@ -2523,7 +2523,7 @@
 		"eslint": [
 			{
 				"name": "react/jsx-props-no-spreading",
-				"url": "https://github.com/jsx-eslint/eslint-react/blob/master/docs/rules/jsx-props-no-spreading.md"
+				"url": "https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-props-no-spreading.md"
 			}
 		],
 		"flint": {
@@ -2537,7 +2537,7 @@
 		"eslint": [
 			{
 				"name": "react/no-redundant-should-component-update",
-				"url": "https://github.com/jsx-eslint/eslint-react/blob/master/docs/rules/no-redundant-should-component-update.md"
+				"url": "https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-redundant-should-component-update.md"
 			}
 		],
 		"flint": {
@@ -2551,7 +2551,7 @@
 		"eslint": [
 			{
 				"name": "react/jsx-no-leaked-render",
-				"url": "https://github.com/jsx-eslint/eslint-react/blob/master/docs/rules/jsx-no-leaked-render.md"
+				"url": "https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-no-leaked-render.md"
 			}
 		],
 		"flint": {
@@ -2565,7 +2565,7 @@
 		"eslint": [
 			{
 				"name": "jsx-a11y/no-redundant-roles",
-				"url": "https://github.com/jsx-eslint/eslint-jsx-a11y/blob/HEAD/docs/rules/no-redundant-roles.md"
+				"url": "https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/no-redundant-roles.md"
 			}
 		],
 		"flint": {
@@ -2585,7 +2585,7 @@
 		"eslint": [
 			{
 				"name": "jsx-a11y/role-has-required-aria-props",
-				"url": "https://github.com/jsx-eslint/eslint-jsx-a11y/blob/HEAD/docs/rules/role-has-required-aria-props.md"
+				"url": "https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/role-has-required-aria-props.md"
 			}
 		],
 		"flint": {
@@ -2605,7 +2605,7 @@
 		"eslint": [
 			{
 				"name": "jsx-a11y/role-supports-aria-props",
-				"url": "https://github.com/jsx-eslint/eslint-jsx-a11y/blob/HEAD/docs/rules/role-supports-aria-props.md"
+				"url": "https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/role-supports-aria-props.md"
 			}
 		],
 		"flint": {
@@ -2625,7 +2625,7 @@
 		"eslint": [
 			{
 				"name": "jsx-a11y/prefer-tag-over-role",
-				"url": "https://github.com/jsx-eslint/eslint-jsx-a11y/blob/HEAD/docs/rules/prefer-tag-over-role.md"
+				"url": "https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/prefer-tag-over-role.md"
 			}
 		],
 		"flint": {
@@ -2646,7 +2646,7 @@
 		"eslint": [
 			{
 				"name": "jsx-a11y/scope",
-				"url": "https://github.com/jsx-eslint/eslint-jsx-a11y/blob/HEAD/docs/rules/scope.md"
+				"url": "https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/scope.md"
 			}
 		],
 		"flint": {
@@ -2666,7 +2666,7 @@
 		"eslint": [
 			{
 				"name": "react/jsx-no-script-url",
-				"url": "https://github.com/jsx-eslint/eslint-react/blob/master/docs/rules/jsx-no-script-url.md"
+				"url": "https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-no-script-url.md"
 			}
 		],
 		"flint": {
@@ -2679,7 +2679,7 @@
 		"eslint": [
 			{
 				"name": "react/jsx-no-target-blank",
-				"url": "https://github.com/jsx-eslint/eslint-react/blob/master/docs/rules/jsx-no-target-blank.md"
+				"url": "https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-no-target-blank.md"
 			}
 		],
 		"flint": {
@@ -2693,7 +2693,7 @@
 		"eslint": [
 			{
 				"name": "react/self-closing-comp",
-				"url": "https://react.dev/reference/eslint-react-hooks/lints/self-closing-comp"
+				"url": "https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/self-closing-comp.md"
 			}
 		],
 		"flint": {
@@ -2706,7 +2706,7 @@
 		"eslint": [
 			{
 				"name": "react/no-access-state-in-setstate",
-				"url": "https://github.com/jsx-eslint/eslint-react/blob/master/docs/rules/no-access-state-in-setstate.md"
+				"url": "https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-access-state-in-setstate.md"
 			}
 		],
 		"flint": {
@@ -2720,7 +2720,7 @@
 		"eslint": [
 			{
 				"name": "jsx-a11y/no-static-element-interactions",
-				"url": "https://github.com/jsx-eslint/eslint-jsx-a11y/blob/HEAD/docs/rules/no-static-element-interactions.md"
+				"url": "https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/no-static-element-interactions.md"
 			}
 		],
 		"flint": {
@@ -2748,7 +2748,7 @@
 		"eslint": [
 			{
 				"name": "jsx-a11y/tabindex-no-positive",
-				"url": "https://github.com/jsx-eslint/eslint-jsx-a11y/blob/HEAD/docs/rules/tabindex-no-positive.md"
+				"url": "https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/tabindex-no-positive.md"
 			}
 		],
 		"flint": {
@@ -2788,7 +2788,7 @@
 		"eslint": [
 			{
 				"name": "react/no-unescaped-entities",
-				"url": "https://github.com/jsx-eslint/eslint-react/blob/master/docs/rules/no-unescaped-entities.md"
+				"url": "https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-unescaped-entities.md"
 			}
 		],
 		"flint": {
@@ -2802,7 +2802,7 @@
 		"eslint": [
 			{
 				"name": "react/jsx-no-useless-fragment",
-				"url": "https://github.com/jsx-eslint/eslint-react/blob/master/docs/rules/jsx-no-useless-fragment.md"
+				"url": "https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-no-useless-fragment.md"
 			}
 		],
 		"deno": [
@@ -2822,7 +2822,7 @@
 		"eslint": [
 			{
 				"name": "react/jsx-wrap-multilines",
-				"url": "https://github.com/jsx-eslint/eslint-react/blob/master/docs/rules/jsx-wrap-multilines.md"
+				"url": "https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-wrap-multilines.md"
 			}
 		],
 		"flint": {
@@ -6198,7 +6198,7 @@
 		"eslint": [
 			{
 				"name": "react/no-array-index-key",
-				"url": "https://github.com/jsx-eslint/eslint-react/blob/master/docs/rules/no-array-index-key.md"
+				"url": "https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-array-index-key.md"
 			}
 		],
 		"flint": {
@@ -6212,7 +6212,7 @@
 		"eslint": [
 			{
 				"name": "react/prefer-es6-class",
-				"url": "https://github.com/jsx-eslint/eslint-react/blob/master/docs/rules/prefer-es6-class.md"
+				"url": "https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/prefer-es6-class.md"
 			}
 		],
 		"flint": {
@@ -6240,7 +6240,7 @@
 		"eslint": [
 			{
 				"name": "react/state-in-constructor",
-				"url": "https://github.com/jsx-eslint/eslint-react/blob/master/docs/rules/state-in-constructor.md"
+				"url": "https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/state-in-constructor.md"
 			}
 		],
 		"flint": {
@@ -6254,7 +6254,7 @@
 		"eslint": [
 			{
 				"name": "react-hooks/config",
-				"url": "https://react.dev/reference/eslint-react-hooks/lints/config"
+				"url": "https://react.dev/reference/eslint-plugin-react-hooks/lints/config"
 			}
 		],
 		"flint": {
@@ -6267,7 +6267,7 @@
 		"eslint": [
 			{
 				"name": "react/prefer-read-only-props",
-				"url": "https://github.com/jsx-eslint/eslint-react/blob/master/docs/rules/prefer-read-only-props.md"
+				"url": "https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/prefer-read-only-props.md"
 			}
 		],
 		"flint": {
@@ -6280,7 +6280,7 @@
 		"eslint": [
 			{
 				"name": "react/no-did-mount-set-state",
-				"url": "https://github.com/jsx-eslint/eslint-react/blob/master/docs/rules/no-did-mount-set-state.md"
+				"url": "https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-did-mount-set-state.md"
 			}
 		],
 		"flint": {
@@ -6294,7 +6294,7 @@
 		"eslint": [
 			{
 				"name": "react/no-did-update-set-state",
-				"url": "https://github.com/jsx-eslint/eslint-react/blob/master/docs/rules/no-did-update-set-state.md"
+				"url": "https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-did-update-set-state.md"
 			}
 		],
 		"flint": {
@@ -6308,7 +6308,7 @@
 		"eslint": [
 			{
 				"name": "react/display-name",
-				"url": "https://github.com/jsx-eslint/eslint-react/blob/master/docs/rules/display-name.md"
+				"url": "https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/display-name.md"
 			}
 		],
 		"flint": {
@@ -6322,7 +6322,7 @@
 		"eslint": [
 			{
 				"name": "react-hooks/component-hook-factories",
-				"url": "https://react.dev/reference/eslint-react-hooks/lints/component-hook-factories"
+				"url": "https://react.dev/reference/eslint-plugin-react-hooks/lints/component-hook-factories"
 			}
 		],
 		"flint": {
@@ -6335,7 +6335,7 @@
 		"eslint": [
 			{
 				"name": "react/no-unstable-nested-components",
-				"url": "https://github.com/jsx-eslint/eslint-react/blob/master/docs/rules/no-unstable-nested-components.md"
+				"url": "https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-unstable-nested-components.md"
 			}
 		],
 		"flint": {
@@ -6348,7 +6348,7 @@
 		"eslint": [
 			{
 				"name": "react/require-optimization",
-				"url": "https://github.com/jsx-eslint/eslint-react/blob/master/docs/rules/require-optimization.md"
+				"url": "https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/require-optimization.md"
 			}
 		],
 		"flint": {
@@ -6390,7 +6390,7 @@
 		"eslint": [
 			{
 				"name": "react/no-will-update-set-state",
-				"url": "https://github.com/jsx-eslint/eslint-react/blob/master/docs/rules/no-will-update-set-state.md"
+				"url": "https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-will-update-set-state.md"
 			}
 		],
 		"flint": {
@@ -6404,7 +6404,7 @@
 		"eslint": [
 			{
 				"name": "react/jsx-no-constructed-context-values",
-				"url": "https://github.com/jsx-eslint/eslint-react/blob/master/docs/rules/jsx-no-constructed-context-values.md"
+				"url": "https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-no-constructed-context-values.md"
 			}
 		],
 		"flint": {
@@ -6418,7 +6418,7 @@
 		"eslint": [
 			{
 				"name": "react/forbid-foreign-prop-types",
-				"url": "https://github.com/jsx-eslint/eslint-react/blob/master/docs/rules/forbid-foreign-prop-types.md"
+				"url": "https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/forbid-foreign-prop-types.md"
 			}
 		],
 		"flint": {
@@ -6432,7 +6432,7 @@
 		"eslint": [
 			{
 				"name": "react/no-deprecated",
-				"url": "https://github.com/jsx-eslint/eslint-react/blob/master/docs/rules/no-deprecated.md"
+				"url": "https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-deprecated.md"
 			}
 		],
 		"flint": {
@@ -6446,7 +6446,7 @@
 		"eslint": [
 			{
 				"name": "react/no-danger-with-children",
-				"url": "https://github.com/jsx-eslint/eslint-react/blob/master/docs/rules/no-danger-with-children.md"
+				"url": "https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-danger-with-children.md"
 			}
 		],
 		"flint": {
@@ -6459,7 +6459,7 @@
 		"eslint": [
 			{
 				"name": "react/no-danger",
-				"url": "https://github.com/jsx-eslint/eslint-react/blob/master/docs/rules/no-danger.md"
+				"url": "https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-danger.md"
 			}
 		],
 		"flint": {
@@ -6473,7 +6473,7 @@
 		"eslint": [
 			{
 				"name": "react/default-props-match-prop-types",
-				"url": "https://github.com/jsx-eslint/eslint-react/blob/master/docs/rules/default-props-match-prop-types.md"
+				"url": "https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/default-props-match-prop-types.md"
 			}
 		],
 		"flint": {
@@ -6513,7 +6513,7 @@
 		"eslint": [
 			{
 				"name": "react-hooks/set-state-in-effect",
-				"url": "https://react.dev/reference/eslint-react-hooks/lints/set-state-in-effect"
+				"url": "https://react.dev/reference/eslint-plugin-react-hooks/lints/set-state-in-effect"
 			}
 		],
 		"flint": {
@@ -6526,7 +6526,7 @@
 		"eslint": [
 			{
 				"name": "react-hooks/error-boundaries",
-				"url": "https://react.dev/reference/eslint-react-hooks/lints/error-boundaries"
+				"url": "https://react.dev/reference/eslint-plugin-react-hooks/lints/error-boundaries"
 			}
 		],
 		"flint": {
@@ -6539,7 +6539,7 @@
 		"eslint": [
 			{
 				"name": "react-hooks/exhaustive-deps",
-				"url": "https://react.dev/reference/eslint-react-hooks/lints/exhaustive-deps"
+				"url": "https://react.dev/reference/eslint-plugin-react-hooks/lints/exhaustive-deps"
 			}
 		],
 		"flint": {
@@ -6552,7 +6552,7 @@
 		"eslint": [
 			{
 				"name": "react/no-find-dom-node",
-				"url": "https://github.com/jsx-eslint/eslint-react/blob/master/docs/rules/no-find-dom-node.md"
+				"url": "https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-find-dom-node.md"
 			}
 		],
 		"flint": {
@@ -6566,7 +6566,7 @@
 		"eslint": [
 			{
 				"name": "react/forward-ref-uses-ref",
-				"url": "https://github.com/jsx-eslint/eslint-react/blob/master/docs/rules/forward-ref-uses-ref.md"
+				"url": "https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/forward-ref-uses-ref.md"
 			}
 		],
 		"flint": {
@@ -6580,7 +6580,7 @@
 		"eslint": [
 			{
 				"name": "react/function-component-definition",
-				"url": "https://github.com/jsx-eslint/eslint-react/blob/master/docs/rules/function-component-definition.md"
+				"url": "https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/function-component-definition.md"
 			}
 		],
 		"flint": {
@@ -6593,7 +6593,7 @@
 		"eslint": [
 			{
 				"name": "react/no-this-in-sfc",
-				"url": "https://github.com/jsx-eslint/eslint-react/blob/master/docs/rules/no-this-in-sfc.md"
+				"url": "https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-this-in-sfc.md"
 			}
 		],
 		"flint": {
@@ -6606,7 +6606,7 @@
 		"eslint": [
 			{
 				"name": "react-hooks/gating",
-				"url": "https://react.dev/reference/eslint-react-hooks/lints/gating"
+				"url": "https://react.dev/reference/eslint-plugin-react-hooks/lints/gating"
 			}
 		],
 		"flint": {
@@ -6619,7 +6619,7 @@
 		"eslint": [
 			{
 				"name": "react-hooks/globals",
-				"url": "https://react.dev/reference/eslint-react-hooks/lints/globals"
+				"url": "https://react.dev/reference/eslint-plugin-react-hooks/lints/globals"
 			}
 		],
 		"flint": {
@@ -6632,7 +6632,7 @@
 		"eslint": [
 			{
 				"name": "react-hooks/immutability",
-				"url": "https://react.dev/reference/eslint-react-hooks/lints/immutability"
+				"url": "https://react.dev/reference/eslint-plugin-react-hooks/lints/immutability"
 			}
 		],
 		"flint": {
@@ -6645,7 +6645,7 @@
 		"eslint": [
 			{
 				"name": "react-hooks/incompatible-library",
-				"url": "https://react.dev/reference/eslint-react-hooks/lints/incompatible-library"
+				"url": "https://react.dev/reference/eslint-plugin-react-hooks/lints/incompatible-library"
 			}
 		],
 		"flint": {
@@ -6658,7 +6658,7 @@
 		"eslint": [
 			{
 				"name": "react/no-is-mounted",
-				"url": "https://github.com/jsx-eslint/eslint-react/blob/master/docs/rules/no-is-mounted.md"
+				"url": "https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-is-mounted.md"
 			}
 		],
 		"flint": {
@@ -6672,7 +6672,7 @@
 		"eslint": [
 			{
 				"name": "react/jsx-key",
-				"url": "https://github.com/jsx-eslint/eslint-react/blob/master/docs/rules/jsx-key.md"
+				"url": "https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-key.md"
 			}
 		],
 		"flint": {
@@ -6686,7 +6686,7 @@
 		"eslint": [
 			{
 				"name": "react-hooks/preserve-manual-memoization",
-				"url": "https://react.dev/reference/eslint-react-hooks/lints/preserve-manual-memoization"
+				"url": "https://react.dev/reference/eslint-plugin-react-hooks/lints/preserve-manual-memoization"
 			}
 		],
 		"flint": {
@@ -6699,7 +6699,7 @@
 		"eslint": [
 			{
 				"name": "react/require-default-props",
-				"url": "https://github.com/jsx-eslint/eslint-react/blob/master/docs/rules/require-default-props.md"
+				"url": "https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/require-default-props.md"
 			}
 		],
 		"flint": {
@@ -6713,7 +6713,7 @@
 		"eslint": [
 			{
 				"name": "react/no-unknown-property",
-				"url": "https://github.com/jsx-eslint/eslint-react/blob/master/docs/rules/no-unknown-property.md"
+				"url": "https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-unknown-property.md"
 			}
 		],
 		"flint": {
@@ -6726,7 +6726,7 @@
 		"eslint": [
 			{
 				"name": "react/prop-types",
-				"url": "https://github.com/jsx-eslint/eslint-react/blob/master/docs/rules/prop-types.md"
+				"url": "https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/prop-types.md"
 			}
 		],
 		"flint": {
@@ -6739,7 +6739,7 @@
 		"eslint": [
 			{
 				"name": "react/prefer-exact-props",
-				"url": "https://github.com/jsx-eslint/eslint-react/blob/master/docs/rules/prefer-exact-props.md"
+				"url": "https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/prefer-exact-props.md"
 			}
 		],
 		"flint": {
@@ -6753,7 +6753,7 @@
 		"eslint": [
 			{
 				"name": "react/prefer-read-only-props",
-				"url": "https://github.com/jsx-eslint/eslint-react/blob/master/docs/rules/prefer-read-only-props.md"
+				"url": "https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/prefer-read-only-props.md"
 			}
 		],
 		"flint": {
@@ -6781,7 +6781,7 @@
 		"eslint": [
 			{
 				"name": "react-hooks/purity",
-				"url": "https://react.dev/reference/eslint-react-hooks/lints/purity"
+				"url": "https://react.dev/reference/eslint-plugin-react-hooks/lints/purity"
 			}
 		],
 		"flint": {
@@ -6794,7 +6794,7 @@
 		"eslint": [
 			{
 				"name": "react/react-in-jsx-scope",
-				"url": "https://github.com/jsx-eslint/eslint-react/blob/master/docs/rules/react-in-jsx-scope.md"
+				"url": "https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/react-in-jsx-scope.md"
 			}
 		],
 		"flint": {
@@ -6808,7 +6808,7 @@
 		"eslint": [
 			{
 				"name": "react-hooks/refs",
-				"url": "https://react.dev/reference/eslint-react-hooks/lints/refs"
+				"url": "https://react.dev/reference/eslint-plugin-react-hooks/lints/refs"
 			}
 		],
 		"flint": {
@@ -6821,7 +6821,7 @@
 		"eslint": [
 			{
 				"name": "react/no-string-refs",
-				"url": "https://github.com/jsx-eslint/eslint-react/blob/master/docs/rules/no-string-refs.md"
+				"url": "https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-string-refs.md"
 			}
 		],
 		"flint": {
@@ -6834,7 +6834,7 @@
 		"eslint": [
 			{
 				"name": "react/no-render-return-value",
-				"url": "https://github.com/jsx-eslint/eslint-react/blob/master/docs/rules/no-render-return-value.md"
+				"url": "https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-render-return-value.md"
 			}
 		],
 		"flint": {
@@ -6848,7 +6848,7 @@
 		"eslint": [
 			{
 				"name": "react-hooks/set-state-in-render",
-				"url": "https://react.dev/reference/eslint-react-hooks/lints/set-state-in-render"
+				"url": "https://react.dev/reference/eslint-plugin-react-hooks/lints/set-state-in-render"
 			}
 		],
 		"flint": {
@@ -6861,7 +6861,7 @@
 		"eslint": [
 			{
 				"name": "react/forbid-component-props",
-				"url": "https://github.com/jsx-eslint/eslint-react/blob/master/docs/rules/forbid-component-props.md"
+				"url": "https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/forbid-component-props.md"
 			}
 		],
 		"flint": {
@@ -6873,7 +6873,7 @@
 		"eslint": [
 			{
 				"name": "react/forbid-dom-props",
-				"url": "https://github.com/jsx-eslint/eslint-react/blob/master/docs/rules/forbid-dom-props.md"
+				"url": "https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/forbid-dom-props.md"
 			}
 		],
 		"flint": {
@@ -6885,7 +6885,7 @@
 		"eslint": [
 			{
 				"name": "react/forbid-elements",
-				"url": "https://github.com/jsx-eslint/eslint-react/blob/master/docs/rules/forbid-elements.md"
+				"url": "https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/forbid-elements.md"
 			}
 		],
 		"flint": {
@@ -6897,7 +6897,7 @@
 		"eslint": [
 			{
 				"name": "react/forbid-prop-types",
-				"url": "https://github.com/jsx-eslint/eslint-react/blob/master/docs/rules/forbid-prop-types.md"
+				"url": "https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/forbid-prop-types.md"
 			}
 		],
 		"flint": {
@@ -6909,7 +6909,7 @@
 		"eslint": [
 			{
 				"name": "react-hooks/rules-of-hooks",
-				"url": "https://react.dev/reference/eslint-react-hooks/lints/rules-of-hooks"
+				"url": "https://react.dev/reference/eslint-plugin-react-hooks/lints/rules-of-hooks"
 			}
 		],
 		"flint": {
@@ -6922,7 +6922,7 @@
 		"eslint": [
 			{
 				"name": "react/no-set-state",
-				"url": "https://github.com/jsx-eslint/eslint-react/blob/master/docs/rules/no-set-state.md"
+				"url": "https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-set-state.md"
 			}
 		],
 		"flint": {
@@ -6936,7 +6936,7 @@
 		"eslint": [
 			{
 				"name": "react/no-direct-mutation-state",
-				"url": "https://github.com/jsx-eslint/eslint-react/blob/master/docs/rules/no-direct-mutation-state.md"
+				"url": "https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-direct-mutation-state.md"
 			}
 		],
 		"flint": {
@@ -6949,7 +6949,7 @@
 		"eslint": [
 			{
 				"name": "react-hooks/static-components",
-				"url": "https://react.dev/reference/eslint-react-hooks/lints/static-components"
+				"url": "https://react.dev/reference/eslint-plugin-react-hooks/lints/static-components"
 			}
 		],
 		"flint": {
@@ -6962,7 +6962,7 @@
 		"eslint": [
 			{
 				"name": "react/style-prop-object",
-				"url": "https://github.com/jsx-eslint/eslint-react/blob/master/docs/rules/style-prop-object.md"
+				"url": "https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/style-prop-object.md"
 			}
 		],
 		"flint": {
@@ -6976,7 +6976,7 @@
 		"eslint": [
 			{
 				"name": "react/no-typos",
-				"url": "https://github.com/jsx-eslint/eslint-react/blob/master/docs/rules/no-typos.md"
+				"url": "https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-typos.md"
 			}
 		],
 		"flint": {
@@ -6989,7 +6989,7 @@
 		"eslint": [
 			{
 				"name": "react-hooks/unsupported-syntax",
-				"url": "https://react.dev/reference/eslint-react-hooks/lints/unsupported-syntax"
+				"url": "https://react.dev/reference/eslint-plugin-react-hooks/lints/unsupported-syntax"
 			}
 		],
 		"flint": {
@@ -7002,7 +7002,7 @@
 		"eslint": [
 			{
 				"name": "react/no-unused-class-component-methods",
-				"url": "https://github.com/jsx-eslint/eslint-react/blob/master/docs/rules/no-unused-class-component-methods.md"
+				"url": "https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-unused-class-component-methods.md"
 			}
 		],
 		"flint": {
@@ -7015,7 +7015,7 @@
 		"eslint": [
 			{
 				"name": "react/no-unused-prop-types",
-				"url": "https://github.com/jsx-eslint/eslint-react/blob/master/docs/rules/no-unused-prop-types.md"
+				"url": "https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-unused-prop-types.md"
 			}
 		],
 		"flint": {
@@ -7028,7 +7028,7 @@
 		"eslint": [
 			{
 				"name": "react/no-unused-state",
-				"url": "https://github.com/jsx-eslint/eslint-react/blob/master/docs/rules/no-unused-state.md"
+				"url": "https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-unused-state.md"
 			}
 		],
 		"flint": {
@@ -7041,7 +7041,7 @@
 		"eslint": [
 			{
 				"name": "react-hooks/use-memo",
-				"url": "https://react.dev/reference/eslint-react-hooks/lints/use-memo"
+				"url": "https://react.dev/reference/eslint-plugin-react-hooks/lints/use-memo"
 			}
 		],
 		"flint": {
@@ -7054,7 +7054,7 @@
 		"eslint": [
 			{
 				"name": "react/jsx-uses-react",
-				"url": "https://github.com/jsx-eslint/eslint-react/blob/master/docs/rules/jsx-uses-react.md"
+				"url": "https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-uses-react.md"
 			}
 		],
 		"flint": {
@@ -7068,7 +7068,7 @@
 		"eslint": [
 			{
 				"name": "react/hook-use-state",
-				"url": "https://github.com/jsx-eslint/eslint-react/blob/master/docs/rules/hook-use-state.md"
+				"url": "https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/hook-use-state.md"
 			}
 		],
 		"flint": {


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to flint! ❤️‍🔥
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [`status: accepting prs`](https://github.com/flint-fyi/flint/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/flint-fyi/flint/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

These links appear to have regressed in [#1746](https://github.com/flint-fyi/flint/pull/1746/changes#diff-24fe8725f2433db271c4e8519108df8f7c42b8dedfbdc9886a2d1ec0cbfb5a5e), where the package split removed `plugin-` from Flint package names.
That rename also touched external documentation URLs in `packages/comparisons/src/data.json`, changing paths such as `eslint-plugin-react` to the non-existent `eslint-react`.


<!-- Description of what is changed and how the code change does that. -->
