### PR TITLE
feat(ts): implement variableBlockScopeUsage rule

### DIFF
--- a/.changeset/variable-block-scope-usage.md
+++ b/.changeset/variable-block-scope-usage.md
@@ -1,0 +1,5 @@
+---
+"@flint.fyi/ts": patch
+---
+
+Implement the `variableBlockScopeUsage` rule.

--- a/packages/comparisons/src/data.json
+++ b/packages/comparisons/src/data.json
@@ -21631,7 +21631,8 @@
 		"flint": {
 			"name": "variableBlockScopeUsage",
 			"plugin": "ts",
-			"preset": "javascript"
+			"preset": "javascript",
+			"status": "implemented"
 		},
 		"oxlint": [
 			{

--- a/packages/site/src/content/docs/rules/ts/variableBlockScopeUsage.mdx
+++ b/packages/site/src/content/docs/rules/ts/variableBlockScopeUsage.mdx
@@ -1,0 +1,87 @@
+---
+description: "Variables declared with var should only be used within their block scope."
+title: "variableBlockScopeUsage"
+topic: "rules"
+---
+
+import { TabItem, Tabs } from "@astrojs/starlight/components";
+import { RuleEquivalents } from "~/components/RuleEquivalents";
+import RuleSummary from "~/components/RuleSummary.astro";
+
+<RuleSummary plugin="ts" rule="variableBlockScopeUsage" />
+
+Variables declared with `var` are function-scoped, not block-scoped, which means they are accessible throughout the entire function regardless of where they are declared within blocks like `if` statements, loops, or other block constructs.
+This can lead to unexpected behavior and bugs, as variables may be accessible in places where they logically shouldn't be.
+
+This rule enforces treating `var` declarations as if they were block-scoped, like `let` and `const`, by reporting usages that occur outside the block where the variable is declared.
+
+## Examples
+
+<Tabs>
+<TabItem label="❌ Incorrect">
+
+```ts
+function test() {
+	if (condition) {
+		var value = 1;
+	}
+	console.log(value);
+}
+
+function calculate() {
+	for (var index = 0; index < 10; index++) {
+		doSomething();
+	}
+	console.log(index);
+}
+```
+
+</TabItem>
+<TabItem label="✅ Correct">
+
+```ts
+function test() {
+	if (condition) {
+		var value = 1;
+		console.log(value);
+	}
+}
+
+function calculate() {
+	var index = 0;
+	for (index = 0; index < 10; index++) {
+		doSomething();
+	}
+	console.log(index);
+}
+
+function better() {
+	let value = 1;
+	if (condition) {
+		console.log(value);
+	}
+}
+```
+
+</TabItem>
+</Tabs>
+
+## Options
+
+This rule is not configurable.
+
+## When Not To Use It
+
+If you are working in a legacy codebase that heavily uses `var` declarations and refactoring to `let`/`const` is not feasible, you may want to disable this rule.
+However, the better solution is to gradually migrate to using `let` and `const` instead of `var`.
+
+## Further Reading
+
+- [MDN Web Docs: var](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/var)
+- [MDN Web Docs: let](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/let)
+- [MDN Web Docs: const](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/const)
+- [MDN Web Docs: Block statement](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/block)
+
+## Equivalents in Other Linters
+
+<RuleEquivalents pluginId="ts" ruleId="variableBlockScopeUsage" />

--- a/packages/ts/src/plugin.ts
+++ b/packages/ts/src/plugin.ts
@@ -297,6 +297,7 @@ import unnecessaryRenames from "./rules/unnecessaryRenames.ts";
 import unnecessaryTernaries from "./rules/unnecessaryTernaries.ts";
 import unnecessaryUseStricts from "./rules/unnecessaryUseStricts.ts";
 import unsafeNegations from "./rules/unsafeNegations.ts";
+import variableBlockScopeUsage from "./rules/variableBlockScopeUsage.ts";
 import variableDeletions from "./rules/variableDeletions.ts";
 import voidOperator from "./rules/voidOperator.ts";
 import withStatements from "./rules/withStatements.ts";
@@ -611,6 +612,7 @@ export const ts = createPlugin({
 		unnecessaryTernaries,
 		unnecessaryUseStricts,
 		unsafeNegations,
+		variableBlockScopeUsage,
 		variableDeletions,
 		voidOperator,
 		withStatements,

--- a/packages/ts/src/rules/variableBlockScopeUsage.test.ts
+++ b/packages/ts/src/rules/variableBlockScopeUsage.test.ts
@@ -1,0 +1,166 @@
+import { ruleTester } from "./ruleTester.ts";
+import rule from "./variableBlockScopeUsage.ts";
+
+ruleTester.describe(rule, {
+	invalid: [
+		{
+			code: `
+function test() {
+    if (true) {
+        var value = 1;
+    }
+    console.log(value);
+}
+`,
+			snapshot: `
+function test() {
+    if (true) {
+        var value = 1;
+    }
+    console.log(value);
+                ~~~~~
+                Variable 'value' is declared with var but used outside its block scope.
+}
+`,
+		},
+		{
+			code: `
+function test() {
+    for (var index = 0; index < 10; index++) {
+        doSomething();
+    }
+    console.log(index);
+}
+`,
+			snapshot: `
+function test() {
+    for (var index = 0; index < 10; index++) {
+        doSomething();
+    }
+    console.log(index);
+                ~~~~~
+                Variable 'index' is declared with var but used outside its block scope.
+}
+`,
+		},
+		{
+			code: `
+function test() {
+    while (condition) {
+        var result = calculate();
+    }
+    return result;
+}
+`,
+			snapshot: `
+function test() {
+    while (condition) {
+        var result = calculate();
+    }
+    return result;
+           ~~~~~~
+           Variable 'result' is declared with var but used outside its block scope.
+}
+`,
+		},
+		{
+			code: `
+function test() {
+    {
+        var nested = 1;
+    }
+    console.log(nested);
+}
+`,
+			snapshot: `
+function test() {
+    {
+        var nested = 1;
+    }
+    console.log(nested);
+                ~~~~~~
+                Variable 'nested' is declared with var but used outside its block scope.
+}
+`,
+		},
+		{
+			code: `
+function test() {
+    if (condition) {
+        var value = 1;
+    }
+    const getter = () => value;
+}
+`,
+			snapshot: `
+function test() {
+    if (condition) {
+        var value = 1;
+    }
+    const getter = () => value;
+                         ~~~~~
+                         Variable 'value' is declared with var but used outside its block scope.
+}
+`,
+		},
+	],
+	valid: [
+		`function test() { var value = 1; console.log(value); }`,
+		`function test() { if (true) { var value = 1; console.log(value); } }`,
+		`function test() { let value = 1; if (true) { console.log(value); } }`,
+		`function test() { const value = 1; if (true) { console.log(value); } }`,
+		`function test() { for (let index = 0; index < 10; index++) { doSomething(); } }`,
+		`var globalValue = 1; function test() { console.log(globalValue); }`,
+		`
+function test() {
+    for (var index = 0; index < 10; index++) {
+        console.log(index);
+    }
+}
+`,
+		`
+function test() {
+    if (true) {
+        var value = 1;
+        console.log(value);
+    }
+}
+`,
+		`
+function test() {
+    switch (value) {
+        case 1:
+            var message = "one";
+            console.log(message);
+            break;
+    }
+}
+`,
+		`
+function outer() {
+    var value = 1;
+    console.log(value);
+}
+`,
+		`
+function test() {
+    if (condition) {
+        var value = 1;
+        var getter = function() { return value; };
+        getter();
+    }
+}
+`,
+		`
+function test(value) {
+    switch (value) {
+        case 1:
+            var message = "one";
+            break;
+        default:
+            message = "other";
+    }
+}
+`,
+	],
+});

--- a/packages/ts/src/rules/variableBlockScopeUsage.ts
+++ b/packages/ts/src/rules/variableBlockScopeUsage.ts
@@ -1,0 +1,145 @@
+import ts from "typescript";
+
+import {
+	typescriptLanguage,
+	type Checker,
+} from "@flint.fyi/typescript-language";
+
+import { ruleCreator } from "./ruleCreator.ts";
+
+export default ruleCreator.createRule(typescriptLanguage, {
+	about: {
+		description:
+			"Reports variables declared with var that are referenced outside their defining block scope.",
+		id: "variableBlockScopeUsage",
+		presets: ["javascript"],
+	},
+	messages: {
+		outOfScope: {
+			primary:
+				"Variable '{{ name }}' is declared with var but used outside its block scope.",
+			secondary: [
+				"Variables declared with var are function-scoped, not block-scoped, which can lead to unexpected behavior.",
+				"When a var is declared in a block (like an if statement or for loop), it's actually hoisted to the function scope.",
+				"References outside the declaring block can access variables that may not be initialized or may have unexpected values.",
+			],
+			suggestions: [
+				"Use let or const instead of var to ensure block-level scoping.",
+				"Move the variable declaration to a scope that encompasses all its usages.",
+			],
+		},
+	},
+	setup(context) {
+		function getDeclaringScope(node: ts.Node): ts.Node | undefined {
+			let current = node.parent;
+			while (!ts.isSourceFile(current)) {
+				if (
+					ts.isBlock(current) ||
+					ts.isForInStatement(current) ||
+					ts.isForOfStatement(current) ||
+					ts.isForStatement(current) ||
+					ts.isSwitchStatement(current)
+				) {
+					return current;
+				}
+				current = current.parent;
+			}
+			return undefined;
+		}
+
+		function isInScope(scope: ts.Node, reference: ts.Node): boolean {
+			let current: ts.Node = reference;
+			while (!ts.isSourceFile(current)) {
+				if (current === scope) {
+					return true;
+				}
+				current = current.parent;
+			}
+			return false;
+		}
+
+		function getSearchRoot(node: ts.Node): ts.Node {
+			let current: ts.Node = node;
+			while (!ts.isSourceFile(current)) {
+				const parent = current.parent;
+				if (ts.isFunctionLike(parent) || ts.isSourceFile(parent)) {
+					return parent;
+				}
+				current = parent;
+			}
+			return current;
+		}
+
+		function collectReferences(
+			root: ts.Node,
+			symbol: ts.Symbol,
+			declarationName: ts.Identifier,
+			typeChecker: Checker,
+		): ts.Identifier[] {
+			const references: ts.Identifier[] = [];
+
+			function visit(node: ts.Node): void {
+				if (
+					ts.isIdentifier(node) &&
+					node !== declarationName &&
+					typeChecker.getSymbolAtLocation(node) === symbol
+				) {
+					references.push(node);
+				}
+				ts.forEachChild(node, visit);
+			}
+
+			visit(root);
+
+			return references;
+		}
+
+		return {
+			visitors: {
+				VariableDeclarationList: (node, { sourceFile, typeChecker }) => {
+					if (node.flags & ts.NodeFlags.BlockScoped) {
+						return;
+					}
+
+					for (const declaration of node.declarations) {
+						if (!ts.isIdentifier(declaration.name)) {
+							continue;
+						}
+
+						const declaringScope = getDeclaringScope(declaration.name);
+						if (!declaringScope) {
+							continue;
+						}
+
+						const symbol = typeChecker.getSymbolAtLocation(declaration.name);
+						if (!symbol) {
+							continue;
+						}
+
+						const references = collectReferences(
+							getSearchRoot(declaration),
+							symbol,
+							declaration.name,
+							typeChecker,
+						);
+
+						for (const reference of references) {
+							if (!isInScope(declaringScope, reference)) {
+								context.report({
+									data: {
+										name: declaration.name.text,
+									},
+									message: "outOfScope",
+									range: {
+										begin: reference.getStart(sourceFile),
+										end: reference.getEnd(),
+									},
+								});
+							}
+						}
+					}
+				},
+			},
+		};
+	},
+});


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #451
- [x] That issue was marked as [`status: accepting prs`](https://github.com/flint-fyi/flint/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22) — **caveat:** The issue is labeled `status: blocked` (its original draft, #477, stalled on the legacy rule API) — this PR is the revival of that draft, opened as a draft for maintainer review
- [x] Steps in [CONTRIBUTING.md](https://github.com/flint-fyi/flint/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

> **Draft revival** — opening for maintainer review, not asserting merge-readiness.

Revives #477 (`variableBlockScopeUsage`), which stalled when the rule-authoring API migrated underneath it. This branch ports it to the current `ruleCreator.createRule(language, …)` + visitor-`services` API and restores the full rule set.

The rule reports variables declared with `var` that are referenced outside their defining block scope — equivalent to ESLint [`block-scoped-var`](https://eslint.org/docs/latest/rules/block-scoped-var) and Oxlint `eslint/block-scoped-var`.

### Files
- `packages/ts/src/rules/variableBlockScopeUsage.ts` — the rule
- `packages/ts/src/rules/variableBlockScopeUsage.test.ts` — co-located rule-tester snapshots
- `packages/site/src/content/docs/rules/ts/variableBlockScopeUsage.mdx` — docs
- `packages/ts/src/plugin.ts` — alphabetical registration
- `packages/comparisons/src/data.json` — entry flipped to `status: implemented`
- `.changeset/variable-block-scope-usage.md`

### Review fixes applied (deltas vs the original draft, verified against ESLint's implementation)
The original #477 draft diverged from ESLint `block-scoped-var` in three ways; this revival aligns with ESLint's purely positional semantics (verified empirically against ESLint's own implementation):
- **Closures no longer break scope containment.** The draft treated function boundaries as scope exits, falsely reporting `if (c) { var x = 1; var g = function() { return x; }; }` (ESLint: valid). Scope checking is now a pure ancestor walk — a closure *outside* the declaring block is still reported, matching ESLint.
- **`switch` is one scope.** The draft scoped per `case`/`default` clause, falsely reporting `case 1: var m = 1; … default: m = 2;` (ESLint: valid, whole-switch scope).
- **`using`/`await using` declarations are excluded** via `NodeFlags.BlockScoped` (the draft's flag check matched them as `var`).

Deliberately *not* changed: per-declaration-statement reporting on `var` redeclarations (e.g. two `var x` statements + one out-of-scope use ⇒ 4 reports) — that exactly matches ESLint's behavior, verified empirically.

### Local gates
`eslint` · `tsc -b packages/ts` · `vitest` (17/17) · `prettier` — all pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
