### PR TITLE
feat(ts): implement floatingPromises rule

### DIFF
--- a/.changeset/floating-promises.md
+++ b/.changeset/floating-promises.md
@@ -1,0 +1,5 @@
+---
+"@flint.fyi/ts": patch
+---
+
+Implement the `floatingPromises` rule.

--- a/packages/comparisons/src/data.json
+++ b/packages/comparisons/src/data.json
@@ -13230,7 +13230,8 @@
 		"flint": {
 			"name": "floatingPromises",
 			"plugin": "ts",
-			"preset": "logical"
+			"preset": "logical",
+			"status": "implemented"
 		},
 		"oxlint": [
 			{

--- a/packages/site/src/content/docs/rules/ts/floatingPromises.mdx
+++ b/packages/site/src/content/docs/rules/ts/floatingPromises.mdx
@@ -1,0 +1,107 @@
+---
+description: "Require Promise-like statements to be handled appropriately."
+title: "floatingPromises"
+topic: "rules"
+---
+
+import { TabItem, Tabs } from "@astrojs/starlight/components";
+import { RuleEquivalents } from "~/components/RuleEquivalents";
+import RuleSummary from "~/components/RuleSummary.astro";
+
+<RuleSummary plugin="ts" rule="floatingPromises" />
+
+A "floating" Promise is one that is created without any code set up to handle any errors it might throw.
+Floating Promises can cause several issues, such as improperly sequenced operations, ignored Promise rejections, and silent failures.
+
+This rule reports Promise-valued statements that are not handled in one of the following ways:
+
+- Calling its `.then()` with two arguments (including a rejection handler)
+- Calling its `.catch()` with one argument
+- `await`ing it
+- `return`ing it
+- `void`ing it
+
+This rule also reports when an array containing Promises is created and not properly handled.
+The main way to resolve this is by using one of the Promise concurrency methods to create a single Promise, then handling that accordingly.
+
+## Examples
+
+<Tabs>
+<TabItem label="❌ Incorrect">
+
+```ts
+async function getValue(): Promise<number> {
+	return 1;
+}
+
+getValue();
+```
+
+```ts
+Promise.resolve(1);
+```
+
+```ts
+new Promise((resolve) => resolve(1));
+```
+
+```ts
+Promise.resolve(1).then(() => {});
+```
+
+```ts
+[Promise.resolve(1), Promise.resolve(2)];
+```
+
+</TabItem>
+<TabItem label="✅ Correct">
+
+```ts
+await Promise.resolve(1);
+```
+
+```ts
+Promise.resolve(1).catch(() => {});
+```
+
+```ts
+Promise.resolve(1).then(
+	() => {},
+	() => {},
+);
+```
+
+```ts
+void Promise.resolve(1);
+```
+
+```ts
+const promise = Promise.resolve(1);
+```
+
+```ts
+await Promise.all([Promise.resolve(1), Promise.resolve(2)]);
+```
+
+</TabItem>
+</Tabs>
+
+## Options
+
+This rule is not configurable.
+
+## When Not To Use It
+
+This rule can be difficult to enable on large existing projects that set up many floating Promises.
+If you're not worried about crashes from floating or misused Promises, such as if you have global unhandled Promise handlers registered, then in some cases it may be safe to not use this rule.
+
+You might consider using `void` expressions and/or lint disable comments for specific situations instead of completely disabling this rule.
+
+## Further Reading
+
+- [MDN: Using Promises](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Using_promises)
+- [MDN: Promise rejection events](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Using_promises#promise_rejection_events)
+
+## Equivalents in Other Linters
+
+<RuleEquivalents pluginId="ts" ruleId="floatingPromises" />

--- a/packages/ts/src/plugin.ts
+++ b/packages/ts/src/plugin.ts
@@ -102,6 +102,7 @@ import exportUniqueNames from "./rules/exportUniqueNames.ts";
 import extraneousClasses from "./rules/extraneousClasses.ts";
 import fetchMethodBodies from "./rules/fetchMethodBodies.ts";
 import finallyStatementSafety from "./rules/finallyStatementSafety.ts";
+import floatingPromises from "./rules/floatingPromises.ts";
 import forDirections from "./rules/forDirections.ts";
 import forInArrays from "./rules/forInArrays.ts";
 import forInGuards from "./rules/forInGuards.ts";
@@ -415,6 +416,7 @@ export const ts = createPlugin({
 		extraneousClasses,
 		fetchMethodBodies,
 		finallyStatementSafety,
+		floatingPromises,
 		forDirections,
 		forInArrays,
 		forInGuards,

--- a/packages/ts/src/rules/floatingPromises.test.ts
+++ b/packages/ts/src/rules/floatingPromises.test.ts
@@ -1,0 +1,135 @@
+import rule from "./floatingPromises.ts";
+import { domLibRuleTester } from "./ruleTester.ts";
+
+domLibRuleTester.describe(rule, {
+	invalid: [
+		{
+			code: `
+async function getValue(): Promise<number> { return 1; }
+getValue();
+`,
+			snapshot: `
+async function getValue(): Promise<number> { return 1; }
+getValue();
+~~~~~~~~~~~
+Promises must be awaited, returned, or have their errors handled with \`.catch()\` or \`.then()\` with a rejection handler.
+`,
+		},
+		{
+			code: `
+const promise = Promise.resolve(1);
+promise;
+`,
+			snapshot: `
+const promise = Promise.resolve(1);
+promise;
+~~~~~~~~
+Promises must be awaited, returned, or have their errors handled with \`.catch()\` or \`.then()\` with a rejection handler.
+`,
+		},
+		{
+			code: `
+Promise.resolve(1);
+`,
+			snapshot: `
+Promise.resolve(1);
+~~~~~~~~~~~~~~~~~~~
+Promises must be awaited, returned, or have their errors handled with \`.catch()\` or \`.then()\` with a rejection handler.
+`,
+		},
+		{
+			code: `
+new Promise((resolve) => resolve(1));
+`,
+			snapshot: `
+new Promise((resolve) => resolve(1));
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Promises must be awaited, returned, or have their errors handled with \`.catch()\` or \`.then()\` with a rejection handler.
+`,
+		},
+		{
+			code: `
+Promise.resolve(1).then(() => {});
+`,
+			snapshot: `
+Promise.resolve(1).then(() => {});
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Promises must be awaited, returned, or have their errors handled with \`.catch()\` or \`.then()\` with a rejection handler.
+`,
+		},
+		{
+			code: `
+Promise.resolve(1).finally(() => {});
+`,
+			snapshot: `
+Promise.resolve(1).finally(() => {});
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Promises must be awaited, returned, or have their errors handled with \`.catch()\` or \`.then()\` with a rejection handler.
+`,
+		},
+		{
+			code: `
+async function getValue(): Promise<number> { return 1; }
+true ? getValue() : getValue();
+`,
+			snapshot: `
+async function getValue(): Promise<number> { return 1; }
+true ? getValue() : getValue();
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Promises must be awaited, returned, or have their errors handled with \`.catch()\` or \`.then()\` with a rejection handler.
+`,
+		},
+		{
+			code: `
+async function getValue(): Promise<number> { return 1; }
+true && getValue();
+`,
+			snapshot: `
+async function getValue(): Promise<number> { return 1; }
+true && getValue();
+~~~~~~~~~~~~~~~~~~~
+Promises must be awaited, returned, or have their errors handled with \`.catch()\` or \`.then()\` with a rejection handler.
+`,
+		},
+		{
+			code: `
+async function getValue(): Promise<number> { return 1; }
+null ?? getValue();
+`,
+			snapshot: `
+async function getValue(): Promise<number> { return 1; }
+null ?? getValue();
+~~~~~~~~~~~~~~~~~~~
+Promises must be awaited, returned, or have their errors handled with \`.catch()\` or \`.then()\` with a rejection handler.
+`,
+		},
+		{
+			code: `
+[Promise.resolve(1), Promise.resolve(2)];
+`,
+			snapshot: `
+[Promise.resolve(1), Promise.resolve(2)];
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Promises must be awaited, returned, or have their errors handled with \`.catch()\` or \`.then()\` with a rejection handler.
+`,
+		},
+	],
+	valid: [
+		`await Promise.resolve(1);`,
+		`await new Promise((resolve) => resolve(1));`,
+		`const result = await Promise.resolve(1);`,
+		`Promise.resolve(1).catch(() => {});`,
+		`Promise.resolve(1).then(() => {}, () => {});`,
+		`Promise.resolve(1).then(() => {}).catch(() => {});`,
+		`Promise.resolve(1).finally(() => {}).catch(() => {});`,
+		`void Promise.resolve(1);`,
+		`const promise = Promise.resolve(1);`,
+		`function getValue() { return Promise.resolve(1); }`,
+		`async function test() { return Promise.resolve(1); }`,
+		`const x = condition ? Promise.resolve(1) : Promise.resolve(2);`,
+		`await Promise.all([Promise.resolve(1), Promise.resolve(2)]);`,
+		`1 + 2;`,
+		`console.log("hello");`,
+		`const value = 42;`,
+	],
+});

--- a/packages/ts/src/rules/floatingPromises.ts
+++ b/packages/ts/src/rules/floatingPromises.ts
@@ -1,0 +1,185 @@
+import * as tsutils from "ts-api-utils";
+import ts, { SyntaxKind } from "typescript";
+
+import {
+	getTSNodeRange,
+	typescriptLanguage,
+	type AST,
+	type Checker,
+} from "@flint.fyi/typescript-language";
+
+import { ruleCreator } from "./ruleCreator.ts";
+
+export default ruleCreator.createRule(typescriptLanguage, {
+	about: {
+		description: "Require Promise-like statements to be handled appropriately.",
+		id: "floatingPromises",
+		presets: ["logical", "logicalStrict"],
+	},
+	messages: {
+		floating: {
+			primary:
+				"Promises must be awaited, returned, or have their errors handled with `.catch()` or `.then()` with a rejection handler.",
+			secondary: [
+				"A 'floating' Promise is one that is created without any code set up to handle any errors it might throw.",
+				"Floating Promises can cause unhandled rejections, improperly sequenced operations, and silent failures.",
+			],
+			suggestions: [
+				"Add `await` before the Promise expression.",
+				"Add `.catch()` to handle potential rejections.",
+				"Add `void` operator to explicitly mark the Promise as intentionally not awaited.",
+			],
+		},
+	},
+	setup(context) {
+		function isPromiseLike(tsNode: ts.Node, checker: Checker, type?: ts.Type) {
+			type ??= checker.getTypeAtLocation(tsNode);
+
+			return tsutils.isThenableType(checker, tsNode, type);
+		}
+
+		function isPromiseArray(tsNode: ts.Node, checker: Checker) {
+			const type = checker.getTypeAtLocation(tsNode);
+
+			for (const typePart of tsutils
+				.unionConstituents(type)
+				.map((t) => checker.getApparentType(t))) {
+				if (checker.isArrayType(typePart)) {
+					const arrayType = checker.getTypeArguments(typePart)[0];
+					if (arrayType && isPromiseLike(tsNode, checker, arrayType)) {
+						return true;
+					}
+				}
+
+				if (checker.isTupleType(typePart)) {
+					for (const tupleElementType of checker.getTypeArguments(typePart)) {
+						if (isPromiseLike(tsNode, checker, tupleElementType)) {
+							return true;
+						}
+					}
+				}
+			}
+
+			return false;
+		}
+
+		function isCatchOrThenWithRejectionHandler(node: AST.CallExpression) {
+			if (node.expression.kind !== SyntaxKind.PropertyAccessExpression) {
+				return false;
+			}
+
+			const methodName = node.expression.name;
+			if (methodName.kind !== SyntaxKind.Identifier) {
+				return false;
+			}
+
+			if (methodName.text === "catch" && node.arguments.length >= 1) {
+				return true;
+			}
+
+			if (methodName.text === "then" && node.arguments.length >= 2) {
+				return true;
+			}
+
+			return false;
+		}
+
+		function isFinallyCall(node: AST.CallExpression) {
+			if (node.expression.kind !== SyntaxKind.PropertyAccessExpression) {
+				return false;
+			}
+
+			const methodName = node.expression.name;
+			return (
+				methodName.kind === SyntaxKind.Identifier &&
+				methodName.text === "finally"
+			);
+		}
+
+		function isUnhandledPromise(
+			node: AST.Expression,
+			checker: Checker,
+		): boolean {
+			if (node.kind === SyntaxKind.BinaryExpression) {
+				if (
+					node.operatorToken.kind === SyntaxKind.EqualsToken ||
+					node.operatorToken.kind === SyntaxKind.CommaToken
+				) {
+					return false;
+				}
+			}
+
+			if (node.kind === SyntaxKind.VoidExpression) {
+				return false;
+			}
+
+			if (node.kind === SyntaxKind.AwaitExpression) {
+				return false;
+			}
+
+			const tsNode = node as ts.Node;
+
+			if (isPromiseArray(tsNode, checker)) {
+				return true;
+			}
+
+			if (!isPromiseLike(tsNode, checker)) {
+				return false;
+			}
+
+			if (node.kind === SyntaxKind.CallExpression) {
+				if (isCatchOrThenWithRejectionHandler(node)) {
+					return false;
+				}
+
+				if (isFinallyCall(node)) {
+					const objectExpr = node.expression as AST.PropertyAccessExpression;
+					return isUnhandledPromise(objectExpr.expression, checker);
+				}
+			}
+
+			if (node.kind === SyntaxKind.ConditionalExpression) {
+				return (
+					isUnhandledPromise(node.whenTrue, checker) ||
+					isUnhandledPromise(node.whenFalse, checker)
+				);
+			}
+
+			if (node.kind === SyntaxKind.BinaryExpression) {
+				if (
+					node.operatorToken.kind === SyntaxKind.AmpersandAmpersandToken ||
+					node.operatorToken.kind === SyntaxKind.BarBarToken ||
+					node.operatorToken.kind === SyntaxKind.QuestionQuestionToken
+				) {
+					return (
+						isUnhandledPromise(node.left, checker) ||
+						isUnhandledPromise(node.right, checker)
+					);
+				}
+			}
+
+			return true;
+		}
+
+		return {
+			visitors: {
+				ExpressionStatement: (node, { sourceFile, typeChecker }) => {
+					let expression = node.expression;
+
+					while (expression.kind === SyntaxKind.ParenthesizedExpression) {
+						expression = expression.expression;
+					}
+
+					if (!isUnhandledPromise(expression, typeChecker)) {
+						return;
+					}
+
+					context.report({
+						message: "floating",
+						range: getTSNodeRange(node, sourceFile),
+					});
+				},
+			},
+		};
+	},
+});


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #1452
- [x] That issue was marked as [`status: accepting prs`](https://github.com/flint-fyi/flint/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22) — **caveat:** The issue is labeled `status: blocked` (its original draft, #1502, was blocked pending @kirkwaiblinger's input on async-rule defaults) — this PR is the revival of that draft, with the design feedback flagged below rather than applied unilaterally
- [x] Steps in [CONTRIBUTING.md](https://github.com/flint-fyi/flint/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

> **Draft revival** — opening for maintainer review, not asserting merge-readiness. Carries open design feedback (below) deliberately unapplied.

Revives #1502 (`floatingPromises`), which stalled when the rule-authoring API migrated and while awaiting maintainer input on async-rule defaults. This branch ports it to the current `ruleCreator.createRule(language, …)` + visitor-`services` API: imports remapped to `@flint.fyi/typescript-language` (`getTSNodeRange`, `type AST`, `type Checker`), constructor swap, `preset` → `presets`. The visitor/report bodies are unchanged — **behavior is preserved verbatim** from the original PR.

The rule reports statement-level Promises that are neither awaited, returned, nor error-handled — equivalent to typescript-eslint [`no-floating-promises`](https://typescript-eslint.io/rules/no-floating-promises) and Oxlint `typescript/noFloatingPromises`.

### Files
- `packages/ts/src/rules/floatingPromises.ts` — the rule
- `packages/ts/src/rules/floatingPromises.test.ts` — co-located rule-tester snapshots (uses `domLibRuleTester`; one fixture references `console`)
- `packages/site/src/content/docs/rules/ts/floatingPromises.mdx` — docs
- `packages/ts/src/plugin.ts` — alphabetical registration
- `packages/comparisons/src/data.json` — entry flipped to `status: implemented`
- `.changeset/floating-promises.md`

### Porting notes (addendum)
- **Preset note:** `presets` is `["logical", "logicalStrict"]` — preset membership is literal (no superset expansion) and most implemented plain-`logical` rules declare both tiers; flag if you'd rather have it single-tier.

### Local gates
`eslint --max-warnings 0` · `tsc -b packages/ts` · `vitest` (26/26, rule test) · `comparisons/data.test.ts` (28/28) · `prettier --check` — all pass locally.

## Open design feedback (for maintainers — unchanged from the #1502 review)

Kirk's review on #1502 proposed simplifications that I deliberately did **not** apply, since they change reported behavior:

1. **Drop `.catch()` / `.then(onFulfilled, onRejected)` / `.finally()` as silencers.** Kirk: people add `.catch(() => {})` to silence the rule, which is worse than an informative disable comment; dropping that logic would also simplify the message and docs. The port keeps the original silencing behavior.
2. **`void promise` handling.** Kirk: `void` shouldn't be a sanctioned escape hatch (though fine to not make it an option — this draft has no options, which he 👍'd). The port keeps `void` as silencing.
3. **Sequence-expression gap.** `(promise, 42);` contains a floating promise but isn't reported (the comma-operator early-return). Kirk noted typescript-eslint handles this; acknowledged as acceptable for an initial implementation.
4. **`getNumberIndexType()`** was suggested over `getTypeArguments(...)[0]` for the array-element type in `isPromiseArray`. Kept as-is to preserve the original implementation; happy to switch.

Each is a behavior/style decision on a notoriously opinionated rule. Glad to apply any subset once decided.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
