### PR TITLE
ci: reduce site build work

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/prepare
       - run: pnpm run build # Ensure packages pass attw, etc.
-      - run: pnpm run -r build # Build packages/site
+      - run: pnpm --filter=site build:no-og # Build packages/site without OG images.
   dedupe_check:
     name: Dedupe Check
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/prepare
       - run: pnpm run build # Ensure packages pass attw, etc.
-      - run: pnpm --filter=site build:no-og # Build packages/site without OG images.
+      - run: pnpm --filter=site check # Validate packages/site without a full Astro build.
   dedupe_check:
     name: Dedupe Check
     runs-on: ubuntu-latest

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,2 @@
+[context.deploy-preview.environment]
+  SKIP_OG = "true"

--- a/packages/site/package.json
+++ b/packages/site/package.json
@@ -7,7 +7,7 @@
 	"scripts": {
 		"astro": "astro",
 		"prebuild": "astro sync",
-		"build": "pnpm run check && astro build",
+		"build": "astro build",
 		"check": "astro check",
 		"dev": "astro dev",
 		"preview": "astro preview",

--- a/packages/site/package.json
+++ b/packages/site/package.json
@@ -8,7 +8,6 @@
 		"astro": "astro",
 		"prebuild": "astro sync",
 		"build": "pnpm run check && astro build",
-		"build:no-og": "pnpm run check && SKIP_OG=true astro build",
 		"check": "astro check",
 		"dev": "astro dev",
 		"preview": "astro preview",

--- a/packages/site/package.json
+++ b/packages/site/package.json
@@ -8,6 +8,7 @@
 		"astro": "astro",
 		"prebuild": "astro sync",
 		"build": "astro check && astro build",
+		"build:no-og": "astro check && SKIP_OG=true astro build",
 		"dev": "astro dev",
 		"preview": "astro preview",
 		"start": "astro dev"

--- a/packages/site/package.json
+++ b/packages/site/package.json
@@ -7,8 +7,9 @@
 	"scripts": {
 		"astro": "astro",
 		"prebuild": "astro sync",
-		"build": "astro check && astro build",
-		"build:no-og": "astro check && SKIP_OG=true astro build",
+		"build": "pnpm run check && astro build",
+		"build:no-og": "pnpm run check && SKIP_OG=true astro build",
+		"check": "astro check",
 		"dev": "astro dev",
 		"preview": "astro preview",
 		"start": "astro dev"

--- a/packages/site/src/pages/og/[...path].ts
+++ b/packages/site/src/pages/og/[...path].ts
@@ -4,9 +4,11 @@ import { getCollection } from "astro:content";
 
 const paths = await getCollection("docs");
 const pages = Object.fromEntries(
-	paths.map(({ data, id }) => {
-		return [id, { data }] as const;
-	}),
+	process.env.SKIP_OG
+		? []
+		: paths.map(({ data, id }) => {
+				return [id, { data }] as const;
+			}),
 );
 
 export const { GET, getStaticPaths } = await OGImageRoute({


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to flint! ❤️‍🔥
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #1781
- [x] That issue was marked as [`status: accepting prs`](https://github.com/flint-fyi/flint/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/flint-fyi/flint/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Reference the Biome website setup by splitting site validation from full site builds. GitHub Actions now runs the site check script instead of a full Astro production build, while Netlify Deploy Previews set `SKIP_OG=true` to skip Open Graph image generation during preview builds.

<!-- Description of what is changed and how the code change does that. -->
