### PR TITLE
Revert "ci: remove PAT from release workflow"

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,6 +5,10 @@ on:
     branches:
       - main
 
+permissions:
+  contents: write
+  id-token: write
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
 
@@ -13,21 +17,13 @@ jobs:
     if: github.event.repository.fork != true
     name: Release
     runs-on: ubuntu-latest
-    permissions:
-      id-token: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/prepare
-
-      - name: Create Token
-        id: create_token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
-        with:
-          client-id: ${{ vars.FLINT_TOKENS_BOT_CLIENT_ID }}
-          private-key: ${{ secrets.FLINT_TOKENS_BOT_PRIVATE_KEY }}
-
-      - name: Changesets Release
+      - run: pnpm build
+      - env:
+          GITHUB_TOKEN: ${{ secrets.ACCESS_TOKEN }}
+        name: Create Release Pull Request
         uses: changesets/action@v1
         with:
-          github-token: ${{ steps.create_token.outputs.token }}
-          publish: pnpm release
+          publish: pnpm -r publish

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
 		"lint:knip": "knip",
 		"lint:knip:prod": "knip --strict",
 		"prepare": "husky",
-		"release": "pnpm build && pnpm -r publish",
 		"start:site": "pnpm --filter=site prebuild && pnpm --filter=site start",
 		"test": "vitest"
 	},


### PR DESCRIPTION
Reverts flint-fyi/flint#2520

https://github.com/flint-fyi/flint/actions/runs/27233337721

The app isn't showing as installed. I don't have enough access to do anything about it.