### PR TITLE
fix(ts): [asyncFunctionAwaits] detect awaits in expression-bodied async arrow functions

### DIFF
--- a/.changeset/ts-async-arrow-expression-await.md
+++ b/.changeset/ts-async-arrow-expression-await.md
@@ -2,5 +2,4 @@
 "@flint.fyi/ts": patch
 ---
 
-Fix a false positive in `asyncFunctionAwaits` for async arrow functions with expression bodies.
-`async () => await loadData()` is now correctly recognized as containing an `await`, since the body expression itself is checked rather than only its children.
+`asyncFunctionAwaits` no longer incorrectly flags arrow functions with expression bodies; e.g. `async () => await loadData()` is now correctly recognized as containing an `await`.

--- a/.changeset/ts-async-arrow-expression-await.md
+++ b/.changeset/ts-async-arrow-expression-await.md
@@ -1,0 +1,6 @@
+---
+"@flint.fyi/ts": patch
+---
+
+Fix a false positive in `asyncFunctionAwaits` for async arrow functions with expression bodies.
+`async () => await loadData()` is now correctly recognized as containing an `await`, since the body expression itself is checked rather than only its children.

--- a/packages/ts/src/rules/asyncFunctionAwaits.test.ts
+++ b/packages/ts/src/rules/asyncFunctionAwaits.test.ts
@@ -125,6 +125,10 @@ const fn = async () => {
 };
 `,
 		`
+declare function loadData(): Promise<void>;
+const load = async () => await loadData();
+`,
+		`
 class Example {
     async method() {
         await this.fetchData();

--- a/packages/ts/src/rules/asyncFunctionAwaits.test.ts
+++ b/packages/ts/src/rules/asyncFunctionAwaits.test.ts
@@ -125,8 +125,8 @@ const fn = async () => {
 };
 `,
 		`
-declare function loadData(): Promise<void>;
-const load = async () => await loadData();
+declare function asyncOperation(): Promise<void>;
+const withAbstract = async () => await asyncOperation();
 `,
 		`
 class Example {

--- a/packages/ts/src/rules/asyncFunctionAwaits.ts
+++ b/packages/ts/src/rules/asyncFunctionAwaits.ts
@@ -47,7 +47,7 @@ export default ruleCreator.createRule(typescriptLanguage, {
 				node.asteriskToken ||
 				!node.body ||
 				isEmptyBody(node.body) ||
-				bodyContainsAwait(node.body) ||
+				checkForAwait(node.body) ||
 				bodyReturnsThenable(node.body, typeChecker)
 			) {
 				return;
@@ -71,26 +71,6 @@ export default ruleCreator.createRule(typescriptLanguage, {
 });
 
 // TODO: Use a scope analyzer (#400)?
-function bodyContainsAwait(body: ts.Block | ts.Expression) {
-	function checkForAwait(node: ts.Node): boolean | undefined {
-		if (ts.isAwaitExpression(node)) {
-			return true;
-		}
-
-		if (ts.isForOfStatement(node) && node.awaitModifier) {
-			return true;
-		}
-
-		if (tsutils.isFunctionScopeBoundary(node)) {
-			return false;
-		}
-
-		return ts.forEachChild(node, checkForAwait);
-	}
-
-	return checkForAwait(body);
-}
-
 function bodyReturnsThenable(
 	body: ts.Block | ts.Expression,
 	typeChecker: ts.TypeChecker,
@@ -116,6 +96,22 @@ function bodyReturnsThenable(
 	}
 
 	return ts.forEachChild(body, checkReturnStatements);
+}
+
+function checkForAwait(node: ts.Node): boolean | undefined {
+	if (ts.isAwaitExpression(node)) {
+		return true;
+	}
+
+	if (ts.isForOfStatement(node) && node.awaitModifier) {
+		return true;
+	}
+
+	if (tsutils.isFunctionScopeBoundary(node)) {
+		return false;
+	}
+
+	return ts.forEachChild(node, checkForAwait);
 }
 
 function isEmptyBody(body: ts.Block | ts.Expression) {

--- a/packages/ts/src/rules/asyncFunctionAwaits.ts
+++ b/packages/ts/src/rules/asyncFunctionAwaits.ts
@@ -70,7 +70,6 @@ export default ruleCreator.createRule(typescriptLanguage, {
 	},
 });
 
-// TODO: Use a scope analyzer (#400)?
 function bodyReturnsThenable(
 	body: ts.Block | ts.Expression,
 	typeChecker: ts.TypeChecker,
@@ -98,6 +97,7 @@ function bodyReturnsThenable(
 	return ts.forEachChild(body, checkReturnStatements);
 }
 
+// TODO: Use a scope analyzer (#400)?
 function checkForAwait(node: ts.Node): boolean | undefined {
 	if (ts.isAwaitExpression(node)) {
 		return true;

--- a/packages/ts/src/rules/asyncFunctionAwaits.ts
+++ b/packages/ts/src/rules/asyncFunctionAwaits.ts
@@ -88,7 +88,7 @@ function bodyContainsAwait(body: ts.Block | ts.Expression) {
 		return ts.forEachChild(node, checkForAwait);
 	}
 
-	return ts.forEachChild(body, checkForAwait);
+	return checkForAwait(body);
 }
 
 function bodyReturnsThenable(


### PR DESCRIPTION
## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [`status: accepting prs`](https://github.com/flint-fyi/flint/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/flint-fyi/flint/blob/main/.github/CONTRIBUTING.md) were taken

<!-- Note: no tracking issue — this is a small self-contained bug fix found incidentally while cleaning up an unrelated branch. Happy to file an issue first if preferred. -->

## Overview

`asyncFunctionAwaits` had a false positive for async arrow functions with **expression bodies**: `async () => await loadData()` was reported as not containing an `await`.

The body of an expression-bodied arrow is the awaited expression *itself*, but the check used `ts.forEachChild(body, checkForAwait)`, which only visits the body's **children** — so the top-level `await` was missed. Changed it to call `checkForAwait(body)` directly so the body node is examined, with a regression test for the expression-body case.