### PR TITLE
feat: assert that rule tester cases contain no language reports

### DIFF
--- a/packages/astro/src/rules/ruleTester.ts
+++ b/packages/astro/src/rules/ruleTester.ts
@@ -3,7 +3,7 @@ import { createRuleTesterTSConfig } from "@flint.fyi/typescript-language";
 import { describe, it } from "vitest";
 
 export const ruleTester = new RuleTester({
-	assertNoTSErrors: true,
+	assertNoLanguageReports: true,
 	defaults: {
 		fileName: "file.astro",
 		files: {

--- a/packages/astro/src/rules/ruleTester.ts
+++ b/packages/astro/src/rules/ruleTester.ts
@@ -3,12 +3,33 @@ import { createRuleTesterTSConfig } from "@flint.fyi/typescript-language";
 import { describe, it } from "vitest";
 
 export const ruleTester = new RuleTester({
+	assertNoTSErrors: true,
 	defaults: {
 		fileName: "file.astro",
-		files: createRuleTesterTSConfig({
-			jsx: "preserve",
-			lib: ["dom", "esnext"],
-		}),
+		files: {
+			...createRuleTesterTSConfig({
+				jsx: "preserve",
+				lib: ["dom", "esnext"],
+			}),
+			"fixtures.d.ts": `
+declare module "*.astro" {
+	const Component: (props: Record<string, unknown>) => unknown;
+	export default Component;
+}
+
+declare module "*.svelte" {
+	const Component: (props: Record<string, unknown>) => unknown;
+	export default Component;
+}
+`,
+			"node_modules/astro/jsx-runtime.d.ts": `
+export namespace JSX {
+	interface IntrinsicElements {
+		[name: string]: Record<string, unknown>;
+	}
+}
+`,
+		},
 	},
 	describe,
 	diskBackedFSRoot: import.meta.dirname,

--- a/packages/rule-tester/src/RuleTester.ts
+++ b/packages/rule-tester/src/RuleTester.ts
@@ -31,7 +31,7 @@ export interface RuleTesterDefaults {
 	files?: Record<string, string>;
 }
 export interface RuleTesterOptions {
-	assertNoTSErrors?: boolean;
+	assertNoLanguageReports?: boolean;
 	defaults?: RuleTesterDefaults;
 	describe?: TesterSetupDescribe;
 	diskBackedFSRoot?: string;
@@ -62,7 +62,7 @@ export class RuleTester {
 	#testerOptions: Required<Omit<RuleTesterOptions, "diskBackedFSRoot">>;
 
 	constructor({
-		assertNoTSErrors = false,
+		assertNoLanguageReports = false,
 		defaults = {},
 		describe,
 		diskBackedFSRoot,
@@ -119,7 +119,7 @@ export class RuleTester {
 		}
 
 		this.#testerOptions = {
-			assertNoTSErrors,
+			assertNoLanguageReports,
 			defaults,
 			describe: defaultTo(describe, scope, "describe"),
 			it,
@@ -164,10 +164,10 @@ export class RuleTester {
 				{ options: parseOptions(rule.options, testCase.options), rule },
 				testCaseNormalized,
 				{
-					collectLanguageReports: this.#testerOptions.assertNoTSErrors,
+					collectLanguageReports: this.#testerOptions.assertNoLanguageReports,
 				},
 			);
-			assertNoTSErrors(languageReports);
+			assertNoLanguageReports(languageReports);
 			const actualSnapshot = createReportSnapshot(testCase.code, reports);
 
 			assert.equal(actualSnapshot, testCase.snapshot);
@@ -241,10 +241,10 @@ export class RuleTester {
 				{ options: parseOptions(rule.options, testCase.options), rule },
 				testCaseNormalized,
 				{
-					collectLanguageReports: this.#testerOptions.assertNoTSErrors,
+					collectLanguageReports: this.#testerOptions.assertNoLanguageReports,
 				},
 			);
-			assertNoTSErrors(languageReports);
+			assertNoLanguageReports(languageReports);
 
 			if (reports.length) {
 				assert.deepStrictEqual(
@@ -256,22 +256,16 @@ export class RuleTester {
 	}
 }
 
-function assertNoTSErrors(languageReports: LanguageReports) {
-	// TODO: Replace this with a structured LanguageReport source when available.
-	const typeScriptReports = languageReports.filter((languageReport) =>
-		languageReport.code?.startsWith("TS"),
-	);
-
-	if (!typeScriptReports.length) {
-		return;
+function assertNoLanguageReports(languageReports: LanguageReports) {
+	// TODO (#2842): Surface each report's structured source
+	if (languageReports.length) {
+		assert.fail(
+			[
+				`Expected no language reports, but found ${languageReports.length}:`,
+				...languageReports.map((languageReport) => languageReport.text),
+			].join("\n\n"),
+		);
 	}
-
-	assert.fail(
-		[
-			`Expected no TS errors, but found ${typeScriptReports.length}:`,
-			...typeScriptReports.map((languageReport) => languageReport.text),
-		].join("\n\n"),
-	);
 }
 
 function defaultTo<TesterSetup extends TesterSetupDescribe | TesterSetupIt>(

--- a/packages/rule-tester/src/RuleTester.ts
+++ b/packages/rule-tester/src/RuleTester.ts
@@ -7,6 +7,7 @@ import {
 	createEphemeralLinterHost,
 	createVFSLinterHost,
 	type InferredInputObject,
+	type LanguageReports,
 	parseOptions,
 	type RuleAbout,
 	type VFSLinterHost,
@@ -30,6 +31,7 @@ export interface RuleTesterDefaults {
 	files?: Record<string, string>;
 }
 export interface RuleTesterOptions {
+	assertNoTSErrors?: boolean;
 	defaults?: RuleTesterDefaults;
 	describe?: TesterSetupDescribe;
 	diskBackedFSRoot?: string;
@@ -61,6 +63,7 @@ export class RuleTester {
 
 	constructor({
 		defaults = {},
+		assertNoTSErrors = false,
 		describe,
 		diskBackedFSRoot,
 		it,
@@ -117,6 +120,7 @@ export class RuleTester {
 
 		this.#testerOptions = {
 			defaults,
+			assertNoTSErrors,
 			describe: defaultTo(describe, scope, "describe"),
 			it,
 			only,
@@ -154,12 +158,16 @@ export class RuleTester {
 		);
 
 		this.#itTestCase(testCaseNormalized, async () => {
-			const reports = await runTestCaseRule(
+			const { languageReports, reports } = await runTestCaseRule(
 				this.#fileFactories,
 				this.#linterHost,
 				{ options: parseOptions(rule.options, testCase.options), rule },
 				testCaseNormalized,
+				{
+					collectLanguageReports: this.#testerOptions.assertNoTSErrors,
+				},
 			);
+			assertNoTSErrors(languageReports);
 			const actualSnapshot = createReportSnapshot(testCase.code, reports);
 
 			assert.equal(actualSnapshot, testCase.snapshot);
@@ -227,12 +235,16 @@ export class RuleTester {
 		);
 
 		this.#itTestCase(testCaseNormalized, async () => {
-			const reports = await runTestCaseRule(
+			const { languageReports, reports } = await runTestCaseRule(
 				this.#fileFactories,
 				this.#linterHost,
 				{ options: parseOptions(rule.options, testCase.options), rule },
 				testCaseNormalized,
+				{
+					collectLanguageReports: this.#testerOptions.assertNoTSErrors,
+				},
 			);
+			assertNoTSErrors(languageReports);
 
 			if (reports.length) {
 				assert.deepStrictEqual(
@@ -242,6 +254,24 @@ export class RuleTester {
 			}
 		});
 	}
+}
+
+function assertNoTSErrors(languageReports: LanguageReports) {
+	// TODO: Replace this with a structured LanguageReport source when available.
+	const typeScriptReports = languageReports.filter((languageReport) =>
+		languageReport.code?.startsWith("TS"),
+	);
+
+	if (!typeScriptReports.length) {
+		return;
+	}
+
+	assert.fail(
+		[
+			`Expected no TS errors, but found ${typeScriptReports.length}:`,
+			...typeScriptReports.map((languageReport) => languageReport.text),
+		].join("\n\n"),
+	);
 }
 
 function defaultTo<TesterSetup extends TesterSetupDescribe | TesterSetupIt>(

--- a/packages/rule-tester/src/RuleTester.ts
+++ b/packages/rule-tester/src/RuleTester.ts
@@ -62,8 +62,8 @@ export class RuleTester {
 	#testerOptions: Required<Omit<RuleTesterOptions, "diskBackedFSRoot">>;
 
 	constructor({
-		defaults = {},
 		assertNoTSErrors = false,
+		defaults = {},
 		describe,
 		diskBackedFSRoot,
 		it,
@@ -119,8 +119,8 @@ export class RuleTester {
 		}
 
 		this.#testerOptions = {
-			defaults,
 			assertNoTSErrors,
+			defaults,
 			describe: defaultTo(describe, scope, "describe"),
 			it,
 			only,

--- a/packages/rule-tester/src/runTestCaseRule.ts
+++ b/packages/rule-tester/src/runTestCaseRule.ts
@@ -24,6 +24,10 @@ export interface TestCaseRuleConfiguration<
 	rule: AnyRule<RuleAbout, OptionsSchema>;
 }
 
+export interface RunTestCaseRuleOptions {
+	collectLanguageReports?: boolean;
+}
+
 export async function runTestCaseRule<
 	OptionsSchema extends AnyOptionalSchema | undefined,
 >(
@@ -31,7 +35,8 @@ export async function runTestCaseRule<
 	linterHost: VFSLinterHost,
 	{ options, rule }: Required<TestCaseRuleConfiguration<OptionsSchema>>,
 	{ code, fileName, files }: TestCaseNormalized,
-): Promise<NormalizedReport[]> {
+	{ collectLanguageReports = false }: RunTestCaseRuleOptions = {},
+) {
 	const filePathAbsolute = normalizePath(
 		path.resolve(linterHost.getCurrentDirectory(), fileName),
 	);
@@ -79,9 +84,14 @@ export async function runTestCaseRule<
 		await ruleRuntime.teardown?.();
 	}
 
-	return reports.toSorted(
-		(a, b) =>
-			a.range.begin.raw - b.range.begin.raw ||
-			a.range.end.raw - b.range.end.raw,
-	);
+	return {
+		languageReports: collectLanguageReports
+			? (rule.language.getLanguageReports?.(file) ?? [])
+			: [],
+		reports: reports.toSorted(
+			(a, b) =>
+				a.range.begin.raw - b.range.begin.raw ||
+				a.range.end.raw - b.range.end.raw,
+		),
+	};
 }

--- a/packages/rule-tester/src/runTestCaseRule.ts
+++ b/packages/rule-tester/src/runTestCaseRule.ts
@@ -5,7 +5,6 @@ import {
 	type AnyRule,
 	type FileReport,
 	type InferredOutputObject,
-	type NormalizedReport,
 	processRuleReport,
 	type RuleAbout,
 	type VFSLinterHost,
@@ -17,15 +16,15 @@ import path from "node:path";
 
 import type { TestCaseNormalized } from "./normalizeTestCase.ts";
 
+export interface RunTestCaseRuleOptions {
+	collectLanguageReports?: boolean;
+}
+
 export interface TestCaseRuleConfiguration<
 	OptionsSchema extends AnyOptionalSchema | undefined,
 > {
 	options?: InferredOutputObject<OptionsSchema | undefined>;
 	rule: AnyRule<RuleAbout, OptionsSchema>;
-}
-
-export interface RunTestCaseRuleOptions {
-	collectLanguageReports?: boolean;
 }
 
 export async function runTestCaseRule<

--- a/packages/svelte/src/rules/rawSpecialElements.test.ts
+++ b/packages/svelte/src/rules/rawSpecialElements.test.ts
@@ -86,7 +86,7 @@ ruleTester.describe(rule, {
 		"<svelte:body></svelte:body>",
 		"<svelte:window></svelte:window>",
 		"<svelte:document></svelte:document>",
-		"<svelte:element this={{}}></svelte:element>",
+		'<svelte:element this="div"></svelte:element>',
 		"<svelte:options></svelte:options>",
 	],
 });

--- a/packages/svelte/src/rules/ruleTester.ts
+++ b/packages/svelte/src/rules/ruleTester.ts
@@ -3,7 +3,7 @@ import { createRuleTesterTSConfig } from "@flint.fyi/typescript-language";
 import { describe, it } from "vitest";
 
 export const ruleTester = new RuleTester({
-	assertNoTSErrors: true,
+	assertNoLanguageReports: true,
 	defaults: {
 		fileName: "file.svelte",
 		files: createRuleTesterTSConfig({

--- a/packages/svelte/src/rules/ruleTester.ts
+++ b/packages/svelte/src/rules/ruleTester.ts
@@ -3,6 +3,7 @@ import { createRuleTesterTSConfig } from "@flint.fyi/typescript-language";
 import { describe, it } from "vitest";
 
 export const ruleTester = new RuleTester({
+	assertNoTSErrors: true,
 	defaults: {
 		fileName: "file.svelte",
 		files: createRuleTesterTSConfig({

--- a/packages/vue/src/rules/ruleTester.ts
+++ b/packages/vue/src/rules/ruleTester.ts
@@ -3,7 +3,7 @@ import { createRuleTesterTSConfig } from "@flint.fyi/typescript-language";
 import { describe, it } from "vitest";
 
 export const ruleTester = new RuleTester({
-	assertNoTSErrors: true,
+	assertNoLanguageReports: true,
 	defaults: {
 		fileName: "file.vue",
 		files: createRuleTesterTSConfig({

--- a/packages/vue/src/rules/ruleTester.ts
+++ b/packages/vue/src/rules/ruleTester.ts
@@ -3,6 +3,7 @@ import { createRuleTesterTSConfig } from "@flint.fyi/typescript-language";
 import { describe, it } from "vitest";
 
 export const ruleTester = new RuleTester({
+	assertNoTSErrors: true,
 	defaults: {
 		fileName: "file.vue",
 		files: createRuleTesterTSConfig({

--- a/packages/vue/src/rules/vForKeys.test.ts
+++ b/packages/vue/src/rules/vForKeys.test.ts
@@ -461,14 +461,6 @@ ruleTester.describe(rule, {
 </template>
 		`,
 		`
-<template>
-	<div
-		v-for="n in 10"
-		key
-	></div>
-</template>
-		`,
-		`
 <script setup lang="ts">
 	const key = 5
 </script>


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to flint! ❤️‍🔥
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: Part of #2471
- [x] That issue was marked as [`status: accepting prs`](https://github.com/flint-fyi/flint/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/flint-fyi/flint/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

This is a minimal implementation: `assertNoTSErrors` is a transitional opt-in flag. Once each plugin's TS errors are resolved, the parameter will be removed and the check will apply by default.
