### PR TITLE
refactor(json): migrate all rules to new json language

### DIFF
--- a/packages/json-language/src/new/language.ts
+++ b/packages/json-language/src/new/language.ts
@@ -12,6 +12,7 @@ import type { JsonNodeVisitors } from "./nodes.ts";
 
 export interface JsonFileServices {
 	root: DocumentNode;
+	sourceText: string;
 }
 
 export const jsonLanguage: Language<JsonNodeVisitors, JsonFileServices> =
@@ -29,7 +30,7 @@ export const jsonLanguage: Language<JsonNodeVisitors, JsonFileServices> =
 
 					return {
 						about: data,
-						services: { root },
+						services: { root, sourceText: data.sourceText },
 					};
 				},
 			};

--- a/packages/json/package.json
+++ b/packages/json/package.json
@@ -28,11 +28,11 @@
 	"dependencies": {
 		"@flint.fyi/core": "workspace:^",
 		"@flint.fyi/json-language": "workspace:^",
-		"typescript": "^5.9.3 || ^6.0.0",
 		"zod": "^4.3.6"
 	},
 	"devDependencies": {
 		"@flint.fyi/rule-tester": "workspace:^",
+		"@humanwhocodes/momoa": "^3.3.10",
 		"tsdown": "catalog:dev",
 		"vitest": "catalog:dev"
 	},

--- a/packages/json/src/rules/keyDuplicates.test.ts
+++ b/packages/json/src/rules/keyDuplicates.test.ts
@@ -7,7 +7,7 @@ ruleTester.describe(rule, {
 			code: `
 {
   "a": "first",
-  "a": "second",
+  "a": "second"
 }
 `,
 			snapshot: `
@@ -15,7 +15,7 @@ ruleTester.describe(rule, {
   "a": "first",
   ~~~
   This key is made redundant by an identical key later in the object.
-  "a": "second",
+  "a": "second"
 }
 `,
 		},
@@ -23,7 +23,7 @@ ruleTester.describe(rule, {
 			code: `
 {
   "a": "first",
-  "a": "second",
+  "a": "second"
 }
 `,
 			options: {
@@ -34,7 +34,7 @@ ruleTester.describe(rule, {
   "a": "first",
   ~~~
   This key is made redundant by an identical key later in the object.
-  "a": "second",
+  "a": "second"
 }
 `,
 		},
@@ -45,14 +45,14 @@ ruleTester.describe(rule, {
 		`
 {
   "a": "first",
-  "b": "second",
+  "b": "second"
 }
 `,
 		{
 			code: `
 {
   "//": "first",
-  "//": "second",
+  "//": "second"
 }`,
 			options: {
 				allowKeys: ["//"],

--- a/packages/json/src/rules/keyDuplicates.ts
+++ b/packages/json/src/rules/keyDuplicates.ts
@@ -1,7 +1,6 @@
-import ts from "typescript";
 import z from "zod/v4";
 
-import { jsonLanguage } from "@flint.fyi/json-language";
+import { getJsonNodeRange, jsonLanguage } from "@flint.fyi/json-language/new";
 
 import { ruleCreator } from "./ruleCreator.ts";
 
@@ -36,18 +35,15 @@ export default ruleCreator.createRule(jsonLanguage, {
 	setup(context) {
 		return {
 			visitors: {
-				ObjectLiteralExpression(node, { options, sourceFile }) {
+				Object(node, { options }) {
 					const seenKeys = new Set<string>();
 
-					for (const property of node.properties.toReversed()) {
-						if (
-							!ts.isPropertyAssignment(property) ||
-							!ts.isStringLiteral(property.name)
-						) {
+					for (const property of node.members.toReversed()) {
+						if (property.name.type !== "String") {
 							continue;
 						}
 
-						const key = property.name.text;
+						const key = property.name.value;
 						if (options.allowKeys.includes(key)) {
 							continue;
 						}
@@ -58,13 +54,10 @@ export default ruleCreator.createRule(jsonLanguage, {
 							seenKeys.add(key);
 							continue;
 						}
-
+						const range = getJsonNodeRange(property.name);
 						context.report({
 							message: "duplicateKey",
-							range: {
-								begin: property.name.getStart(sourceFile),
-								end: property.name.end,
-							},
+							range,
 						});
 					}
 				},

--- a/packages/json/src/rules/keyNormalization.ts
+++ b/packages/json/src/rules/keyNormalization.ts
@@ -1,7 +1,6 @@
-import ts from "typescript";
 import z from "zod/v4";
 
-import { jsonLanguage } from "@flint.fyi/json-language";
+import { getJsonNodeRange, jsonLanguage } from "@flint.fyi/json-language/new";
 
 import { ruleCreator } from "./ruleCreator.ts";
 
@@ -36,35 +35,30 @@ export default ruleCreator.createRule(jsonLanguage, {
 	setup(context) {
 		return {
 			visitors: {
-				ObjectLiteralExpression(node, { options: { form }, sourceFile }) {
-					for (const property of node.properties) {
-						if (
-							!ts.isPropertyAssignment(property) ||
-							!ts.isStringLiteral(property.name)
-						) {
+				Object(node, { options: { form } }) {
+					for (const property of node.members) {
+						if (property.name.type !== "String") {
 							continue;
 						}
 
-						const key = property.name.text;
+						const key = property.name.value;
 						const normalizedKey = key.normalize(form);
 
 						if (key === normalizedKey) {
 							continue;
 						}
 
+						const range = getJsonNodeRange(property.name);
 						context.report({
 							data: { form },
 							message: "unnormalizedKey",
-							range: {
-								begin: property.name.getStart(sourceFile),
-								end: property.name.end,
-							},
+							range,
 							suggestions: [
 								{
 									id: "normalizeKey",
 									range: {
-										begin: property.name.getStart(sourceFile) + 1,
-										end: property.name.end - 1,
+										begin: range.begin + 1,
+										end: range.end - 1,
 									},
 									text: normalizedKey,
 								},

--- a/packages/json/src/rules/valueSafety.test.ts
+++ b/packages/json/src/rules/valueSafety.test.ts
@@ -19,8 +19,8 @@ ruleTester.describe(rule, {
 `,
 			snapshot: `
 [-2e308]
-  ~~~~~
-  This number evaluates to Infinity.
+ ~~~~~~
+ This number evaluates to -Infinity.
 `,
 		},
 		{
@@ -101,8 +101,8 @@ ruleTester.describe(rule, {
 `,
 			snapshot: `
 [-9007199254740992]
-  ~~~~~~~~~~~~~~~~
-  This integer is outside the safe integer range.
+ ~~~~~~~~~~~~~~~~~
+ This integer is outside the safe integer range.
 `,
 		},
 		{

--- a/packages/json/src/rules/valueSafety.ts
+++ b/packages/json/src/rules/valueSafety.ts
@@ -1,6 +1,6 @@
-import ts from "typescript";
+import type { AnyNode, NumberNode, StringNode } from "@humanwhocodes/momoa";
 
-import { jsonLanguage } from "@flint.fyi/json-language";
+import { getJsonNodeRange, jsonLanguage } from "@flint.fyi/json-language/new";
 
 import { ruleCreator } from "./ruleCreator.ts";
 
@@ -92,24 +92,16 @@ export default ruleCreator.createRule(jsonLanguage, {
 		},
 	},
 	setup(context) {
-		function checkNumericLiteral(
-			node: ts.NumericLiteral,
-			sourceFile: ts.SourceFile,
-		) {
-			const originalText = sourceFile.text.substring(
-				node.getStart(sourceFile),
-				node.end,
-			);
+		function checkNumber(node: NumberNode, sourceText: string) {
+			const range = getJsonNodeRange(node);
+			const originalText = sourceText.slice(range.begin, range.end);
 			const value = Number(originalText);
 
 			if (!Number.isFinite(value)) {
 				context.report({
 					data: { sign: value > 0 ? "" : "-" },
 					message: "infinity",
-					range: {
-						begin: node.getStart(sourceFile),
-						end: node.end,
-					},
+					range,
 				});
 				return;
 			}
@@ -123,10 +115,7 @@ export default ruleCreator.createRule(jsonLanguage, {
 				) {
 					context.report({
 						message: "unsafeZero",
-						range: {
-							begin: node.getStart(sourceFile),
-							end: node.end,
-						},
+						range,
 					});
 				}
 				return;
@@ -136,10 +125,7 @@ export default ruleCreator.createRule(jsonLanguage, {
 				if (value > MAX_SAFE_INTEGER || value < MIN_SAFE_INTEGER) {
 					context.report({
 						message: "unsafeInteger",
-						range: {
-							begin: node.getStart(sourceFile),
-							end: node.end,
-						},
+						range,
 					});
 				}
 				return;
@@ -148,48 +134,44 @@ export default ruleCreator.createRule(jsonLanguage, {
 			if (value !== 0 && Math.abs(value) < MIN_NORMAL) {
 				context.report({
 					message: "subnormal",
-					range: {
-						begin: node.getStart(sourceFile),
-						end: node.end,
-					},
+					range,
 				});
 			}
 		}
 
-		function checkStringLiteral(
-			node: ts.StringLiteral,
-			sourceFile: ts.SourceFile,
-		) {
-			if (hasLoneSurrogate(node.text)) {
+		function checkString(node: StringNode) {
+			if (hasLoneSurrogate(node.value)) {
+				const range = getJsonNodeRange(node);
 				context.report({
 					message: "loneSurrogate",
-					range: {
-						begin: node.getStart(sourceFile),
-						end: node.end,
-					},
+					range,
 				});
 			}
 		}
 
-		function checkNode(node: ts.Node, sourceFile: ts.SourceFile) {
-			if (ts.isNumericLiteral(node)) {
-				checkNumericLiteral(node, sourceFile);
-			} else if (ts.isStringLiteral(node)) {
-				checkStringLiteral(node, sourceFile);
-			} else {
-				node.forEachChild((child) => {
-					checkNode(child, sourceFile);
-				});
+		function checkNode(node: AnyNode, sourceText: string) {
+			if (node.type === "Number") {
+				checkNumber(node, sourceText);
+			} else if (node.type === "String") {
+				checkString(node);
+			} else if (node.type === "Array") {
+				for (const element of node.elements) {
+					checkNode(element.value, sourceText);
+				}
+			} else if (node.type === "Object") {
+				for (const property of node.members) {
+					checkNode(property.value, sourceText);
+				}
 			}
 		}
 
 		return {
 			visitors: {
-				ArrayLiteralExpression: (node, { sourceFile }) => {
-					checkNode(node, sourceFile);
+				Array: (node, { sourceText }) => {
+					checkNode(node, sourceText);
 				},
-				ObjectLiteralExpression: (node, { sourceFile }) => {
-					checkNode(node, sourceFile);
+				Object: (node, { sourceText }) => {
+					checkNode(node, sourceText);
 				},
 			},
 		};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -748,9 +748,6 @@ importers:
       '@flint.fyi/json-language':
         specifier: workspace:^
         version: link:../json-language
-      typescript:
-        specifier: ^5.9.3 || ^6.0.0
-        version: 5.9.3
       zod:
         specifier: ^4.3.6
         version: 4.4.1
@@ -758,6 +755,9 @@ importers:
       '@flint.fyi/rule-tester':
         specifier: workspace:^
         version: link:../rule-tester
+      '@humanwhocodes/momoa':
+        specifier: ^3.3.10
+        version: 3.3.10
       tsdown:
         specifier: catalog:dev
         version: 0.21.0(@arethetypeswrong/core@0.18.2)(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(synckit@0.11.12)(typescript@5.9.3)


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to flint! ❤️‍🔥
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: 
   - fixes #2887
   - fixes #2888
   - fixes #2889
- [x] That issue was marked as [`status: accepting prs`](https://github.com/flint-fyi/flint/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/flint-fyi/flint/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

This change migrates all of the rules in the `json` plugin to our new `momoa`-based language.  It removes the dependency on typescript entirely :tada:
