### PR TITLE
docs: fix '3 report(s) across 2 file(s)' typo

### DIFF
--- a/packages/site/src/content/docs/cli.mdx
+++ b/packages/site/src/content/docs/cli.mdx
@@ -90,7 +90,7 @@ Flint's interactive CLI view can be controlled by using the arrow keys printed i
 [90m│ [39m [38;2;170;204;170m[3m→ flint.fyi/rules/forInArrays
 [90m╰[39m
 
-[31m✖ Found [1m3 report[22m across [1m2 file[22m.[39m
+[31m✖ Found [1m3 reports[22m across [1m2 files[22m.[39m
 ```
 
 </div>
@@ -116,7 +116,7 @@ Flint's interactive CLI view can be controlled by using the arrow keys printed i
 [38;2;120;120;120m│ [39m [38;2;0;128;90m[3m→ flint.fyi/rules/forInArrays[23m[39m
 [38;2;120;120;120m╰[39m
 
-[3m[38;2;170;0;0m✖ Found [1m3 report[22m across [1m2 file[22m.[39m[23m
+[3m[38;2;170;0;0m✖ Found [1m3 reports[22m across [1m2 files[22m.[39m[23m
 ```
 
 </div>


### PR DESCRIPTION
## Overview

Quick docs fix I noticed today: it says "3 report across ...".

This is under https://flint.fyi/cli#--interactive.

<table>
<thead>
<tr>
<th>Before</th>
<th>After</th>
</tr>
</thead>
<tbody>
<td>
<img width="304" height="88" alt="Bold italic red text: '3 report across 2 file'" src="https://github.com/user-attachments/assets/1a3836dd-c734-4cf3-aa29-26411d840f12" />
</td>
<td>
<img width="304" height="88" alt="Bold italic red text: '3 reports across 2 files'" src="https://github.com/user-attachments/assets/d01e99cd-ef40-4962-9508-59321cc23d54" />
</td>
</tr>
</tbody>
</table>

❤️‍🔥