### PR TITLE
feat(json-language): add new version of the language based on `momoa`

### DIFF
--- a/.changeset/wise-eagles-strive.md
+++ b/.changeset/wise-eagles-strive.md
@@ -1,0 +1,6 @@
+---
+"@flint.fyi/json-language": patch
+---
+
+Add `./new` entry point with new version of the language based on the AST provided by `momoa`.
+This will utlimately replace the current TS-based implementation.

--- a/knip.ts
+++ b/knip.ts
@@ -33,6 +33,9 @@ export default {
 		"packages/json": {
 			project: ["src/**/*.ts!", "!src/rules/ruleTester.ts!"],
 		},
+		"packages/json-language": {
+			project: ["src/**/*.ts!", "!src/rules/ruleTester.ts!"],
+		},
 		"packages/jsx": {
 			project: ["src/**/*.ts!", "!src/rules/ruleTester.ts!"],
 		},

--- a/knip.ts
+++ b/knip.ts
@@ -33,9 +33,6 @@ export default {
 		"packages/json": {
 			project: ["src/**/*.ts!", "!src/rules/ruleTester.ts!"],
 		},
-		"packages/json-language": {
-			project: ["src/**/*.ts!", "!src/rules/ruleTester.ts!"],
-		},
 		"packages/jsx": {
 			project: ["src/**/*.ts!", "!src/rules/ruleTester.ts!"],
 		},

--- a/packages/css-language/src/language.ts
+++ b/packages/css-language/src/language.ts
@@ -40,10 +40,10 @@ export const cssLanguage: Language<CssNodeVisitors, CssFileServices> =
 			const visitorServices = { options, ...file.services };
 
 			walk(file.services.root, {
-				// @ts-expect-error -- Expression produces a union type that is too complex to represent
+				// @ts-expect-error -- The intersection AnPlusB & Atrule & AtrulePrelude &...was reduced to `never` because property `type` has conflicting types in some constituents.
 				enter: (node: CssNode) => visitors[node.type]?.(node, visitorServices),
 				leave: (node: CssNode) =>
-					// @ts-expect-error -- Expression produces a union type that is too complex to represent
+					// @ts-expect-error -- Argument of type `CssNode` is not assignable to parameter of type `undefined`.
 					visitors[`${node.type}:exit`]?.(node, visitorServices),
 			});
 		},

--- a/packages/json-language/package.json
+++ b/packages/json-language/package.json
@@ -16,7 +16,8 @@
 	"sideEffects": false,
 	"type": "module",
 	"exports": {
-		".": "./src/index.ts"
+		".": "./src/index.ts",
+		"./new": "./src/new/index.ts"
 	},
 	"files": [
 		"lib/",
@@ -28,6 +29,7 @@
 	"dependencies": {
 		"@flint.fyi/core": "workspace:^",
 		"@flint.fyi/typescript-language": "workspace:^",
+		"@humanwhocodes/momoa": "^3.3.10",
 		"typescript": "^5.9.0 || ^6.0.0"
 	},
 	"devDependencies": {
@@ -40,7 +42,8 @@
 	"publishConfig": {
 		"access": "public",
 		"exports": {
-			".": "./lib/index.js"
+			".": "./lib/index.js",
+			"./new": "./lib/new/index.js"
 		}
 	}
 }

--- a/packages/json-language/src/new/getJsonNodeRange.ts
+++ b/packages/json-language/src/new/getJsonNodeRange.ts
@@ -1,5 +1,6 @@
-import type { CharacterReportRange } from "@flint.fyi/core";
 import type { AnyNode } from "@humanwhocodes/momoa";
+
+import type { CharacterReportRange } from "@flint.fyi/core";
 
 export function getJsonNodeRange(node: AnyNode): CharacterReportRange {
 	return {

--- a/packages/json-language/src/new/getJsonNodeRange.ts
+++ b/packages/json-language/src/new/getJsonNodeRange.ts
@@ -1,0 +1,11 @@
+import type { CharacterReportRange } from "@flint.fyi/core";
+import type { AnyNode } from "@humanwhocodes/momoa";
+
+export function getJsonNodeRange(node: AnyNode): CharacterReportRange {
+	return {
+		// eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- we're opting into ranges
+		begin: node.range![0],
+		// eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- we're opting into ranges
+		end: node.range![1],
+	};
+}

--- a/packages/json-language/src/new/index.ts
+++ b/packages/json-language/src/new/index.ts
@@ -1,0 +1,2 @@
+export { getJsonNodeRange } from "./getJsonNodeRange.ts";
+export { jsonLanguage } from "./language.ts";

--- a/packages/json-language/src/new/index.ts
+++ b/packages/json-language/src/new/index.ts
@@ -1,2 +1,3 @@
 export { getJsonNodeRange } from "./getJsonNodeRange.ts";
 export { jsonLanguage } from "./language.ts";
+export type { JsonVisitorKey } from "./nodes.ts";

--- a/packages/json-language/src/new/language.ts
+++ b/packages/json-language/src/new/language.ts
@@ -1,11 +1,12 @@
-import { createLanguage, type Language } from "@flint.fyi/core";
 import {
+	parse,
+	traverse,
 	type AnyNode,
 	type DocumentNode,
 	type Node,
-	parse,
-	traverse,
 } from "@humanwhocodes/momoa";
+
+import { createLanguage, type Language } from "@flint.fyi/core";
 
 import type { JsonNodeVisitors } from "./nodes.ts";
 

--- a/packages/json-language/src/new/language.ts
+++ b/packages/json-language/src/new/language.ts
@@ -1,0 +1,56 @@
+import { createLanguage, type Language } from "@flint.fyi/core";
+import {
+	type AnyNode,
+	type DocumentNode,
+	type Node,
+	parse,
+	traverse,
+} from "@humanwhocodes/momoa";
+
+import type { JsonNodeVisitors } from "./nodes.ts";
+
+export interface JsonFileServices {
+	root: DocumentNode;
+}
+
+export const jsonLanguage: Language<JsonNodeVisitors, JsonFileServices> =
+	createLanguage<JsonNodeVisitors, JsonFileServices>({
+		about: {
+			name: "JSON",
+		},
+		createFileFactory: () => {
+			return {
+				createFile: (data) => {
+					const root = parse(data.sourceText, {
+						mode: "json",
+						ranges: true,
+					});
+
+					return {
+						about: data,
+						services: { root },
+					};
+				},
+			};
+		},
+		runFileVisitors: (file, options, runtime) => {
+			if (!runtime.visitors) {
+				return;
+			}
+
+			const { visitors } = runtime;
+			const visitorServices = { options, ...file.services };
+
+			traverse(file.services.root, {
+				enter: (node: Node) =>
+					// @ts-expect-error -- The intersection DocumentNode & ArrayNode &...was reduced to `never` because property `type` has conflicting types in some constituents.
+					visitors[node.type as AnyNode["type"]]?.(node, visitorServices),
+				exit: (node: Node) =>
+					visitors[`${node.type as AnyNode["type"]}:exit`]?.(
+						// @ts-expect-error -- Argument of type `Node` is not assignable to parameter of type `undefined`
+						node,
+						visitorServices,
+					),
+			});
+		},
+	});

--- a/packages/json-language/src/new/nodes.ts
+++ b/packages/json-language/src/new/nodes.ts
@@ -1,5 +1,6 @@
-import type { WithExitKeys } from "@flint.fyi/core";
 import type { AnyNode } from "@humanwhocodes/momoa";
+
+import type { WithExitKeys } from "@flint.fyi/core";
 
 export type JsonNodesByName = {
 	[Node in AnyNode as Node["type"]]: Node;

--- a/packages/json-language/src/new/nodes.ts
+++ b/packages/json-language/src/new/nodes.ts
@@ -1,0 +1,10 @@
+import type { WithExitKeys } from "@flint.fyi/core";
+import type { AnyNode } from "@humanwhocodes/momoa";
+
+export type JsonNodesByName = {
+	[Node in AnyNode as Node["type"]]: Node;
+};
+
+export type JsonNodeVisitors = WithExitKeys<JsonNodesByName>;
+
+export type JsonVisitorKey = AnyNode["type"];

--- a/packages/json-language/tsdown.config.ts
+++ b/packages/json-language/tsdown.config.ts
@@ -7,7 +7,7 @@ export default defineConfig({
 	},
 	clean: ["./node_modules/.cache/tsbuild/"],
 	dts: { build: true, incremental: true },
-	entry: ["src/index.ts"],
+	entry: ["src/index.ts", "src/new/index.ts"],
 	exports: {
 		devExports: true,
 		packageJson: false,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -773,6 +773,9 @@ importers:
       '@flint.fyi/typescript-language':
         specifier: workspace:^
         version: link:../typescript-language
+      '@humanwhocodes/momoa':
+        specifier: ^3.3.10
+        version: 3.3.10
       typescript:
         specifier: ^5.9.0 || ^6.0.0
         version: 5.9.3


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to flint! ❤️‍🔥
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #2868
- [x] That issue was marked as [`status: accepting prs`](https://github.com/flint-fyi/flint/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/flint-fyi/flint/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

This change adds a new `./new` entry point to the `json-language` package, providing a new language, based on the parser and ast provided by `@humanwhocodes/momoa`.  The plan is to ultimately replace the TS-based implementation with this one.