### PR TITLE
feat(ts): implement unnecessaryConstructors rule

### DIFF
--- a/.changeset/unnecessary-constructors.md
+++ b/.changeset/unnecessary-constructors.md
@@ -1,0 +1,5 @@
+---
+"@flint.fyi/ts": patch
+---
+
+Implement the `unnecessaryConstructors` rule.

--- a/packages/comparisons/src/data.json
+++ b/packages/comparisons/src/data.json
@@ -20673,7 +20673,8 @@
 		"flint": {
 			"name": "unnecessaryConstructors",
 			"plugin": "ts",
-			"preset": "stylistic"
+			"preset": "stylistic",
+			"status": "implemented"
 		},
 		"oxlint": [
 			{

--- a/packages/site/src/content/docs/rules/ts/unnecessaryConstructors.mdx
+++ b/packages/site/src/content/docs/rules/ts/unnecessaryConstructors.mdx
@@ -1,0 +1,21 @@
+---
+description: 'Disallow unnecessary constructors.'
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+> 🛑 This file is source code, not the primary documentation location! 🛑
+>
+> See **https://typescript-eslint.io/rules/no-useless-constructor** for documentation.
+
+It adds support for:
+
+- constructors marked as `protected` / `private` (i.e. marking a constructor as non-public),
+- `public` constructors when there is no superclass,
+- constructors with only parameter properties.
+
+### Caveat
+
+This lint rule will report on constructors whose sole purpose is to change visibility of a parent constructor.
+See [discussion on this rule's lack of type information](https://github.com/typescript-eslint/typescript-eslint/issues/3820#issuecomment-917821240) for context.

--- a/packages/site/src/content/docs/rules/ts/unnecessaryConstructors.mdx
+++ b/packages/site/src/content/docs/rules/ts/unnecessaryConstructors.mdx
@@ -1,21 +1,105 @@
 ---
-description: 'Disallow unnecessary constructors.'
+description: "Reports constructors that are equivalent to the implicit default constructor."
+title: "unnecessaryConstructors"
+topic: "rules"
 ---
 
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
+import { TabItem, Tabs } from "@astrojs/starlight/components";
+import { RuleEquivalents } from "~/components/RuleEquivalents";
+import RuleSummary from "~/components/RuleSummary.astro";
 
-> 🛑 This file is source code, not the primary documentation location! 🛑
->
-> See **https://typescript-eslint.io/rules/no-useless-constructor** for documentation.
+<RuleSummary plugin="ts" rule="unnecessaryConstructors" />
 
-It adds support for:
+Classes that don't declare a constructor receive an implicit one automatically:
 
-- constructors marked as `protected` / `private` (i.e. marking a constructor as non-public),
-- `public` constructors when there is no superclass,
-- constructors with only parameter properties.
+- Base classes get an empty constructor, equivalent to `constructor() {}`.
+- Derived classes get a constructor that forwards all arguments to the parent class, equivalent to `constructor(...args) { super(...args); }`.
 
-### Caveat
+Writing either of those constructors out manually adds code to read and maintain without changing how the class works.
 
-This lint rule will report on constructors whose sole purpose is to change visibility of a parent constructor.
-See [discussion on this rule's lack of type information](https://github.com/typescript-eslint/typescript-eslint/issues/3820#issuecomment-917821240) for context.
+Constructors that do change behavior are not reported, including:
+
+- Constructors marked `private` or `protected`, or marked `public` on a derived class, as those modifiers change who may instantiate the class
+- Constructors with parameter properties such as `constructor(private name: string)`, as those declare and initialize class fields
+- Constructors with parameter decorators, as those can have side effects
+- Constructor overload signatures, which declare types rather than behavior
+
+## Examples
+
+<Tabs>
+<TabItem label="❌ Incorrect">
+
+```ts
+class Logger {
+	constructor() {}
+}
+```
+
+```ts
+class HttpError extends Error {
+	constructor(message: string) {
+		super(message);
+	}
+}
+```
+
+</TabItem>
+<TabItem label="✅ Correct">
+
+```ts
+class Logger {}
+```
+
+```ts
+class HttpError extends Error {
+	constructor(message: string) {
+		super(message);
+		this.name = "HttpError";
+	}
+}
+```
+
+```ts
+class Point {
+	constructor(
+		public x: number,
+		public y: number,
+	) {}
+}
+```
+
+</TabItem>
+</Tabs>
+
+Constructors that exist only to widen the visibility of a parent class's `protected` constructor should declare an explicit `public` modifier.
+The rule treats an explicit `public` on a derived class as intentional and does not report it:
+
+```ts
+class Base {
+	protected constructor() {}
+}
+
+class Derived extends Base {
+	public constructor() {
+		super();
+	}
+}
+```
+
+## Options
+
+This rule is not configurable.
+
+## When Not To Use It
+
+If your project deliberately declares an explicit constructor on every class, such as to serve as a documented extension point or to keep generated code uniform, you may not want this rule.
+You might consider using [Flint disable comments](/directives) and/or [configuration file disables](/configuration#files) for those specific situations instead of completely disabling this rule.
+
+## Further Reading
+
+- [MDN: constructor](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes/constructor)
+- [TypeScript Handbook: Parameter Properties](https://www.typescriptlang.org/docs/handbook/2/classes.html#parameter-properties)
+
+## Equivalents in Other Linters
+
+<RuleEquivalents pluginId="ts" ruleId="unnecessaryConstructors" />

--- a/packages/ts/src/plugin.ts
+++ b/packages/ts/src/plugin.ts
@@ -290,6 +290,7 @@ import unnecessaryBooleanCasts from "./rules/unnecessaryBooleanCasts.ts";
 import unnecessaryCatches from "./rules/unnecessaryCatches.ts";
 import unnecessaryComparisons from "./rules/unnecessaryComparisons.ts";
 import unnecessaryConcatenation from "./rules/unnecessaryConcatenation.ts";
+import unnecessaryConstructors from "./rules/unnecessaryConstructors.ts";
 import unnecessaryEscapes from "./rules/unnecessaryEscapes.ts";
 import unnecessaryMathClamps from "./rules/unnecessaryMathClamps.ts";
 import unnecessaryNumericFractions from "./rules/unnecessaryNumericFractions.ts";
@@ -604,6 +605,7 @@ export const ts = createPlugin({
 		unnecessaryCatches,
 		unnecessaryComparisons,
 		unnecessaryConcatenation,
+		unnecessaryConstructors,
 		unnecessaryEscapes,
 		unnecessaryMathClamps,
 		unnecessaryNumericFractions,

--- a/packages/ts/src/rules/unnecessaryConstructors.test.ts
+++ b/packages/ts/src/rules/unnecessaryConstructors.test.ts
@@ -1,0 +1,424 @@
+import { RuleTester } from '@typescript-eslint/rule-tester';
+
+import rule from '../../src/rules/no-useless-constructor';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('no-useless-constructor', rule, {
+  valid: [
+    'class A {}',
+    `
+class A {
+  constructor() {
+    doSomething();
+  }
+}
+    `,
+    `
+class A extends B {
+  constructor() {}
+}
+    `,
+    `
+class A extends B {
+  constructor() {
+    super('foo');
+  }
+}
+    `,
+    `
+class A extends B {
+  constructor(foo, bar) {
+    super(foo, bar, 1);
+  }
+}
+    `,
+    `
+class A extends B {
+  constructor() {
+    super();
+    doSomething();
+  }
+}
+    `,
+    `
+class A extends B {
+  constructor(...args) {
+    super(...args);
+    doSomething();
+  }
+}
+    `,
+    `
+class A {
+  dummyMethod() {
+    doSomething();
+  }
+}
+    `,
+    `
+class A extends B.C {
+  constructor() {
+    super(foo);
+  }
+}
+    `,
+    `
+class A extends B.C {
+  constructor([a, b, c]) {
+    super(...arguments);
+  }
+}
+    `,
+    `
+class A extends B.C {
+  constructor(a = f()) {
+    super(...arguments);
+  }
+}
+    `,
+    `
+class A extends B {
+  constructor(a, b, c) {
+    super(a, b);
+  }
+}
+    `,
+    `
+class A extends B {
+  constructor(foo, bar) {
+    super(foo);
+  }
+}
+    `,
+    `
+class A extends B {
+  constructor(test) {
+    super();
+  }
+}
+    `,
+    `
+class A extends B {
+  constructor() {
+    foo;
+  }
+}
+    `,
+    `
+class A extends B {
+  constructor(foo, bar) {
+    super(bar);
+  }
+}
+    `,
+    // https://github.com/typescript-eslint/typescript-eslint/issues/15
+    `
+declare class A {
+  constructor();
+}
+    `,
+    `
+class A {
+  constructor();
+}
+    `,
+    `
+abstract class A {
+  constructor();
+}
+    `,
+    // https://github.com/typescript-eslint/typescript-eslint/issues/48
+    `
+class A {
+  constructor(private name: string) {}
+}
+    `,
+    `
+class A {
+  constructor(public name: string) {}
+}
+    `,
+    `
+class A {
+  constructor(protected name: string) {}
+}
+    `,
+    // https://github.com/typescript-eslint/typescript-eslint/pull/167#discussion_r252638401
+    `
+class A {
+  private constructor() {}
+}
+    `,
+    `
+class A {
+  protected constructor() {}
+}
+    `,
+    `
+class A extends B {
+  public constructor() {}
+}
+    `,
+    `
+class A extends B {
+  protected constructor(foo, bar) {
+    super(bar);
+  }
+}
+    `,
+    `
+class A extends B {
+  private constructor(foo, bar) {
+    super(bar);
+  }
+}
+    `,
+    `
+class A extends B {
+  public constructor(foo) {
+    super(foo);
+  }
+}
+    `,
+    `
+class A extends B {
+  public constructor(foo) {}
+}
+    `,
+    // type definition / overload
+    `
+class A {
+  constructor(foo);
+}
+    `,
+    `
+class A extends Object {
+  constructor(@Foo foo: string) {
+    super(foo);
+  }
+}
+    `,
+    `
+class A extends Object {
+  constructor(foo: string, @Bar() bar) {
+    super(foo, bar);
+  }
+}
+    `,
+  ],
+  invalid: [
+    {
+      code: `
+class A {
+  constructor() {}
+}
+      `,
+      errors: [
+        {
+          messageId: 'noUselessConstructor',
+          suggestions: [
+            {
+              messageId: 'removeConstructor',
+              output: `
+class A {
+${'  '}
+}
+      `,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: `
+class A extends B {
+  constructor() {
+    super();
+  }
+}
+      `,
+      errors: [
+        {
+          messageId: 'noUselessConstructor',
+          suggestions: [
+            {
+              messageId: 'removeConstructor',
+              output: `
+class A extends B {
+${'  '}
+}
+      `,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: `
+class A extends B {
+  constructor(foo) {
+    super(foo);
+  }
+}
+      `,
+      errors: [
+        {
+          messageId: 'noUselessConstructor',
+          suggestions: [
+            {
+              messageId: 'removeConstructor',
+              output: `
+class A extends B {
+${'  '}
+}
+      `,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: `
+class A extends B {
+  constructor(foo, bar) {
+    super(foo, bar);
+  }
+}
+      `,
+      errors: [
+        {
+          messageId: 'noUselessConstructor',
+          suggestions: [
+            {
+              messageId: 'removeConstructor',
+              output: `
+class A extends B {
+${'  '}
+}
+      `,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: `
+class A extends B {
+  constructor(...args) {
+    super(...args);
+  }
+}
+      `,
+      errors: [
+        {
+          messageId: 'noUselessConstructor',
+          suggestions: [
+            {
+              messageId: 'removeConstructor',
+              output: `
+class A extends B {
+${'  '}
+}
+      `,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: `
+class A extends B.C {
+  constructor() {
+    super(...arguments);
+  }
+}
+      `,
+      errors: [
+        {
+          messageId: 'noUselessConstructor',
+          suggestions: [
+            {
+              messageId: 'removeConstructor',
+              output: `
+class A extends B.C {
+${'  '}
+}
+      `,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: `
+class A extends B {
+  constructor(a, b, ...c) {
+    super(...arguments);
+  }
+}
+      `,
+      errors: [
+        {
+          messageId: 'noUselessConstructor',
+          suggestions: [
+            {
+              messageId: 'removeConstructor',
+              output: `
+class A extends B {
+${'  '}
+}
+      `,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: `
+class A extends B {
+  constructor(a, b, ...c) {
+    super(a, b, ...c);
+  }
+}
+      `,
+      errors: [
+        {
+          messageId: 'noUselessConstructor',
+          suggestions: [
+            {
+              messageId: 'removeConstructor',
+              output: `
+class A extends B {
+${'  '}
+}
+      `,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: `
+class A {
+  public constructor() {}
+}
+      `,
+      errors: [
+        {
+          messageId: 'noUselessConstructor',
+          suggestions: [
+            {
+              messageId: 'removeConstructor',
+              output: `
+class A {
+${'  '}
+}
+      `,
+            },
+          ],
+        },
+      ],
+    },
+  ],
+});

--- a/packages/ts/src/rules/unnecessaryConstructors.test.ts
+++ b/packages/ts/src/rules/unnecessaryConstructors.test.ts
@@ -1,5 +1,5 @@
-import rule from "./unnecessaryConstructors.ts";
 import { ruleTester } from "./ruleTester.ts";
+import rule from "./unnecessaryConstructors.ts";
 
 ruleTester.describe(rule, {
 	invalid: [

--- a/packages/ts/src/rules/unnecessaryConstructors.test.ts
+++ b/packages/ts/src/rules/unnecessaryConstructors.test.ts
@@ -1,424 +1,762 @@
-import { RuleTester } from '@typescript-eslint/rule-tester';
+import rule from "./unnecessaryConstructors.ts";
+import { ruleTester } from "./ruleTester.ts";
 
-import rule from '../../src/rules/no-useless-constructor';
-
-const ruleTester = new RuleTester();
-
-ruleTester.run('no-useless-constructor', rule, {
-  valid: [
-    'class A {}',
-    `
-class A {
-  constructor() {
-    doSomething();
-  }
+ruleTester.describe(rule, {
+	invalid: [
+		{
+			code: `
+class Logger {
+    constructor() {}
 }
-    `,
-    `
-class A extends B {
-  constructor() {}
+`,
+			snapshot: `
+class Logger {
+    constructor() {}
+    ~~~~~~~~~~~
+    This constructor is equivalent to the implicit default constructor, so it adds no behavior to the class.
 }
-    `,
-    `
-class A extends B {
-  constructor() {
-    super('foo');
-  }
+`,
+			suggestions: [
+				{
+					id: "removeConstructor",
+					updated: `
+class Logger {
+    
 }
-    `,
-    `
-class A extends B {
-  constructor(foo, bar) {
-    super(foo, bar, 1);
-  }
+`,
+				},
+			],
+		},
+		{
+			code: `
+class Logger {
+    constructor     () {}
 }
-    `,
-    `
-class A extends B {
-  constructor() {
-    super();
-    doSomething();
-  }
+`,
+			snapshot: `
+class Logger {
+    constructor     () {}
+    ~~~~~~~~~~~
+    This constructor is equivalent to the implicit default constructor, so it adds no behavior to the class.
 }
-    `,
-    `
-class A extends B {
-  constructor(...args) {
-    super(...args);
-    doSomething();
-  }
+`,
+			suggestions: [
+				{
+					id: "removeConstructor",
+					updated: `
+class Logger {
+    
 }
-    `,
-    `
-class A {
-  dummyMethod() {
-    doSomething();
-  }
+`,
+				},
+			],
+		},
+		{
+			code: `
+class Logger {
+    'constructor'() {}
 }
-    `,
-    `
-class A extends B.C {
-  constructor() {
-    super(foo);
-  }
+`,
+			snapshot: `
+class Logger {
+    'constructor'() {}
+    ~~~~~~~~~~~~~
+    This constructor is equivalent to the implicit default constructor, so it adds no behavior to the class.
 }
-    `,
-    `
-class A extends B.C {
-  constructor([a, b, c]) {
-    super(...arguments);
-  }
+`,
+			suggestions: [
+				{
+					id: "removeConstructor",
+					updated: `
+class Logger {
+    
 }
-    `,
-    `
-class A extends B.C {
-  constructor(a = f()) {
-    super(...arguments);
-  }
+`,
+				},
+			],
+		},
+		{
+			code: `
+class Logger {
+    public constructor() {}
 }
-    `,
-    `
-class A extends B {
-  constructor(a, b, c) {
-    super(a, b);
-  }
+`,
+			snapshot: `
+class Logger {
+    public constructor() {}
+    ~~~~~~~~~~~~~~~~~~
+    This constructor is equivalent to the implicit default constructor, so it adds no behavior to the class.
 }
-    `,
-    `
-class A extends B {
-  constructor(foo, bar) {
-    super(foo);
-  }
+`,
+			suggestions: [
+				{
+					id: "removeConstructor",
+					updated: `
+class Logger {
+    
 }
-    `,
-    `
-class A extends B {
-  constructor(test) {
-    super();
-  }
+`,
+				},
+			],
+		},
+		{
+			code: `
+class Logger implements Contract {
+    constructor() {}
 }
-    `,
-    `
-class A extends B {
-  constructor() {
-    foo;
-  }
+`,
+			snapshot: `
+class Logger implements Contract {
+    constructor() {}
+    ~~~~~~~~~~~
+    This constructor is equivalent to the implicit default constructor, so it adds no behavior to the class.
 }
-    `,
-    `
-class A extends B {
-  constructor(foo, bar) {
-    super(bar);
-  }
+`,
+			suggestions: [
+				{
+					id: "removeConstructor",
+					updated: `
+class Logger implements Contract {
+    
 }
-    `,
-    // https://github.com/typescript-eslint/typescript-eslint/issues/15
-    `
-declare class A {
-  constructor();
+`,
+				},
+			],
+		},
+		{
+			code: `
+const Logger = class {
+    constructor() {}
+};
+`,
+			snapshot: `
+const Logger = class {
+    constructor() {}
+    ~~~~~~~~~~~
+    This constructor is equivalent to the implicit default constructor, so it adds no behavior to the class.
+};
+`,
+			suggestions: [
+				{
+					id: "removeConstructor",
+					updated: `
+const Logger = class {
+    
+};
+`,
+				},
+			],
+		},
+		{
+			code: `
+class Child extends Base {
+    constructor() {
+        super();
+    }
 }
-    `,
-    `
-class A {
-  constructor();
+`,
+			snapshot: `
+class Child extends Base {
+    constructor() {
+    ~~~~~~~~~~~
+    This constructor is equivalent to the implicit default constructor, so it adds no behavior to the class.
+        super();
+    }
 }
-    `,
-    `
-abstract class A {
-  constructor();
+`,
+			suggestions: [
+				{
+					id: "removeConstructor",
+					updated: `
+class Child extends Base {
+    
 }
-    `,
-    // https://github.com/typescript-eslint/typescript-eslint/issues/48
-    `
-class A {
-  constructor(private name: string) {}
+`,
+				},
+			],
+		},
+		{
+			code: `
+class Child extends Base {
+    constructor(value) {
+        super(value);
+    }
 }
-    `,
-    `
-class A {
-  constructor(public name: string) {}
+`,
+			snapshot: `
+class Child extends Base {
+    constructor(value) {
+    ~~~~~~~~~~~
+    This constructor is equivalent to the implicit default constructor, so it adds no behavior to the class.
+        super(value);
+    }
 }
-    `,
-    `
-class A {
-  constructor(protected name: string) {}
+`,
+			suggestions: [
+				{
+					id: "removeConstructor",
+					updated: `
+class Child extends Base {
+    
 }
-    `,
-    // https://github.com/typescript-eslint/typescript-eslint/pull/167#discussion_r252638401
-    `
-class A {
-  private constructor() {}
+`,
+				},
+			],
+		},
+		{
+			code: `
+class Child extends Base {
+    constructor(first, second) {
+        super(first, second);
+    }
 }
-    `,
-    `
-class A {
-  protected constructor() {}
+`,
+			snapshot: `
+class Child extends Base {
+    constructor(first, second) {
+    ~~~~~~~~~~~
+    This constructor is equivalent to the implicit default constructor, so it adds no behavior to the class.
+        super(first, second);
+    }
 }
-    `,
-    `
-class A extends B {
-  public constructor() {}
+`,
+			suggestions: [
+				{
+					id: "removeConstructor",
+					updated: `
+class Child extends Base {
+    
 }
-    `,
-    `
-class A extends B {
-  protected constructor(foo, bar) {
-    super(bar);
-  }
+`,
+				},
+			],
+		},
+		{
+			code: `
+class Child extends Base {
+    constructor(...args) {
+        super(...args);
+    }
 }
-    `,
-    `
-class A extends B {
-  private constructor(foo, bar) {
-    super(bar);
-  }
+`,
+			snapshot: `
+class Child extends Base {
+    constructor(...args) {
+    ~~~~~~~~~~~
+    This constructor is equivalent to the implicit default constructor, so it adds no behavior to the class.
+        super(...args);
+    }
 }
-    `,
-    `
-class A extends B {
-  public constructor(foo) {
-    super(foo);
-  }
+`,
+			suggestions: [
+				{
+					id: "removeConstructor",
+					updated: `
+class Child extends Base {
+    
 }
-    `,
-    `
-class A extends B {
-  public constructor(foo) {}
+`,
+				},
+			],
+		},
+		{
+			code: `
+class Child extends namespaces.Base {
+    constructor() {
+        super(...arguments);
+    }
 }
-    `,
-    // type definition / overload
-    `
-class A {
-  constructor(foo);
+`,
+			snapshot: `
+class Child extends namespaces.Base {
+    constructor() {
+    ~~~~~~~~~~~
+    This constructor is equivalent to the implicit default constructor, so it adds no behavior to the class.
+        super(...arguments);
+    }
 }
-    `,
-    `
-class A extends Object {
-  constructor(@Foo foo: string) {
-    super(foo);
-  }
+`,
+			suggestions: [
+				{
+					id: "removeConstructor",
+					updated: `
+class Child extends namespaces.Base {
+    
 }
-    `,
-    `
-class A extends Object {
-  constructor(foo: string, @Bar() bar) {
-    super(foo, bar);
-  }
+`,
+				},
+			],
+		},
+		{
+			code: `
+class Child extends Base {
+    constructor(first, second, ...others) {
+        super(...arguments);
+    }
 }
-    `,
-  ],
-  invalid: [
-    {
-      code: `
-class A {
-  constructor() {}
+`,
+			snapshot: `
+class Child extends Base {
+    constructor(first, second, ...others) {
+    ~~~~~~~~~~~
+    This constructor is equivalent to the implicit default constructor, so it adds no behavior to the class.
+        super(...arguments);
+    }
 }
-      `,
-      errors: [
-        {
-          messageId: 'noUselessConstructor',
-          suggestions: [
-            {
-              messageId: 'removeConstructor',
-              output: `
-class A {
-${'  '}
+`,
+			suggestions: [
+				{
+					id: "removeConstructor",
+					updated: `
+class Child extends Base {
+    
 }
-      `,
-            },
-          ],
-        },
-      ],
-    },
-    {
-      code: `
-class A extends B {
-  constructor() {
-    super();
-  }
+`,
+				},
+			],
+		},
+		{
+			code: `
+class Child extends Base {
+    constructor(first, second, ...others) {
+        super(first, second, ...others);
+    }
 }
-      `,
-      errors: [
-        {
-          messageId: 'noUselessConstructor',
-          suggestions: [
-            {
-              messageId: 'removeConstructor',
-              output: `
-class A extends B {
-${'  '}
+`,
+			snapshot: `
+class Child extends Base {
+    constructor(first, second, ...others) {
+    ~~~~~~~~~~~
+    This constructor is equivalent to the implicit default constructor, so it adds no behavior to the class.
+        super(first, second, ...others);
+    }
 }
-      `,
-            },
-          ],
-        },
-      ],
-    },
-    {
-      code: `
-class A extends B {
-  constructor(foo) {
-    super(foo);
-  }
+`,
+			suggestions: [
+				{
+					id: "removeConstructor",
+					updated: `
+class Child extends Base {
+    
 }
-      `,
-      errors: [
-        {
-          messageId: 'noUselessConstructor',
-          suggestions: [
-            {
-              messageId: 'removeConstructor',
-              output: `
-class A extends B {
-${'  '}
+`,
+				},
+			],
+		},
+		{
+			code: `
+class Child extends Base {
+    constructor(value) {
+        (super(value));
+    }
 }
-      `,
-            },
-          ],
-        },
-      ],
-    },
-    {
-      code: `
-class A extends B {
-  constructor(foo, bar) {
-    super(foo, bar);
-  }
+`,
+			snapshot: `
+class Child extends Base {
+    constructor(value) {
+    ~~~~~~~~~~~
+    This constructor is equivalent to the implicit default constructor, so it adds no behavior to the class.
+        (super(value));
+    }
 }
-      `,
-      errors: [
-        {
-          messageId: 'noUselessConstructor',
-          suggestions: [
-            {
-              messageId: 'removeConstructor',
-              output: `
-class A extends B {
-${'  '}
+`,
+			suggestions: [
+				{
+					id: "removeConstructor",
+					updated: `
+class Child extends Base {
+    
 }
-      `,
-            },
-          ],
-        },
-      ],
-    },
-    {
-      code: `
-class A extends B {
-  constructor(...args) {
-    super(...args);
-  }
+`,
+				},
+			],
+		},
+		{
+			code: `
+class Child extends Base {
+    constructor(value) {
+        super((value));
+    }
 }
-      `,
-      errors: [
-        {
-          messageId: 'noUselessConstructor',
-          suggestions: [
-            {
-              messageId: 'removeConstructor',
-              output: `
-class A extends B {
-${'  '}
+`,
+			snapshot: `
+class Child extends Base {
+    constructor(value) {
+    ~~~~~~~~~~~
+    This constructor is equivalent to the implicit default constructor, so it adds no behavior to the class.
+        super((value));
+    }
 }
-      `,
-            },
-          ],
-        },
-      ],
-    },
-    {
-      code: `
-class A extends B.C {
-  constructor() {
-    super(...arguments);
-  }
+`,
+			suggestions: [
+				{
+					id: "removeConstructor",
+					updated: `
+class Child extends Base {
+    
 }
-      `,
-      errors: [
-        {
-          messageId: 'noUselessConstructor',
-          suggestions: [
-            {
-              messageId: 'removeConstructor',
-              output: `
-class A extends B.C {
-${'  '}
+`,
+				},
+			],
+		},
+		{
+			code: `
+class Child extends Base {
+    constructor() {
+        super(...(arguments));
+    }
 }
-      `,
-            },
-          ],
-        },
-      ],
-    },
-    {
-      code: `
-class A extends B {
-  constructor(a, b, ...c) {
-    super(...arguments);
-  }
+`,
+			snapshot: `
+class Child extends Base {
+    constructor() {
+    ~~~~~~~~~~~
+    This constructor is equivalent to the implicit default constructor, so it adds no behavior to the class.
+        super(...(arguments));
+    }
 }
-      `,
-      errors: [
-        {
-          messageId: 'noUselessConstructor',
-          suggestions: [
-            {
-              messageId: 'removeConstructor',
-              output: `
-class A extends B {
-${'  '}
+`,
+			suggestions: [
+				{
+					id: "removeConstructor",
+					updated: `
+class Child extends Base {
+    
 }
-      `,
-            },
-          ],
-        },
-      ],
-    },
-    {
-      code: `
-class A extends B {
-  constructor(a, b, ...c) {
-    super(a, b, ...c);
-  }
+`,
+				},
+			],
+		},
+		{
+			code: `
+class Logger {
+    label = "ready"
+    constructor() {}
+    [0]() {}
 }
-      `,
-      errors: [
-        {
-          messageId: 'noUselessConstructor',
-          suggestions: [
-            {
-              messageId: 'removeConstructor',
-              output: `
-class A extends B {
-${'  '}
+`,
+			snapshot: `
+class Logger {
+    label = "ready"
+    constructor() {}
+    ~~~~~~~~~~~
+    This constructor is equivalent to the implicit default constructor, so it adds no behavior to the class.
+    [0]() {}
 }
-      `,
-            },
-          ],
-        },
-      ],
-    },
-    {
-      code: `
-class A {
-  public constructor() {}
+`,
+			suggestions: [
+				{
+					id: "removeConstructor",
+					updated: `
+class Logger {
+    label = "ready"
+    ;
+    [0]() {}
 }
-      `,
-      errors: [
-        {
-          messageId: 'noUselessConstructor',
-          suggestions: [
-            {
-              messageId: 'removeConstructor',
-              output: `
-class A {
-${'  '}
+`,
+				},
+			],
+		},
+		{
+			code: `
+class Logger {
+    label = "ready"
+    constructor() {}
+    *run() {}
 }
-      `,
-            },
-          ],
-        },
-      ],
-    },
-  ],
+`,
+			snapshot: `
+class Logger {
+    label = "ready"
+    constructor() {}
+    ~~~~~~~~~~~
+    This constructor is equivalent to the implicit default constructor, so it adds no behavior to the class.
+    *run() {}
+}
+`,
+			suggestions: [
+				{
+					id: "removeConstructor",
+					updated: `
+class Logger {
+    label = "ready"
+    ;
+    *run() {}
+}
+`,
+				},
+			],
+		},
+		{
+			code: `
+class Logger {
+    label = "ready"
+    constructor() {}
+    in
+}
+`,
+			snapshot: `
+class Logger {
+    label = "ready"
+    constructor() {}
+    ~~~~~~~~~~~
+    This constructor is equivalent to the implicit default constructor, so it adds no behavior to the class.
+    in
+}
+`,
+			suggestions: [
+				{
+					id: "removeConstructor",
+					updated: `
+class Logger {
+    label = "ready"
+    ;
+    in
+}
+`,
+				},
+			],
+		},
+		{
+			code: `
+class Logger {
+    label = "ready"
+    constructor() {}
+    instanceof
+}
+`,
+			snapshot: `
+class Logger {
+    label = "ready"
+    constructor() {}
+    ~~~~~~~~~~~
+    This constructor is equivalent to the implicit default constructor, so it adds no behavior to the class.
+    instanceof
+}
+`,
+			suggestions: [
+				{
+					id: "removeConstructor",
+					updated: `
+class Logger {
+    label = "ready"
+    ;
+    instanceof
+}
+`,
+				},
+			],
+		},
+		{
+			code: `
+class Logger {
+    label = "ready"
+    constructor() {}
+    #instanceof
+}
+`,
+			snapshot: `
+class Logger {
+    label = "ready"
+    constructor() {}
+    ~~~~~~~~~~~
+    This constructor is equivalent to the implicit default constructor, so it adds no behavior to the class.
+    #instanceof
+}
+`,
+			suggestions: [
+				{
+					id: "removeConstructor",
+					updated: `
+class Logger {
+    label = "ready"
+    
+    #instanceof
+}
+`,
+				},
+			],
+		},
+		{
+			code: `
+class Logger {
+    label
+    constructor() {}
+    [0]() {}
+}
+`,
+			snapshot: `
+class Logger {
+    label
+    constructor() {}
+    ~~~~~~~~~~~
+    This constructor is equivalent to the implicit default constructor, so it adds no behavior to the class.
+    [0]() {}
+}
+`,
+			suggestions: [
+				{
+					id: "removeConstructor",
+					updated: `
+class Logger {
+    label
+    
+    [0]() {}
+}
+`,
+				},
+			],
+		},
+		{
+			code: `
+class Logger {
+    label = "ready";
+    constructor() {}
+    [0]() {}
+}
+`,
+			snapshot: `
+class Logger {
+    label = "ready";
+    constructor() {}
+    ~~~~~~~~~~~
+    This constructor is equivalent to the implicit default constructor, so it adds no behavior to the class.
+    [0]() {}
+}
+`,
+			suggestions: [
+				{
+					id: "removeConstructor",
+					updated: `
+class Logger {
+    label = "ready";
+    
+    [0]() {}
+}
+`,
+				},
+			],
+		},
+		{
+			code: `
+class Logger {
+    label = "ready"
+    constructor() {}
+    run() {}
+}
+`,
+			snapshot: `
+class Logger {
+    label = "ready"
+    constructor() {}
+    ~~~~~~~~~~~
+    This constructor is equivalent to the implicit default constructor, so it adds no behavior to the class.
+    run() {}
+}
+`,
+			suggestions: [
+				{
+					id: "removeConstructor",
+					updated: `
+class Logger {
+    label = "ready"
+    
+    run() {}
+}
+`,
+				},
+			],
+		},
+		{
+			code: `
+class Logger {
+    constructor() {}
+    [0]() {}
+    label = "ready"
+}
+`,
+			snapshot: `
+class Logger {
+    constructor() {}
+    ~~~~~~~~~~~
+    This constructor is equivalent to the implicit default constructor, so it adds no behavior to the class.
+    [0]() {}
+    label = "ready"
+}
+`,
+			suggestions: [
+				{
+					id: "removeConstructor",
+					updated: `
+class Logger {
+    
+    [0]() {}
+    label = "ready"
+}
+`,
+				},
+			],
+		},
+	],
+	valid: [
+		"class Logger {}",
+		"class Logger { constructor() { setup(); } }",
+		"class Logger { log() { setup(); } }",
+		"class Child extends Base { constructor() {} }",
+		'class Child extends Base { constructor() { super("label"); } }',
+		"class Child extends Base { constructor(first, second) { super(first, second, 1); } }",
+		"class Child extends Base { constructor() { super(); setup(); } }",
+		"class Child extends Base { constructor(...args) { super(...args); setup(); } }",
+		"class Child extends namespaces.Base { constructor() { super(outside); } }",
+		"class Child extends namespaces.Base { constructor([first, second]) { super(...arguments); } }",
+		"class Child extends namespaces.Base { constructor(first = make()) { super(...arguments); } }",
+		"class Child extends Base { constructor(first, second, third) { super(first, second); } }",
+		"class Child extends Base { constructor(first, second) { super(first); } }",
+		"class Child extends Base { constructor(value) { super(); } }",
+		"class Child extends Base { constructor() { ready; } }",
+		"class Child extends Base { constructor(first, second) { super(second, first); } }",
+		"class Child extends Base { constructor() { setup(); } }",
+		"class Child extends Base { constructor() { return super(); } }",
+		"class Child extends Base { constructor(...args) { super(args); } }",
+		"class Child extends Base { constructor() { super(...outside); } }",
+		"class Child extends Base { constructor() { super(...arguments, extra); } }",
+		"class Child extends Base { constructor(value) { super(value + 1); } }",
+		"class Logger { constructor() { super(); } }",
+		`
+declare class Logger {
+    constructor();
+}
+`,
+		"class Logger { constructor(); }",
+		"abstract class Logger { constructor(); }",
+		"class Logger { constructor(name); }",
+		"class Logger { constructor(private name: string) {} }",
+		"class Logger { constructor(public name: string) {} }",
+		"class Logger { constructor(protected name: string) {} }",
+		"class Logger { constructor(readonly name: string) {} }",
+		"class Logger { private constructor() {} }",
+		"class Logger { protected constructor() {} }",
+		"class Child extends Base { public constructor() {} }",
+		"class Child extends Base { public constructor() { super(); } }",
+		"class Child extends Base { protected constructor(first, second) { super(second); } }",
+		"class Child extends Base { private constructor(first, second) { super(second); } }",
+		"class Child extends Base { public constructor(value) { super(value); } }",
+		"class Child extends Base { public constructor(value) {} }",
+		"class Logger { constructor(@inject service) {} }",
+		`
+class Child extends Base {
+    constructor(@inject service: Service) {
+        super(service);
+    }
+}
+`,
+		`
+class Child extends Base {
+    constructor(name: string, @optional() label) {
+        super(name, label);
+    }
+}
+`,
+		"const factory = { constructor() {} };",
+	],
 });

--- a/packages/ts/src/rules/unnecessaryConstructors.ts
+++ b/packages/ts/src/rules/unnecessaryConstructors.ts
@@ -1,0 +1,75 @@
+import type { TSESTree } from '@typescript-eslint/utils';
+
+import { AST_NODE_TYPES } from '@typescript-eslint/utils';
+
+import type {
+  InferMessageIdsTypeFromRule,
+  InferOptionsTypeFromRule,
+} from '../util';
+
+import { createRule } from '../util';
+import { getESLintCoreRule } from '../util/getESLintCoreRule';
+
+const baseRule = getESLintCoreRule('no-useless-constructor');
+
+export type Options = InferOptionsTypeFromRule<typeof baseRule>;
+export type MessageIds = InferMessageIdsTypeFromRule<typeof baseRule>;
+
+/**
+ * Check if method with accessibility is not useless
+ */
+function checkAccessibility(node: TSESTree.MethodDefinition): boolean {
+  switch (node.accessibility) {
+    case 'protected':
+    case 'private':
+      return false;
+    case 'public':
+      if (node.parent.parent.superClass) {
+        return false;
+      }
+      break;
+  }
+  return true;
+}
+
+/**
+ * Check if method is not useless due to typescript parameter properties and decorators
+ */
+function checkParams(node: TSESTree.MethodDefinition): boolean {
+  return !node.value.params.some(
+    param =>
+      param.type === AST_NODE_TYPES.TSParameterProperty ||
+      param.decorators.length,
+  );
+}
+
+export default createRule<Options, MessageIds>({
+  name: 'no-useless-constructor',
+  meta: {
+    type: 'problem',
+    // defaultOptions, -- base rule does not use defaultOptions
+    docs: {
+      description: 'Disallow unnecessary constructors',
+      extendsBaseRule: true,
+      recommended: 'strict',
+    },
+    hasSuggestions: baseRule.meta.hasSuggestions,
+    messages: baseRule.meta.messages,
+    schema: baseRule.meta.schema,
+  },
+  defaultOptions: [],
+  create(context) {
+    const rules = baseRule.create(context);
+    return {
+      MethodDefinition(node): void {
+        if (
+          node.value.type === AST_NODE_TYPES.FunctionExpression &&
+          checkAccessibility(node) &&
+          checkParams(node)
+        ) {
+          rules.MethodDefinition(node);
+        }
+      },
+    };
+  },
+});

--- a/packages/ts/src/rules/unnecessaryConstructors.ts
+++ b/packages/ts/src/rules/unnecessaryConstructors.ts
@@ -1,75 +1,242 @@
-import type { TSESTree } from '@typescript-eslint/utils';
+import ts from "typescript";
 
-import { AST_NODE_TYPES } from '@typescript-eslint/utils';
+import { typescriptLanguage, type AST } from "@flint.fyi/typescript-language";
 
-import type {
-  InferMessageIdsTypeFromRule,
-  InferOptionsTypeFromRule,
-} from '../util';
+import { ruleCreator } from "./ruleCreator.ts";
 
-import { createRule } from '../util';
-import { getESLintCoreRule } from '../util/getESLintCoreRule';
+export default ruleCreator.createRule(typescriptLanguage, {
+	about: {
+		description:
+			"Reports constructors that are equivalent to the implicit default constructor.",
+		id: "unnecessaryConstructors",
+		presets: ["stylistic", "stylisticStrict"],
+	},
+	messages: {
+		unnecessaryConstructor: {
+			primary:
+				"This constructor is equivalent to the implicit default constructor, so it adds no behavior to the class.",
+			secondary: [
+				"Classes without an explicit constructor receive an implicit one: empty in base classes, and forwarding all arguments to the parent class in derived classes.",
+				"Writing that same behavior out manually adds code to read without changing how the class works.",
+			],
+			suggestions: [
+				"Remove the constructor in favor of the implicit default constructor.",
+			],
+		},
+	},
+	setup(context) {
+		return {
+			visitors: {
+				Constructor: (node, { sourceFile }) => {
+					if (
+						!node.body ||
+						hasUsefulAccessibility(node) ||
+						hasParameterPropertiesOrDecorators(node)
+					) {
+						return;
+					}
 
-const baseRule = getESLintCoreRule('no-useless-constructor');
+					const redundant = classHasExtendsClause(node.parent)
+						? isRedundantSuperCall(node.body, node.parameters)
+						: !node.body.statements.length;
 
-export type Options = InferOptionsTypeFromRule<typeof baseRule>;
-export type MessageIds = InferMessageIdsTypeFromRule<typeof baseRule>;
+					if (!redundant) {
+						return;
+					}
 
-/**
- * Check if method with accessibility is not useless
- */
-function checkAccessibility(node: TSESTree.MethodDefinition): boolean {
-  switch (node.accessibility) {
-    case 'protected':
-    case 'private':
-      return false;
-    case 'public':
-      if (node.parent.parent.superClass) {
-        return false;
-      }
-      break;
-  }
-  return true;
-}
-
-/**
- * Check if method is not useless due to typescript parameter properties and decorators
- */
-function checkParams(node: TSESTree.MethodDefinition): boolean {
-  return !node.value.params.some(
-    param =>
-      param.type === AST_NODE_TYPES.TSParameterProperty ||
-      param.decorators.length,
-  );
-}
-
-export default createRule<Options, MessageIds>({
-  name: 'no-useless-constructor',
-  meta: {
-    type: 'problem',
-    // defaultOptions, -- base rule does not use defaultOptions
-    docs: {
-      description: 'Disallow unnecessary constructors',
-      extendsBaseRule: true,
-      recommended: 'strict',
-    },
-    hasSuggestions: baseRule.meta.hasSuggestions,
-    messages: baseRule.meta.messages,
-    schema: baseRule.meta.schema,
-  },
-  defaultOptions: [],
-  create(context) {
-    const rules = baseRule.create(context);
-    return {
-      MethodDefinition(node): void {
-        if (
-          node.value.type === AST_NODE_TYPES.FunctionExpression &&
-          checkAccessibility(node) &&
-          checkParams(node)
-        ) {
-          rules.MethodDefinition(node);
-        }
-      },
-    };
-  },
+					context.report({
+						message: "unnecessaryConstructor",
+						range: {
+							begin: node.getStart(sourceFile),
+							end: getConstructorKeywordEnd(node, sourceFile),
+						},
+						suggestions: [
+							{
+								id: "removeConstructor",
+								range: {
+									begin: node.getStart(sourceFile),
+									end: node.getEnd(),
+								},
+								text: needsSeparatingSemicolon(node, sourceFile) ? ";" : "",
+							},
+						],
+					});
+				},
+			},
+		};
+	},
 });
+
+function beginsWithExpressionContinuation(
+	member: AST.ClassElement | undefined,
+	sourceFile: AST.SourceFile,
+) {
+	const firstToken = member?.getFirstToken(sourceFile);
+	if (!firstToken) {
+		return false;
+	}
+
+	if (ts.isIdentifier(firstToken)) {
+		return firstToken.text === "in" || firstToken.text === "instanceof";
+	}
+
+	return (
+		firstToken.kind === ts.SyntaxKind.AsteriskToken ||
+		firstToken.kind === ts.SyntaxKind.OpenBracketToken
+	);
+}
+
+function classHasExtendsClause(
+	node: AST.ClassDeclaration | AST.ClassExpression,
+) {
+	return (
+		node.heritageClauses?.some(
+			(clause) => clause.token === ts.SyntaxKind.ExtendsKeyword,
+		) ?? false
+	);
+}
+
+function endsWithUnterminatedInitializer(
+	member: AST.ClassElement | undefined,
+	sourceFile: AST.SourceFile,
+) {
+	return (
+		member !== undefined &&
+		ts.isPropertyDeclaration(member) &&
+		member.initializer !== undefined &&
+		member.getLastToken(sourceFile)?.kind !== ts.SyntaxKind.SemicolonToken
+	);
+}
+
+function getConstructorKeywordEnd(
+	node: AST.ConstructorDeclaration,
+	sourceFile: AST.SourceFile,
+) {
+	const keywordOrName = node
+		.getChildren(sourceFile)
+		.find(
+			(child) =>
+				child.kind === ts.SyntaxKind.ConstructorKeyword ||
+				child.kind === ts.SyntaxKind.StringLiteral,
+		);
+
+	return (
+		keywordOrName?.getEnd() ??
+		node.getStart(sourceFile) + "constructor".length
+	);
+}
+
+function hasParameterPropertiesOrDecorators(node: AST.ConstructorDeclaration) {
+	return node.parameters.some(
+		(parameter) =>
+			ts.isParameterPropertyDeclaration(parameter, node) ||
+			(ts.canHaveDecorators(parameter) &&
+				!!ts.getDecorators(parameter)?.length),
+	);
+}
+
+function hasUsefulAccessibility(node: AST.ConstructorDeclaration) {
+	for (const modifier of node.modifiers ?? []) {
+		switch (modifier.kind) {
+			case ts.SyntaxKind.PrivateKeyword:
+			case ts.SyntaxKind.ProtectedKeyword:
+				return true;
+
+			case ts.SyntaxKind.PublicKeyword:
+				return classHasExtendsClause(node.parent);
+		}
+	}
+
+	return false;
+}
+
+function isMatchingArgument(
+	parameter: AST.ParameterDeclaration,
+	argument: ts.Expression,
+) {
+	return parameter.dotDotDotToken
+		? ts.isSpreadElement(argument) &&
+				isMatchingIdentifiers(
+					parameter.name,
+					ts.skipParentheses(argument.expression),
+				)
+		: isMatchingIdentifiers(parameter.name, ts.skipParentheses(argument));
+}
+
+function isMatchingIdentifiers(first: ts.Node, second: ts.Node) {
+	return (
+		ts.isIdentifier(first) &&
+		ts.isIdentifier(second) &&
+		first.text === second.text
+	);
+}
+
+function isPassingThrough(
+	parameters: ts.NodeArray<AST.ParameterDeclaration>,
+	superArguments: ts.NodeArray<ts.Expression>,
+) {
+	return (
+		parameters.length === superArguments.length &&
+		parameters.every((parameter, index) => {
+			const argument = superArguments[index];
+			return argument !== undefined && isMatchingArgument(parameter, argument);
+		})
+	);
+}
+
+function isRedundantSuperCall(
+	body: AST.FunctionBody,
+	parameters: ts.NodeArray<AST.ParameterDeclaration>,
+) {
+	const [statement] = body.statements;
+	if (
+		body.statements.length !== 1 ||
+		!statement ||
+		!ts.isExpressionStatement(statement)
+	) {
+		return false;
+	}
+
+	const call = ts.skipParentheses(statement.expression);
+
+	return (
+		ts.isCallExpression(call) &&
+		call.expression.kind === ts.SyntaxKind.SuperKeyword &&
+		parameters.every(isSimpleParameter) &&
+		(isSpreadArguments(call.arguments) ||
+			isPassingThrough(parameters, call.arguments))
+	);
+}
+
+function isSimpleParameter(parameter: AST.ParameterDeclaration) {
+	return ts.isIdentifier(parameter.name) && !parameter.initializer;
+}
+
+function isSpreadArguments(superArguments: ts.NodeArray<ts.Expression>) {
+	const [argument] = superArguments;
+	if (
+		superArguments.length !== 1 ||
+		!argument ||
+		!ts.isSpreadElement(argument)
+	) {
+		return false;
+	}
+
+	const value = ts.skipParentheses(argument.expression);
+
+	return ts.isIdentifier(value) && value.text === "arguments";
+}
+
+function needsSeparatingSemicolon(
+	node: AST.ConstructorDeclaration,
+	sourceFile: AST.SourceFile,
+) {
+	const members = node.parent.members;
+	const index = members.indexOf(node);
+
+	return (
+		index > 0 &&
+		endsWithUnterminatedInitializer(members.at(index - 1), sourceFile) &&
+		beginsWithExpressionContinuation(members.at(index + 1), sourceFile)
+	);
+}

--- a/packages/ts/src/rules/unnecessaryConstructors.ts
+++ b/packages/ts/src/rules/unnecessaryConstructors.ts
@@ -3,6 +3,7 @@ import ts from "typescript";
 import { typescriptLanguage, type AST } from "@flint.fyi/typescript-language";
 
 import { ruleCreator } from "./ruleCreator.ts";
+import { skipParentheses } from "./utils/skipParentheses.ts";
 
 export default ruleCreator.createRule(typescriptLanguage, {
 	about: {
@@ -121,8 +122,7 @@ function getConstructorKeywordEnd(
 		);
 
 	return (
-		keywordOrName?.getEnd() ??
-		node.getStart(sourceFile) + "constructor".length
+		keywordOrName?.getEnd() ?? node.getStart(sourceFile) + "constructor".length
 	);
 }
 
@@ -152,15 +152,15 @@ function hasUsefulAccessibility(node: AST.ConstructorDeclaration) {
 
 function isMatchingArgument(
 	parameter: AST.ParameterDeclaration,
-	argument: ts.Expression,
+	argument: AST.Expression,
 ) {
 	return parameter.dotDotDotToken
 		? ts.isSpreadElement(argument) &&
 				isMatchingIdentifiers(
 					parameter.name,
-					ts.skipParentheses(argument.expression),
+					skipParentheses(argument.expression),
 				)
-		: isMatchingIdentifiers(parameter.name, ts.skipParentheses(argument));
+		: isMatchingIdentifiers(parameter.name, skipParentheses(argument));
 }
 
 function isMatchingIdentifiers(first: ts.Node, second: ts.Node) {
@@ -173,7 +173,7 @@ function isMatchingIdentifiers(first: ts.Node, second: ts.Node) {
 
 function isPassingThrough(
 	parameters: ts.NodeArray<AST.ParameterDeclaration>,
-	superArguments: ts.NodeArray<ts.Expression>,
+	superArguments: ts.NodeArray<AST.Expression>,
 ) {
 	return (
 		parameters.length === superArguments.length &&
@@ -197,7 +197,7 @@ function isRedundantSuperCall(
 		return false;
 	}
 
-	const call = ts.skipParentheses(statement.expression);
+	const call = skipParentheses(statement.expression);
 
 	return (
 		ts.isCallExpression(call) &&
@@ -212,7 +212,7 @@ function isSimpleParameter(parameter: AST.ParameterDeclaration) {
 	return ts.isIdentifier(parameter.name) && !parameter.initializer;
 }
 
-function isSpreadArguments(superArguments: ts.NodeArray<ts.Expression>) {
+function isSpreadArguments(superArguments: ts.NodeArray<AST.Expression>) {
 	const [argument] = superArguments;
 	if (
 		superArguments.length !== 1 ||
@@ -222,7 +222,7 @@ function isSpreadArguments(superArguments: ts.NodeArray<ts.Expression>) {
 		return false;
 	}
 
-	const value = ts.skipParentheses(argument.expression);
+	const value = skipParentheses(argument.expression);
 
 	return ts.isIdentifier(value) && value.text === "arguments";
 }


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #2226
- [x] That issue was marked as [`status: accepting prs`](https://github.com/flint-fyi/flint/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/flint-fyi/flint/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

> **Draft port** — opening for maintainer review, not asserting merge-readiness.

Implements `ts/unnecessaryConstructors`, the flint equivalent of [`@typescript-eslint/no-useless-constructor`](https://typescript-eslint.io/rules/no-useless-constructor).
Reports constructors that are equivalent to the implicit default constructor — an empty constructor in a base class, or a derived-class constructor that only forwards its parameters to `super` — with a suggestion to remove them.

### Provenance (staged commits)

Ported from [typescript-eslint/typescript-eslint@4ba3e02e](https://github.com/typescript-eslint/typescript-eslint/blob/4ba3e02e46a3d01c24b030771ec6fc8d52385c61/packages/eslint-plugin/src/rules/no-useless-constructor.ts) (75 LOC):

1. verbatim upstream copy → 2. flint scaffolding match → 3. implementation.
Diff commits 1→3 to see exactly what the port changed.

Note on sources: the upstream rule is an extension rule that delegates its core logic to ESLint core's [`no-useless-constructor`](https://github.com/eslint/eslint/blob/main/lib/rules/no-useless-constructor.js) via `getESLintCoreRule`. Since flint rules are self-contained, this port merges the core semantics and the TS-specific exemptions (accessibility modifiers, parameter properties, parameter decorators) into one rule; both upstream test suites were used as the edge-case reference.

### Behavior vs upstream

- **Rest parameter with a destructuring pattern** (`constructor(...[a, b]) { super(...arguments); }`): ESLint core treats any rest element as "simple" and reports; this port requires the rest parameter to be a plain identifier and does not report. Removing such a constructor can change behavior (pattern defaults may have side effects), so the port takes the safe direction.
- **Suggestion ASI guard simplified**: core uses its general-purpose `needsPrecedingSemicolon` machinery to decide whether removing the constructor needs a separating `;`; this port uses class-member-shaped checks (previous member ends in an unterminated initializer, next member begins with `[`/`*`/`in`/`instanceof`). Output is identical across core's suggestion test matrix (all ported); the only known delta inserts a harmless extra `;` in one TS-specific corner.
- Core's `removeConstructor` suggestion is ported as a real flint suggestion, not dropped.

Everything else is behavior parity, including: overload signatures / ambient declarations never flagged, `implements`-only classes treated as base classes, `'constructor'()` string-key form flagged, and parentheses skipped at all expression positions.

A courtesy note: rule naming for the `unnecessary*` family is under discussion in #2802 — happy to rename if that lands on a different convention.

### Files

- `packages/ts/src/rules/unnecessaryConstructors.ts` — the rule (self-contained port)
- `packages/ts/src/rules/unnecessaryConstructors.test.ts` — 25 invalid cases (snapshot + suggestion output each) + 43 valid cases
- `packages/site/src/content/docs/rules/ts/unnecessaryConstructors.mdx` — full rule doc
- `packages/ts/src/plugin.ts` — rule registered alphabetically
- `packages/comparisons/src/data.json` — existing entry marked `"status": "implemented"`
- `.changeset/unnecessary-constructors.md` — patch changeset

### Local gates

`eslint --max-warnings 0` · `tsc -b packages/ts` · `vitest` (rule test, 68 passing) · `vitest` (comparisons) · `prettier --check` — all pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
