### PR TITLE
ci: add cache for `.astro` build output

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,6 +13,15 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/prepare
+      - name: Cache Astro build assets
+        uses: actions/cache@v5
+        with:
+          path: packages/site/.astro
+          # Scope the hash specifically to the site's package.json
+          key: ${{ runner.os }}-astro-${{ hashFiles('packages/site/package.json') }}-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-astro-${{ hashFiles('packages/site/package.json') }}-
+            ${{ runner.os }}-astro-
       - run: pnpm run build # Ensure packages pass attw, etc.
       - run: pnpm run -r build # Build packages/site
   dedupe_check:


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to flint! ❤️‍🔥
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #1781
- [x] That issue was marked as [`status: accepting prs`](https://github.com/flint-fyi/flint/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/flint-fyi/flint/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

This change adds a workflow cache for the CI build step that caches `packages/site/.astro` across build executions.
