### PR TITLE
feat(ts): implement functionDefinitionScopeConsistency rule

### DIFF
--- a/.changeset/function-definition-scope-consistency.md
+++ b/.changeset/function-definition-scope-consistency.md
@@ -1,0 +1,5 @@
+---
+"@flint.fyi/ts": patch
+---
+
+Implement the `functionDefinitionScopeConsistency` rule.

--- a/packages/comparisons/src/data.json
+++ b/packages/comparisons/src/data.json
@@ -13424,6 +13424,7 @@
 			"name": "functionDefinitionScopeConsistency",
 			"plugin": "ts",
 			"preset": "stylistic",
+			"status": "implemented",
 			"strictness": "strict"
 		},
 		"oxlint": [

--- a/packages/site/src/content/docs/rules/ts/functionDefinitionScopeConsistency.mdx
+++ b/packages/site/src/content/docs/rules/ts/functionDefinitionScopeConsistency.mdx
@@ -1,0 +1,98 @@
+---
+description: "Move function definitions to the highest possible scope."
+title: "functionDefinitionScopeConsistency"
+topic: "rules"
+---
+
+import { TabItem, Tabs } from "@astrojs/starlight/components";
+import { RuleEquivalents } from "~/components/RuleEquivalents";
+import RuleSummary from "~/components/RuleSummary.astro";
+
+<RuleSummary plugin="ts" rule="functionDefinitionScopeConsistency" />
+
+A function definition should be placed as close to the top-level scope as possible without breaking its captured values.
+This improves readability, directly improves performance, and allows JavaScript engines to better optimize performance.
+
+When a function doesn't reference any variables from its enclosing scope, it can be moved to the outer scope.
+This rule reports nested functions that could be moved up.
+
+## Examples
+
+<Tabs>
+<TabItem label="❌ Incorrect">
+
+```ts
+function outer(value: string) {
+	function inner(text: string) {
+		return text === "test";
+	}
+	return inner;
+}
+```
+
+```ts
+function outer(value: string) {
+	const inner = (text: string) => {
+		return text === "test";
+	};
+	return inner;
+}
+```
+
+```ts
+function outer() {
+	return (dispatch: Function) => dispatch({ type: "ACTION" });
+}
+```
+
+</TabItem>
+<TabItem label="✅ Correct">
+
+```ts
+function inner(text: string) {
+	return text === "test";
+}
+
+function outer(value: string) {
+	return inner;
+}
+```
+
+```ts
+function outer(value: string) {
+	function inner() {
+		return value === "test";
+	}
+	return inner;
+}
+```
+
+```ts
+function outer() {
+	return function inner() {
+		return this;
+	};
+}
+```
+
+</TabItem>
+</Tabs>
+
+## Options
+
+This rule is not configurable.
+
+## When Not To Use It
+
+If you prefer to keep related functions close together for readability, even when they don't share scope, you may want to disable this rule.
+
+For large existing codebases, this rule may produce many warnings that are not critical to fix.
+
+## Further Reading
+
+- [MDN: Closures](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Closures)
+- [JavaScript Performance Pitfalls in V8](https://ponyfoo.com/articles/javascript-performance-pitfalls-v8)
+
+## Equivalents in Other Linters
+
+<RuleEquivalents pluginId="ts" ruleId="functionDefinitionScopeConsistency" />

--- a/packages/ts/src/plugin.ts
+++ b/packages/ts/src/plugin.ts
@@ -109,6 +109,7 @@ import functionApplySpreads from "./rules/functionApplySpreads.ts";
 import functionAssignments from "./rules/functionAssignments.ts";
 import functionCurryingRedundancy from "./rules/functionCurryingRedundancy.ts";
 import functionDeclarationStyles from "./rules/functionDeclarationStyles.ts";
+import functionDefinitionScopeConsistency from "./rules/functionDefinitionScopeConsistency.ts";
 import functionNameMatches from "./rules/functionNameMatches.ts";
 import functionNewCalls from "./rules/functionNewCalls.ts";
 import generatorFunctionYields from "./rules/generatorFunctionYields.ts";
@@ -422,6 +423,7 @@ export const ts = createPlugin({
 		functionAssignments,
 		functionCurryingRedundancy,
 		functionDeclarationStyles,
+		functionDefinitionScopeConsistency,
 		functionNameMatches,
 		functionNewCalls,
 		generatorFunctionYields,

--- a/packages/ts/src/rules/functionDefinitionScopeConsistency.test.ts
+++ b/packages/ts/src/rules/functionDefinitionScopeConsistency.test.ts
@@ -1,0 +1,135 @@
+import rule from "./functionDefinitionScopeConsistency.ts";
+import { ruleTester } from "./ruleTester.ts";
+
+ruleTester.describe(rule, {
+	invalid: [
+		{
+			code: `
+function outer(value: string) {
+    function inner(text: string) {
+        return text === "test";
+    }
+    return inner;
+}
+`,
+			snapshot: `
+function outer(value: string) {
+    function inner(text: string) {
+    ~~~~~~~~
+    Function does not capture any variables from the enclosing scope and can be moved to the outer scope.
+        return text === "test";
+    }
+    return inner;
+}
+`,
+		},
+		{
+			code: `
+function outer(value: string) {
+    const inner = (text: string) => {
+        return text === "test";
+    };
+    return inner;
+}
+`,
+			snapshot: `
+function outer(value: string) {
+    const inner = (text: string) => {
+                  ~
+                  Function does not capture any variables from the enclosing scope and can be moved to the outer scope.
+        return text === "test";
+    };
+    return inner;
+}
+`,
+		},
+		{
+			code: `
+function outer() {
+    return (dispatch: Function) => dispatch({ type: "ACTION" });
+}
+`,
+			snapshot: `
+function outer() {
+    return (dispatch: Function) => dispatch({ type: "ACTION" });
+           ~
+           Function does not capture any variables from the enclosing scope and can be moved to the outer scope.
+}
+`,
+		},
+		{
+			code: `
+const outer = () => {
+    function helper(value: number) {
+        return value * 2;
+    }
+    return helper;
+};
+`,
+			snapshot: `
+const outer = () => {
+    function helper(value: number) {
+    ~~~~~~~~
+    Function does not capture any variables from the enclosing scope and can be moved to the outer scope.
+        return value * 2;
+    }
+    return helper;
+};
+`,
+		},
+	],
+	valid: [
+		`function doBar(value: string) { return value === "bar"; }`,
+		`const doBar = (value: string) => value === "bar";`,
+		`
+function outer(value: string) {
+    function inner() {
+        return value === "test";
+    }
+    return inner;
+}
+`,
+		`
+function outer(multiplier: number) {
+    const inner = (value: number) => value * multiplier;
+    return inner;
+}
+`,
+		`
+function outer() {
+    return function inner() {
+        return this;
+    };
+}
+`,
+		`
+class Example {
+    method() {
+        const handler = () => {
+            return this.value;
+        };
+        return handler;
+    }
+    value = 1;
+}
+`,
+		`
+function outer() {
+    const data = "test";
+    function inner() {
+        return data;
+    }
+    return inner;
+}
+`,
+		`
+function outer(data: string) {
+    function helper() { return data; }
+    function inner() {
+        return helper();
+    }
+    return inner;
+}
+`,
+	],
+});

--- a/packages/ts/src/rules/functionDefinitionScopeConsistency.ts
+++ b/packages/ts/src/rules/functionDefinitionScopeConsistency.ts
@@ -1,0 +1,193 @@
+import * as tsutils from "ts-api-utils";
+import ts, { SyntaxKind } from "typescript";
+
+import {
+	typescriptLanguage,
+	type AST,
+	type Checker,
+} from "@flint.fyi/typescript-language";
+
+import { ruleCreator } from "./ruleCreator.ts";
+
+export default ruleCreator.createRule(typescriptLanguage, {
+	about: {
+		description: "Move function definitions to the highest possible scope.",
+		id: "functionDefinitionScopeConsistency",
+		presets: ["stylisticStrict"],
+	},
+	messages: {
+		moveToOuterScope: {
+			primary:
+				"Function does not capture any variables from the enclosing scope and can be moved to the outer scope.",
+			secondary: [
+				"Functions that don't use variables from their enclosing scope can be defined at a higher level.",
+				"This improves readability and allows JavaScript engines to better optimize performance.",
+			],
+			suggestions: [
+				"Move the function to the outer scope, above its current containing function.",
+			],
+		},
+	},
+	setup(context) {
+		function collectScopeVariables(scopeNode: ts.Node, typeChecker: Checker) {
+			const variables = new Set<ts.Symbol>();
+
+			function collectFromNode(node: ts.Node) {
+				if (ts.isVariableDeclaration(node) && ts.isIdentifier(node.name)) {
+					const symbol = typeChecker.getSymbolAtLocation(node.name);
+					if (symbol) {
+						variables.add(symbol);
+					}
+				}
+
+				if (ts.isParameter(node) && ts.isIdentifier(node.name)) {
+					const symbol = typeChecker.getSymbolAtLocation(node.name);
+					if (symbol) {
+						variables.add(symbol);
+					}
+				}
+
+				if (ts.isFunctionDeclaration(node) && node.name) {
+					const symbol = typeChecker.getSymbolAtLocation(node.name);
+					if (symbol) {
+						variables.add(symbol);
+					}
+				}
+
+				if (tsutils.isFunctionScopeBoundary(node) && node !== scopeNode) {
+					return;
+				}
+
+				ts.forEachChild(node, collectFromNode);
+			}
+
+			collectFromNode(scopeNode);
+			return variables;
+		}
+
+		function referencesVariable(
+			node: ts.Node,
+			variables: Set<ts.Symbol>,
+			typeChecker: Checker,
+			selfSymbol: ts.Symbol | undefined,
+		): boolean | undefined {
+			if (ts.isIdentifier(node)) {
+				const symbol = typeChecker.getSymbolAtLocation(node);
+				if (symbol && symbol !== selfSymbol && variables.has(symbol)) {
+					return true;
+				}
+			}
+
+			if (node.kind === SyntaxKind.ThisKeyword) {
+				return true;
+			}
+
+			return ts.forEachChild(node, (child) =>
+				referencesVariable(child, variables, typeChecker, selfSymbol),
+			);
+		}
+
+		function isNestedFunction(node: ts.Node) {
+			for (
+				let current = node.parent;
+				!ts.isSourceFile(current);
+				current = current.parent
+			) {
+				if (tsutils.isFunctionScopeBoundary(current)) {
+					return true;
+				}
+			}
+
+			return false;
+		}
+
+		function getEnclosingFunction(
+			node: ts.Node,
+		): ts.FunctionLikeDeclaration | undefined {
+			for (
+				let current = node.parent;
+				!ts.isSourceFile(current);
+				current = current.parent
+			) {
+				if (tsutils.isFunctionScopeBoundary(current)) {
+					return current as ts.FunctionLikeDeclaration;
+				}
+			}
+
+			return undefined;
+		}
+
+		function checkFunction(
+			node:
+				| AST.ArrowFunction
+				| AST.FunctionDeclaration
+				| AST.FunctionExpression,
+			sourceFile: AST.SourceFile,
+			typeChecker: Checker,
+		) {
+			if (!isNestedFunction(node)) {
+				return;
+			}
+
+			const enclosingFunction = getEnclosingFunction(node);
+			if (!enclosingFunction) {
+				return;
+			}
+
+			const enclosingScopeVariables = collectScopeVariables(
+				enclosingFunction,
+				typeChecker,
+			);
+
+			let selfSymbol: ts.Symbol | undefined;
+			if (ts.isFunctionDeclaration(node) && node.name) {
+				selfSymbol = typeChecker.getSymbolAtLocation(node.name);
+			}
+			if (ts.isFunctionExpression(node) && node.name) {
+				selfSymbol = typeChecker.getSymbolAtLocation(node.name);
+			}
+
+			if (
+				referencesVariable(
+					node,
+					enclosingScopeVariables,
+					typeChecker,
+					selfSymbol,
+				)
+			) {
+				return;
+			}
+
+			const functionKeyword =
+				node.kind === SyntaxKind.ArrowFunction
+					? undefined
+					: node
+							.getChildren(sourceFile)
+							.find((child) => child.kind === SyntaxKind.FunctionKeyword);
+
+			const start = functionKeyword
+				? functionKeyword.getStart(sourceFile)
+				: node.getStart(sourceFile);
+			const end = functionKeyword ? functionKeyword.getEnd() : start + 1;
+
+			context.report({
+				message: "moveToOuterScope",
+				range: { begin: start, end },
+			});
+		}
+
+		return {
+			visitors: {
+				ArrowFunction: (node, { sourceFile, typeChecker }) => {
+					checkFunction(node, sourceFile, typeChecker);
+				},
+				FunctionDeclaration: (node, { sourceFile, typeChecker }) => {
+					checkFunction(node, sourceFile, typeChecker);
+				},
+				FunctionExpression: (node, { sourceFile, typeChecker }) => {
+					checkFunction(node, sourceFile, typeChecker);
+				},
+			},
+		};
+	},
+});


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #1464
- [x] That issue was marked as [`status: accepting prs`](https://github.com/flint-fyi/flint/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22) — **caveat:** the issue is labeled `status: blocked` (its original draft, #1504, was blocked on #400 scope analysis — **#400 has since closed**; see below) — this PR is the revival of that draft, opened as a draft for maintainer review
- [x] Steps in [CONTRIBUTING.md](https://github.com/flint-fyi/flint/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

> **Draft revival** — opening for maintainer review, not asserting merge-readiness.

Revives #1504 (`functionDefinitionScopeConsistency`), which stalled on the legacy rule API and on #400. This branch ports it to the current `ruleCreator.createRule(language, …)` + visitor-`services` API; the visitor bodies were already on the services signature, so the port is imports + constructor + preset (`stylistic`/`strict` → `presets: ["stylisticStrict"]`). **Behavior is preserved verbatim.**

The rule reports nested functions that capture nothing from their enclosing scope and could be hoisted — equivalent to eslint-plugin-unicorn [`consistent-function-scoping`](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/consistent-function-scoping.md) and Oxlint `unicorn/consistent-function-scoping`.

### The #400 blocker has lifted — follow-up opportunity

#1504 was marked blocked because it "heavily uses scopes" and predates the TypeScript scope manager (#400). That scope manager has since landed (#2828, extended with `ScopeManager.getScope` in #2916). This revival **keeps the original hand-rolled symbol-based scope walk** (`collectScopeVariables`/`referencesVariable` over `typeChecker.getSymbolAtLocation`); rewriting it on top of the ScopeManager is now possible and likely both simpler and more correct — happy to do that in this PR or a follow-up, whichever you prefer.

### Files
- `packages/ts/src/rules/functionDefinitionScopeConsistency.ts` — the rule
- `packages/ts/src/rules/functionDefinitionScopeConsistency.test.ts` — co-located rule-tester snapshots
- `packages/site/src/content/docs/rules/ts/functionDefinitionScopeConsistency.mdx` — docs
- `packages/ts/src/plugin.ts` — alphabetical registration
- `packages/comparisons/src/data.json` — entry flipped to `status: implemented`
- `.changeset/function-definition-scope-consistency.md`

### Local gates
`eslint --max-warnings 0` · `tsc -b packages/ts` · `vitest` (12/12, rule test) · `comparisons/data.test.ts` (28/28) · `prettier --check` — all pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
