### PR TITLE
fix(ts): [nullishCoalescingOperators] emit `??=` for if-statement autofix

### DIFF
--- a/.changeset/nullish-assignment-fixer.md
+++ b/.changeset/nullish-assignment-fixer.md
@@ -1,0 +1,5 @@
+---
+"@flint.fyi/ts": patch
+---
+
+Fix the `nullishCoalescingOperators` autofix for `if` statement assignments to produce `??=` instead of a no-op `??` expression.

--- a/packages/ts/src/rules/nullishCoalescingOperators.test.ts
+++ b/packages/ts/src/rules/nullishCoalescingOperators.test.ts
@@ -329,6 +329,44 @@ const result = arr !== undefined ? arr.map(x => x * 2).filter(x => x > 0) : [];
                Prefer nullish coalescing operator (\`??\`) over ternary expression for nullish checks.
 `,
 		},
+		{
+			code: `
+let value: { x: number } | undefined;
+if (value === undefined) {
+  value = { x: 1 };
+}
+`,
+			output: `
+let value: { x: number } | undefined;
+value ??= { x: 1 };
+`,
+			snapshot: `
+let value: { x: number } | undefined;
+if (value === undefined) {
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+Prefer nullish coalescing assignment (\`??=\`) over assignment with null/undefined check.
+  value = { x: 1 };
+  ~~~~~~~~~~~~~~~~~
+}
+~
+`,
+		},
+		{
+			code: `
+let value: { x: number } | undefined;
+if (value === undefined) value = { x: 1 };
+`,
+			output: `
+let value: { x: number } | undefined;
+value ??= { x: 1 };
+`,
+			snapshot: `
+let value: { x: number } | undefined;
+if (value === undefined) value = { x: 1 };
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Prefer nullish coalescing assignment (\`??=\`) over assignment with null/undefined check.
+`,
+		},
 	],
 	valid: [
 		`

--- a/packages/ts/src/rules/nullishCoalescingOperators.ts
+++ b/packages/ts/src/rules/nullishCoalescingOperators.ts
@@ -583,6 +583,18 @@ export default ruleCreator.createRule(typescriptLanguage, {
 			return { range, text: `${leftText} ?? ${getText(alternate)}` };
 		}
 
+		function createNullishAssignmentFix(
+			left: AST.AnyNode,
+			right: AST.AnyNode,
+			sourceFile: AST.SourceFile,
+			range: CharacterReportRange,
+		) {
+			const getText = (node: AST.AnyNode) =>
+				sourceFile.text.substring(node.getStart(sourceFile), node.getEnd());
+
+			return { range, text: `${getText(left)} ??= ${getText(right)};` };
+		}
+
 		return {
 			visitors: {
 				BinaryExpression: (node, { options, sourceFile, typeChecker }) => {
@@ -673,7 +685,7 @@ export default ruleCreator.createRule(typescriptLanguage, {
 					const range = getTSNodeRange(node, sourceFile);
 
 					context.report({
-						fix: createNullishNodesFix(
+						fix: createNullishAssignmentFix(
 							assignmentExpression.left,
 							assignmentExpression.right,
 							sourceFile,


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #2855
- [x] That issue was marked as [`status: accepting prs`](https://github.com/flint-fyi/flint/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/flint-fyi/flint/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

The `ts/nullishCoalescingOperators` autofix for the if-statement assignment pattern produced a broken result:

```ts
if (value === undefined) {
  value = fallback;
}
```

was fixed to `value ?? fallback` — a no-op expression statement that drops the assignment entirely — instead of the expected `value ??= fallback`.

The cause: the `IfStatement` visitor reused `createNullishNodesFix`, which is built for ternary expressions and emits `left ?? right`, missing the `=`. This change adds a dedicated `createNullishAssignmentFix` helper (mirroring `createNullishNodesFix`) that emits `left ??= right;`, and switches the `IfStatement` visitor to it. New invalid test cases cover both the block and single-line `if` forms, using nullish-only types (`{ x: number } | undefined`) so `??=` is exactly equivalent to the original `=== undefined` check.
