### PR TITLE
chore: adopt experimental eslint-plugin-package-json

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -1,4 +1,5 @@
 import eslint from "@eslint/js";
+import eslintJson from "@eslint/json";
 import markdown from "@eslint/markdown";
 import comments from "@eslint-community/eslint-plugin-eslint-comments/configs";
 import vitest from "@vitest/eslint-plugin";
@@ -6,7 +7,7 @@ import { defineConfig, globalIgnores } from "eslint/config";
 import jsdoc from "eslint-plugin-jsdoc";
 import jsonc from "eslint-plugin-jsonc";
 import n from "eslint-plugin-n";
-import packageJson from "eslint-plugin-package-json";
+import packageJson from "eslint-plugin-package-json/experimental";
 import perfectionist from "eslint-plugin-perfectionist";
 import { Alphabet } from "eslint-plugin-perfectionist/alphabet";
 import * as regexp from "eslint-plugin-regexp";
@@ -258,11 +259,9 @@ export default defineConfig(
 	},
 	{
 		extends: [packageJson.configs.recommended, packageJson.configs.stylistic],
+		files: ["**/package.json"],
 		ignores: ["packages/e2e/tests/**/package.json"],
-	},
-	{
-		extends: [packageJson.configs["recommended-publishable"]],
-		files: ["packages/*/package.json"],
+		plugins: { json: eslintJson },
 		rules: {
 			"package-json/require-homepage": "error",
 		},

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
 		"@changesets/cli": "catalog:dev",
 		"@eslint-community/eslint-plugin-eslint-comments": "catalog:dev",
 		"@eslint/js": "catalog:dev",
+		"@eslint/json": "1.2.0",
 		"@eslint/markdown": "catalog:dev",
 		"@flint.fyi/node": "workspace:^",
 		"@flint.fyi/performance": "workspace:^",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -61,8 +61,8 @@ catalogs:
       specifier: 18.0.0
       version: 18.0.0
     eslint-plugin-package-json:
-      specifier: 1.1.0
-      version: 1.1.0
+      specifier: 1.2.0
+      version: 1.2.0
     eslint-plugin-perfectionist:
       specifier: 5.9.0
       version: 5.9.0
@@ -220,6 +220,9 @@ importers:
       '@eslint/js':
         specifier: catalog:dev
         version: 10.0.1(eslint@10.3.0(jiti@2.7.0))
+      '@eslint/json':
+        specifier: 1.2.0
+        version: 1.2.0
       '@eslint/markdown':
         specifier: catalog:dev
         version: 8.0.0
@@ -267,7 +270,7 @@ importers:
         version: 18.0.0(eslint@10.3.0(jiti@2.7.0))(typescript@5.9.3)
       eslint-plugin-package-json:
         specifier: catalog:dev
-        version: 1.1.0(@types/estree@1.0.8)(eslint@10.3.0(jiti@2.7.0))
+        version: 1.2.0(@eslint/json@1.2.0)(@types/estree@1.0.8)(eslint@10.3.0(jiti@2.7.0))
       eslint-plugin-perfectionist:
         specifier: catalog:dev
         version: 5.9.0(eslint@10.3.0(jiti@2.7.0))(typescript@5.9.3)
@@ -554,7 +557,7 @@ importers:
         version: 18.0.0(eslint@10.3.0(jiti@2.7.0))(typescript@5.9.3)
       eslint-plugin-package-json:
         specifier: catalog:dev
-        version: 1.1.0(@types/estree@1.0.8)(eslint@10.3.0(jiti@2.7.0))
+        version: 1.2.0(@eslint/json@1.2.0)(@types/estree@1.0.8)(eslint@10.3.0(jiti@2.7.0))
       eslint-plugin-perfectionist:
         specifier: catalog:dev
         version: 5.9.0(eslint@10.3.0(jiti@2.7.0))(typescript@5.9.3)
@@ -4578,11 +4581,15 @@ packages:
       typescript:
         optional: true
 
-  eslint-plugin-package-json@1.1.0:
-    resolution: {integrity: sha512-yFBkYxHBlGKBi3Av17pCkJie+G3/DN/XEy1KGkHnTLXCY8eX7rF2kGiFn8a3N4iIGV4NJzKA0HdpINwVxczX0Q==}
+  eslint-plugin-package-json@1.2.0:
+    resolution: {integrity: sha512-3BszsD7XVddaUNbMfK+1lF1Qg8ck0nO3bNT/7IjXP8wrGzPThHZpkhm5UnbY1Nb/s3o6DUNgHI4aEqQV/t83fw==}
     engines: {node: ^22.22.2 || >=24.15.0}
     peerDependencies:
+      '@eslint/json': '>=1.0.0'
       eslint: '>=9.0.0'
+    peerDependenciesMeta:
+      '@eslint/json':
+        optional: true
 
   eslint-plugin-perfectionist@5.9.0:
     resolution: {integrity: sha512-8TWzg02zmnBdZwCkWLi8jhzqXI+fE7Z/RwV8SL6xD45tJ8Bp3wGuYL2XtQgfe/Wd0eBqOUX+s6ey73IyszvKTA==}
@@ -10973,7 +10980,7 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.3
 
-  eslint-plugin-package-json@1.1.0(@types/estree@1.0.8)(eslint@10.3.0(jiti@2.7.0)):
+  eslint-plugin-package-json@1.2.0(@eslint/json@1.2.0)(@types/estree@1.0.8)(eslint@10.3.0(jiti@2.7.0)):
     dependencies:
       '@altano/repository-tools': 2.0.1
       change-case: 5.4.4
@@ -10981,11 +10988,14 @@ snapshots:
       detect-newline: 4.0.1
       eslint: 10.3.0(jiti@2.7.0)
       eslint-fix-utils: 0.4.2(@types/estree@1.0.8)(eslint@10.3.0(jiti@2.7.0))
+      eslint-json-compat-utils: 0.2.3(@eslint/json@1.2.0)(eslint@10.3.0(jiti@2.7.0))(jsonc-eslint-parser@3.1.0)
       jsonc-eslint-parser: 3.1.0
       package-json-validator: 1.5.1
       semver: 7.8.0
       sort-object-keys: 2.1.0
       sort-package-json: 3.6.1
+    optionalDependencies:
+      '@eslint/json': 1.2.0
     transitivePeerDependencies:
       - '@types/estree'
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -23,7 +23,7 @@ catalogs:
     eslint-plugin-jsdoc: 62.9.0
     eslint-plugin-jsonc: 3.1.0
     eslint-plugin-n: 18.0.0
-    eslint-plugin-package-json: 1.1.0
+    eslint-plugin-package-json: 1.2.0
     eslint-plugin-perfectionist: 5.9.0
     eslint-plugin-regexp: 3.1.0
     eslint-plugin-yml: 3.3.0


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to flint! ❤️‍🔥
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [`status: accepting prs`](https://github.com/flint-fyi/flint/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [ ] Steps in [CONTRIBUTING.md](https://github.com/flint-fyi/flint/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

This change updates our usage of `eslint-plugin-package-json` to use the new `experimental` entry point, which provides a version of the plugin that works with the `@eslint/json` language, instead of the jsonc parser.
