### PR TITLE
feat(ts): implement caughtErrorCauses rule

### DIFF
--- a/.changeset/caught-error-causes.md
+++ b/.changeset/caught-error-causes.md
@@ -1,0 +1,5 @@
+---
+"@flint.fyi/ts": patch
+---
+
+Implement the `caughtErrorCauses` rule.

--- a/packages/comparisons/src/data.json
+++ b/packages/comparisons/src/data.json
@@ -11203,6 +11203,7 @@
 			"name": "caughtErrorCauses",
 			"plugin": "ts",
 			"preset": "logical",
+			"status": "implemented",
 			"strictness": "strict"
 		}
 	},

--- a/packages/site/src/content/docs/rules/ts/caughtErrorCauses.mdx
+++ b/packages/site/src/content/docs/rules/ts/caughtErrorCauses.mdx
@@ -1,0 +1,85 @@
+---
+description: "Reports throwing new errors in catch blocks without preserving the original error as the cause."
+title: "caughtErrorCauses"
+topic: "rules"
+---
+
+import { TabItem, Tabs } from "@astrojs/starlight/components";
+import { RuleEquivalents } from "~/components/RuleEquivalents";
+import RuleSummary from "~/components/RuleSummary.astro";
+
+<RuleSummary plugin="ts" rule="caughtErrorCauses" />
+
+When re-throwing errors in catch blocks, the original error contains valuable debugging information.
+Using the `cause` option when throwing new errors maintains the complete error chain, improving traceability and debuggability.
+Without preserving the cause, the original stack trace and error details are lost.
+
+## Examples
+
+<Tabs>
+<TabItem label="❌ Incorrect">
+
+```ts
+try {
+	doSomething();
+} catch (error) {
+	throw new Error("Something went wrong");
+}
+```
+
+```ts
+try {
+	parse(data);
+} catch (error) {
+	throw new SyntaxError("Failed to parse");
+}
+```
+
+</TabItem>
+<TabItem label="✅ Correct">
+
+```ts
+try {
+	doSomething();
+} catch (error) {
+	throw new Error("Something went wrong", { cause: error });
+}
+```
+
+```ts
+try {
+	parse(data);
+} catch (error) {
+	throw new SyntaxError("Failed to parse", { cause: error });
+}
+```
+
+```ts
+try {
+	doSomething();
+} catch (error) {
+	throw error;
+}
+```
+
+</TabItem>
+</Tabs>
+
+## Options
+
+This rule is not configurable.
+
+## When Not To Use It
+
+If you follow a custom error-handling approach where the original error is intentionally omitted (e.g., to avoid exposing internal details), you may disable this rule.
+If you use a third-party error-handling library that preserves error context using non-standard properties, this rule may not be necessary.
+In rare cases, if you target legacy environments where the `cause` option in `Error` constructors is not supported, you may need to disable this rule.
+
+## Further Reading
+
+- [MDN documentation on Error.cause](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/cause)
+- [TC39 Error Cause Proposal](https://github.com/tc39/proposal-error-cause)
+
+## Equivalents in Other Linters
+
+<RuleEquivalents pluginId="ts" ruleId="caughtErrorCauses" />

--- a/packages/ts/src/plugin.ts
+++ b/packages/ts/src/plugin.ts
@@ -45,6 +45,7 @@ import caseDeclarations from "./rules/caseDeclarations.ts";
 import caseDuplicates from "./rules/caseDuplicates.ts";
 import caseFallthroughs from "./rules/caseFallthroughs.ts";
 import catchCallbackTypes from "./rules/catchCallbackTypes.ts";
+import caughtErrorCauses from "./rules/caughtErrorCauses.ts";
 import caughtVariableNames from "./rules/caughtVariableNames.ts";
 import chainedAssignments from "./rules/chainedAssignments.ts";
 import charAtComparisons from "./rules/charAtComparisons.ts";
@@ -358,6 +359,7 @@ export const ts = createPlugin({
 		caseDuplicates,
 		caseFallthroughs,
 		catchCallbackTypes,
+		caughtErrorCauses,
 		caughtVariableNames,
 		chainedAssignments,
 		charAtComparisons,

--- a/packages/ts/src/rules/caughtErrorCauses.test.ts
+++ b/packages/ts/src/rules/caughtErrorCauses.test.ts
@@ -1,0 +1,180 @@
+import rule from "./caughtErrorCauses.ts";
+import { domLibRuleTester } from "./ruleTester.ts";
+
+domLibRuleTester.describe(rule, {
+	invalid: [
+		{
+			code: `
+try {
+    doSomething();
+} catch (error) {
+    throw new Error("Something went wrong");
+}
+`,
+			snapshot: `
+try {
+    doSomething();
+} catch (error) {
+    throw new Error("Something went wrong");
+          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+          Preserve the original error by passing it as the \`cause\` option when throwing a new error.
+}
+`,
+		},
+		{
+			code: `
+try {
+    doSomething();
+} catch (err) {
+    throw new TypeError("Invalid type");
+}
+`,
+			snapshot: `
+try {
+    doSomething();
+} catch (err) {
+    throw new TypeError("Invalid type");
+          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+          Preserve the original error by passing it as the \`cause\` option when throwing a new error.
+}
+`,
+		},
+		{
+			code: `
+try {
+    parse(data);
+} catch (error) {
+    throw new SyntaxError("Failed to parse");
+}
+`,
+			snapshot: `
+try {
+    parse(data);
+} catch (error) {
+    throw new SyntaxError("Failed to parse");
+          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+          Preserve the original error by passing it as the \`cause\` option when throwing a new error.
+}
+`,
+		},
+		{
+			code: `
+try {
+    getValue();
+} catch (error) {
+    throw new RangeError("Value out of range", {});
+}
+`,
+			snapshot: `
+try {
+    getValue();
+} catch (error) {
+    throw new RangeError("Value out of range", {});
+          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+          Preserve the original error by passing it as the \`cause\` option when throwing a new error.
+}
+`,
+		},
+		{
+			code: `
+try {
+    doSomething();
+} catch (errors) {
+    throw new AggregateError([errors], "All attempts failed");
+}
+`,
+			snapshot: `
+try {
+    doSomething();
+} catch (errors) {
+    throw new AggregateError([errors], "All attempts failed");
+          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+          Preserve the original error by passing it as the \`cause\` option when throwing a new error.
+}
+`,
+		},
+	],
+	valid: [
+		`
+try {
+    doSomething();
+} catch (error) {
+    throw new Error("Something went wrong", { cause: error });
+}
+`,
+		`
+try {
+    doSomething();
+} catch (err) {
+    throw new TypeError("Invalid type", { cause: err });
+}
+`,
+		`
+try {
+    doSomething();
+} catch (error) {
+    throw error;
+}
+`,
+		`
+try {
+    doSomething();
+} catch {
+    throw new Error("Something went wrong");
+}
+`,
+		`
+try {
+    doSomething();
+} catch (error) {
+    console.error(error);
+}
+`,
+		`
+throw new Error("Not in a catch block");
+`,
+		`
+try {
+    doSomething();
+} catch (error) {
+    throw new Error("Message", { cause: wrapError(error) });
+}
+`,
+		`
+try {
+    doSomething();
+} catch (errors) {
+    throw new AggregateError([errors], "All attempts failed", { cause: errors });
+}
+`,
+		`
+try {
+    doSomething();
+} catch (cause) {
+    throw new Error("Something went wrong", { cause });
+}
+`,
+		`
+try {
+    doSomething();
+} catch (error) {
+    throw new Error("Something went wrong", { "cause": error });
+}
+`,
+		`
+try {
+    doSomething();
+} catch (error) {
+    const options = { cause: error };
+    throw new Error("Something went wrong", options);
+}
+`,
+		`
+try {
+    doSomething();
+} catch (error) {
+    throw new Error("Something went wrong", { ...getOptions(error) });
+}
+`,
+	],
+});

--- a/packages/ts/src/rules/caughtErrorCauses.ts
+++ b/packages/ts/src/rules/caughtErrorCauses.ts
@@ -1,0 +1,133 @@
+import ts from "typescript";
+
+import { typescriptLanguage } from "@flint.fyi/typescript-language";
+
+import { ruleCreator } from "./ruleCreator.ts";
+
+const errorConstructors = new Set([
+	"AggregateError",
+	"Error",
+	"EvalError",
+	"RangeError",
+	"ReferenceError",
+	"SyntaxError",
+	"TypeError",
+	"URIError",
+]);
+
+export default ruleCreator.createRule(typescriptLanguage, {
+	about: {
+		description:
+			"Reports throwing new errors in catch blocks without preserving the original error as the cause.",
+		id: "caughtErrorCauses",
+		presets: ["logicalStrict"],
+	},
+	messages: {
+		missingCause: {
+			primary:
+				"Preserve the original error by passing it as the `cause` option when throwing a new error.",
+			secondary: [
+				"When re-throwing errors, the original error contains valuable debugging information.",
+				"Using the `cause` option maintains the complete error chain, improving traceability.",
+				"Without preserving the cause, the original stack trace and error details are lost.",
+			],
+			suggestions: [
+				"Add `{ cause: <caughtError> }` as the second argument to the error constructor.",
+			],
+		},
+	},
+	setup(context) {
+		function getCatchParameter(node: ts.Node): ts.Identifier | undefined {
+			const catchClause = ts.findAncestor(node, ts.isCatchClause);
+			if (!catchClause) {
+				return undefined;
+			}
+
+			const variable = catchClause.variableDeclaration;
+			if (variable && ts.isIdentifier(variable.name)) {
+				return variable.name;
+			}
+
+			return undefined;
+		}
+
+		function isCauseProperty(property: ts.ObjectLiteralElementLike) {
+			if (ts.isPropertyAssignment(property)) {
+				return (
+					(ts.isIdentifier(property.name) ||
+						ts.isStringLiteral(property.name)) &&
+					property.name.text === "cause"
+				);
+			}
+
+			return (
+				ts.isShorthandPropertyAssignment(property) &&
+				property.name.text === "cause"
+			);
+		}
+
+		// A `cause` is provably missing only when the options argument slot is
+		// absent or is an object literal without a `cause` property. Spreads and
+		// non-literal options could carry a cause, so they don't report.
+		function lacksErrorCause(node: ts.NewExpression, errorName: string) {
+			// AggregateError takes its options object as the third argument.
+			const optionsIndex = errorName === "AggregateError" ? 2 : 1;
+			const args = node.arguments ?? [];
+
+			if (args.slice(0, optionsIndex + 1).some(ts.isSpreadElement)) {
+				return false;
+			}
+
+			const optionsArg = args[optionsIndex];
+			if (optionsArg === undefined) {
+				return true;
+			}
+
+			if (!ts.isObjectLiteralExpression(optionsArg)) {
+				return false;
+			}
+
+			if (optionsArg.properties.some(ts.isSpreadAssignment)) {
+				return false;
+			}
+
+			return !optionsArg.properties.some(isCauseProperty);
+		}
+
+		return {
+			visitors: {
+				ThrowStatement: (node, { sourceFile }) => {
+					if (!ts.isNewExpression(node.expression)) {
+						return;
+					}
+
+					const newExpr = node.expression;
+					if (!ts.isIdentifier(newExpr.expression)) {
+						return;
+					}
+
+					const errorName = newExpr.expression.text;
+					if (!errorConstructors.has(errorName)) {
+						return;
+					}
+
+					if (!getCatchParameter(node)) {
+						return;
+					}
+
+					if (!lacksErrorCause(newExpr, errorName)) {
+						return;
+					}
+
+					context.report({
+						message: "missingCause",
+						range: {
+							begin: newExpr.getStart(sourceFile),
+							end: newExpr.getEnd(),
+						},
+					});
+				},
+			},
+		};
+	},
+});


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #1306
- [x] That issue was marked as [`status: accepting prs`](https://github.com/flint-fyi/flint/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22) — **caveat:** The issue is labeled `status: blocked` (its original draft, #1363, was blocked on #400 scope analysis — **#400 has since closed**; see below) — this PR is the revival of that draft, opened as a draft for maintainer review
- [x] Steps in [CONTRIBUTING.md](https://github.com/flint-fyi/flint/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

> **Draft revival** — opening for maintainer review, not asserting merge-readiness.

Revives #1363 (`caughtErrorCauses`), which stalled on the legacy rule API and on #400. This branch ports it to the current `ruleCreator.createRule(language, …)` + visitor-`services` API.

The rule reports `throw new <Error>(…)` inside a `catch` block when no `cause` option is passed, so the original error chain isn't lost.

### Porting notes

- The old `preset: "logical"` + `strictness: "strict"` pair maps to `presets: ["logicalStrict"]` — flag if you'd rather have it in both tiers.
- `hasErrorCause` was simplified to the presence check it always effectively was: the original compared the `cause` initializer against the catch parameter but then returned `true` unconditionally, so the comparison was dead code. Any `cause:` property still satisfies the rule (e.g. `{ cause: wrapError(error) }`).
- The cause detection was then aligned with ESLint [`preserve-caught-error`](https://eslint.org/docs/latest/rules/preserve-caught-error)'s semantics, fixing three false positives the original draft had:
  - **`AggregateError` takes its options as the *third* argument** — `new AggregateError([e], "msg", { cause: e })` is now valid (and `new AggregateError([e], "msg")` is now correctly reported).
  - **Shorthand `{ cause }` and string-literal `{ "cause": e }` keys** are now recognized.
  - **Unknown-shaped options don't report**: options passed as a variable, spread arguments at/before the options slot, and object literals containing spreads are treated as unanalyzable, same as ESLint's `UNKNOWN_CAUSE` bail-out.
- An `undefined` guard on the options argument was added for `noUncheckedIndexedAccess`.
- Test fixtures reference `console`, so the test uses `domLibRuleTester`; fixtures cover all the cases above.

### The #400 blocker has lifted — follow-up opportunity

#1363 was marked blocked because verifying that the thrown error's `cause` is *actually the caught error* (vs. any value) needs scope analysis (#400). The TypeScript scope manager has since landed (#2828, extended in #2916 with `ScopeManager.getScope`). This revival **preserves the original lenient behavior**; tightening it to verify the caught error flows into the `cause` (directly or wrapped) is now implementable and left as a maintainer-scoped decision — happy to do it in this PR or a follow-up if wanted.

### Files
- `packages/ts/src/rules/caughtErrorCauses.ts` — the rule
- `packages/ts/src/rules/caughtErrorCauses.test.ts` — co-located rule-tester snapshots
- `packages/site/src/content/docs/rules/ts/caughtErrorCauses.mdx` — docs
- `packages/ts/src/plugin.ts` — alphabetical registration
- `packages/comparisons/src/data.json` — entry flipped to `status: implemented`
- `.changeset/caught-error-causes.md`

### Local gates
`eslint --max-warnings 0` · `tsc -b packages/ts` · `vitest` (17/17, rule test) · `comparisons/data.test.ts` (28/28) · `prettier --check` — all pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
