### PR TITLE
refactor(package-json): add new momoa-based helpers

### DIFF
--- a/knip.ts
+++ b/knip.ts
@@ -50,6 +50,12 @@ export default {
 			project: ["src/**/*.ts!", "!src/rules/ruleTester.ts!"],
 		},
 		"packages/package-json": {
+			// Temporary, until we migrate rules
+			entry: [
+				"src/getPackagePropertiesOfNames.ts",
+				"src/getPackagePropertyOfName.ts",
+				"src/getPackageProperties.ts",
+			],
 			project: ["src/**/*.ts!", "!src/ruleTester.ts!"],
 		},
 		"packages/performance": {

--- a/packages/core/src/types/visitors.ts
+++ b/packages/core/src/types/visitors.ts
@@ -10,6 +10,6 @@ export type Simplify<T> = {
  */
 export type WithExitKeys<T> = Simplify<
 	T & {
-		[K in keyof T & string as `${K}:exit`]?: T[K];
+		[K in keyof T & string as `${K}:exit`]: T[K];
 	}
 >;

--- a/packages/css-language/src/language.ts
+++ b/packages/css-language/src/language.ts
@@ -43,7 +43,7 @@ export const cssLanguage: Language<CssNodeVisitors, CssFileServices> =
 				// @ts-expect-error -- The intersection AnPlusB & Atrule & AtrulePrelude &...was reduced to `never` because property `type` has conflicting types in some constituents.
 				enter: (node: CssNode) => visitors[node.type]?.(node, visitorServices),
 				leave: (node: CssNode) =>
-					// @ts-expect-error -- Argument of type `CssNode` is not assignable to parameter of type `undefined`.
+					// @ts-expect-error -- The intersection AnPlusB & Atrule & AtrulePrelude &...was reduced to `never` because property `type` has conflicting types in some constituents.
 					visitors[`${node.type}:exit`]?.(node, visitorServices),
 			});
 		},

--- a/packages/package-json/package.json
+++ b/packages/package-json/package.json
@@ -36,6 +36,7 @@
 	},
 	"devDependencies": {
 		"@flint.fyi/rule-tester": "workspace:^",
+		"@humanwhocodes/momoa": "^3.3.10",
 		"tsdown": "catalog:dev",
 		"vitest": "catalog:dev"
 	},

--- a/packages/package-json/src/createDirectPropertyPresenceRule.ts
+++ b/packages/package-json/src/createDirectPropertyPresenceRule.ts
@@ -4,7 +4,7 @@ import { z } from "zod/v4";
 import type { AnyRule } from "@flint.fyi/core";
 import { jsonLanguage, type JsonSourceFile } from "@flint.fyi/json-language";
 
-import { getPackagePropertyOfName } from "./getPackagePropertyOfName.ts";
+import { getPackagePropertyOfNameLegacy } from "./getPackagePropertyOfName.ts";
 import { ruleCreator } from "./ruleCreator.ts";
 
 export interface CreatePropertyPresenceRuleOptions {
@@ -60,7 +60,7 @@ export function createDirectPropertyValidityRule<PropertyName extends string>(
 							return;
 						}
 
-						if (!getPackagePropertyOfName(node, propertyName)) {
+						if (!getPackagePropertyOfNameLegacy(node, propertyName)) {
 							context.report({
 								data: { propertyName },
 								message: "missing",
@@ -77,7 +77,7 @@ export function createDirectPropertyValidityRule<PropertyName extends string>(
 }
 
 function isPrivatePackage(node: JsonSourceFile) {
-	const privacy = getPackagePropertyOfName(node, "private");
+	const privacy = getPackagePropertyOfNameLegacy(node, "private");
 
 	return (
 		privacy?.kind === ts.SyntaxKind.PropertyAssignment &&

--- a/packages/package-json/src/createDirectPropertyValidityRule.ts
+++ b/packages/package-json/src/createDirectPropertyValidityRule.ts
@@ -9,7 +9,7 @@ import {
 	type JsonSourceFile,
 } from "@flint.fyi/json-language";
 
-import { getPackagePropertiesOfNames } from "./getPackagePropertiesOfNames.ts";
+import { getPackagePropertiesOfNamesLegacy } from "./getPackagePropertiesOfNames.ts";
 import { ruleCreator } from "./ruleCreator.ts";
 
 export type PropertyValidator = (value: unknown) => Result;
@@ -103,7 +103,10 @@ export function createDirectPropertyValidityRule<PropertyName extends string>(
 			return {
 				visitors: {
 					JsonSourceFile: (node) => {
-						const properties = getPackagePropertiesOfNames(node, propertyNames);
+						const properties = getPackagePropertiesOfNamesLegacy(
+							node,
+							propertyNames,
+						);
 						for (const property of Object.values(properties)) {
 							if (property?.initializer) {
 								checkValue(property.initializer, node);

--- a/packages/package-json/src/getPackageProperties.ts
+++ b/packages/package-json/src/getPackageProperties.ts
@@ -1,9 +1,21 @@
+import type { DocumentNode, MemberNode } from "@humanwhocodes/momoa";
 import ts from "typescript";
 
 import type { JsonSourceFile } from "@flint.fyi/json-language";
 import type { AST } from "@flint.fyi/typescript-language";
 
 export function getPackageProperties(
+	rootNode: DocumentNode,
+): MemberNode[] | undefined {
+	const root = rootNode.body;
+	if (root.type !== "Object") {
+		return undefined;
+	}
+
+	return root.members;
+}
+
+export function getPackagePropertiesLegacy(
 	sourceFile: JsonSourceFile,
 ): ts.NodeArray<AST.ObjectLiteralElementLike> | undefined {
 	if (sourceFile.statements.length !== 1) {

--- a/packages/package-json/src/getPackagePropertiesOfNames.test.ts
+++ b/packages/package-json/src/getPackagePropertiesOfNames.test.ts
@@ -1,0 +1,60 @@
+import { parse, type StringNode } from "@humanwhocodes/momoa";
+import { describe, expect, it } from "vitest";
+
+import { getPackagePropertiesOfNames } from "./getPackagePropertiesOfNames.ts";
+
+describe(getPackagePropertiesOfNames, () => {
+	it("returns the matching root property node", () => {
+		const sourceText = `{
+			"name": "flint",
+			"version": "1.0.0",
+			"type": "module"
+		}`;
+		const document = parse(sourceText);
+
+		const properties = getPackagePropertiesOfNames(document, [
+			"name",
+			"version",
+		]);
+
+		expect(properties.name?.type).toBe("Member");
+		expect(properties.name?.name.type).toBe("String");
+		expect((properties.name?.name as StringNode).value).toBe("name");
+		expect(properties.version?.type).toBe("Member");
+		expect((properties.version?.name as StringNode).value).toBe("version");
+	});
+
+	it("returns empty object when the requested property does not exist", () => {
+		const sourceText = `{
+			"name": "flint",
+			"version": "1.0.0"
+		}`;
+		const document = parse(sourceText);
+
+		const properties = getPackagePropertiesOfNames(document, ["nonExistent"]);
+
+		expect(properties).toEqual({});
+	});
+
+	it("returns empty object when the root node is not an object", () => {
+		const document = parse("[1, 2, 3]");
+
+		const properties = getPackagePropertiesOfNames(document, ["name"]);
+
+		expect(properties).toEqual({});
+	});
+
+	it("returns the last matching property when duplicate keys exist", () => {
+		const sourceText = `{
+			"name": "first",
+			"name": "second"
+		}`;
+		const document = parse(sourceText);
+
+		const properties = getPackagePropertiesOfNames(document, ["name"]);
+
+		expect(properties).toBeDefined();
+		expect(properties.name?.value.type).toBe("String");
+		expect((properties.name?.value as StringNode).value).toBe("second");
+	});
+});

--- a/packages/package-json/src/getPackagePropertiesOfNames.ts
+++ b/packages/package-json/src/getPackagePropertiesOfNames.ts
@@ -1,17 +1,49 @@
+import type { DocumentNode, MemberNode } from "@humanwhocodes/momoa";
 import { SyntaxKind } from "typescript";
 
 import type { JsonSourceFile } from "@flint.fyi/json-language";
 import type { AST } from "@flint.fyi/typescript-language";
 
-import { getPackageProperties } from "./getPackageProperties.ts";
+import {
+	getPackageProperties,
+	getPackagePropertiesLegacy,
+} from "./getPackageProperties.ts";
 
 export function getPackagePropertiesOfNames<T extends string[]>(
+	rootNode: DocumentNode,
+	propertyNames: T,
+): Partial<Record<T[number], MemberNode>> {
+	const result: Partial<Record<T[number], MemberNode>> = {};
+
+	const properties = getPackageProperties(rootNode);
+	if (!properties) {
+		return result;
+	}
+
+	const propertyNameSet = new Set(propertyNames);
+
+	const isPropertyName = (name: string): name is T[number] => {
+		return propertyNameSet.has(name as T[number]);
+	};
+
+	for (const property of properties) {
+		if (
+			property.name.type === "String" &&
+			isPropertyName(property.name.value)
+		) {
+			result[property.name.value] = property;
+		}
+	}
+	return result;
+}
+
+export function getPackagePropertiesOfNamesLegacy<T extends string[]>(
 	sourceFile: JsonSourceFile,
 	propertyNames: T,
 ): Partial<Record<T[number], AST.PropertyAssignment>> {
 	const result: Partial<Record<T[number], AST.PropertyAssignment>> = {};
 
-	const properties = getPackageProperties(sourceFile);
+	const properties = getPackagePropertiesLegacy(sourceFile);
 	if (!properties) {
 		return result;
 	}

--- a/packages/package-json/src/getPackagePropertyOfName.test.ts
+++ b/packages/package-json/src/getPackagePropertyOfName.test.ts
@@ -1,0 +1,55 @@
+import { parse, type StringNode } from "@humanwhocodes/momoa";
+import { describe, expect, it } from "vitest";
+
+import { getPackagePropertyOfName } from "./getPackagePropertyOfName.ts";
+
+describe(getPackagePropertyOfName, () => {
+	it("returns the matching root property node", () => {
+		const sourceText = `{
+			"name": "flint",
+			"version": "1.0.0"
+		}`;
+		const document = parse(sourceText);
+
+		const property = getPackagePropertyOfName(document, "name");
+
+		expect(property).toBeDefined();
+		expect(property?.name.type).toBe("String");
+		expect((property?.name as StringNode).value).toBe("name");
+		expect(property?.value.type).toBe("String");
+		expect((property?.value as StringNode).value).toBe("flint");
+	});
+
+	it("returns undefined when the requested property does not exist", () => {
+		const sourceText = `{
+			"name": "flint"
+		}`;
+		const document = parse(sourceText);
+
+		const property = getPackagePropertyOfName(document, "version");
+
+		expect(property).toBeUndefined();
+	});
+
+	it("returns undefined when the root node is not an object", () => {
+		const document = parse("[1, 2, 3]");
+
+		const property = getPackagePropertyOfName(document, "name");
+
+		expect(property).toBeUndefined();
+	});
+
+	it("returns the first matching property when duplicate keys exist", () => {
+		const sourceText = `{
+			"name": "first",
+			"name": "second"
+		}`;
+		const document = parse(sourceText);
+
+		const property = getPackagePropertyOfName(document, "name");
+
+		expect(property).toBeDefined();
+		expect(property?.value.type).toBe("String");
+		expect((property?.value as StringNode).value).toBe("first");
+	});
+});

--- a/packages/package-json/src/getPackagePropertyOfName.ts
+++ b/packages/package-json/src/getPackagePropertyOfName.ts
@@ -1,15 +1,29 @@
+import type { DocumentNode, MemberNode } from "@humanwhocodes/momoa";
 import ts from "typescript";
 
 import type { JsonSourceFile } from "@flint.fyi/json-language";
 import type { AST } from "@flint.fyi/typescript-language";
 
-import { getPackageProperties } from "./getPackageProperties.ts";
+import {
+	getPackageProperties,
+	getPackagePropertiesLegacy,
+} from "./getPackageProperties.ts";
 
 export function getPackagePropertyOfName(
+	rootNode: DocumentNode,
+	propertyName: string,
+): MemberNode | undefined {
+	return getPackageProperties(rootNode)?.find(
+		(property) =>
+			property.name.type === "String" && property.name.value === propertyName,
+	);
+}
+
+export function getPackagePropertyOfNameLegacy(
 	sourceFile: JsonSourceFile,
 	propertyName: string,
 ): AST.ObjectLiteralElementLike | undefined {
-	return getPackageProperties(sourceFile)?.find(
+	return getPackagePropertiesLegacy(sourceFile)?.find(
 		(property) =>
 			property.name?.kind === ts.SyntaxKind.StringLiteral &&
 			property.name.text === propertyName,

--- a/packages/package-json/src/rules/attribution.ts
+++ b/packages/package-json/src/rules/attribution.ts
@@ -3,7 +3,7 @@ import { z } from "zod/v4";
 
 import { getJsonNodeRange, jsonLanguage } from "@flint.fyi/json-language";
 
-import { getPackagePropertiesOfNames } from "../getPackagePropertiesOfNames.ts";
+import { getPackagePropertiesOfNamesLegacy } from "../getPackagePropertiesOfNames.ts";
 import { ruleCreator } from "../ruleCreator.ts";
 
 export default ruleCreator.createRule(jsonLanguage, {
@@ -66,7 +66,7 @@ export default ruleCreator.createRule(jsonLanguage, {
 						author,
 						contributors,
 						private: privateNode,
-					} = getPackagePropertiesOfNames(node, [
+					} = getPackagePropertiesOfNamesLegacy(node, [
 						"private",
 						"author",
 						"contributors",

--- a/packages/package-json/src/rules/binNameCasing.ts
+++ b/packages/package-json/src/rules/binNameCasing.ts
@@ -3,7 +3,7 @@ import ts from "typescript";
 
 import { getJsonNodeRange, jsonLanguage } from "@flint.fyi/json-language";
 
-import { getPackagePropertyOfName } from "../getPackagePropertyOfName.ts";
+import { getPackagePropertyOfNameLegacy } from "../getPackagePropertyOfName.ts";
 import { ruleCreator } from "../ruleCreator.ts";
 
 export default ruleCreator.createRule(jsonLanguage, {
@@ -26,7 +26,7 @@ export default ruleCreator.createRule(jsonLanguage, {
 		return {
 			visitors: {
 				JsonSourceFile(node) {
-					const property = getPackagePropertyOfName(node, "bin");
+					const property = getPackagePropertyOfNameLegacy(node, "bin");
 					if (
 						property?.kind !== ts.SyntaxKind.PropertyAssignment ||
 						property.initializer.kind !== ts.SyntaxKind.ObjectLiteralExpression

--- a/packages/package-json/src/rules/dependencyUniqueness.ts
+++ b/packages/package-json/src/rules/dependencyUniqueness.ts
@@ -3,7 +3,7 @@ import { SyntaxKind } from "typescript";
 import { getJsonNodeRange, jsonLanguage } from "@flint.fyi/json-language";
 import type { AST } from "@flint.fyi/typescript-language";
 
-import { getPackageProperties } from "../getPackageProperties.ts";
+import { getPackagePropertiesLegacy } from "../getPackageProperties.ts";
 import { removeArrayElement } from "../removeArrayElement.ts";
 import { removeObjectProperty } from "../removeObjectProperty.ts";
 import { ruleCreator } from "../ruleCreator.ts";
@@ -162,7 +162,7 @@ export default ruleCreator.createRule(jsonLanguage, {
 						}
 					}
 
-					for (const property of getPackageProperties(node) ?? []) {
+					for (const property of getPackagePropertiesLegacy(node) ?? []) {
 						if (
 							property.kind !== SyntaxKind.PropertyAssignment ||
 							property.name.kind !== SyntaxKind.StringLiteral ||

--- a/packages/package-json/src/rules/exportsSubpathsStyle.ts
+++ b/packages/package-json/src/rules/exportsSubpathsStyle.ts
@@ -4,7 +4,7 @@ import { z } from "zod/v4";
 import { getJsonNodeRange, jsonLanguage } from "@flint.fyi/json-language";
 import type { AST } from "@flint.fyi/typescript-language";
 
-import { getPackagePropertyOfName } from "../getPackagePropertyOfName.ts";
+import { getPackagePropertyOfNameLegacy } from "../getPackagePropertyOfName.ts";
 import { ruleCreator } from "../ruleCreator.ts";
 
 function getSingleRootSubpath(node: AST.ObjectLiteralExpression) {
@@ -69,7 +69,7 @@ export default ruleCreator.createRule(jsonLanguage, {
 		return {
 			visitors: {
 				JsonSourceFile(node, { options }) {
-					const property = getPackagePropertyOfName(node, "exports");
+					const property = getPackagePropertyOfNameLegacy(node, "exports");
 
 					if (
 						property?.kind !== SyntaxKind.PropertyAssignment ||

--- a/packages/package-json/src/rules/peerDependenciesInstallation.ts
+++ b/packages/package-json/src/rules/peerDependenciesInstallation.ts
@@ -2,7 +2,7 @@ import { SyntaxKind } from "typescript";
 
 import { getJsonNodeRange, jsonLanguage } from "@flint.fyi/json-language";
 
-import { getPackagePropertiesOfNames } from "../getPackagePropertiesOfNames.ts";
+import { getPackagePropertiesOfNamesLegacy } from "../getPackagePropertiesOfNames.ts";
 import { ruleCreator } from "../ruleCreator.ts";
 
 export default ruleCreator.createRule(jsonLanguage, {
@@ -27,7 +27,7 @@ export default ruleCreator.createRule(jsonLanguage, {
 			visitors: {
 				JsonSourceFile(node) {
 					const { devDependencies, peerDependencies } =
-						getPackagePropertiesOfNames(node, [
+						getPackagePropertiesOfNamesLegacy(node, [
 							"peerDependencies",
 							"devDependencies",
 						]);

--- a/packages/package-json/src/rules/peerDependenciesMetaRelationship.ts
+++ b/packages/package-json/src/rules/peerDependenciesMetaRelationship.ts
@@ -2,7 +2,7 @@ import { SyntaxKind } from "typescript";
 
 import { getJsonNodeRange, jsonLanguage } from "@flint.fyi/json-language";
 
-import { getPackagePropertiesOfNames } from "../getPackagePropertiesOfNames.ts";
+import { getPackagePropertiesOfNamesLegacy } from "../getPackagePropertiesOfNames.ts";
 import { removeObjectProperty } from "../removeObjectProperty.ts";
 import { ruleCreator } from "../ruleCreator.ts";
 
@@ -28,7 +28,7 @@ export default ruleCreator.createRule(jsonLanguage, {
 			visitors: {
 				JsonSourceFile(node) {
 					const { peerDependencies, peerDependenciesMeta } =
-						getPackagePropertiesOfNames(node, [
+						getPackagePropertiesOfNamesLegacy(node, [
 							"peerDependencies",
 							"peerDependenciesMeta",
 						]);

--- a/packages/package-json/src/rules/privatePackageProperties.ts
+++ b/packages/package-json/src/rules/privatePackageProperties.ts
@@ -3,8 +3,8 @@ import { z } from "zod/v4";
 
 import { getJsonNodeRange, jsonLanguage } from "@flint.fyi/json-language";
 
-import { getPackageProperties } from "../getPackageProperties.ts";
-import { getPackagePropertyOfName } from "../getPackagePropertyOfName.ts";
+import { getPackagePropertiesLegacy } from "../getPackageProperties.ts";
+import { getPackagePropertyOfNameLegacy } from "../getPackagePropertyOfName.ts";
 import { removeObjectProperty } from "../removeObjectProperty.ts";
 import { ruleCreator } from "../ruleCreator.ts";
 
@@ -35,7 +35,7 @@ export default ruleCreator.createRule(jsonLanguage, {
 		return {
 			visitors: {
 				JsonSourceFile(node, { options }) {
-					const properties = getPackageProperties(node);
+					const properties = getPackagePropertiesLegacy(node);
 					const root = node.statements[0];
 
 					if (
@@ -45,7 +45,10 @@ export default ruleCreator.createRule(jsonLanguage, {
 						return;
 					}
 
-					const privateProperty = getPackagePropertyOfName(node, "private");
+					const privateProperty = getPackagePropertyOfNameLegacy(
+						node,
+						"private",
+					);
 
 					if (
 						privateProperty?.kind !== SyntaxKind.PropertyAssignment ||

--- a/packages/package-json/src/rules/privatePresence.ts
+++ b/packages/package-json/src/rules/privatePresence.ts
@@ -1,6 +1,6 @@
 import { jsonLanguage } from "@flint.fyi/json-language";
 
-import { getPackagePropertyOfName } from "../getPackagePropertyOfName.ts";
+import { getPackagePropertyOfNameLegacy } from "../getPackagePropertyOfName.ts";
 import { ruleCreator } from "../ruleCreator.ts";
 
 export default ruleCreator.createRule(jsonLanguage, {
@@ -22,7 +22,7 @@ export default ruleCreator.createRule(jsonLanguage, {
 		return {
 			visitors: {
 				JsonSourceFile: (node) => {
-					if (!getPackagePropertyOfName(node, "private")) {
+					if (!getPackagePropertyOfNameLegacy(node, "private")) {
 						context.report({
 							message: "missing",
 							range: { begin: 0, end: 1 },

--- a/packages/package-json/src/rules/publishConfigRedundancy.ts
+++ b/packages/package-json/src/rules/publishConfigRedundancy.ts
@@ -2,7 +2,7 @@ import { SyntaxKind } from "typescript";
 
 import { getJsonNodeRange, jsonLanguage } from "@flint.fyi/json-language";
 
-import { getPackagePropertiesOfNames } from "../getPackagePropertiesOfNames.ts";
+import { getPackagePropertiesOfNamesLegacy } from "../getPackagePropertiesOfNames.ts";
 import { removeObjectProperty } from "../removeObjectProperty.ts";
 import { ruleCreator } from "../ruleCreator.ts";
 
@@ -27,10 +27,10 @@ export default ruleCreator.createRule(jsonLanguage, {
 		return {
 			visitors: {
 				JsonSourceFile(node) {
-					const { name, publishConfig } = getPackagePropertiesOfNames(node, [
-						"name",
-						"publishConfig",
-					]);
+					const { name, publishConfig } = getPackagePropertiesOfNamesLegacy(
+						node,
+						["name", "publishConfig"],
+					);
 
 					if (
 						name?.kind !== SyntaxKind.PropertyAssignment ||

--- a/packages/package-json/src/rules/repositoryShorthand.ts
+++ b/packages/package-json/src/rules/repositoryShorthand.ts
@@ -3,7 +3,7 @@ import ts from "typescript";
 import { jsonLanguage } from "@flint.fyi/json-language";
 import { getTSNodeRange } from "@flint.fyi/typescript-language";
 
-import { getPackagePropertyOfName } from "../getPackagePropertyOfName.ts";
+import { getPackagePropertyOfNameLegacy } from "../getPackagePropertyOfName.ts";
 import { ruleCreator } from "../ruleCreator.ts";
 
 const providerRegexes = {
@@ -64,7 +64,7 @@ export default ruleCreator.createRule(jsonLanguage, {
 		return {
 			visitors: {
 				JsonSourceFile: (node) => {
-					const property = getPackagePropertyOfName(node, "repository");
+					const property = getPackagePropertyOfNameLegacy(node, "repository");
 					if (
 						property?.kind !== ts.SyntaxKind.PropertyAssignment ||
 						property.initializer.kind !== ts.SyntaxKind.StringLiteral

--- a/packages/package-json/src/rules/scriptsNameCasing.ts
+++ b/packages/package-json/src/rules/scriptsNameCasing.ts
@@ -3,7 +3,7 @@ import ts from "typescript";
 
 import { getJsonNodeRange, jsonLanguage } from "@flint.fyi/json-language";
 
-import { getPackagePropertyOfName } from "../getPackagePropertyOfName.ts";
+import { getPackagePropertyOfNameLegacy } from "../getPackagePropertyOfName.ts";
 import { ruleCreator } from "../ruleCreator.ts";
 
 // See https://docs.npmjs.com/cli/v11/using-npm/scripts
@@ -30,7 +30,7 @@ export default ruleCreator.createRule(jsonLanguage, {
 		return {
 			visitors: {
 				JsonSourceFile(node) {
-					const property = getPackagePropertyOfName(node, "scripts");
+					const property = getPackagePropertyOfNameLegacy(node, "scripts");
 					if (
 						property?.kind !== ts.SyntaxKind.PropertyAssignment ||
 						property.initializer.kind !== ts.SyntaxKind.ObjectLiteralExpression

--- a/packages/vitest/src/rules/testCasesWithinDescribes.ts
+++ b/packages/vitest/src/rules/testCasesWithinDescribes.ts
@@ -65,8 +65,7 @@ export default ruleCreator.createRule(typescriptLanguage, {
 					}
 				},
 				"CallExpression:exit": (node) => {
-					// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-					switch (parseVitestFunctionCall(node!)?.name) {
+					switch (parseVitestFunctionCall(node)?.name) {
 						case "describe":
 						case "xdescribe":
 							insideDescribeStack -= 1;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -958,6 +958,9 @@ importers:
       '@flint.fyi/rule-tester':
         specifier: workspace:^
         version: link:../rule-tester
+      '@humanwhocodes/momoa':
+        specifier: ^3.3.10
+        version: 3.3.10
       tsdown:
         specifier: catalog:dev
         version: 0.21.0(@arethetypeswrong/core@0.18.2)(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(synckit@0.11.12)(typescript@5.9.3)


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to flint! ❤️‍🔥
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [`status: accepting prs`](https://github.com/flint-fyi/flint/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [ ] Steps in [CONTRIBUTING.md](https://github.com/flint-fyi/flint/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

This change is in preparation of the rule migrations to our new `json-language`, adding new versions of the node helper functions.  I can't do the removeArrayElement and removeObjectProperty functions yet, since those depend on the language, which hasn't merged yet.  This is just clearing the rest out of the way to make the migrations a bit cleaner.
