### PR TITLE
feat(ts): implement unusedLabels rule

### DIFF
--- a/.changeset/unused-labels.md
+++ b/.changeset/unused-labels.md
@@ -1,0 +1,5 @@
+---
+"@flint.fyi/ts": patch
+---
+
+Implement the `unusedLabels` rule.

--- a/packages/comparisons/src/data.json
+++ b/packages/comparisons/src/data.json
@@ -21406,7 +21406,8 @@
 		"flint": {
 			"name": "unusedLabels",
 			"plugin": "ts",
-			"preset": "stylistic"
+			"preset": "stylistic",
+			"status": "implemented"
 		},
 		"oxlint": [
 			{

--- a/packages/site/src/content/docs/rules/ts/unusedLabels.mdx
+++ b/packages/site/src/content/docs/rules/ts/unusedLabels.mdx
@@ -1,0 +1,79 @@
+---
+description: "Labels should not be declared if they are never used with break or continue statements."
+title: "unusedLabels"
+topic: "rules"
+---
+
+import { TabItem, Tabs } from "@astrojs/starlight/components";
+import { RuleEquivalents } from "~/components/RuleEquivalents";
+import RuleSummary from "~/components/RuleSummary.astro";
+
+<RuleSummary plugin="ts" rule="unusedLabels" />
+
+Labels in JavaScript and TypeScript are used to identify loops or blocks, allowing break and continue statements to reference them.
+If a label is declared but never referenced, it serves no purpose and should be removed to keep the code clean.
+
+## Examples
+
+<Tabs>
+<TabItem label="❌ Incorrect">
+
+```ts
+unused: for (let i = 0; i < 10; i++) {
+	console.log(i);
+}
+
+unused: {
+	console.log("block");
+}
+
+unused: while (true) {
+	break;
+}
+```
+
+</TabItem>
+<TabItem label="✅ Correct">
+
+```ts
+for (let i = 0; i < 10; i++) {
+	console.log(i);
+}
+
+used: for (let i = 0; i < 10; i++) {
+	if (i === 5) {
+		break used;
+	}
+	console.log(i);
+}
+
+loopLabel: for (let i = 0; i < 10; i++) {
+	for (let j = 0; j < 10; j++) {
+		if (j === 5) {
+			continue loopLabel;
+		}
+	}
+}
+```
+
+</TabItem>
+</Tabs>
+
+## Options
+
+This rule is not configurable.
+
+## When Not To Use It
+
+This rule is always recommended.
+Unused labels clutter code and can be confusing to readers.
+
+## Further Reading
+
+- [MDN JavaScript Reference: label](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/label)
+- [MDN JavaScript Reference: break](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/break)
+- [MDN JavaScript Reference: continue](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/continue)
+
+## Equivalents in Other Linters
+
+<RuleEquivalents pluginId="ts" ruleId="unusedLabels" />

--- a/packages/ts/src/plugin.ts
+++ b/packages/ts/src/plugin.ts
@@ -297,6 +297,7 @@ import unnecessaryRenames from "./rules/unnecessaryRenames.ts";
 import unnecessaryTernaries from "./rules/unnecessaryTernaries.ts";
 import unnecessaryUseStricts from "./rules/unnecessaryUseStricts.ts";
 import unsafeNegations from "./rules/unsafeNegations.ts";
+import unusedLabels from "./rules/unusedLabels.ts";
 import variableDeletions from "./rules/variableDeletions.ts";
 import voidOperator from "./rules/voidOperator.ts";
 import withStatements from "./rules/withStatements.ts";
@@ -611,6 +612,7 @@ export const ts = createPlugin({
 		unnecessaryTernaries,
 		unnecessaryUseStricts,
 		unsafeNegations,
+		unusedLabels,
 		variableDeletions,
 		voidOperator,
 		withStatements,

--- a/packages/ts/src/rules/unusedLabels.test.ts
+++ b/packages/ts/src/rules/unusedLabels.test.ts
@@ -1,0 +1,136 @@
+import { ruleTester } from "./ruleTester.ts";
+import rule from "./unusedLabels.ts";
+
+ruleTester.describe(rule, {
+	invalid: [
+		{
+			code: `
+unused: for (let i = 0; i < 10; i++) {
+    console.log(i);
+}
+`,
+			snapshot: `
+unused: for (let i = 0; i < 10; i++) {
+~~~~~~
+Remove the unused label 'unused'.
+    console.log(i);
+}
+`,
+		},
+		{
+			code: `
+unused: {
+    console.log("block");
+}
+`,
+			snapshot: `
+unused: {
+~~~~~~
+Remove the unused label 'unused'.
+    console.log("block");
+}
+`,
+		},
+		{
+			code: `
+outer: for (let i = 0; i < 10; i++) {
+    inner: for (let j = 0; j < 10; j++) {
+        console.log(i, j);
+    }
+}
+`,
+			snapshot: `
+outer: for (let i = 0; i < 10; i++) {
+~~~~~
+Remove the unused label 'outer'.
+    inner: for (let j = 0; j < 10; j++) {
+    ~~~~~
+    Remove the unused label 'inner'.
+        console.log(i, j);
+    }
+}
+`,
+		},
+		{
+			code: `
+unused: while (true) {
+    break;
+}
+`,
+			snapshot: `
+unused: while (true) {
+~~~~~~
+Remove the unused label 'unused'.
+    break;
+}
+`,
+		},
+		{
+			code: `
+unused: do {
+    console.log("test");
+} while (false);
+`,
+			snapshot: `
+unused: do {
+~~~~~~
+Remove the unused label 'unused'.
+    console.log("test");
+} while (false);
+`,
+		},
+		{
+			code: `
+outer: {
+    const run = () => {
+        outer: while (true) {
+            break outer;
+        }
+    };
+    run();
+}
+`,
+			snapshot: `
+outer: {
+~~~~~
+Remove the unused label 'outer'.
+    const run = () => {
+        outer: while (true) {
+            break outer;
+        }
+    };
+    run();
+}
+`,
+		},
+	],
+	valid: [
+		`for (let i = 0; i < 10; i++) { console.log(i); }`,
+		`
+used: for (let i = 0; i < 10; i++) {
+    if (i === 5) break used;
+    console.log(i);
+}
+`,
+		`
+loopLabel: for (let i = 0; i < 10; i++) {
+    for (let j = 0; j < 10; j++) {
+        if (j === 5) continue loopLabel;
+    }
+}
+`,
+		`
+outer: for (let i = 0; i < 10; i++) {
+    for (let j = 0; j < 10; j++) {
+        if (i === 5 && j === 5) break outer;
+    }
+}
+`,
+		`
+used: {
+    if (true) break used;
+    console.log("block");
+}
+`,
+	],
+});

--- a/packages/ts/src/rules/unusedLabels.ts
+++ b/packages/ts/src/rules/unusedLabels.ts
@@ -1,0 +1,75 @@
+import ts from "typescript";
+
+import { typescriptLanguage } from "@flint.fyi/typescript-language";
+
+import { ruleCreator } from "./ruleCreator.ts";
+
+export default ruleCreator.createRule(typescriptLanguage, {
+	about: {
+		description: "Reports labels that are declared but never used.",
+		id: "unusedLabels",
+		presets: ["stylistic", "stylisticStrict"],
+	},
+	messages: {
+		unusedLabel: {
+			primary: "Remove the unused label '{{ labelName }}'.",
+			secondary: [
+				"Labels in JavaScript and TypeScript are used to identify loops or blocks, allowing break and continue statements to reference them.",
+				"If a label is declared but never referenced, it serves no purpose and should be removed to keep the code clean.",
+			],
+			suggestions: [
+				"Remove the unused label to simplify the code.",
+				"Add a break or continue statement that references this label if it was intended to be used.",
+			],
+		},
+	},
+	setup(context) {
+		// Stack of label-usage entries, one per nesting level of LabeledStatement.
+		const labelStack: { node: ts.LabeledStatement; used: boolean }[] = [];
+
+		// Innermost-first: a break/continue targets the nearest enclosing label,
+		// which matters when a name is shadowed across a function boundary.
+		function markUsed(labelName: string) {
+			const entry = labelStack.findLast(
+				(candidate) => candidate.node.label.text === labelName,
+			);
+			if (entry) {
+				entry.used = true;
+			}
+		}
+
+		return {
+			visitors: {
+				BreakStatement: (node) => {
+					if (node.label != null) {
+						markUsed(node.label.text);
+					}
+				},
+				ContinueStatement: (node) => {
+					if (node.label != null) {
+						markUsed(node.label.text);
+					}
+				},
+				LabeledStatement: (node) => {
+					labelStack.push({ node, used: false });
+				},
+				"LabeledStatement:exit": (_node, { sourceFile }) => {
+					const entry = labelStack.pop();
+
+					if (entry != null && !entry.used) {
+						context.report({
+							data: {
+								labelName: entry.node.label.text,
+							},
+							message: "unusedLabel",
+							range: {
+								begin: entry.node.label.getStart(sourceFile),
+								end: entry.node.label.getEnd(),
+							},
+						});
+					}
+				},
+			},
+		};
+	},
+});


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #453
- [x] That issue was marked as [`status: accepting prs`](https://github.com/flint-fyi/flint/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22) — **caveat:** The issue is labeled `status: blocked` (its original draft, #479, stalled on the legacy rule API) — this PR is the revival of that draft, opened as a draft for maintainer review
- [x] Steps in [CONTRIBUTING.md](https://github.com/flint-fyi/flint/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

> **Draft revival** — opening for maintainer review, not asserting merge-readiness.

Revives #479 (`unusedLabels`), which stalled when the rule-authoring API migrated underneath it. This branch ports it to the current `ruleCreator.createRule(language, …)` + visitor-`services` API.

Because the source file is no longer walkable inside `setup()`, label-usage tracking was re-architected onto a stack: pushed on `LabeledStatement`, marked used by `break`/`continue`, and reported on `LabeledStatement:exit` (using the `:exit` capability from #1163, now available).

The rule reports labels that are never referenced — equivalent to ESLint [`no-unused-labels`](https://eslint.org/docs/latest/rules/no-unused-labels), Biome `noUnusedLabels`, Deno `no-unused-labels`, Oxlint `eslint/no-unused-labels`.

### Files
- `packages/ts/src/rules/unusedLabels.ts` — the rule
- `packages/ts/src/rules/unusedLabels.test.ts` — co-located rule-tester snapshots
- `packages/site/src/content/docs/rules/ts/unusedLabels.mdx` — docs
- `packages/ts/src/plugin.ts` — alphabetical registration
- `packages/comparisons/src/data.json` — entry flipped to `status: implemented`
- `.changeset/unused-labels.md`

### Review fixes applied (deltas vs the original draft)
- **Label resolution is innermost-first** (`findLast` over the label stack). An earlier revision searched outermost-first, which mis-attributed usage when a label name is shadowed across a function boundary; a regression test covers the shadowing case. (The original #479 used a file-wide name set, which had the inverse false-negative.)
- `presets` is `["stylistic", "stylisticStrict"]` — preset membership is literal (no superset expansion), and most implemented plain-`stylistic` rules declare both tiers; flag if you'd rather have it strict-only.

### Local gates
`eslint` · `tsc -b packages/ts` · `vitest` (11/11) · `prettier` — all pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
