### PR TITLE
test: stabilize disk-backed host watcher tests

### DIFF
--- a/packages/core/src/host/createDiskBackedLinterHost.test.ts
+++ b/packages/core/src/host/createDiskBackedLinterHost.test.ts
@@ -434,9 +434,10 @@ describe("createDiskBackedLinterHost", () => {
 			fs.writeFileSync(path.join(baseDir, "src.txt"), "content");
 
 			const normalizedFile = normalizePath(path.join(baseDir, "src.txt"));
-			await sleep(50);
 
-			expect(onEvent).toHaveBeenCalledWith(normalizedFile);
+			await vi.waitFor(() => {
+				expect(onEvent).toHaveBeenCalledWith(normalizedFile);
+			});
 		});
 
 		it("ignores node_modules directories within watched paths", async () => {
@@ -461,9 +462,10 @@ describe("createDiskBackedLinterHost", () => {
 			fs.writeFileSync(path.join(baseDir, "src.txt"), "content");
 
 			const normalizedFile = normalizePath(path.join(baseDir, "src.txt"));
-			await sleep(50);
 
-			expect(onEvent).toHaveBeenCalledWith(normalizedFile);
+			await vi.waitFor(() => {
+				expect(onEvent).toHaveBeenCalledWith(normalizedFile);
+			});
 		});
 
 		it("does not ignore lookalike names such as .gitignore", async () => {


### PR DESCRIPTION
﻿## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [`status: accepting prs`](https://github.com/flint-fyi/flint/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [ ] Steps in [CONTRIBUTING.md](https://github.com/flint-fyi/flint/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

This PR is fully automated.

Stabilizes the disk-backed linter host watcher tests by replacing fixed post-write sleeps with `vi.waitFor(...)` assertions.
This avoids racing `fs.watch` delivery when an intermediate ignored directory event arrives before the expected `src.txt` event.

https://github.com/flint-fyi/flint/pull/1246#discussion_r2659043325, for a blast from the past 

Verification: `pnpm vitest run packages/core/src/host/createDiskBackedLinterHost.test.ts`
