### PR TITLE
chore: remove unused eslint/flint disable

### DIFF
--- a/packages/json/src/rules/keyDuplicates.ts
+++ b/packages/json/src/rules/keyDuplicates.ts
@@ -4,8 +4,6 @@ import { getJsonNodeRange, jsonLanguage } from "@flint.fyi/json-language/new";
 
 import { ruleCreator } from "./ruleCreator.ts";
 
-// flint-disable-next-line ts/deprecated
-// eslint-disable-next-line @typescript-eslint/no-deprecated
 export default ruleCreator.createRule(jsonLanguage, {
 	about: {
 		description:

--- a/packages/json/src/rules/keyNormalization.ts
+++ b/packages/json/src/rules/keyNormalization.ts
@@ -4,8 +4,6 @@ import { getJsonNodeRange, jsonLanguage } from "@flint.fyi/json-language/new";
 
 import { ruleCreator } from "./ruleCreator.ts";
 
-// flint-disable-next-line ts/deprecated
-// eslint-disable-next-line @typescript-eslint/no-deprecated
 export default ruleCreator.createRule(jsonLanguage, {
 	about: {
 		description:

--- a/packages/json/src/rules/valueSafety.ts
+++ b/packages/json/src/rules/valueSafety.ts
@@ -28,8 +28,6 @@ function hasLoneSurrogate(text: string): boolean {
 	return false;
 }
 
-// flint-disable-next-line ts/deprecated
-// eslint-disable-next-line @typescript-eslint/no-deprecated
 export default ruleCreator.createRule(jsonLanguage, {
 	about: {
 		description: "Reports JSON values that are unsafe for data interchange.",


### PR DESCRIPTION
Fixing a merge issue that's causing `main` builds to fail.