### PR TITLE
refactor(package-json): quality of life tweaks

### DIFF
--- a/.changeset/fair-flies-talk.md
+++ b/.changeset/fair-flies-talk.md
@@ -1,0 +1,5 @@
+---
+"@flint.fyi/json-language": patch
+---
+
+Add `JsonExpression` and `PropertyAssignment` to the `JsonNode` union.

--- a/packages/json-language/src/nodes.ts
+++ b/packages/json-language/src/nodes.ts
@@ -17,12 +17,14 @@ export type JsonNodeName = keyof JsonNodesByName;
 export interface JsonNodesByName {
 	ArrayLiteralExpression: AST.ArrayLiteralExpression;
 	BooleanLiteral: AST.BooleanLiteral;
+	JsonExpression: AST.Expression;
 	JsonMinusNumericLiteral: JsonMinusNumericLiteral;
 	JsonObjectExpressionStatement: JsonObjectExpressionStatement;
 	JsonSourceFile: JsonSourceFile;
 	NullLiteral: AST.NullLiteral;
 	NumericLiteral: AST.NumericLiteral;
 	ObjectLiteralExpression: AST.ObjectLiteralExpression;
+	PropertyAssignment: AST.PropertyAssignment;
 	StringLiteral: AST.StringLiteral;
 }
 

--- a/packages/package-json/src/createDirectPropertyValidityRule.ts
+++ b/packages/package-json/src/createDirectPropertyValidityRule.ts
@@ -19,7 +19,7 @@ export function createDirectPropertyValidityRule<PropertyName extends string>(
 	propertyValidator: PropertyValidator,
 ) {
 	const id = `${propertyName}Validity` as const;
-	const propertyNames = new Set([propertyName, ...propertyNameAliases]);
+	const propertyNames = [propertyName, ...propertyNameAliases];
 
 	const rule: AnyRule = ruleCreator.createRule(jsonLanguage, {
 		about: {
@@ -101,12 +101,12 @@ export function createDirectPropertyValidityRule<PropertyName extends string>(
 
 			return {
 				visitors: {
-					JsonSourceFile: (node, { sourceFile }) => {
-						for (const initializer of getPackagePropertiesOfNames(
-							node,
-							propertyNames,
-						)) {
-							checkValue(initializer, sourceFile);
+					JsonSourceFile: (node) => {
+						const properties = getPackagePropertiesOfNames(node, propertyNames);
+						for (const property of Object.values(properties)) {
+							if (property?.initializer) {
+								checkValue(property.initializer, node);
+							}
 						}
 					},
 				},

--- a/packages/package-json/src/getPackagePropertiesOfNames.ts
+++ b/packages/package-json/src/getPackagePropertiesOfNames.ts
@@ -1,24 +1,34 @@
-import type { JsonNode, JsonSourceFile } from "@flint.fyi/json-language";
+import type { JsonSourceFile } from "@flint.fyi/json-language";
+import type { AST } from "@flint.fyi/typescript-language";
 import { SyntaxKind } from "typescript";
 
 import { getPackageProperties } from "./getPackageProperties.ts";
 
-export function* getPackagePropertiesOfNames(
+export function getPackagePropertiesOfNames<T extends string[]>(
 	sourceFile: JsonSourceFile,
-	propertyNames: ReadonlySet<string>,
-) {
+	propertyNames: T,
+): Partial<Record<T[number], AST.PropertyAssignment>> {
+	const result: Partial<Record<T[number], AST.PropertyAssignment>> = {};
+
 	const properties = getPackageProperties(sourceFile);
 	if (!properties) {
-		return;
+		return result;
 	}
+
+	const propertyNameSet = new Set(propertyNames);
+
+	const isPropertyName = (name: string): name is T[number] => {
+		return propertyNameSet.has(name as T[number]);
+	};
 
 	for (const property of properties) {
 		if (
 			property.kind === SyntaxKind.PropertyAssignment &&
 			property.name.kind === SyntaxKind.StringLiteral &&
-			propertyNames.has(property.name.text)
+			isPropertyName(property.name.text)
 		) {
-			yield property.initializer as JsonNode;
+			result[property.name.text] = property;
 		}
 	}
+	return result;
 }

--- a/packages/package-json/src/rules/attribution.ts
+++ b/packages/package-json/src/rules/attribution.ts
@@ -2,7 +2,7 @@ import { getJsonNodeRange, jsonLanguage } from "@flint.fyi/json-language";
 import { SyntaxKind } from "typescript";
 import { z } from "zod/v4";
 
-import { getPackagePropertyOfName } from "../getPackagePropertyOfName.ts";
+import { getPackagePropertiesOfNames } from "../getPackagePropertiesOfNames.ts";
 import { ruleCreator } from "../ruleCreator.ts";
 
 export default ruleCreator.createRule(jsonLanguage, {
@@ -60,19 +60,25 @@ export default ruleCreator.createRule(jsonLanguage, {
 	setup(context) {
 		return {
 			visitors: {
-				JsonSourceFile(node, { options, sourceFile }) {
+				JsonSourceFile(node, { options }) {
+					const {
+						author,
+						contributors,
+						private: privateNode,
+					} = getPackagePropertiesOfNames(node, [
+						"private",
+						"author",
+						"contributors",
+					]);
 					if (options.ignorePrivate) {
-						const isPrivate = getPackagePropertyOfName(node, "private");
-
 						if (
-							isPrivate?.kind === SyntaxKind.PropertyAssignment &&
-							isPrivate.initializer.kind === SyntaxKind.TrueKeyword
+							privateNode?.kind === SyntaxKind.PropertyAssignment &&
+							privateNode.initializer.kind === SyntaxKind.TrueKeyword
 						) {
 							return;
 						}
 					}
 
-					const author = getPackagePropertyOfName(node, "author");
 					if (
 						options.preferContributorsOnly &&
 						author?.kind === SyntaxKind.PropertyAssignment &&
@@ -80,11 +86,10 @@ export default ruleCreator.createRule(jsonLanguage, {
 					) {
 						context.report({
 							message: "preferContributorsOnly",
-							range: getJsonNodeRange(author.name, sourceFile),
+							range: getJsonNodeRange(author.name, node),
 						});
 					}
 
-					const contributors = getPackagePropertyOfName(node, "contributors");
 					if (
 						contributors?.kind === SyntaxKind.PropertyAssignment &&
 						contributors.initializer.kind ===
@@ -93,7 +98,7 @@ export default ruleCreator.createRule(jsonLanguage, {
 					) {
 						context.report({
 							message: "emptyContributors",
-							range: getJsonNodeRange(contributors.initializer, sourceFile),
+							range: getJsonNodeRange(contributors.initializer, node),
 						});
 					}
 

--- a/packages/package-json/src/rules/attribution.ts
+++ b/packages/package-json/src/rules/attribution.ts
@@ -70,13 +70,12 @@ export default ruleCreator.createRule(jsonLanguage, {
 						"author",
 						"contributors",
 					]);
-					if (options.ignorePrivate) {
-						if (
-							privateNode?.kind === SyntaxKind.PropertyAssignment &&
-							privateNode.initializer.kind === SyntaxKind.TrueKeyword
-						) {
-							return;
-						}
+					if (
+						options.ignorePrivate &&
+						privateNode?.kind === SyntaxKind.PropertyAssignment &&
+						privateNode.initializer.kind === SyntaxKind.TrueKeyword
+					) {
+						return;
 					}
 
 					if (

--- a/packages/package-json/src/rules/binNameCasing.ts
+++ b/packages/package-json/src/rules/binNameCasing.ts
@@ -24,7 +24,7 @@ export default ruleCreator.createRule(jsonLanguage, {
 	setup(context) {
 		return {
 			visitors: {
-				JsonSourceFile(node, { sourceFile }) {
+				JsonSourceFile(node) {
 					const property = getPackagePropertyOfName(node, "bin");
 					if (
 						property?.kind !== ts.SyntaxKind.PropertyAssignment ||
@@ -48,7 +48,7 @@ export default ruleCreator.createRule(jsonLanguage, {
 							continue;
 						}
 
-						const range = getJsonNodeRange(binProperty.name, sourceFile);
+						const range = getJsonNodeRange(binProperty.name, node);
 
 						context.report({
 							message: "invalidCase",

--- a/packages/package-json/src/rules/dependencyUniqueness.ts
+++ b/packages/package-json/src/rules/dependencyUniqueness.ts
@@ -50,7 +50,7 @@ export default ruleCreator.createRule(jsonLanguage, {
 	setup(context) {
 		return {
 			visitors: {
-				JsonSourceFile(node, { sourceFile }) {
+				JsonSourceFile(node) {
 					const dependencies = new Set<string>();
 					const crossGroupDependencies: AST.ObjectLiteralExpression[] = [];
 
@@ -70,14 +70,14 @@ export default ruleCreator.createRule(jsonLanguage, {
 							}
 
 							const { range, text } = removeArrayElement(
-								sourceFile,
+								node,
 								element,
 								initializer,
 							);
 
 							context.report({
 								message: "duplicateDependency",
-								range: getJsonNodeRange(element, sourceFile),
+								range: getJsonNodeRange(element, node),
 								suggestions: [
 									{
 										id: "removeDependency",
@@ -110,14 +110,14 @@ export default ruleCreator.createRule(jsonLanguage, {
 							}
 
 							const { range, text } = removeObjectProperty(
-								sourceFile,
+								node,
 								dependency,
 								initializer,
 							);
 
 							context.report({
 								message: "duplicateDependency",
-								range: getJsonNodeRange(dependencyName, sourceFile),
+								range: getJsonNodeRange(dependencyName, node),
 								suggestions: [
 									{
 										id: "removeDependency",
@@ -141,14 +141,14 @@ export default ruleCreator.createRule(jsonLanguage, {
 								}
 
 								const { range, text } = removeObjectProperty(
-									sourceFile,
+									node,
 									dependency,
 									dependencyGroup,
 								);
 
 								context.report({
 									message: "crossGroupDuplicate",
-									range: getJsonNodeRange(dependency.name, sourceFile),
+									range: getJsonNodeRange(dependency.name, node),
 									suggestions: [
 										{
 											id: "removeDependency",

--- a/packages/package-json/src/rules/emptyFields.ts
+++ b/packages/package-json/src/rules/emptyFields.ts
@@ -171,7 +171,7 @@ export default ruleCreator.createRule(jsonLanguage, {
 
 		return {
 			visitors: {
-				JsonSourceFile(node, { options, sourceFile }) {
+				JsonSourceFile(node, { options }) {
 					const ignoredProperties = new Set(options.ignoreProperties);
 
 					if (node.statements.length !== 1) {
@@ -189,7 +189,7 @@ export default ruleCreator.createRule(jsonLanguage, {
 							property.name.kind === SyntaxKind.StringLiteral &&
 							!ignoredProperties.has(property.name.text)
 						) {
-							checkPropertyValue(property, sourceFile, expression);
+							checkPropertyValue(property, node, expression);
 						}
 					}
 				},

--- a/packages/package-json/src/rules/exportsSubpathsStyle.ts
+++ b/packages/package-json/src/rules/exportsSubpathsStyle.ts
@@ -67,7 +67,7 @@ export default ruleCreator.createRule(jsonLanguage, {
 	setup(context) {
 		return {
 			visitors: {
-				JsonSourceFile(node, { options, sourceFile }) {
+				JsonSourceFile(node, { options }) {
 					const property = getPackagePropertyOfName(node, "exports");
 
 					if (
@@ -78,7 +78,7 @@ export default ruleCreator.createRule(jsonLanguage, {
 					}
 
 					const initializer = property.initializer;
-					const range = getJsonNodeRange(property.name, sourceFile);
+					const range = getJsonNodeRange(property.name, node);
 
 					if (
 						options.prefer === "explicit" &&
@@ -88,8 +88,8 @@ export default ruleCreator.createRule(jsonLanguage, {
 					) {
 						context.report({
 							fix: {
-								range: getJsonNodeRange(initializer, sourceFile),
-								text: `{ ".": ${initializer.getText(sourceFile)} }`,
+								range: getJsonNodeRange(initializer, node),
+								text: `{ ".": ${initializer.getText(node)} }`,
 							},
 							message: "preferExplicit",
 							range,
@@ -112,8 +112,8 @@ export default ruleCreator.createRule(jsonLanguage, {
 
 					context.report({
 						fix: {
-							range: getJsonNodeRange(initializer, sourceFile),
-							text: rootSubpath.initializer.getText(sourceFile),
+							range: getJsonNodeRange(initializer, node),
+							text: rootSubpath.initializer.getText(node),
 						},
 						message: "preferImplicit",
 						range,

--- a/packages/package-json/src/rules/peerDependenciesInstallation.ts
+++ b/packages/package-json/src/rules/peerDependenciesInstallation.ts
@@ -1,7 +1,7 @@
 import { getJsonNodeRange, jsonLanguage } from "@flint.fyi/json-language";
 import { SyntaxKind } from "typescript";
 
-import { getPackagePropertyOfName } from "../getPackagePropertyOfName.ts";
+import { getPackagePropertiesOfNames } from "../getPackagePropertiesOfNames.ts";
 import { ruleCreator } from "../ruleCreator.ts";
 
 export default ruleCreator.createRule(jsonLanguage, {
@@ -24,11 +24,13 @@ export default ruleCreator.createRule(jsonLanguage, {
 	setup(context) {
 		return {
 			visitors: {
-				JsonSourceFile(node, { sourceFile }) {
-					const peerDependencies = getPackagePropertyOfName(
-						node,
-						"peerDependencies",
-					);
+				JsonSourceFile(node) {
+					const { devDependencies, peerDependencies } =
+						getPackagePropertiesOfNames(node, [
+							"peerDependencies",
+							"devDependencies",
+						]);
+
 					if (
 						peerDependencies?.kind !== SyntaxKind.PropertyAssignment ||
 						peerDependencies.initializer.kind !==
@@ -38,10 +40,6 @@ export default ruleCreator.createRule(jsonLanguage, {
 					}
 
 					const devDependencyNames = new Set<string>();
-					const devDependencies = getPackagePropertyOfName(
-						node,
-						"devDependencies",
-					);
 					if (
 						devDependencies?.kind === SyntaxKind.PropertyAssignment &&
 						devDependencies.initializer.kind ===
@@ -66,7 +64,7 @@ export default ruleCreator.createRule(jsonLanguage, {
 							context.report({
 								data: { name: dependency.name.text },
 								message: "missingDevDependency",
-								range: getJsonNodeRange(dependency.name, sourceFile),
+								range: getJsonNodeRange(dependency.name, node),
 							});
 						}
 					}

--- a/packages/package-json/src/rules/peerDependenciesMetaRelationship.ts
+++ b/packages/package-json/src/rules/peerDependenciesMetaRelationship.ts
@@ -4,6 +4,7 @@ import { SyntaxKind } from "typescript";
 import { getPackagePropertyOfName } from "../getPackagePropertyOfName.ts";
 import { removeObjectProperty } from "../removeObjectProperty.ts";
 import { ruleCreator } from "../ruleCreator.ts";
+import { getPackagePropertiesOfNames } from "../getPackagePropertiesOfNames.ts";
 
 export default ruleCreator.createRule(jsonLanguage, {
 	about: {
@@ -25,11 +26,12 @@ export default ruleCreator.createRule(jsonLanguage, {
 	setup(context) {
 		return {
 			visitors: {
-				JsonSourceFile(node, { sourceFile }) {
-					const peerDependenciesMeta = getPackagePropertyOfName(
-						node,
-						"peerDependenciesMeta",
-					);
+				JsonSourceFile(node) {
+					const { peerDependencies, peerDependenciesMeta } =
+						getPackagePropertiesOfNames(node, [
+							"peerDependencies",
+							"peerDependenciesMeta",
+						]);
 
 					// Bail early if there are no peerDependenciesMeta or if it's the wrong shape
 					if (
@@ -39,11 +41,6 @@ export default ruleCreator.createRule(jsonLanguage, {
 					) {
 						return;
 					}
-
-					const peerDependencies = getPackagePropertyOfName(
-						node,
-						"peerDependencies",
-					);
 
 					// Collect the set of dependency names declared in peerDependencies
 					const declaredPeerDependencyNames = new Set<string>();
@@ -72,14 +69,14 @@ export default ruleCreator.createRule(jsonLanguage, {
 
 							if (!declaredPeerDependencyNames.has(dependencyName)) {
 								const { range, text } = removeObjectProperty(
-									sourceFile,
+									node,
 									element,
 									peerDependenciesMeta.initializer,
 								);
 								context.report({
 									data: { dependencyName },
 									message: "unnecessaryPeerDependency",
-									range: getJsonNodeRange(element.name, sourceFile),
+									range: getJsonNodeRange(element.name, node),
 									suggestions: [
 										{
 											id: "removeUnnecessaryPeerDependencyMeta",

--- a/packages/package-json/src/rules/peerDependenciesMetaRelationship.ts
+++ b/packages/package-json/src/rules/peerDependenciesMetaRelationship.ts
@@ -1,10 +1,9 @@
 import { getJsonNodeRange, jsonLanguage } from "@flint.fyi/json-language";
 import { SyntaxKind } from "typescript";
 
-import { getPackagePropertyOfName } from "../getPackagePropertyOfName.ts";
+import { getPackagePropertiesOfNames } from "../getPackagePropertiesOfNames.ts";
 import { removeObjectProperty } from "../removeObjectProperty.ts";
 import { ruleCreator } from "../ruleCreator.ts";
-import { getPackagePropertiesOfNames } from "../getPackagePropertiesOfNames.ts";
 
 export default ruleCreator.createRule(jsonLanguage, {
 	about: {

--- a/packages/package-json/src/rules/privatePackageProperties.ts
+++ b/packages/package-json/src/rules/privatePackageProperties.ts
@@ -33,7 +33,7 @@ export default ruleCreator.createRule(jsonLanguage, {
 	setup(context) {
 		return {
 			visitors: {
-				JsonSourceFile(node, { options, sourceFile }) {
+				JsonSourceFile(node, { options }) {
 					const properties = getPackageProperties(node);
 					const root = node.statements[0];
 
@@ -65,7 +65,7 @@ export default ruleCreator.createRule(jsonLanguage, {
 						}
 
 						const { range, text } = removeObjectProperty(
-							sourceFile,
+							node,
 							property,
 							root.expression,
 						);
@@ -75,7 +75,7 @@ export default ruleCreator.createRule(jsonLanguage, {
 								propertyName: property.name.text,
 							},
 							message: "unnecessaryProperty",
-							range: getJsonNodeRange(property.name, sourceFile),
+							range: getJsonNodeRange(property.name, node),
 							suggestions: [
 								{
 									id: "removePrivatePackageProperty",

--- a/packages/package-json/src/rules/publishConfigRedundancy.ts
+++ b/packages/package-json/src/rules/publishConfigRedundancy.ts
@@ -1,7 +1,7 @@
 import { getJsonNodeRange, jsonLanguage } from "@flint.fyi/json-language";
 import { SyntaxKind } from "typescript";
 
-import { getPackagePropertyOfName } from "../getPackagePropertyOfName.ts";
+import { getPackagePropertiesOfNames } from "../getPackagePropertiesOfNames.ts";
 import { removeObjectProperty } from "../removeObjectProperty.ts";
 import { ruleCreator } from "../ruleCreator.ts";
 
@@ -25,47 +25,45 @@ export default ruleCreator.createRule(jsonLanguage, {
 	setup(context) {
 		return {
 			visitors: {
-				JsonSourceFile(node, { sourceFile }) {
-					const nameProperty = getPackagePropertyOfName(node, "name");
+				JsonSourceFile(node) {
+					const { name, publishConfig } = getPackagePropertiesOfNames(node, [
+						"name",
+						"publishConfig",
+					]);
 
 					if (
-						nameProperty?.kind !== SyntaxKind.PropertyAssignment ||
-						nameProperty.initializer.kind !== SyntaxKind.StringLiteral ||
-						nameProperty.initializer.text.startsWith("@")
+						name?.kind !== SyntaxKind.PropertyAssignment ||
+						name.initializer.kind !== SyntaxKind.StringLiteral ||
+						name.initializer.text.startsWith("@")
 					) {
 						return;
 					}
 
-					const publishConfigProperty = getPackagePropertyOfName(
-						node,
-						"publishConfig",
-					);
-
 					if (
-						publishConfigProperty?.kind !== SyntaxKind.PropertyAssignment ||
-						publishConfigProperty.initializer.kind !==
+						publishConfig?.kind !== SyntaxKind.PropertyAssignment ||
+						publishConfig.initializer.kind !==
 							SyntaxKind.ObjectLiteralExpression
 					) {
 						return;
 					}
 
-					const publishConfig = publishConfigProperty.initializer;
+					const publishConfigValue = publishConfig.initializer;
 
-					for (const property of publishConfig.properties) {
+					for (const property of publishConfigValue.properties) {
 						if (
 							property.kind === SyntaxKind.PropertyAssignment &&
 							property.name.kind === SyntaxKind.StringLiteral &&
 							property.name.text === "access"
 						) {
 							const { range, text } = removeObjectProperty(
-								sourceFile,
+								node,
 								property,
-								publishConfig,
+								publishConfigValue,
 							);
 
 							context.report({
 								message: "redundantAccess",
-								range: getJsonNodeRange(property.name, sourceFile),
+								range: getJsonNodeRange(property.name, node),
 								suggestions: [
 									{
 										id: "removeAccess",

--- a/packages/package-json/src/rules/repositoryShorthand.ts
+++ b/packages/package-json/src/rules/repositoryShorthand.ts
@@ -62,7 +62,7 @@ export default ruleCreator.createRule(jsonLanguage, {
 	setup(context) {
 		return {
 			visitors: {
-				JsonSourceFile: (node, { sourceFile }) => {
+				JsonSourceFile: (node) => {
 					const property = getPackagePropertyOfName(node, "repository");
 					if (
 						property?.kind !== ts.SyntaxKind.PropertyAssignment ||
@@ -71,7 +71,7 @@ export default ruleCreator.createRule(jsonLanguage, {
 						return;
 					}
 
-					const range = getTSNodeRange(property.initializer, sourceFile);
+					const range = getTSNodeRange(property.initializer, node);
 					const url = createUrl(property.initializer.text);
 
 					context.report({

--- a/packages/package-json/src/rules/scriptsNameCasing.ts
+++ b/packages/package-json/src/rules/scriptsNameCasing.ts
@@ -28,7 +28,7 @@ export default ruleCreator.createRule(jsonLanguage, {
 	setup(context) {
 		return {
 			visitors: {
-				JsonSourceFile(node, { sourceFile }) {
+				JsonSourceFile(node) {
 					const property = getPackagePropertyOfName(node, "scripts");
 					if (
 						property?.kind !== ts.SyntaxKind.PropertyAssignment ||
@@ -56,7 +56,7 @@ export default ruleCreator.createRule(jsonLanguage, {
 							continue;
 						}
 
-						const range = getJsonNodeRange(scriptsProperty.name, sourceFile);
+						const range = getJsonNodeRange(scriptsProperty.name, node);
 
 						context.report({
 							message: "invalidCase",


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to flint! ❤️‍🔥
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [`status: accepting prs`](https://github.com/flint-fyi/flint/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/flint-fyi/flint/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

This change addresses a gripe i've had for a while, with the way the top-level property retrieval was being done.  There are two convenience functions that help with getting properties from the root: `getPackagePropertyOfName` and `getPackagePropertiesOfNames`.  The first takes the property name and returns the corresponding `PropertyAssignment`.  The plural version of the function is a generator function that takes an array of property names and yields the corresponding `PropertyAssignment`'s _initializer_.  So that's one gripe: despite parallel naming, they returned nodes from two different parts of the AST.  

Secondly, the plural one being a generator function, severely limited its reusability.  It was only used in one place, despite serving a generally useful purpose.  The lack of a more general purpose plural version of the function, forced rules to just make multiple calls to the singular version of the function.  The problem with that is that the singular version did a complete loop over all of the top-level properties to find the one with the appropriate name.  So running that for multiple properties in the same rule, leads to a O(nm) runtime.  Whereas, if we have a plural version of the function that did one loop and gathered all of the properties requested, it would just be O(n+m) time.  I recognize that we're working with such small collections that that difference isn't significant, but it still bothered me.

The new version of the plural function is no longer a generator, and returns a `Record`, with property name to corresponding `PropertyAssignment` node.  I replaced all uses of the singular function where it was called more than once in a rule.

**Question for the group:** in order to prevent people from adding new uses of the singular function multiple times in the same rule, we could either create a repo-specific flint rule to flag those cases, or just remove the singular version of the function entirely and replace it with the equivalent call to the plural function.  Any preferences?

I also cleaned up some unnecessary uses of `sourceFile`, in places where the visitor function was already `JsonSourceFile` (the `node` _is_ the source file node).
