### PR TITLE
docs: remove stale rule equivalence note

### DIFF
--- a/packages/site/src/content/docs/rules/implementing.mdx
+++ b/packages/site/src/content/docs/rules/implementing.mdx
@@ -20,6 +20,5 @@ See [Rules](/rules) for an overview of how rules are sorted into plugins.
 
 This is a full table of all rules that will be implemented in the main Flint project.
 It includes rules from all three provided categories of plugins: [Core](/rules#core-plugins), [Focused](/rules#focused-plugins), and [Incubator](/rules#incubator-plugins).
-Each rule is equivalent to at least one existing rule in another linter.
 
 <RulesTable implementing small sortBy="name" />


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #2790
- [x] That issue was marked as [`status: accepting prs`](https://github.com/flint-fyi/flint/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/flint-fyi/flint/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Removes the stale line saying every rule is equivalent to an existing linter rule, since Flint now has Flint-specific rules.