### PR TITLE
feat(typescript-language): add ScopeManager.getScope

### DIFF
--- a/.changeset/tidy-scopes-call.md
+++ b/.changeset/tidy-scopes-call.md
@@ -1,0 +1,5 @@
+---
+"@flint.fyi/typescript-language": patch
+---
+
+Add `ScopeManager.getScope(node)` to resolve the innermost scope containing a node.

--- a/packages/typescript-language/src/scope/scopeManager.test.ts
+++ b/packages/typescript-language/src/scope/scopeManager.test.ts
@@ -696,4 +696,58 @@ describe(createScopeManager, () => {
 			innerValue?.references.map((reference) => reference.isWrite),
 		).toEqual([true]);
 	});
+
+	it("getScope returns the scope a boundary node creates", () => {
+		const sourceFile = createSourceFile(`
+			function outer() {
+				function inner() {}
+			}
+		`);
+
+		const scopeManager = createScopeManager(sourceFile);
+		const outer = findNthNode<AST.FunctionDeclaration>(
+			sourceFile,
+			SyntaxKind.FunctionDeclaration,
+			0,
+		);
+		const inner = findNthNode<AST.FunctionDeclaration>(
+			sourceFile,
+			SyntaxKind.FunctionDeclaration,
+			1,
+		);
+
+		// A scope-boundary node maps to the scope it creates, not its parent.
+		expect(scopeManager.getScope(inner).block).toBe(inner);
+		expect(scopeManager.getScope(inner).upper).toBe(
+			scopeManager.getScope(outer),
+		);
+		expect(scopeManager.getScope(outer).upper).toBe(scopeManager.globalScope);
+	});
+
+	it("getScope returns the innermost enclosing scope for a non-boundary node", () => {
+		const sourceFile = createSourceFile(`
+			const outerValue = 1;
+			function fn() {
+				const innerValue = 2;
+				innerValue;
+			}
+		`);
+
+		const scopeManager = createScopeManager(sourceFile);
+		const fn = findFirstNode<AST.FunctionDeclaration>(
+			sourceFile,
+			SyntaxKind.FunctionDeclaration,
+		);
+		// Identifiers in source order: outerValue, fn, innerValue (declaration),
+		// innerValue (reference). The reference is the fourth.
+		const innerReference = findNthNode<AST.Identifier>(
+			sourceFile,
+			SyntaxKind.Identifier,
+			3,
+		);
+
+		const scope = scopeManager.getScope(innerReference);
+		expect(scope.block).toBe(fn);
+		expect(scope.upper).toBe(scopeManager.globalScope);
+	});
 });

--- a/packages/typescript-language/src/scope/scopeManager.ts
+++ b/packages/typescript-language/src/scope/scopeManager.ts
@@ -241,6 +241,9 @@ export function createScopeManager(sourceFile: AST.SourceFile) {
 		getReferencesInScope(node) {
 			return getReferencesInScope(nodeScopes.get(node) ?? globalScope);
 		},
+		getScope(node) {
+			return nodeScopes.get(node) ?? globalScope;
+		},
 		globalScope,
 	} satisfies ScopeManager;
 }

--- a/packages/typescript-language/src/scope/types.ts
+++ b/packages/typescript-language/src/scope/types.ts
@@ -30,6 +30,7 @@ export interface ScopeManager {
 	findVariable(identifier: AST.Identifier): ScopeVariable | undefined;
 	getDeclaredVariables(node: AST.AnyNode): ScopeVariable[];
 	getReferencesInScope(node: AST.AnyNode): ScopeReference[];
+	getScope(node: AST.AnyNode): Scope;
 	globalScope: Scope;
 }
 


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to flint! ❤️‍🔥 -->

## PR Checklist

- [x] Addresses an existing open issue: unblocks #1481, #1464
- [x] That issue was marked as [`status: accepting prs`](https://github.com/flint-fyi/flint/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/flint-fyi/flint/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Follow-up to the TypeScript scope manager (#400, shipped in #2828).

Adds `ScopeManager.getScope(node)` — returns the innermost scope containing a node (the scope it creates if it is a scope boundary, otherwise the nearest enclosing scope). The manager already tracks the node→scope mapping internally but only exposes it indirectly through `getReferencesInScope`; this surfaces it directly, mirroring how `findVariable`/`getReferencesInScope` already resolve a node to its scope (no new bookkeeping).

It is a foundational primitive for scope-based rules and unblocks `invalidThis` (#1481) and `functionDefinitionScopeConsistency` (#1464), both marked blocked on #400.

Tests cover both cases: a scope-boundary node returns the scope it creates (with the correct `upper` chain), and a non-boundary node returns its innermost enclosing scope.
