### PR TITLE
fix(ts): guard nullish assignment autofix target

### DIFF
--- a/.changeset/curly-maps-guard.md
+++ b/.changeset/curly-maps-guard.md
@@ -1,0 +1,5 @@
+---
+"@flint.fyi/ts": patch
+---
+
+Fix the `nullishCoalescingOperators` `if` statement assignment autofix to skip cases where the nullish check expression differs from the assignment target.

--- a/packages/ts/src/rules/nullishCoalescingOperators.test.ts
+++ b/packages/ts/src/rules/nullishCoalescingOperators.test.ts
@@ -439,5 +439,12 @@ const result = obj.value || "default";
 declare const baseHost: string[] | null;
 console.log(baseHost == null ? { cwd: process.cwd() } : { baseHost });
 `,
+		`
+let content: { value: string } | undefined;
+let matcher: { value: string } | undefined;
+if (content !== undefined) {
+    matcher = content;
+}
+`,
 	],
 });

--- a/packages/ts/src/rules/nullishCoalescingOperators.ts
+++ b/packages/ts/src/rules/nullishCoalescingOperators.ts
@@ -246,6 +246,25 @@ function getComparisonOperator(
 	}
 }
 
+function getIfStatementNullishCheckValue(node: AST.IfStatement) {
+	switch (node.expression.kind) {
+		case ts.SyntaxKind.BinaryExpression:
+			if (isNullLikeComparison(node.expression)) {
+				return extractValueFromComparison(node.expression).value ?? undefined;
+			}
+			return;
+
+		case ts.SyntaxKind.PrefixUnaryExpression:
+			if (node.expression.operator === ts.SyntaxKind.ExclamationToken) {
+				return node.expression.operand;
+			}
+			return;
+
+		default:
+			return;
+	}
+}
+
 function getTypeFlags(type: ts.Type): ts.TypeFlags {
 	let flags = 0;
 	for (const constituent of tsutils.unionConstituents(type)) {
@@ -318,19 +337,6 @@ function isFalsyLiteralType(part: ts.Type) {
 	}
 
 	return false;
-}
-
-function isIfStatementNullishCheck(node: AST.IfStatement) {
-	switch (node.expression.kind) {
-		case ts.SyntaxKind.BinaryExpression:
-			return isNullLikeComparison(node.expression);
-
-		case ts.SyntaxKind.PrefixUnaryExpression:
-			return node.expression.operator === ts.SyntaxKind.ExclamationToken;
-
-		default:
-			return false;
-	}
 }
 
 function isMixedLogicalExpression(node: AST.BinaryExpression) {
@@ -662,10 +668,11 @@ export default ruleCreator.createRule(typescriptLanguage, {
 					});
 				},
 				IfStatement: (node, { options, sourceFile, typeChecker }) => {
+					const checkedValue = getIfStatementNullishCheckValue(node);
 					if (
 						options.ignoreIfStatements ||
 						node.elseStatement ||
-						!isIfStatementNullishCheck(node)
+						!checkedValue
 					) {
 						return;
 					}
@@ -673,6 +680,11 @@ export default ruleCreator.createRule(typescriptLanguage, {
 					const assignmentExpression = extractAssignmentFromIfStatement(node);
 					if (
 						!assignmentExpression ||
+						!hasSameTokens(
+							assignmentExpression.left,
+							checkedValue,
+							sourceFile,
+						) ||
 						shouldIgnoreNode(
 							assignmentExpression.left,
 							options.ignorePrimitives,


### PR DESCRIPTION
## PR Checklist

- [ ] Addresses an existing open issue: follow-up to #2855 / #2902, no separate open issue exists.
- [ ] That issue was marked as [`status: accepting prs`](https://github.com/flint-fyi/flint/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/flint-fyi/flint/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

This is a follow-up to #2855 / #2902 for `ts/nullishCoalescingOperators`.

The previous fix made `if` statement assignment autofixes emit `??=` instead of `??`, but the `IfStatement` visitor still accepted any assignment inside a nullish-check branch.
That meant code checking one expression and assigning a different target could be reported and autofixed incorrectly:

```ts
if (content !== undefined) {
  matcher = content;
}
```

This change extracts the expression being checked by the `if` condition and requires it to match the assignment target with `hasSameTokens` before reporting the `??=` autofix.
It also adds a valid regression case for the mismatch scenario and a patch changeset for `@flint.fyi/ts`.

Verification run locally:

- `node scripts/validate-changesets.ts`
- `pnpm test packages/ts/src/rules/nullishCoalescingOperators.test.ts`
- `pnpm test` (558 files, 10026 tests)
- `pnpm build`
- `pnpm run --filter=site prebuild`
- `git diff --check`

I also attempted `pnpm flint` locally.
That run failed on unrelated workspace type-resolution reports in `packages/comparisons/src/getRuleForPlugin.ts` and `packages/site/src/components/RulesTable.tsx`, not in this diff.
