### PR TITLE
feat(ts): implement awaitThenable rule

### DIFF
--- a/.changeset/await-thenable.md
+++ b/.changeset/await-thenable.md
@@ -1,0 +1,5 @@
+---
+"@flint.fyi/ts": patch
+---
+
+Implement the `awaitThenable` rule.

--- a/packages/comparisons/src/data.json
+++ b/packages/comparisons/src/data.json
@@ -10886,7 +10886,8 @@
 		"flint": {
 			"name": "awaitThenable",
 			"plugin": "ts",
-			"preset": "logical"
+			"preset": "logical",
+			"status": "implemented"
 		},
 		"oxlint": [
 			{

--- a/packages/site/src/content/docs/rules/ts/awaitThenable.mdx
+++ b/packages/site/src/content/docs/rules/ts/awaitThenable.mdx
@@ -1,0 +1,96 @@
+---
+description: "Reports awaiting a value that is not a Thenable."
+title: "awaitThenable"
+topic: "rules"
+---
+
+import { TabItem, Tabs } from "@astrojs/starlight/components";
+import { RuleEquivalents } from "~/components/RuleEquivalents";
+import RuleSummary from "~/components/RuleSummary.astro";
+
+<RuleSummary plugin="ts" rule="awaitThenable" />
+
+A "Thenable" value is an object with a `then` method, such as a Promise.
+The `await` keyword is designed to retrieve the result of calling a Thenable's `then` method.
+If `await` is used on a non-Thenable value, the value is directly resolved, but execution still pauses until the next microtask.
+This is often a programmer error, such as forgetting to add parentheses to call a function that returns a Promise.
+
+This rule also checks `for await...of` loops to ensure the iterated value is async iterable.
+Using `for await...of` on a synchronous iterable works, but introduces subtle error handling differences and obscures intent.
+
+## Examples
+
+<Tabs>
+<TabItem label="❌ Incorrect">
+
+```ts
+async function getValue() {
+	const value = 42;
+	return await value;
+}
+```
+
+```ts
+async function example() {
+	await null;
+}
+```
+
+```ts
+async function processItems() {
+	const items = [1, 2, 3];
+	for await (const item of items) {
+		console.log(item);
+	}
+}
+```
+
+</TabItem>
+<TabItem label="✅ Correct">
+
+```ts
+async function fetchData() {
+	const data = await fetch("/api");
+	return data;
+}
+```
+
+```ts
+async function waitForPromise() {
+	const promise = Promise.resolve(42);
+	return await promise;
+}
+```
+
+```ts
+async function* asyncGenerator() {
+	yield 1;
+	yield 2;
+}
+async function iterateAsync() {
+	for await (const value of asyncGenerator()) {
+		console.log(value);
+	}
+}
+```
+
+</TabItem>
+</Tabs>
+
+## Options
+
+This rule is not configurable.
+
+## When Not To Use It
+
+If your codebase is transitioning from one style of asynchronous code to another, it may be useful to include `await` on non-Promise values for visual consistency.
+Additionally, if you have generic code that might receive either synchronous or asynchronous values, you might disable this rule.
+
+## Further Reading
+
+- [MDN documentation on await](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/await)
+- [MDN documentation on for await...of](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for-await...of)
+
+## Equivalents in Other Linters
+
+<RuleEquivalents pluginId="ts" ruleId="awaitThenable" />

--- a/packages/ts/src/plugin.ts
+++ b/packages/ts/src/plugin.ts
@@ -39,6 +39,7 @@ import asyncFunctionAwaits from "./rules/asyncFunctionAwaits.ts";
 import asyncPromiseExecutors from "./rules/asyncPromiseExecutors.ts";
 import asyncUnnecessaryPromiseWrappers from "./rules/asyncUnnecessaryPromiseWrappers.ts";
 import atAccesses from "./rules/atAccesses.ts";
+import awaitThenable from "./rules/awaitThenable.ts";
 import builtinCoercions from "./rules/builtinCoercions.ts";
 import builtinConstructorNews from "./rules/builtinConstructorNews.ts";
 import caseDeclarations from "./rules/caseDeclarations.ts";
@@ -352,6 +353,7 @@ export const ts = createPlugin({
 		asyncPromiseExecutors,
 		asyncUnnecessaryPromiseWrappers,
 		atAccesses,
+		awaitThenable,
 		builtinCoercions,
 		builtinConstructorNews,
 		caseDeclarations,

--- a/packages/ts/src/rules/awaitThenable.test.ts
+++ b/packages/ts/src/rules/awaitThenable.test.ts
@@ -1,0 +1,162 @@
+import rule from "./awaitThenable.ts";
+import { domLibRuleTester } from "./ruleTester.ts";
+
+domLibRuleTester.describe(rule, {
+	invalid: [
+		{
+			code: `
+async function getValue() {
+    const value = 42;
+    return await value;
+}
+`,
+			snapshot: `
+async function getValue() {
+    const value = 42;
+    return await value;
+           ~~~~~
+           Awaiting a non-Promise (non-Thenable) value is unnecessary and indicates a likely mistake.
+}
+`,
+		},
+		{
+			code: `
+async function getString() {
+    return await "hello";
+}
+`,
+			snapshot: `
+async function getString() {
+    return await "hello";
+           ~~~~~
+           Awaiting a non-Promise (non-Thenable) value is unnecessary and indicates a likely mistake.
+}
+`,
+		},
+		{
+			code: `
+async function getObject() {
+    const obj = { key: "value" };
+    return await obj;
+}
+`,
+			snapshot: `
+async function getObject() {
+    const obj = { key: "value" };
+    return await obj;
+           ~~~~~
+           Awaiting a non-Promise (non-Thenable) value is unnecessary and indicates a likely mistake.
+}
+`,
+		},
+		{
+			code: `
+async function example() {
+    await null;
+}
+`,
+			snapshot: `
+async function example() {
+    await null;
+    ~~~~~
+    Awaiting a non-Promise (non-Thenable) value is unnecessary and indicates a likely mistake.
+}
+`,
+		},
+		{
+			code: `
+async function example() {
+    await undefined;
+}
+`,
+			snapshot: `
+async function example() {
+    await undefined;
+    ~~~~~
+    Awaiting a non-Promise (non-Thenable) value is unnecessary and indicates a likely mistake.
+}
+`,
+		},
+		{
+			code: `
+async function processItems() {
+    const items = [1, 2, 3];
+    for await (const item of items) {
+        console.log(item);
+    }
+}
+`,
+			snapshot: `
+async function processItems() {
+    const items = [1, 2, 3];
+    for await (const item of items) {
+        ~~~~~
+        Using \`for await...of\` on a value that is not async iterable is unnecessary.
+        console.log(item);
+    }
+}
+`,
+		},
+		{
+			code: `
+async function processStrings() {
+    for await (const char of "hello") {
+        console.log(char);
+    }
+}
+`,
+			snapshot: `
+async function processStrings() {
+    for await (const char of "hello") {
+        ~~~~~
+        Using \`for await...of\` on a value that is not async iterable is unnecessary.
+        console.log(char);
+    }
+}
+`,
+		},
+	],
+	valid: [
+		`
+async function fetchData() {
+    const data = await fetch("/api");
+    return data;
+}
+`,
+		`
+async function waitForPromise() {
+    const promise = Promise.resolve(42);
+    return await promise;
+}
+`,
+		`
+async function awaitThenable() {
+    const thenable = { then: (resolve: (value: number) => void) => resolve(42) };
+    return await thenable;
+}
+`,
+		`
+async function awaitAny(value: any) {
+    return await value;
+}
+`,
+		`
+async function* asyncGenerator() {
+    yield 1;
+    yield 2;
+}
+async function iterateAsync() {
+    for await (const value of asyncGenerator()) {
+        console.log(value);
+    }
+}
+`,
+		`
+async function processReadable(stream: AsyncIterable<string>) {
+    for await (const chunk of stream) {
+        console.log(chunk);
+    }
+}
+`,
+	],
+});

--- a/packages/ts/src/rules/awaitThenable.ts
+++ b/packages/ts/src/rules/awaitThenable.ts
@@ -1,0 +1,105 @@
+import * as tsutils from "ts-api-utils";
+import ts from "typescript";
+
+import { typescriptLanguage } from "@flint.fyi/typescript-language";
+
+import { ruleCreator } from "./ruleCreator.ts";
+
+export default ruleCreator.createRule(typescriptLanguage, {
+	about: {
+		description: "Reports awaiting a value that is not a Thenable.",
+		id: "awaitThenable",
+		presets: ["logical", "logicalStrict"],
+	},
+	messages: {
+		awaitNonThenable: {
+			primary:
+				"Awaiting a non-Promise (non-Thenable) value is unnecessary and indicates a likely mistake.",
+			secondary: [
+				"The `await` keyword is designed for values with a `then` method, such as Promises.",
+				"If `await` is used on a non-Thenable value, the value is directly resolved, but execution still pauses until the next microtask.",
+				"This often indicates a programmer error, such as forgetting to call a function that returns a Promise.",
+			],
+			suggestions: [
+				"Remove the unnecessary `await` keyword.",
+				"Ensure you are awaiting the correct value, such as a function call that returns a Promise.",
+			],
+		},
+		forAwaitNonAsyncIterable: {
+			primary:
+				"Using `for await...of` on a value that is not async iterable is unnecessary.",
+			secondary: [
+				"The `for await...of` statement is designed for async iterable objects.",
+				"Using it on a synchronous iterable works but introduces subtle error handling differences and obscures intent.",
+			],
+			suggestions: [
+				"Use an ordinary `for...of` loop instead.",
+				"If you need to await each value, use `for...of` with `await` inside the loop body.",
+			],
+		},
+	},
+	setup(context) {
+		return {
+			visitors: {
+				AwaitExpression: (node, { sourceFile, typeChecker }) => {
+					const type = typeChecker.getTypeAtLocation(node.expression);
+
+					if (tsutils.isTypeFlagSet(type, ts.TypeFlags.Any)) {
+						return;
+					}
+
+					if (tsutils.isThenableType(typeChecker, node.expression, type)) {
+						return;
+					}
+
+					const awaitKeyword = node.getFirstToken(sourceFile);
+					if (awaitKeyword?.kind !== ts.SyntaxKind.AwaitKeyword) {
+						return;
+					}
+
+					context.report({
+						message: "awaitNonThenable",
+						range: {
+							begin: awaitKeyword.getStart(sourceFile),
+							end: awaitKeyword.getEnd(),
+						},
+					});
+				},
+				ForOfStatement: (node, { sourceFile, typeChecker }) => {
+					if (!node.awaitModifier) {
+						return;
+					}
+
+					const type = typeChecker.getTypeAtLocation(node.expression);
+
+					if (tsutils.isTypeFlagSet(type, ts.TypeFlags.Any)) {
+						return;
+					}
+
+					const hasAsyncIteratorSymbol = tsutils
+						.unionConstituents(type)
+						.some(
+							(typePart) =>
+								tsutils.getWellKnownSymbolPropertyOfType(
+									typePart,
+									"asyncIterator",
+									typeChecker,
+								) !== undefined,
+						);
+
+					if (hasAsyncIteratorSymbol) {
+						return;
+					}
+
+					context.report({
+						message: "forAwaitNonAsyncIterable",
+						range: {
+							begin: node.awaitModifier.getStart(sourceFile),
+							end: node.awaitModifier.getEnd(),
+						},
+					});
+				},
+			},
+		};
+	},
+});


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #834
- [x] That issue was marked as [`status: accepting prs`](https://github.com/flint-fyi/flint/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22) — **caveat:** The issue is labeled `status: blocked` (its original draft, #1357, was blocked pending async-rule design input) — this PR is the revival of that draft, with the open design questions flagged below rather than answered unilaterally
- [x] Steps in [CONTRIBUTING.md](https://github.com/flint-fyi/flint/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

> **Draft revival** — opening for maintainer review, not asserting merge-readiness. Carries open design questions (below) deliberately unresolved.

Revives #1357 (`awaitThenable`), which stalled when the rule-authoring API migrated and while awaiting maintainer input on async-rule defaults. This branch ports it to the current `ruleCreator.createRule(language, …)` + visitor-`services` API. The visitor bodies were already on the `(node, { sourceFile, typeChecker })` signature, so the port is imports + constructor + preset only — **behavior is preserved verbatim** from the original PR.

The rule reports `await` on a non-Thenable value and `for await...of` over a non-async-iterable — equivalent to typescript-eslint [`await-thenable`](https://typescript-eslint.io/rules/await-thenable) and Oxlint `typescript/await-thenable`.

### Files
- `packages/ts/src/rules/awaitThenable.ts` — the rule
- `packages/ts/src/rules/awaitThenable.test.ts` — co-located rule-tester snapshots (uses `domLibRuleTester`; fixtures reference `console`/`fetch`)
- `packages/site/src/content/docs/rules/ts/awaitThenable.mdx` — docs
- `packages/ts/src/plugin.ts` — alphabetical registration
- `packages/comparisons/src/data.json` — entry flipped to `status: implemented`
- `.changeset/await-thenable.md`

### Porting notes (addendum)
- **Preset note:** `presets` is `["logical", "logicalStrict"]` — preset membership is literal (no superset expansion) and most implemented plain-`logical` rules declare both tiers; flag if you'd rather have it single-tier.

### Local gates
`eslint --max-warnings 0` · `tsc -b packages/ts` · `vitest` (13/13, rule test) · `comparisons/data.test.ts` (28/28) · `prettier --check` — all pass locally.

The one porting change beyond the mechanical migration: the `awaitKeyword` guard was rewritten as an optional chain to satisfy `@typescript-eslint/prefer-optional-chain` (same logic).

## Open questions (for maintainers — unchanged from the #1357 discussion)

This rule was marked `status: blocked` pending @kirkwaiblinger's input on async-rule defaults. I deliberately did **not** invent answers; the original behavior is preserved and the open threads remain:

1. **Rule name.** The #1357 thread didn't converge — `awaitThenable` is disliked (it reads as "thenables must be awaited"); candidates floated were `nonThenableAwaits`, `awaitedNonThenables`, `awaitedAwaitables`. Kept as `awaitThenable` here to match the existing `data.json`/issue stub; happy to rename on your call.
2. **`any` handling.** The rule silently early-returns when the awaited/iterated type is `any`. Kirk asked whether that should instead be a throw-worthy condition.
3. **`unknown` / generic edge cases.** typescript-eslint's [`needsToBeAwaited`](https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/src/util/needsToBeAwaited.ts) has more correct handling for `unknown` and generic type params; this port does not replicate it.
4. **Promise-aggregator checks.** typescript-eslint also flags non-thenables passed to `Promise.all`/`race`/etc.; intentionally out of scope here.
5. **Fixer.** No autofix (remove the `await`/`for await` modifier) is provided — Kirk asked whether one is wanted.

Each is a semantics/naming decision, not a code gap. Glad to implement any of them once decided.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
