### PR TITLE
docs: fix the name of `vitest/toBeTypeOfs`

### DIFF
--- a/.changeset/plenty-comics-deny.md
+++ b/.changeset/plenty-comics-deny.md
@@ -1,0 +1,5 @@
+---
+"@flint.fyi/comparisons": patch
+---
+
+Update data for the vitest plugin.

--- a/packages/comparisons/src/data.json
+++ b/packages/comparisons/src/data.json
@@ -21229,7 +21229,7 @@
 			}
 		],
 		"flint": {
-			"name": "expectTypeOfs",
+			"name": "toBeTypeOfs",
 			"plugin": "vitest",
 			"preset": "stylistic"
 		}


### PR DESCRIPTION
This change updates the name flint rule equivalent of `eslint-plugin-vitest`'s `prefer-expect-type-of` rule.  Their implementation changed to prefer the `expect(...).toBeTypeOf(...)` form, instead of the `expectToBeTypeOf` function.  So, we should have our name and validation parallel the current behavior.

Additional Context: https://github.com/flint-fyi/flint/issues/2674#issuecomment-4500800052
