### PR TITLE
feat(ts): implement unnecessaryComputedKeys rule

### DIFF
--- a/.changeset/unnecessary-computed-keys.md
+++ b/.changeset/unnecessary-computed-keys.md
@@ -1,0 +1,5 @@
+---
+"@flint.fyi/ts": patch
+---
+
+Implement the `unnecessaryComputedKeys` rule.

--- a/packages/comparisons/src/data.json
+++ b/packages/comparisons/src/data.json
@@ -20605,7 +20605,8 @@
 		"flint": {
 			"name": "unnecessaryComputedKeys",
 			"plugin": "ts",
-			"preset": "stylistic"
+			"preset": "stylistic",
+			"status": "implemented"
 		}
 	},
 	{

--- a/packages/site/src/content/docs/rules/ts/unnecessaryComputedKeys.mdx
+++ b/packages/site/src/content/docs/rules/ts/unnecessaryComputedKeys.mdx
@@ -1,0 +1,172 @@
+---
+title: no-useless-computed-key
+rule_type: suggestion
+---
+
+
+
+It's unnecessary to use computed properties with literals such as:
+
+```js
+const foo = {["a"]: "b"};
+```
+
+The code can be rewritten as:
+
+```js
+const foo = {"a": "b"};
+```
+
+## Rule Details
+
+This rule disallows unnecessary usage of computed property keys.
+
+Examples of **incorrect** code for this rule:
+
+::: incorrect
+
+```js
+/*eslint no-useless-computed-key: "error"*/
+
+const a = { ['0']: 0 };
+const b = { ['0+1,234']: 0 };
+const c = { [0]: 0 };
+const d = { ['x']: 0 };
+const e = { ['x']() {} };
+
+const { [0]: foo } = obj;
+const { ['x']: bar } = obj;
+
+class Foo {
+    ["foo"] = "bar";
+
+    [0]() {}
+    ['a']() {}
+    get ['b']() {}
+    set ['c'](value) {}
+
+    static ["foo"] = "bar";
+
+    static ['a']() {}
+}
+```
+
+:::
+
+Examples of **correct** code for this rule:
+
+::: correct
+
+```js
+/*eslint no-useless-computed-key: "error"*/
+
+const a = { 'a': 0 };
+const b = { 0: 0 };
+const c = { x() {} };
+const d = { a: 0 };
+const e = { '0+1,234': 0 };
+
+const { 0: foo } = obj;
+const { 'x': bar } = obj;
+
+class Foo {
+    "foo" = "bar";
+
+    0() {}
+    'a'() {}
+    get 'b'() {}
+    set 'c'(value) {}
+
+    static "foo" = "bar";
+
+    static 'a'() {}
+}
+```
+
+:::
+
+Examples of additional **correct** code for this rule:
+
+::: correct
+
+```js
+/*eslint no-useless-computed-key: "error"*/
+
+const c = {
+    "__proto__": foo, // defines object's prototype
+
+    ["__proto__"]: bar // defines a property named "__proto__"
+};
+
+class Foo {
+    ["constructor"]; // instance field named "constructor"
+
+    "constructor"() {} // the constructor of this class
+
+    ["constructor"]() {} // method named "constructor"
+
+    static ["constructor"]; // static field named "constructor"
+
+    static ["prototype"]; // runtime error, it would be a parsing error without `[]`
+}
+```
+
+:::
+
+## Options
+
+This rule has an object option:
+
+* `enforceForClassMembers` set to `false` disables this rule for class members (Default `true`).
+
+### enforceForClassMembers
+
+By default, this rule also checks class declarations and class expressions,
+as the default value for `enforceForClassMembers` is `true`.
+
+When `enforceForClassMembers` is set to `false`, the rule will allow unnecessary computed keys inside of class fields, class methods, class getters, and class setters.
+
+Examples of **incorrect** code for this rule with the `{ "enforceForClassMembers": false }` option:
+
+::: incorrect
+
+```js
+/*eslint no-useless-computed-key: ["error", { "enforceForClassMembers": false }]*/
+
+const obj = {
+    ["foo"]: "bar",
+    [42]: "baz",
+
+    ['a']() {},
+    get ['b']() {},
+    set ['c'](value) {}
+};
+```
+
+:::
+
+Examples of **correct** code for this rule with the `{ "enforceForClassMembers": false }` option:
+
+::: correct
+
+```js
+/*eslint no-useless-computed-key: ["error", { "enforceForClassMembers": false }]*/
+
+class SomeClass {
+    ["foo"] = "bar";
+    [42] = "baz";
+
+    ['a']() {}
+    get ['b']() {}
+    set ['c'](value) {}
+
+    static ["foo"] = "bar";
+    static ['baz']() {}
+}
+```
+
+:::
+
+## When Not To Use It
+
+If you don't want to be notified about unnecessary computed property keys, you can safely disable this rule.

--- a/packages/site/src/content/docs/rules/ts/unnecessaryComputedKeys.mdx
+++ b/packages/site/src/content/docs/rules/ts/unnecessaryComputedKeys.mdx
@@ -1,172 +1,114 @@
 ---
-title: no-useless-computed-key
-rule_type: suggestion
+description: "Reports computed property keys that unnecessarily wrap literal strings or numbers."
+title: "unnecessaryComputedKeys"
+topic: "rules"
 ---
 
+import { TabItem, Tabs } from "@astrojs/starlight/components";
+import { RuleEquivalents } from "~/components/RuleEquivalents";
+import RuleSummary from "~/components/RuleSummary.astro";
 
+<RuleSummary plugin="ts" rule="unnecessaryComputedKeys" />
 
-It's unnecessary to use computed properties with literals such as:
+Computed property keys (`[...]`) allow property names to be derived from dynamic expressions at runtime.
+When the expression is a plain string or number literal, the resulting name is fixed ahead of time, so the computed syntax only adds visual noise.
+Writing the literal directly as the key expresses the same property more clearly.
 
-```js
-const foo = {["a"]: "b"};
-```
+A few literal keys are exempt because removing their brackets would change behavior or produce a syntax error:
 
-The code can be rewritten as:
+- `{ ["__proto__"]: value }` defines a property named `"__proto__"`, while `{ "__proto__": value }` sets the object's prototype.
+- `class Example { ["constructor"]() {} }` defines a method named `"constructor"`, while `class Example { "constructor"() {} }` declares the class constructor.
+- Class fields named `["constructor"]` and static class members named `["prototype"]` cannot be written without brackets at all.
 
-```js
-const foo = {"a": "b"};
-```
+## Examples
 
-## Rule Details
+<Tabs>
+<TabItem label="❌ Incorrect">
 
-This rule disallows unnecessary usage of computed property keys.
-
-Examples of **incorrect** code for this rule:
-
-::: incorrect
-
-```js
-/*eslint no-useless-computed-key: "error"*/
-
-const a = { ['0']: 0 };
-const b = { ['0+1,234']: 0 };
-const c = { [0]: 0 };
-const d = { ['x']: 0 };
-const e = { ['x']() {} };
-
-const { [0]: foo } = obj;
-const { ['x']: bar } = obj;
-
-class Foo {
-    ["foo"] = "bar";
-
-    [0]() {}
-    ['a']() {}
-    get ['b']() {}
-    set ['c'](value) {}
-
-    static ["foo"] = "bar";
-
-    static ['a']() {}
-}
-```
-
-:::
-
-Examples of **correct** code for this rule:
-
-::: correct
-
-```js
-/*eslint no-useless-computed-key: "error"*/
-
-const a = { 'a': 0 };
-const b = { 0: 0 };
-const c = { x() {} };
-const d = { a: 0 };
-const e = { '0+1,234': 0 };
-
-const { 0: foo } = obj;
-const { 'x': bar } = obj;
-
-class Foo {
-    "foo" = "bar";
-
-    0() {}
-    'a'() {}
-    get 'b'() {}
-    set 'c'(value) {}
-
-    static "foo" = "bar";
-
-    static 'a'() {}
-}
-```
-
-:::
-
-Examples of additional **correct** code for this rule:
-
-::: correct
-
-```js
-/*eslint no-useless-computed-key: "error"*/
-
-const c = {
-    "__proto__": foo, // defines object's prototype
-
-    ["__proto__"]: bar // defines a property named "__proto__"
+```ts
+const pagination = {
+	["limit"]: 10,
+	[0]: "zero",
 };
+```
 
-class Foo {
-    ["constructor"]; // instance field named "constructor"
+```ts
+class Cursor {
+	["offset"] = 0;
 
-    "constructor"() {} // the constructor of this class
-
-    ["constructor"]() {} // method named "constructor"
-
-    static ["constructor"]; // static field named "constructor"
-
-    static ["prototype"]; // runtime error, it would be a parsing error without `[]`
+	["advance"]() {
+		this.offset += 1;
+	}
 }
 ```
 
-:::
+```ts
+const { ["limit"]: limit } = pagination;
+```
+
+</TabItem>
+<TabItem label="✅ Correct">
+
+```ts
+const pagination = {
+	limit: 10,
+	0: "zero",
+};
+```
+
+```ts
+class Cursor {
+	offset = 0;
+
+	advance() {
+		this.offset += 1;
+	}
+}
+```
+
+```ts
+const { limit } = pagination;
+```
+
+```ts
+const handlers = {
+	[eventName]: onEvent,
+	["__proto__"]: null,
+};
+```
+
+</TabItem>
+</Tabs>
 
 ## Options
 
-This rule has an object option:
+### `enforceForClassMembers`
 
-* `enforceForClassMembers` set to `false` disables this rule for class members (Default `true`).
+Whether to also check the keys of class fields, methods, and accessors.
 
-### enforceForClassMembers
+**Type:** `boolean`
+**Default:** `true`
 
-By default, this rule also checks class declarations and class expressions,
-as the default value for `enforceForClassMembers` is `true`.
+When set to `false`, computed keys on class members are not reported:
 
-When `enforceForClassMembers` is set to `false`, the rule will allow unnecessary computed keys inside of class fields, class methods, class getters, and class setters.
+```ts
+// eslint ts/unnecessaryComputedKeys: ["error", { enforceForClassMembers: false }]
 
-Examples of **incorrect** code for this rule with the `{ "enforceForClassMembers": false }` option:
-
-::: incorrect
-
-```js
-/*eslint no-useless-computed-key: ["error", { "enforceForClassMembers": false }]*/
-
-const obj = {
-    ["foo"]: "bar",
-    [42]: "baz",
-
-    ['a']() {},
-    get ['b']() {},
-    set ['c'](value) {}
-};
-```
-
-:::
-
-Examples of **correct** code for this rule with the `{ "enforceForClassMembers": false }` option:
-
-::: correct
-
-```js
-/*eslint no-useless-computed-key: ["error", { "enforceForClassMembers": false }]*/
-
-class SomeClass {
-    ["foo"] = "bar";
-    [42] = "baz";
-
-    ['a']() {}
-    get ['b']() {}
-    set ['c'](value) {}
-
-    static ["foo"] = "bar";
-    static ['baz']() {}
+class Cursor {
+	// ✅ OK with the option disabled
+	["offset"] = 0;
 }
 ```
 
-:::
-
 ## When Not To Use It
 
-If you don't want to be notified about unnecessary computed property keys, you can safely disable this rule.
+If your project intentionally writes literal keys with computed syntax, such as to keep them visually consistent with neighboring dynamic keys, you can disable this rule.
+You might consider using [Flint disable comments](/directives) and/or [configuration file disables](/configuration#files) for those specific situations instead of completely disabling this rule.
+
+## Further Reading
+
+- [MDN: Computed property names](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Object_initializer#computed_property_names)
+
+## Equivalents in Other Linters
+
+<RuleEquivalents pluginId="ts" ruleId="unnecessaryComputedKeys" />

--- a/packages/ts/src/plugin.ts
+++ b/packages/ts/src/plugin.ts
@@ -289,6 +289,7 @@ import unnecessaryBlocks from "./rules/unnecessaryBlocks.ts";
 import unnecessaryBooleanCasts from "./rules/unnecessaryBooleanCasts.ts";
 import unnecessaryCatches from "./rules/unnecessaryCatches.ts";
 import unnecessaryComparisons from "./rules/unnecessaryComparisons.ts";
+import unnecessaryComputedKeys from "./rules/unnecessaryComputedKeys.ts";
 import unnecessaryConcatenation from "./rules/unnecessaryConcatenation.ts";
 import unnecessaryEscapes from "./rules/unnecessaryEscapes.ts";
 import unnecessaryMathClamps from "./rules/unnecessaryMathClamps.ts";
@@ -603,6 +604,7 @@ export const ts = createPlugin({
 		unnecessaryBooleanCasts,
 		unnecessaryCatches,
 		unnecessaryComparisons,
+		unnecessaryComputedKeys,
 		unnecessaryConcatenation,
 		unnecessaryEscapes,
 		unnecessaryMathClamps,

--- a/packages/ts/src/rules/unnecessaryComputedKeys.test.ts
+++ b/packages/ts/src/rules/unnecessaryComputedKeys.test.ts
@@ -1,0 +1,777 @@
+/**
+ * @fileoverview Tests for no-useless-computed-key rule.
+ * @author Burak Yigit Kaya
+ */
+
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+const rule = require("../../../lib/rules/no-useless-computed-key"),
+	RuleTester = require("../../../lib/rule-tester/rule-tester");
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+const ruleTester = new RuleTester({ languageOptions: { ecmaVersion: 2022 } });
+
+ruleTester.run("no-useless-computed-key", rule, {
+	valid: [
+		"({ 'a': 0, b(){} })",
+		"({ [x]: 0 });",
+		"({ a: 0, [b](){} })",
+		"({ ['__proto__']: [] })",
+		"var { 'a': foo } = obj",
+		"var { [a]: b } = obj;",
+		"var { a } = obj;",
+		"var { a: a } = obj;",
+		"var { a: b } = obj;",
+		{
+			code: "class Foo { a() {} }",
+			options: [{ enforceForClassMembers: true }],
+		},
+		{
+			code: "class Foo { 'a'() {} }",
+			options: [{ enforceForClassMembers: true }],
+		},
+		{
+			code: "class Foo { [x]() {} }",
+			options: [{ enforceForClassMembers: true }],
+		},
+		{
+			code: "class Foo { ['constructor']() {} }",
+			options: [{ enforceForClassMembers: true }],
+		},
+		{
+			code: "class Foo { static ['prototype']() {} }",
+			options: [{ enforceForClassMembers: true }],
+		},
+		{
+			code: "(class { 'a'() {} })",
+			options: [{ enforceForClassMembers: true }],
+		},
+		{
+			code: "(class { [x]() {} })",
+			options: [{ enforceForClassMembers: true }],
+		},
+		{
+			code: "(class { ['constructor']() {} })",
+			options: [{ enforceForClassMembers: true }],
+		},
+		{
+			code: "(class { static ['prototype']() {} })",
+			options: [{ enforceForClassMembers: true }],
+		},
+		"class Foo { 'x'() {} }",
+		"(class { [x]() {} })",
+		"class Foo { static constructor() {} }",
+		"class Foo { prototype() {} }",
+		{
+			code: "class Foo { ['x']() {} }",
+			options: [{ enforceForClassMembers: false }],
+		},
+		{
+			code: "(class { ['x']() {} })",
+			options: [{ enforceForClassMembers: false }],
+		},
+		{
+			code: "class Foo { static ['constructor']() {} }",
+			options: [{ enforceForClassMembers: false }],
+		},
+		{
+			code: "class Foo { ['prototype']() {} }",
+			options: [{ enforceForClassMembers: false }],
+		},
+		{
+			code: "class Foo { a }",
+			options: [{ enforceForClassMembers: true }],
+		},
+		{
+			code: "class Foo { ['constructor'] }",
+			options: [{ enforceForClassMembers: true }],
+		},
+		{
+			code: "class Foo { static ['constructor'] }",
+			options: [{ enforceForClassMembers: true }],
+		},
+		{
+			code: "class Foo { static ['prototype'] }",
+			options: [{ enforceForClassMembers: true }],
+		},
+
+		/*
+		 * Well-known browsers throw syntax error bigint literals on property names,
+		 * so, this rule doesn't touch those for now.
+		 */
+		{
+			code: "({ [99999999999999999n]: 0 })",
+			languageOptions: { ecmaVersion: 2020 },
+		},
+	],
+	invalid: [
+		{
+			code: "({ ['0']: 0 })",
+			output: "({ '0': 0 })",
+			errors: [
+				{
+					messageId: "unnecessarilyComputedProperty",
+					data: { property: "'0'" },
+				},
+			],
+		},
+		{
+			code: "var { ['0']: a } = obj",
+			output: "var { '0': a } = obj",
+			errors: [
+				{
+					messageId: "unnecessarilyComputedProperty",
+					data: { property: "'0'" },
+				},
+			],
+		},
+		{
+			code: "({ ['0+1,234']: 0 })",
+			output: "({ '0+1,234': 0 })",
+			errors: [
+				{
+					messageId: "unnecessarilyComputedProperty",
+					data: { property: "'0+1,234'" },
+				},
+			],
+		},
+		{
+			code: "({ [0]: 0 })",
+			output: "({ 0: 0 })",
+			errors: [
+				{
+					messageId: "unnecessarilyComputedProperty",
+					data: { property: "0" },
+				},
+			],
+		},
+		{
+			code: "var { [0]: a } = obj",
+			output: "var { 0: a } = obj",
+			errors: [
+				{
+					messageId: "unnecessarilyComputedProperty",
+					data: { property: "0" },
+				},
+			],
+		},
+		{
+			code: "({ ['x']: 0 })",
+			output: "({ 'x': 0 })",
+			errors: [
+				{
+					messageId: "unnecessarilyComputedProperty",
+					data: { property: "'x'" },
+				},
+			],
+		},
+		{
+			code: "var { ['x']: a } = obj",
+			output: "var { 'x': a } = obj",
+			errors: [
+				{
+					messageId: "unnecessarilyComputedProperty",
+					data: { property: "'x'" },
+				},
+			],
+		},
+		{
+			code: "var { ['__proto__']: a } = obj",
+			output: "var { '__proto__': a } = obj",
+			errors: [
+				{
+					messageId: "unnecessarilyComputedProperty",
+					data: { property: "'__proto__'" },
+				},
+			],
+		},
+		{
+			code: "({ ['x']() {} })",
+			output: "({ 'x'() {} })",
+			errors: [
+				{
+					messageId: "unnecessarilyComputedProperty",
+					data: { property: "'x'" },
+				},
+			],
+		},
+		{
+			code: "({ [/* this comment prevents a fix */ 'x']: 0 })",
+			output: null,
+			errors: [
+				{
+					messageId: "unnecessarilyComputedProperty",
+					data: { property: "'x'" },
+				},
+			],
+		},
+		{
+			code: "({ ['x' /* this comment also prevents a fix */]: 0 })",
+			output: null,
+			errors: [
+				{
+					messageId: "unnecessarilyComputedProperty",
+					data: { property: "'x'" },
+				},
+			],
+		},
+		{
+			code: "({ [('x')]: 0 })",
+			output: "({ 'x': 0 })",
+			errors: [
+				{
+					messageId: "unnecessarilyComputedProperty",
+					data: { property: "'x'" },
+				},
+			],
+		},
+		{
+			code: "var { [('x')]: a } = obj",
+			output: "var { 'x': a } = obj",
+			errors: [
+				{
+					messageId: "unnecessarilyComputedProperty",
+					data: { property: "'x'" },
+				},
+			],
+		},
+		{
+			code: "({ *['x']() {} })",
+			output: "({ *'x'() {} })",
+			errors: [
+				{
+					messageId: "unnecessarilyComputedProperty",
+					data: { property: "'x'" },
+				},
+			],
+		},
+		{
+			code: "({ async ['x']() {} })",
+			output: "({ async 'x'() {} })",
+			languageOptions: { ecmaVersion: 8 },
+			errors: [
+				{
+					messageId: "unnecessarilyComputedProperty",
+					data: { property: "'x'" },
+				},
+			],
+		},
+		{
+			code: "({ get[.2]() {} })",
+			output: "({ get.2() {} })",
+			errors: [
+				{
+					messageId: "unnecessarilyComputedProperty",
+					data: { property: ".2" },
+				},
+			],
+		},
+		{
+			code: "({ set[.2](value) {} })",
+			output: "({ set.2(value) {} })",
+			errors: [
+				{
+					messageId: "unnecessarilyComputedProperty",
+					data: { property: ".2" },
+				},
+			],
+		},
+		{
+			code: "({ async[.2]() {} })",
+			output: "({ async.2() {} })",
+			languageOptions: { ecmaVersion: 8 },
+			errors: [
+				{
+					messageId: "unnecessarilyComputedProperty",
+					data: { property: ".2" },
+				},
+			],
+		},
+		{
+			code: "({ [2]() {} })",
+			output: "({ 2() {} })",
+			errors: [
+				{
+					messageId: "unnecessarilyComputedProperty",
+					data: { property: "2" },
+				},
+			],
+		},
+		{
+			code: "({ get [2]() {} })",
+			output: "({ get 2() {} })",
+			errors: [
+				{
+					messageId: "unnecessarilyComputedProperty",
+					data: { property: "2" },
+				},
+			],
+		},
+		{
+			code: "({ set [2](value) {} })",
+			output: "({ set 2(value) {} })",
+			errors: [
+				{
+					messageId: "unnecessarilyComputedProperty",
+					data: { property: "2" },
+				},
+			],
+		},
+		{
+			code: "({ async [2]() {} })",
+			output: "({ async 2() {} })",
+			languageOptions: { ecmaVersion: 8 },
+			errors: [
+				{
+					messageId: "unnecessarilyComputedProperty",
+					data: { property: "2" },
+				},
+			],
+		},
+		{
+			code: "({ get[2]() {} })",
+			output: "({ get 2() {} })",
+			errors: [
+				{
+					messageId: "unnecessarilyComputedProperty",
+					data: { property: "2" },
+				},
+			],
+		},
+		{
+			code: "({ set[2](value) {} })",
+			output: "({ set 2(value) {} })",
+			errors: [
+				{
+					messageId: "unnecessarilyComputedProperty",
+					data: { property: "2" },
+				},
+			],
+		},
+		{
+			code: "({ async[2]() {} })",
+			output: "({ async 2() {} })",
+			languageOptions: { ecmaVersion: 8 },
+			errors: [
+				{
+					messageId: "unnecessarilyComputedProperty",
+					data: { property: "2" },
+				},
+			],
+		},
+		{
+			code: "({ get['foo']() {} })",
+			output: "({ get'foo'() {} })",
+			errors: [
+				{
+					messageId: "unnecessarilyComputedProperty",
+					data: { property: "'foo'" },
+				},
+			],
+		},
+		{
+			code: "({ *[2]() {} })",
+			output: "({ *2() {} })",
+			errors: [
+				{
+					messageId: "unnecessarilyComputedProperty",
+					data: { property: "2" },
+				},
+			],
+		},
+		{
+			code: "({ async*[2]() {} })",
+			output: "({ async*2() {} })",
+			errors: [
+				{
+					messageId: "unnecessarilyComputedProperty",
+					data: { property: "2" },
+				},
+			],
+		},
+		{
+			code: "({ ['constructor']: 1 })",
+			output: "({ 'constructor': 1 })",
+			errors: [
+				{
+					messageId: "unnecessarilyComputedProperty",
+					data: { property: "'constructor'" },
+				},
+			],
+		},
+		{
+			code: "({ ['prototype']: 1 })",
+			output: "({ 'prototype': 1 })",
+			errors: [
+				{
+					messageId: "unnecessarilyComputedProperty",
+					data: { property: "'prototype'" },
+				},
+			],
+		},
+		{
+			code: "class Foo { ['0']() {} }",
+			output: "class Foo { '0'() {} }",
+			options: [{ enforceForClassMembers: true }],
+			errors: [
+				{
+					messageId: "unnecessarilyComputedProperty",
+					data: { property: "'0'" },
+				},
+			],
+		},
+		{
+			code: "class Foo { ['0+1,234']() {} }",
+			output: "class Foo { '0+1,234'() {} }",
+			options: [{}],
+			errors: [
+				{
+					messageId: "unnecessarilyComputedProperty",
+					data: { property: "'0+1,234'" },
+				},
+			],
+		},
+		{
+			code: "class Foo { ['x']() {} }",
+			output: "class Foo { 'x'() {} }",
+			options: [{ enforceForClassMembers: void 0 }],
+			errors: [
+				{
+					messageId: "unnecessarilyComputedProperty",
+					data: { property: "'x'" },
+				},
+			],
+		},
+		{
+			code: "class Foo { [/* this comment prevents a fix */ 'x']() {} }",
+			output: null,
+			errors: [
+				{
+					messageId: "unnecessarilyComputedProperty",
+					data: { property: "'x'" },
+				},
+			],
+		},
+		{
+			code: "class Foo { ['x' /* this comment also prevents a fix */]() {} }",
+			output: null,
+			errors: [
+				{
+					messageId: "unnecessarilyComputedProperty",
+					data: { property: "'x'" },
+				},
+			],
+		},
+		{
+			code: "class Foo { [('x')]() {} }",
+			output: "class Foo { 'x'() {} }",
+			errors: [
+				{
+					messageId: "unnecessarilyComputedProperty",
+					data: { property: "'x'" },
+				},
+			],
+		},
+		{
+			code: "class Foo { *['x']() {} }",
+			output: "class Foo { *'x'() {} }",
+			errors: [
+				{
+					messageId: "unnecessarilyComputedProperty",
+					data: { property: "'x'" },
+				},
+			],
+		},
+		{
+			code: "class Foo { async ['x']() {} }",
+			output: "class Foo { async 'x'() {} }",
+			languageOptions: { ecmaVersion: 8 },
+			errors: [
+				{
+					messageId: "unnecessarilyComputedProperty",
+					data: { property: "'x'" },
+				},
+			],
+		},
+		{
+			code: "class Foo { get[.2]() {} }",
+			output: "class Foo { get.2() {} }",
+			errors: [
+				{
+					messageId: "unnecessarilyComputedProperty",
+					data: { property: ".2" },
+				},
+			],
+		},
+		{
+			code: "class Foo { set[.2](value) {} }",
+			output: "class Foo { set.2(value) {} }",
+			errors: [
+				{
+					messageId: "unnecessarilyComputedProperty",
+					data: { property: ".2" },
+				},
+			],
+		},
+		{
+			code: "class Foo { async[.2]() {} }",
+			output: "class Foo { async.2() {} }",
+			languageOptions: { ecmaVersion: 8 },
+			errors: [
+				{
+					messageId: "unnecessarilyComputedProperty",
+					data: { property: ".2" },
+				},
+			],
+		},
+		{
+			code: "class Foo { [2]() {} }",
+			output: "class Foo { 2() {} }",
+			errors: [
+				{
+					messageId: "unnecessarilyComputedProperty",
+					data: { property: "2" },
+				},
+			],
+		},
+		{
+			code: "class Foo { get [2]() {} }",
+			output: "class Foo { get 2() {} }",
+			errors: [
+				{
+					messageId: "unnecessarilyComputedProperty",
+					data: { property: "2" },
+				},
+			],
+		},
+		{
+			code: "class Foo { set [2](value) {} }",
+			output: "class Foo { set 2(value) {} }",
+			errors: [
+				{
+					messageId: "unnecessarilyComputedProperty",
+					data: { property: "2" },
+				},
+			],
+		},
+		{
+			code: "class Foo { async [2]() {} }",
+			output: "class Foo { async 2() {} }",
+			languageOptions: { ecmaVersion: 8 },
+			errors: [
+				{
+					messageId: "unnecessarilyComputedProperty",
+					data: { property: "2" },
+				},
+			],
+		},
+		{
+			code: "class Foo { get[2]() {} }",
+			output: "class Foo { get 2() {} }",
+			errors: [
+				{
+					messageId: "unnecessarilyComputedProperty",
+					data: { property: "2" },
+				},
+			],
+		},
+		{
+			code: "class Foo { set[2](value) {} }",
+			output: "class Foo { set 2(value) {} }",
+			errors: [
+				{
+					messageId: "unnecessarilyComputedProperty",
+					data: { property: "2" },
+				},
+			],
+		},
+		{
+			code: "class Foo { async[2]() {} }",
+			output: "class Foo { async 2() {} }",
+			languageOptions: { ecmaVersion: 8 },
+			errors: [
+				{
+					messageId: "unnecessarilyComputedProperty",
+					data: { property: "2" },
+				},
+			],
+		},
+		{
+			code: "class Foo { get['foo']() {} }",
+			output: "class Foo { get'foo'() {} }",
+			errors: [
+				{
+					messageId: "unnecessarilyComputedProperty",
+					data: { property: "'foo'" },
+				},
+			],
+		},
+		{
+			code: "class Foo { *[2]() {} }",
+			output: "class Foo { *2() {} }",
+			errors: [
+				{
+					messageId: "unnecessarilyComputedProperty",
+					data: { property: "2" },
+				},
+			],
+		},
+		{
+			code: "class Foo { async*[2]() {} }",
+			output: "class Foo { async*2() {} }",
+			errors: [
+				{
+					messageId: "unnecessarilyComputedProperty",
+					data: { property: "2" },
+				},
+			],
+		},
+		{
+			code: "class Foo { static ['constructor']() {} }",
+			output: "class Foo { static 'constructor'() {} }",
+			errors: [
+				{
+					messageId: "unnecessarilyComputedProperty",
+					data: { property: "'constructor'" },
+				},
+			],
+		},
+		{
+			code: "class Foo { ['prototype']() {} }",
+			output: "class Foo { 'prototype'() {} }",
+			errors: [
+				{
+					messageId: "unnecessarilyComputedProperty",
+					data: { property: "'prototype'" },
+				},
+			],
+		},
+		{
+			code: "(class { ['x']() {} })",
+			output: "(class { 'x'() {} })",
+			errors: [
+				{
+					messageId: "unnecessarilyComputedProperty",
+					data: { property: "'x'" },
+				},
+			],
+		},
+		{
+			code: "(class { ['__proto__']() {} })",
+			output: "(class { '__proto__'() {} })",
+			errors: [
+				{
+					messageId: "unnecessarilyComputedProperty",
+					data: { property: "'__proto__'" },
+				},
+			],
+		},
+		{
+			code: "(class { static ['__proto__']() {} })",
+			output: "(class { static '__proto__'() {} })",
+			errors: [
+				{
+					messageId: "unnecessarilyComputedProperty",
+					data: { property: "'__proto__'" },
+				},
+			],
+		},
+		{
+			code: "(class { static ['constructor']() {} })",
+			output: "(class { static 'constructor'() {} })",
+			errors: [
+				{
+					messageId: "unnecessarilyComputedProperty",
+					data: { property: "'constructor'" },
+				},
+			],
+		},
+		{
+			code: "(class { ['prototype']() {} })",
+			output: "(class { 'prototype'() {} })",
+			errors: [
+				{
+					messageId: "unnecessarilyComputedProperty",
+					data: { property: "'prototype'" },
+				},
+			],
+		},
+		{
+			code: "class Foo { ['0'] }",
+			output: "class Foo { '0' }",
+			errors: [
+				{
+					messageId: "unnecessarilyComputedProperty",
+					data: { property: "'0'" },
+				},
+			],
+		},
+		{
+			code: "class Foo { ['0'] = 0 }",
+			output: "class Foo { '0' = 0 }",
+			errors: [
+				{
+					messageId: "unnecessarilyComputedProperty",
+					data: { property: "'0'" },
+				},
+			],
+		},
+		{
+			code: "class Foo { static[0] }",
+			output: "class Foo { static 0 }",
+			errors: [
+				{
+					messageId: "unnecessarilyComputedProperty",
+					data: { property: "0" },
+				},
+			],
+		},
+		{
+			code: "class Foo { ['#foo'] }",
+			output: "class Foo { '#foo' }",
+			errors: [
+				{
+					messageId: "unnecessarilyComputedProperty",
+					data: { property: "'#foo'" },
+				},
+			],
+		},
+		{
+			code: "(class { ['__proto__'] })",
+			output: "(class { '__proto__' })",
+			errors: [
+				{
+					messageId: "unnecessarilyComputedProperty",
+					data: { property: "'__proto__'" },
+				},
+			],
+		},
+		{
+			code: "(class { static ['__proto__'] })",
+			output: "(class { static '__proto__' })",
+			errors: [
+				{
+					messageId: "unnecessarilyComputedProperty",
+					data: { property: "'__proto__'" },
+				},
+			],
+		},
+		{
+			code: "(class { ['prototype'] })",
+			output: "(class { 'prototype' })",
+			errors: [
+				{
+					messageId: "unnecessarilyComputedProperty",
+					data: { property: "'prototype'" },
+				},
+			],
+		},
+	],
+});

--- a/packages/ts/src/rules/unnecessaryComputedKeys.test.ts
+++ b/packages/ts/src/rules/unnecessaryComputedKeys.test.ts
@@ -1,777 +1,968 @@
-/**
- * @fileoverview Tests for no-useless-computed-key rule.
- * @author Burak Yigit Kaya
- */
+import rule from "./unnecessaryComputedKeys.ts";
+import { ruleTester } from "./ruleTester.ts";
 
-"use strict";
-
-//------------------------------------------------------------------------------
-// Requirements
-//------------------------------------------------------------------------------
-
-const rule = require("../../../lib/rules/no-useless-computed-key"),
-	RuleTester = require("../../../lib/rule-tester/rule-tester");
-
-//------------------------------------------------------------------------------
-// Tests
-//------------------------------------------------------------------------------
-
-const ruleTester = new RuleTester({ languageOptions: { ecmaVersion: 2022 } });
-
-ruleTester.run("no-useless-computed-key", rule, {
-	valid: [
-		"({ 'a': 0, b(){} })",
-		"({ [x]: 0 });",
-		"({ a: 0, [b](){} })",
-		"({ ['__proto__']: [] })",
-		"var { 'a': foo } = obj",
-		"var { [a]: b } = obj;",
-		"var { a } = obj;",
-		"var { a: a } = obj;",
-		"var { a: b } = obj;",
-		{
-			code: "class Foo { a() {} }",
-			options: [{ enforceForClassMembers: true }],
-		},
-		{
-			code: "class Foo { 'a'() {} }",
-			options: [{ enforceForClassMembers: true }],
-		},
-		{
-			code: "class Foo { [x]() {} }",
-			options: [{ enforceForClassMembers: true }],
-		},
-		{
-			code: "class Foo { ['constructor']() {} }",
-			options: [{ enforceForClassMembers: true }],
-		},
-		{
-			code: "class Foo { static ['prototype']() {} }",
-			options: [{ enforceForClassMembers: true }],
-		},
-		{
-			code: "(class { 'a'() {} })",
-			options: [{ enforceForClassMembers: true }],
-		},
-		{
-			code: "(class { [x]() {} })",
-			options: [{ enforceForClassMembers: true }],
-		},
-		{
-			code: "(class { ['constructor']() {} })",
-			options: [{ enforceForClassMembers: true }],
-		},
-		{
-			code: "(class { static ['prototype']() {} })",
-			options: [{ enforceForClassMembers: true }],
-		},
-		"class Foo { 'x'() {} }",
-		"(class { [x]() {} })",
-		"class Foo { static constructor() {} }",
-		"class Foo { prototype() {} }",
-		{
-			code: "class Foo { ['x']() {} }",
-			options: [{ enforceForClassMembers: false }],
-		},
-		{
-			code: "(class { ['x']() {} })",
-			options: [{ enforceForClassMembers: false }],
-		},
-		{
-			code: "class Foo { static ['constructor']() {} }",
-			options: [{ enforceForClassMembers: false }],
-		},
-		{
-			code: "class Foo { ['prototype']() {} }",
-			options: [{ enforceForClassMembers: false }],
-		},
-		{
-			code: "class Foo { a }",
-			options: [{ enforceForClassMembers: true }],
-		},
-		{
-			code: "class Foo { ['constructor'] }",
-			options: [{ enforceForClassMembers: true }],
-		},
-		{
-			code: "class Foo { static ['constructor'] }",
-			options: [{ enforceForClassMembers: true }],
-		},
-		{
-			code: "class Foo { static ['prototype'] }",
-			options: [{ enforceForClassMembers: true }],
-		},
-
-		/*
-		 * Well-known browsers throw syntax error bigint literals on property names,
-		 * so, this rule doesn't touch those for now.
-		 */
-		{
-			code: "({ [99999999999999999n]: 0 })",
-			languageOptions: { ecmaVersion: 2020 },
-		},
-	],
+ruleTester.describe(rule, {
 	invalid: [
 		{
-			code: "({ ['0']: 0 })",
-			output: "({ '0': 0 })",
-			errors: [
-				{
-					messageId: "unnecessarilyComputedProperty",
-					data: { property: "'0'" },
-				},
-			],
-		},
-		{
-			code: "var { ['0']: a } = obj",
-			output: "var { '0': a } = obj",
-			errors: [
-				{
-					messageId: "unnecessarilyComputedProperty",
-					data: { property: "'0'" },
-				},
-			],
-		},
-		{
-			code: "({ ['0+1,234']: 0 })",
-			output: "({ '0+1,234': 0 })",
-			errors: [
-				{
-					messageId: "unnecessarilyComputedProperty",
-					data: { property: "'0+1,234'" },
-				},
-			],
-		},
-		{
-			code: "({ [0]: 0 })",
-			output: "({ 0: 0 })",
-			errors: [
-				{
-					messageId: "unnecessarilyComputedProperty",
-					data: { property: "0" },
-				},
-			],
-		},
-		{
-			code: "var { [0]: a } = obj",
-			output: "var { 0: a } = obj",
-			errors: [
-				{
-					messageId: "unnecessarilyComputedProperty",
-					data: { property: "0" },
-				},
-			],
-		},
-		{
-			code: "({ ['x']: 0 })",
-			output: "({ 'x': 0 })",
-			errors: [
-				{
-					messageId: "unnecessarilyComputedProperty",
-					data: { property: "'x'" },
-				},
-			],
-		},
-		{
-			code: "var { ['x']: a } = obj",
-			output: "var { 'x': a } = obj",
-			errors: [
-				{
-					messageId: "unnecessarilyComputedProperty",
-					data: { property: "'x'" },
-				},
-			],
-		},
-		{
-			code: "var { ['__proto__']: a } = obj",
-			output: "var { '__proto__': a } = obj",
-			errors: [
-				{
-					messageId: "unnecessarilyComputedProperty",
-					data: { property: "'__proto__'" },
-				},
-			],
-		},
-		{
-			code: "({ ['x']() {} })",
-			output: "({ 'x'() {} })",
-			errors: [
-				{
-					messageId: "unnecessarilyComputedProperty",
-					data: { property: "'x'" },
-				},
-			],
-		},
-		{
-			code: "({ [/* this comment prevents a fix */ 'x']: 0 })",
-			output: null,
-			errors: [
-				{
-					messageId: "unnecessarilyComputedProperty",
-					data: { property: "'x'" },
-				},
-			],
-		},
-		{
-			code: "({ ['x' /* this comment also prevents a fix */]: 0 })",
-			output: null,
-			errors: [
-				{
-					messageId: "unnecessarilyComputedProperty",
-					data: { property: "'x'" },
-				},
-			],
-		},
-		{
-			code: "({ [('x')]: 0 })",
-			output: "({ 'x': 0 })",
-			errors: [
-				{
-					messageId: "unnecessarilyComputedProperty",
-					data: { property: "'x'" },
-				},
-			],
-		},
-		{
-			code: "var { [('x')]: a } = obj",
-			output: "var { 'x': a } = obj",
-			errors: [
-				{
-					messageId: "unnecessarilyComputedProperty",
-					data: { property: "'x'" },
-				},
-			],
-		},
-		{
-			code: "({ *['x']() {} })",
-			output: "({ *'x'() {} })",
-			errors: [
-				{
-					messageId: "unnecessarilyComputedProperty",
-					data: { property: "'x'" },
-				},
-			],
-		},
-		{
-			code: "({ async ['x']() {} })",
-			output: "({ async 'x'() {} })",
-			languageOptions: { ecmaVersion: 8 },
-			errors: [
-				{
-					messageId: "unnecessarilyComputedProperty",
-					data: { property: "'x'" },
-				},
-			],
-		},
-		{
-			code: "({ get[.2]() {} })",
-			output: "({ get.2() {} })",
-			errors: [
-				{
-					messageId: "unnecessarilyComputedProperty",
-					data: { property: ".2" },
-				},
-			],
-		},
-		{
-			code: "({ set[.2](value) {} })",
-			output: "({ set.2(value) {} })",
-			errors: [
-				{
-					messageId: "unnecessarilyComputedProperty",
-					data: { property: ".2" },
-				},
-			],
-		},
-		{
-			code: "({ async[.2]() {} })",
-			output: "({ async.2() {} })",
-			languageOptions: { ecmaVersion: 8 },
-			errors: [
-				{
-					messageId: "unnecessarilyComputedProperty",
-					data: { property: ".2" },
-				},
-			],
-		},
-		{
-			code: "({ [2]() {} })",
-			output: "({ 2() {} })",
-			errors: [
-				{
-					messageId: "unnecessarilyComputedProperty",
-					data: { property: "2" },
-				},
-			],
-		},
-		{
-			code: "({ get [2]() {} })",
-			output: "({ get 2() {} })",
-			errors: [
-				{
-					messageId: "unnecessarilyComputedProperty",
-					data: { property: "2" },
-				},
-			],
-		},
-		{
-			code: "({ set [2](value) {} })",
-			output: "({ set 2(value) {} })",
-			errors: [
-				{
-					messageId: "unnecessarilyComputedProperty",
-					data: { property: "2" },
-				},
-			],
-		},
-		{
-			code: "({ async [2]() {} })",
-			output: "({ async 2() {} })",
-			languageOptions: { ecmaVersion: 8 },
-			errors: [
-				{
-					messageId: "unnecessarilyComputedProperty",
-					data: { property: "2" },
-				},
-			],
-		},
-		{
-			code: "({ get[2]() {} })",
-			output: "({ get 2() {} })",
-			errors: [
-				{
-					messageId: "unnecessarilyComputedProperty",
-					data: { property: "2" },
-				},
-			],
-		},
-		{
-			code: "({ set[2](value) {} })",
-			output: "({ set 2(value) {} })",
-			errors: [
-				{
-					messageId: "unnecessarilyComputedProperty",
-					data: { property: "2" },
-				},
-			],
-		},
-		{
-			code: "({ async[2]() {} })",
-			output: "({ async 2() {} })",
-			languageOptions: { ecmaVersion: 8 },
-			errors: [
-				{
-					messageId: "unnecessarilyComputedProperty",
-					data: { property: "2" },
-				},
-			],
-		},
-		{
-			code: "({ get['foo']() {} })",
-			output: "({ get'foo'() {} })",
-			errors: [
-				{
-					messageId: "unnecessarilyComputedProperty",
-					data: { property: "'foo'" },
-				},
-			],
-		},
-		{
-			code: "({ *[2]() {} })",
-			output: "({ *2() {} })",
-			errors: [
-				{
-					messageId: "unnecessarilyComputedProperty",
-					data: { property: "2" },
-				},
-			],
-		},
-		{
-			code: "({ async*[2]() {} })",
-			output: "({ async*2() {} })",
-			errors: [
-				{
-					messageId: "unnecessarilyComputedProperty",
-					data: { property: "2" },
-				},
-			],
-		},
-		{
-			code: "({ ['constructor']: 1 })",
-			output: "({ 'constructor': 1 })",
-			errors: [
-				{
-					messageId: "unnecessarilyComputedProperty",
-					data: { property: "'constructor'" },
-				},
-			],
-		},
-		{
-			code: "({ ['prototype']: 1 })",
-			output: "({ 'prototype': 1 })",
-			errors: [
-				{
-					messageId: "unnecessarilyComputedProperty",
-					data: { property: "'prototype'" },
-				},
-			],
-		},
-		{
-			code: "class Foo { ['0']() {} }",
-			output: "class Foo { '0'() {} }",
-			options: [{ enforceForClassMembers: true }],
-			errors: [
-				{
-					messageId: "unnecessarilyComputedProperty",
-					data: { property: "'0'" },
-				},
-			],
-		},
-		{
-			code: "class Foo { ['0+1,234']() {} }",
-			output: "class Foo { '0+1,234'() {} }",
-			options: [{}],
-			errors: [
-				{
-					messageId: "unnecessarilyComputedProperty",
-					data: { property: "'0+1,234'" },
-				},
-			],
-		},
-		{
-			code: "class Foo { ['x']() {} }",
-			output: "class Foo { 'x'() {} }",
-			options: [{ enforceForClassMembers: void 0 }],
-			errors: [
-				{
-					messageId: "unnecessarilyComputedProperty",
-					data: { property: "'x'" },
-				},
-			],
-		},
-		{
-			code: "class Foo { [/* this comment prevents a fix */ 'x']() {} }",
-			output: null,
-			errors: [
-				{
-					messageId: "unnecessarilyComputedProperty",
-					data: { property: "'x'" },
-				},
-			],
-		},
-		{
-			code: "class Foo { ['x' /* this comment also prevents a fix */]() {} }",
-			output: null,
-			errors: [
-				{
-					messageId: "unnecessarilyComputedProperty",
-					data: { property: "'x'" },
-				},
-			],
-		},
-		{
-			code: "class Foo { [('x')]() {} }",
-			output: "class Foo { 'x'() {} }",
-			errors: [
-				{
-					messageId: "unnecessarilyComputedProperty",
-					data: { property: "'x'" },
-				},
-			],
-		},
-		{
-			code: "class Foo { *['x']() {} }",
-			output: "class Foo { *'x'() {} }",
-			errors: [
-				{
-					messageId: "unnecessarilyComputedProperty",
-					data: { property: "'x'" },
-				},
-			],
-		},
-		{
-			code: "class Foo { async ['x']() {} }",
-			output: "class Foo { async 'x'() {} }",
-			languageOptions: { ecmaVersion: 8 },
-			errors: [
-				{
-					messageId: "unnecessarilyComputedProperty",
-					data: { property: "'x'" },
-				},
-			],
-		},
-		{
-			code: "class Foo { get[.2]() {} }",
-			output: "class Foo { get.2() {} }",
-			errors: [
-				{
-					messageId: "unnecessarilyComputedProperty",
-					data: { property: ".2" },
-				},
-			],
-		},
-		{
-			code: "class Foo { set[.2](value) {} }",
-			output: "class Foo { set.2(value) {} }",
-			errors: [
-				{
-					messageId: "unnecessarilyComputedProperty",
-					data: { property: ".2" },
-				},
-			],
-		},
-		{
-			code: "class Foo { async[.2]() {} }",
-			output: "class Foo { async.2() {} }",
-			languageOptions: { ecmaVersion: 8 },
-			errors: [
-				{
-					messageId: "unnecessarilyComputedProperty",
-					data: { property: ".2" },
-				},
-			],
-		},
-		{
-			code: "class Foo { [2]() {} }",
-			output: "class Foo { 2() {} }",
-			errors: [
-				{
-					messageId: "unnecessarilyComputedProperty",
-					data: { property: "2" },
-				},
-			],
-		},
-		{
-			code: "class Foo { get [2]() {} }",
-			output: "class Foo { get 2() {} }",
-			errors: [
-				{
-					messageId: "unnecessarilyComputedProperty",
-					data: { property: "2" },
-				},
-			],
-		},
-		{
-			code: "class Foo { set [2](value) {} }",
-			output: "class Foo { set 2(value) {} }",
-			errors: [
-				{
-					messageId: "unnecessarilyComputedProperty",
-					data: { property: "2" },
-				},
-			],
-		},
-		{
-			code: "class Foo { async [2]() {} }",
-			output: "class Foo { async 2() {} }",
-			languageOptions: { ecmaVersion: 8 },
-			errors: [
-				{
-					messageId: "unnecessarilyComputedProperty",
-					data: { property: "2" },
-				},
-			],
-		},
-		{
-			code: "class Foo { get[2]() {} }",
-			output: "class Foo { get 2() {} }",
-			errors: [
-				{
-					messageId: "unnecessarilyComputedProperty",
-					data: { property: "2" },
-				},
-			],
-		},
-		{
-			code: "class Foo { set[2](value) {} }",
-			output: "class Foo { set 2(value) {} }",
-			errors: [
-				{
-					messageId: "unnecessarilyComputedProperty",
-					data: { property: "2" },
-				},
-			],
-		},
-		{
-			code: "class Foo { async[2]() {} }",
-			output: "class Foo { async 2() {} }",
-			languageOptions: { ecmaVersion: 8 },
-			errors: [
-				{
-					messageId: "unnecessarilyComputedProperty",
-					data: { property: "2" },
-				},
-			],
-		},
-		{
-			code: "class Foo { get['foo']() {} }",
-			output: "class Foo { get'foo'() {} }",
-			errors: [
-				{
-					messageId: "unnecessarilyComputedProperty",
-					data: { property: "'foo'" },
-				},
-			],
-		},
-		{
-			code: "class Foo { *[2]() {} }",
-			output: "class Foo { *2() {} }",
-			errors: [
-				{
-					messageId: "unnecessarilyComputedProperty",
-					data: { property: "2" },
-				},
-			],
-		},
-		{
-			code: "class Foo { async*[2]() {} }",
-			output: "class Foo { async*2() {} }",
-			errors: [
-				{
-					messageId: "unnecessarilyComputedProperty",
-					data: { property: "2" },
-				},
-			],
-		},
-		{
-			code: "class Foo { static ['constructor']() {} }",
-			output: "class Foo { static 'constructor'() {} }",
-			errors: [
-				{
-					messageId: "unnecessarilyComputedProperty",
-					data: { property: "'constructor'" },
-				},
-			],
-		},
-		{
-			code: "class Foo { ['prototype']() {} }",
-			output: "class Foo { 'prototype'() {} }",
-			errors: [
-				{
-					messageId: "unnecessarilyComputedProperty",
-					data: { property: "'prototype'" },
-				},
-			],
-		},
-		{
-			code: "(class { ['x']() {} })",
-			output: "(class { 'x'() {} })",
-			errors: [
-				{
-					messageId: "unnecessarilyComputedProperty",
-					data: { property: "'x'" },
-				},
-			],
-		},
-		{
-			code: "(class { ['__proto__']() {} })",
-			output: "(class { '__proto__'() {} })",
-			errors: [
-				{
-					messageId: "unnecessarilyComputedProperty",
-					data: { property: "'__proto__'" },
-				},
-			],
-		},
-		{
-			code: "(class { static ['__proto__']() {} })",
-			output: "(class { static '__proto__'() {} })",
-			errors: [
-				{
-					messageId: "unnecessarilyComputedProperty",
-					data: { property: "'__proto__'" },
-				},
-			],
-		},
-		{
-			code: "(class { static ['constructor']() {} })",
-			output: "(class { static 'constructor'() {} })",
-			errors: [
-				{
-					messageId: "unnecessarilyComputedProperty",
-					data: { property: "'constructor'" },
-				},
-			],
-		},
-		{
-			code: "(class { ['prototype']() {} })",
-			output: "(class { 'prototype'() {} })",
-			errors: [
-				{
-					messageId: "unnecessarilyComputedProperty",
-					data: { property: "'prototype'" },
-				},
-			],
-		},
-		{
-			code: "class Foo { ['0'] }",
-			output: "class Foo { '0' }",
-			errors: [
-				{
-					messageId: "unnecessarilyComputedProperty",
-					data: { property: "'0'" },
-				},
-			],
-		},
-		{
-			code: "class Foo { ['0'] = 0 }",
-			output: "class Foo { '0' = 0 }",
-			errors: [
-				{
-					messageId: "unnecessarilyComputedProperty",
-					data: { property: "'0'" },
-				},
-			],
-		},
-		{
-			code: "class Foo { static[0] }",
-			output: "class Foo { static 0 }",
-			errors: [
-				{
-					messageId: "unnecessarilyComputedProperty",
-					data: { property: "0" },
-				},
-			],
-		},
-		{
-			code: "class Foo { ['#foo'] }",
-			output: "class Foo { '#foo' }",
-			errors: [
-				{
-					messageId: "unnecessarilyComputedProperty",
-					data: { property: "'#foo'" },
-				},
-			],
-		},
-		{
-			code: "(class { ['__proto__'] })",
-			output: "(class { '__proto__' })",
-			errors: [
-				{
-					messageId: "unnecessarilyComputedProperty",
-					data: { property: "'__proto__'" },
-				},
-			],
-		},
-		{
-			code: "(class { static ['__proto__'] })",
-			output: "(class { static '__proto__' })",
-			errors: [
-				{
-					messageId: "unnecessarilyComputedProperty",
-					data: { property: "'__proto__'" },
-				},
-			],
-		},
-		{
-			code: "(class { ['prototype'] })",
-			output: "(class { 'prototype' })",
-			errors: [
-				{
-					messageId: "unnecessarilyComputedProperty",
-					data: { property: "'prototype'" },
-				},
-			],
+			code: `
+({ ['0']: 0 })
+`,
+			output: `
+({ '0': 0 })
+`,
+			snapshot: `
+({ ['0']: 0 })
+   ~~~~~
+   This computed key is the literal '0', so its wrapping brackets serve no purpose.
+`,
+		},
+		{
+			code: `
+const { ['0']: first } = source;
+`,
+			output: `
+const { '0': first } = source;
+`,
+			snapshot: `
+const { ['0']: first } = source;
+        ~~~~~
+        This computed key is the literal '0', so its wrapping brackets serve no purpose.
+`,
+		},
+		{
+			code: `
+({ ['0+1,234']: 0 })
+`,
+			output: `
+({ '0+1,234': 0 })
+`,
+			snapshot: `
+({ ['0+1,234']: 0 })
+   ~~~~~~~~~~~
+   This computed key is the literal '0+1,234', so its wrapping brackets serve no purpose.
+`,
+		},
+		{
+			code: `
+({ [0]: 0 })
+`,
+			output: `
+({ 0: 0 })
+`,
+			snapshot: `
+({ [0]: 0 })
+   ~~~
+   This computed key is the literal 0, so its wrapping brackets serve no purpose.
+`,
+		},
+		{
+			code: `
+const { [0]: first } = source;
+`,
+			output: `
+const { 0: first } = source;
+`,
+			snapshot: `
+const { [0]: first } = source;
+        ~~~
+        This computed key is the literal 0, so its wrapping brackets serve no purpose.
+`,
+		},
+		{
+			code: `
+({ ['x']: 0 })
+`,
+			output: `
+({ 'x': 0 })
+`,
+			snapshot: `
+({ ['x']: 0 })
+   ~~~~~
+   This computed key is the literal 'x', so its wrapping brackets serve no purpose.
+`,
+		},
+		{
+			code: `
+const { ['x']: renamed } = source;
+`,
+			output: `
+const { 'x': renamed } = source;
+`,
+			snapshot: `
+const { ['x']: renamed } = source;
+        ~~~~~
+        This computed key is the literal 'x', so its wrapping brackets serve no purpose.
+`,
+		},
+		{
+			code: `
+const { ['__proto__']: proto } = source;
+`,
+			output: `
+const { '__proto__': proto } = source;
+`,
+			snapshot: `
+const { ['__proto__']: proto } = source;
+        ~~~~~~~~~~~~~
+        This computed key is the literal '__proto__', so its wrapping brackets serve no purpose.
+`,
+		},
+		{
+			code: `
+({ ['x']() {} })
+`,
+			output: `
+({ 'x'() {} })
+`,
+			snapshot: `
+({ ['x']() {} })
+   ~~~~~
+   This computed key is the literal 'x', so its wrapping brackets serve no purpose.
+`,
+		},
+		{
+			code: `
+({ ['x']() {} })
+`,
+			options: { enforceForClassMembers: false },
+			output: `
+({ 'x'() {} })
+`,
+			snapshot: `
+({ ['x']() {} })
+   ~~~~~
+   This computed key is the literal 'x', so its wrapping brackets serve no purpose.
+`,
+		},
+		{
+			code: `
+({ [/* this comment prevents a fix */ 'x']: 0 })
+`,
+			snapshot: `
+({ [/* this comment prevents a fix */ 'x']: 0 })
+   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   This computed key is the literal 'x', so its wrapping brackets serve no purpose.
+`,
+		},
+		{
+			code: `
+({ ['x' /* this comment also prevents a fix */]: 0 })
+`,
+			snapshot: `
+({ ['x' /* this comment also prevents a fix */]: 0 })
+   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   This computed key is the literal 'x', so its wrapping brackets serve no purpose.
+`,
+		},
+		{
+			code: `
+({ [('x')]: 0 })
+`,
+			output: `
+({ 'x': 0 })
+`,
+			snapshot: `
+({ [('x')]: 0 })
+   ~~~~~~~
+   This computed key is the literal 'x', so its wrapping brackets serve no purpose.
+`,
+		},
+		{
+			code: `
+const { [('x')]: renamed } = source;
+`,
+			output: `
+const { 'x': renamed } = source;
+`,
+			snapshot: `
+const { [('x')]: renamed } = source;
+        ~~~~~~~
+        This computed key is the literal 'x', so its wrapping brackets serve no purpose.
+`,
+		},
+		{
+			code: `
+({ *['x']() {} })
+`,
+			output: `
+({ *'x'() {} })
+`,
+			snapshot: `
+({ *['x']() {} })
+    ~~~~~
+    This computed key is the literal 'x', so its wrapping brackets serve no purpose.
+`,
+		},
+		{
+			code: `
+({ async ['x']() {} })
+`,
+			output: `
+({ async 'x'() {} })
+`,
+			snapshot: `
+({ async ['x']() {} })
+         ~~~~~
+         This computed key is the literal 'x', so its wrapping brackets serve no purpose.
+`,
+		},
+		{
+			code: `
+({ get[.2]() {} })
+`,
+			output: `
+({ get.2() {} })
+`,
+			snapshot: `
+({ get[.2]() {} })
+      ~~~~
+      This computed key is the literal .2, so its wrapping brackets serve no purpose.
+`,
+		},
+		{
+			code: `
+({ set[.2](value) {} })
+`,
+			output: `
+({ set.2(value) {} })
+`,
+			snapshot: `
+({ set[.2](value) {} })
+      ~~~~
+      This computed key is the literal .2, so its wrapping brackets serve no purpose.
+`,
+		},
+		{
+			code: `
+({ async[.2]() {} })
+`,
+			output: `
+({ async.2() {} })
+`,
+			snapshot: `
+({ async[.2]() {} })
+        ~~~~
+        This computed key is the literal .2, so its wrapping brackets serve no purpose.
+`,
+		},
+		{
+			code: `
+({ [2]() {} })
+`,
+			output: `
+({ 2() {} })
+`,
+			snapshot: `
+({ [2]() {} })
+   ~~~
+   This computed key is the literal 2, so its wrapping brackets serve no purpose.
+`,
+		},
+		{
+			code: `
+({ get [2]() {} })
+`,
+			output: `
+({ get 2() {} })
+`,
+			snapshot: `
+({ get [2]() {} })
+       ~~~
+       This computed key is the literal 2, so its wrapping brackets serve no purpose.
+`,
+		},
+		{
+			code: `
+({ set [2](value) {} })
+`,
+			output: `
+({ set 2(value) {} })
+`,
+			snapshot: `
+({ set [2](value) {} })
+       ~~~
+       This computed key is the literal 2, so its wrapping brackets serve no purpose.
+`,
+		},
+		{
+			code: `
+({ async [2]() {} })
+`,
+			output: `
+({ async 2() {} })
+`,
+			snapshot: `
+({ async [2]() {} })
+         ~~~
+         This computed key is the literal 2, so its wrapping brackets serve no purpose.
+`,
+		},
+		{
+			code: `
+({ get[2]() {} })
+`,
+			output: `
+({ get 2() {} })
+`,
+			snapshot: `
+({ get[2]() {} })
+      ~~~
+      This computed key is the literal 2, so its wrapping brackets serve no purpose.
+`,
+		},
+		{
+			code: `
+({ set[2](value) {} })
+`,
+			output: `
+({ set 2(value) {} })
+`,
+			snapshot: `
+({ set[2](value) {} })
+      ~~~
+      This computed key is the literal 2, so its wrapping brackets serve no purpose.
+`,
+		},
+		{
+			code: `
+({ async[2]() {} })
+`,
+			output: `
+({ async 2() {} })
+`,
+			snapshot: `
+({ async[2]() {} })
+        ~~~
+        This computed key is the literal 2, so its wrapping brackets serve no purpose.
+`,
+		},
+		{
+			code: `
+({ get['name']() {} })
+`,
+			output: `
+({ get'name'() {} })
+`,
+			snapshot: `
+({ get['name']() {} })
+      ~~~~~~~~
+      This computed key is the literal 'name', so its wrapping brackets serve no purpose.
+`,
+		},
+		{
+			code: `
+({ *[2]() {} })
+`,
+			output: `
+({ *2() {} })
+`,
+			snapshot: `
+({ *[2]() {} })
+    ~~~
+    This computed key is the literal 2, so its wrapping brackets serve no purpose.
+`,
+		},
+		{
+			code: `
+({ async*[2]() {} })
+`,
+			output: `
+({ async*2() {} })
+`,
+			snapshot: `
+({ async*[2]() {} })
+         ~~~
+         This computed key is the literal 2, so its wrapping brackets serve no purpose.
+`,
+		},
+		{
+			code: `
+({ ['constructor']: 1 })
+`,
+			output: `
+({ 'constructor': 1 })
+`,
+			snapshot: `
+({ ['constructor']: 1 })
+   ~~~~~~~~~~~~~~~
+   This computed key is the literal 'constructor', so its wrapping brackets serve no purpose.
+`,
+		},
+		{
+			code: `
+({ ['prototype']: 1 })
+`,
+			output: `
+({ 'prototype': 1 })
+`,
+			snapshot: `
+({ ['prototype']: 1 })
+   ~~~~~~~~~~~~~
+   This computed key is the literal 'prototype', so its wrapping brackets serve no purpose.
+`,
+		},
+		{
+			code: `
+class Example { ['0']() {} }
+`,
+			options: { enforceForClassMembers: true },
+			output: `
+class Example { '0'() {} }
+`,
+			snapshot: `
+class Example { ['0']() {} }
+                ~~~~~
+                This computed key is the literal '0', so its wrapping brackets serve no purpose.
+`,
+		},
+		{
+			code: `
+class Example { ['0+1,234']() {} }
+`,
+			options: {},
+			output: `
+class Example { '0+1,234'() {} }
+`,
+			snapshot: `
+class Example { ['0+1,234']() {} }
+                ~~~~~~~~~~~
+                This computed key is the literal '0+1,234', so its wrapping brackets serve no purpose.
+`,
+		},
+		{
+			code: `
+class Example { ['x']() {} }
+`,
+			output: `
+class Example { 'x'() {} }
+`,
+			snapshot: `
+class Example { ['x']() {} }
+                ~~~~~
+                This computed key is the literal 'x', so its wrapping brackets serve no purpose.
+`,
+		},
+		{
+			code: `
+class Example { [/* this comment prevents a fix */ 'x']() {} }
+`,
+			snapshot: `
+class Example { [/* this comment prevents a fix */ 'x']() {} }
+                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                This computed key is the literal 'x', so its wrapping brackets serve no purpose.
+`,
+		},
+		{
+			code: `
+class Example { ['x' /* this comment also prevents a fix */]() {} }
+`,
+			snapshot: `
+class Example { ['x' /* this comment also prevents a fix */]() {} }
+                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                This computed key is the literal 'x', so its wrapping brackets serve no purpose.
+`,
+		},
+		{
+			code: `
+class Example { [('x')]() {} }
+`,
+			output: `
+class Example { 'x'() {} }
+`,
+			snapshot: `
+class Example { [('x')]() {} }
+                ~~~~~~~
+                This computed key is the literal 'x', so its wrapping brackets serve no purpose.
+`,
+		},
+		{
+			code: `
+class Example { *['x']() {} }
+`,
+			output: `
+class Example { *'x'() {} }
+`,
+			snapshot: `
+class Example { *['x']() {} }
+                 ~~~~~
+                 This computed key is the literal 'x', so its wrapping brackets serve no purpose.
+`,
+		},
+		{
+			code: `
+class Example { async ['x']() {} }
+`,
+			output: `
+class Example { async 'x'() {} }
+`,
+			snapshot: `
+class Example { async ['x']() {} }
+                      ~~~~~
+                      This computed key is the literal 'x', so its wrapping brackets serve no purpose.
+`,
+		},
+		{
+			code: `
+class Example { get[.2]() {} }
+`,
+			output: `
+class Example { get.2() {} }
+`,
+			snapshot: `
+class Example { get[.2]() {} }
+                   ~~~~
+                   This computed key is the literal .2, so its wrapping brackets serve no purpose.
+`,
+		},
+		{
+			code: `
+class Example { set[.2](value) {} }
+`,
+			output: `
+class Example { set.2(value) {} }
+`,
+			snapshot: `
+class Example { set[.2](value) {} }
+                   ~~~~
+                   This computed key is the literal .2, so its wrapping brackets serve no purpose.
+`,
+		},
+		{
+			code: `
+class Example { async[.2]() {} }
+`,
+			output: `
+class Example { async.2() {} }
+`,
+			snapshot: `
+class Example { async[.2]() {} }
+                     ~~~~
+                     This computed key is the literal .2, so its wrapping brackets serve no purpose.
+`,
+		},
+		{
+			code: `
+class Example { [2]() {} }
+`,
+			output: `
+class Example { 2() {} }
+`,
+			snapshot: `
+class Example { [2]() {} }
+                ~~~
+                This computed key is the literal 2, so its wrapping brackets serve no purpose.
+`,
+		},
+		{
+			code: `
+class Example { get [2]() {} }
+`,
+			output: `
+class Example { get 2() {} }
+`,
+			snapshot: `
+class Example { get [2]() {} }
+                    ~~~
+                    This computed key is the literal 2, so its wrapping brackets serve no purpose.
+`,
+		},
+		{
+			code: `
+class Example { set [2](value) {} }
+`,
+			output: `
+class Example { set 2(value) {} }
+`,
+			snapshot: `
+class Example { set [2](value) {} }
+                    ~~~
+                    This computed key is the literal 2, so its wrapping brackets serve no purpose.
+`,
+		},
+		{
+			code: `
+class Example { async [2]() {} }
+`,
+			output: `
+class Example { async 2() {} }
+`,
+			snapshot: `
+class Example { async [2]() {} }
+                      ~~~
+                      This computed key is the literal 2, so its wrapping brackets serve no purpose.
+`,
+		},
+		{
+			code: `
+class Example { get[2]() {} }
+`,
+			output: `
+class Example { get 2() {} }
+`,
+			snapshot: `
+class Example { get[2]() {} }
+                   ~~~
+                   This computed key is the literal 2, so its wrapping brackets serve no purpose.
+`,
+		},
+		{
+			code: `
+class Example { set[2](value) {} }
+`,
+			output: `
+class Example { set 2(value) {} }
+`,
+			snapshot: `
+class Example { set[2](value) {} }
+                   ~~~
+                   This computed key is the literal 2, so its wrapping brackets serve no purpose.
+`,
+		},
+		{
+			code: `
+class Example { async[2]() {} }
+`,
+			output: `
+class Example { async 2() {} }
+`,
+			snapshot: `
+class Example { async[2]() {} }
+                     ~~~
+                     This computed key is the literal 2, so its wrapping brackets serve no purpose.
+`,
+		},
+		{
+			code: `
+class Example { get['name']() {} }
+`,
+			output: `
+class Example { get'name'() {} }
+`,
+			snapshot: `
+class Example { get['name']() {} }
+                   ~~~~~~~~
+                   This computed key is the literal 'name', so its wrapping brackets serve no purpose.
+`,
+		},
+		{
+			code: `
+class Example { *[2]() {} }
+`,
+			output: `
+class Example { *2() {} }
+`,
+			snapshot: `
+class Example { *[2]() {} }
+                 ~~~
+                 This computed key is the literal 2, so its wrapping brackets serve no purpose.
+`,
+		},
+		{
+			code: `
+class Example { async*[2]() {} }
+`,
+			output: `
+class Example { async*2() {} }
+`,
+			snapshot: `
+class Example { async*[2]() {} }
+                      ~~~
+                      This computed key is the literal 2, so its wrapping brackets serve no purpose.
+`,
+		},
+		{
+			code: `
+class Example { static ['constructor']() {} }
+`,
+			output: `
+class Example { static 'constructor'() {} }
+`,
+			snapshot: `
+class Example { static ['constructor']() {} }
+                       ~~~~~~~~~~~~~~~
+                       This computed key is the literal 'constructor', so its wrapping brackets serve no purpose.
+`,
+		},
+		{
+			code: `
+class Example { ['prototype']() {} }
+`,
+			output: `
+class Example { 'prototype'() {} }
+`,
+			snapshot: `
+class Example { ['prototype']() {} }
+                ~~~~~~~~~~~~~
+                This computed key is the literal 'prototype', so its wrapping brackets serve no purpose.
+`,
+		},
+		{
+			code: `
+(class { ['x']() {} })
+`,
+			output: `
+(class { 'x'() {} })
+`,
+			snapshot: `
+(class { ['x']() {} })
+         ~~~~~
+         This computed key is the literal 'x', so its wrapping brackets serve no purpose.
+`,
+		},
+		{
+			code: `
+(class { ['__proto__']() {} })
+`,
+			output: `
+(class { '__proto__'() {} })
+`,
+			snapshot: `
+(class { ['__proto__']() {} })
+         ~~~~~~~~~~~~~
+         This computed key is the literal '__proto__', so its wrapping brackets serve no purpose.
+`,
+		},
+		{
+			code: `
+(class { static ['__proto__']() {} })
+`,
+			output: `
+(class { static '__proto__'() {} })
+`,
+			snapshot: `
+(class { static ['__proto__']() {} })
+                ~~~~~~~~~~~~~
+                This computed key is the literal '__proto__', so its wrapping brackets serve no purpose.
+`,
+		},
+		{
+			code: `
+(class { static ['constructor']() {} })
+`,
+			output: `
+(class { static 'constructor'() {} })
+`,
+			snapshot: `
+(class { static ['constructor']() {} })
+                ~~~~~~~~~~~~~~~
+                This computed key is the literal 'constructor', so its wrapping brackets serve no purpose.
+`,
+		},
+		{
+			code: `
+(class { ['prototype']() {} })
+`,
+			output: `
+(class { 'prototype'() {} })
+`,
+			snapshot: `
+(class { ['prototype']() {} })
+         ~~~~~~~~~~~~~
+         This computed key is the literal 'prototype', so its wrapping brackets serve no purpose.
+`,
+		},
+		{
+			code: `
+class Example { ['0'] }
+`,
+			output: `
+class Example { '0' }
+`,
+			snapshot: `
+class Example { ['0'] }
+                ~~~~~
+                This computed key is the literal '0', so its wrapping brackets serve no purpose.
+`,
+		},
+		{
+			code: `
+class Example { ['0'] = 0 }
+`,
+			output: `
+class Example { '0' = 0 }
+`,
+			snapshot: `
+class Example { ['0'] = 0 }
+                ~~~~~
+                This computed key is the literal '0', so its wrapping brackets serve no purpose.
+`,
+		},
+		{
+			code: `
+class Example { static[0] }
+`,
+			output: `
+class Example { static 0 }
+`,
+			snapshot: `
+class Example { static[0] }
+                      ~~~
+                      This computed key is the literal 0, so its wrapping brackets serve no purpose.
+`,
+		},
+		{
+			code: `
+class Example { ['#hidden'] }
+`,
+			output: `
+class Example { '#hidden' }
+`,
+			snapshot: `
+class Example { ['#hidden'] }
+                ~~~~~~~~~~~
+                This computed key is the literal '#hidden', so its wrapping brackets serve no purpose.
+`,
+		},
+		{
+			code: `
+class Example { accessor ['count'] = 0 }
+`,
+			output: `
+class Example { accessor 'count' = 0 }
+`,
+			snapshot: `
+class Example { accessor ['count'] = 0 }
+                         ~~~~~~~~~
+                         This computed key is the literal 'count', so its wrapping brackets serve no purpose.
+`,
+		},
+		{
+			code: `
+(class { ['__proto__'] })
+`,
+			output: `
+(class { '__proto__' })
+`,
+			snapshot: `
+(class { ['__proto__'] })
+         ~~~~~~~~~~~~~
+         This computed key is the literal '__proto__', so its wrapping brackets serve no purpose.
+`,
+		},
+		{
+			code: `
+(class { static ['__proto__'] })
+`,
+			output: `
+(class { static '__proto__' })
+`,
+			snapshot: `
+(class { static ['__proto__'] })
+                ~~~~~~~~~~~~~
+                This computed key is the literal '__proto__', so its wrapping brackets serve no purpose.
+`,
+		},
+		{
+			code: `
+(class { ['prototype'] })
+`,
+			output: `
+(class { 'prototype' })
+`,
+			snapshot: `
+(class { ['prototype'] })
+         ~~~~~~~~~~~~~
+         This computed key is the literal 'prototype', so its wrapping brackets serve no purpose.
+`,
+		},
+	],
+	valid: [
+		`({ 'first': 0, second() {} })`,
+		`({ [key]: 0 });`,
+		`({ count: 0, [key]() {} })`,
+		`({ ['__proto__']: [] })`,
+		`({ ['__proto__']() {} })`,
+		`({ get ['__proto__']() { return 0; } })`,
+		"({ [`name`]: 0 })",
+		`({ [-1]: 0 })`,
+		`({ [99999999999999999n]: 0 })`,
+		`const { 'first': value } = source;`,
+		`const { [key]: value } = source;`,
+		`const { value } = source;`,
+		`const { count: count } = source;`,
+		`const { count: renamed } = source;`,
+		{
+			code: `class Example { method() {} }`,
+			options: { enforceForClassMembers: true },
+		},
+		{
+			code: `class Example { 'method'() {} }`,
+			options: { enforceForClassMembers: true },
+		},
+		{
+			code: `class Example { [key]() {} }`,
+			options: { enforceForClassMembers: true },
+		},
+		{
+			code: `class Example { ['constructor']() {} }`,
+			options: { enforceForClassMembers: true },
+		},
+		{
+			code: `class Example { static ['prototype']() {} }`,
+			options: { enforceForClassMembers: true },
+		},
+		{
+			code: `(class { 'method'() {} })`,
+			options: { enforceForClassMembers: true },
+		},
+		{
+			code: `(class { [key]() {} })`,
+			options: { enforceForClassMembers: true },
+		},
+		{
+			code: `(class { ['constructor']() {} })`,
+			options: { enforceForClassMembers: true },
+		},
+		{
+			code: `(class { static ['prototype']() {} })`,
+			options: { enforceForClassMembers: true },
+		},
+		`class Example { 'method'() {} }`,
+		`(class { [key]() {} })`,
+		`class Example { static constructor() {} }`,
+		`class Example { prototype() {} }`,
+		`class Example { get ['constructor']() { return 0; } }`,
+		`class Example { static get ['prototype']() { return 0; } }`,
+		`interface Shape { get ['area'](): number; }`,
+		{
+			code: `class Example { ['method']() {} }`,
+			options: { enforceForClassMembers: false },
+		},
+		{
+			code: `(class { ['method']() {} })`,
+			options: { enforceForClassMembers: false },
+		},
+		{
+			code: `class Example { static ['constructor']() {} }`,
+			options: { enforceForClassMembers: false },
+		},
+		{
+			code: `class Example { ['prototype']() {} }`,
+			options: { enforceForClassMembers: false },
+		},
+		{
+			code: `class Example { ['count'] = 0 }`,
+			options: { enforceForClassMembers: false },
+		},
+		{
+			code: `class Example { get ['value']() { return 0; } }`,
+			options: { enforceForClassMembers: false },
+		},
+		{
+			code: `class Example { count = 0 }`,
+			options: { enforceForClassMembers: true },
+		},
+		{
+			code: `class Example { ['constructor'] = 0 }`,
+			options: { enforceForClassMembers: true },
+		},
+		{
+			code: `class Example { static ['constructor'] = 0 }`,
+			options: { enforceForClassMembers: true },
+		},
+		{
+			code: `class Example { static ['prototype'] = 0 }`,
+			options: { enforceForClassMembers: true },
 		},
 	],
 });

--- a/packages/ts/src/rules/unnecessaryComputedKeys.test.ts
+++ b/packages/ts/src/rules/unnecessaryComputedKeys.test.ts
@@ -1,5 +1,5 @@
-import rule from "./unnecessaryComputedKeys.ts";
 import { ruleTester } from "./ruleTester.ts";
+import rule from "./unnecessaryComputedKeys.ts";
 
 ruleTester.describe(rule, {
 	invalid: [

--- a/packages/ts/src/rules/unnecessaryComputedKeys.ts
+++ b/packages/ts/src/rules/unnecessaryComputedKeys.ts
@@ -1,0 +1,204 @@
+/**
+ * @fileoverview Rule to disallow unnecessary computed property keys in object literals
+ * @author Burak Yigit Kaya
+ */
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+const astUtils = require("./utils/ast-utils");
+
+//------------------------------------------------------------------------------
+// Helpers
+//------------------------------------------------------------------------------
+
+/**
+ * Determines whether the computed key syntax is unnecessarily used for the given node.
+ * In particular, it determines whether removing the square brackets and using the content between them
+ * directly as the key (e.g. ['foo'] -> 'foo') would produce valid syntax and preserve the same behavior.
+ * Valid non-computed keys are only: identifiers, number literals and string literals.
+ * Only literals can preserve the same behavior, with a few exceptions for specific node types:
+ * Property
+ *   - { ["__proto__"]: foo } defines a property named "__proto__"
+ *     { "__proto__": foo } defines object's prototype
+ * PropertyDefinition
+ *   - class C { ["constructor"]; } defines an instance field named "constructor"
+ *     class C { "constructor"; } produces a parsing error
+ *   - class C { static ["constructor"]; } defines a static field named "constructor"
+ *     class C { static "constructor"; } produces a parsing error
+ *   - class C { static ["prototype"]; } produces a runtime error (doesn't break the whole script)
+ *     class C { static "prototype"; } produces a parsing error (breaks the whole script)
+ * MethodDefinition
+ *   - class C { ["constructor"]() {} } defines a prototype method named "constructor"
+ *     class C { "constructor"() {} } defines the constructor
+ *   - class C { static ["prototype"]() {} } produces a runtime error (doesn't break the whole script)
+ *     class C { static "prototype"() {} } produces a parsing error (breaks the whole script)
+ * @param {ASTNode} node The node to check. It can be `Property`, `PropertyDefinition` or `MethodDefinition`.
+ * @throws {Error} (Unreachable.)
+ * @returns {void} `true` if the node has useless computed key.
+ */
+function hasUselessComputedKey(node) {
+	if (!node.computed) {
+		return false;
+	}
+
+	const { key } = node;
+
+	if (key.type !== "Literal") {
+		return false;
+	}
+
+	const { value } = key;
+
+	if (typeof value !== "number" && typeof value !== "string") {
+		return false;
+	}
+
+	switch (node.type) {
+		case "Property":
+			if (node.parent.type === "ObjectExpression") {
+				return value !== "__proto__";
+			}
+			return true;
+
+		case "PropertyDefinition":
+			if (node.static) {
+				return value !== "constructor" && value !== "prototype";
+			}
+
+			return value !== "constructor";
+
+		case "MethodDefinition":
+			if (node.static) {
+				return value !== "prototype";
+			}
+
+			return value !== "constructor";
+
+		/* c8 ignore next */
+		default:
+			throw new Error(`Unexpected node type: ${node.type}`);
+	}
+}
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+/** @type {import('../types').Rule.RuleModule} */
+module.exports = {
+	meta: {
+		type: "suggestion",
+
+		defaultOptions: [
+			{
+				enforceForClassMembers: true,
+			},
+		],
+
+		docs: {
+			description:
+				"Disallow unnecessary computed property keys in objects and classes",
+			recommended: false,
+			frozen: true,
+			url: "https://eslint.org/docs/latest/rules/no-useless-computed-key",
+		},
+
+		schema: [
+			{
+				type: "object",
+				properties: {
+					enforceForClassMembers: {
+						type: "boolean",
+					},
+				},
+				additionalProperties: false,
+			},
+		],
+		fixable: "code",
+
+		messages: {
+			unnecessarilyComputedProperty:
+				"Unnecessarily computed property [{{property}}] found.",
+		},
+	},
+	create(context) {
+		const sourceCode = context.sourceCode;
+		const [{ enforceForClassMembers }] = context.options;
+
+		/**
+		 * Reports a given node if it violated this rule.
+		 * @param {ASTNode} node The node to check.
+		 * @returns {void}
+		 */
+		function check(node) {
+			if (hasUselessComputedKey(node)) {
+				const { key } = node;
+
+				context.report({
+					node,
+					messageId: "unnecessarilyComputedProperty",
+					data: { property: sourceCode.getText(key) },
+					fix(fixer) {
+						const leftSquareBracket = sourceCode.getTokenBefore(
+							key,
+							astUtils.isOpeningBracketToken,
+						);
+						const rightSquareBracket = sourceCode.getTokenAfter(
+							key,
+							astUtils.isClosingBracketToken,
+						);
+
+						// If there are comments between the brackets and the property name, don't do a fix.
+						if (
+							sourceCode.commentsExistBetween(
+								leftSquareBracket,
+								rightSquareBracket,
+							)
+						) {
+							return null;
+						}
+
+						const tokenBeforeLeftBracket =
+							sourceCode.getTokenBefore(leftSquareBracket);
+
+						// Insert a space before the key to avoid changing identifiers, e.g. ({ get[2]() {} }) to ({ get2() {} })
+						const needsSpaceBeforeKey =
+							tokenBeforeLeftBracket.range[1] ===
+								leftSquareBracket.range[0] &&
+							!astUtils.canTokensBeAdjacent(
+								tokenBeforeLeftBracket,
+								sourceCode.getFirstToken(key),
+							);
+
+						const replacementKey =
+							(needsSpaceBeforeKey ? " " : "") + key.raw;
+
+						return fixer.replaceTextRange(
+							[
+								leftSquareBracket.range[0],
+								rightSquareBracket.range[1],
+							],
+							replacementKey,
+						);
+					},
+				});
+			}
+		}
+
+		/**
+		 * A no-op function to act as placeholder for checking a node when the `enforceForClassMembers` option is `false`.
+		 * @returns {void}
+		 * @private
+		 */
+		function noop() {}
+
+		return {
+			Property: check,
+			MethodDefinition: enforceForClassMembers ? check : noop,
+			PropertyDefinition: enforceForClassMembers ? check : noop,
+		};
+	},
+};

--- a/packages/ts/src/rules/unnecessaryComputedKeys.ts
+++ b/packages/ts/src/rules/unnecessaryComputedKeys.ts
@@ -1,204 +1,211 @@
-/**
- * @fileoverview Rule to disallow unnecessary computed property keys in object literals
- * @author Burak Yigit Kaya
- */
-"use strict";
+import ts from "typescript";
+import { z } from "zod/v4";
 
-//------------------------------------------------------------------------------
-// Requirements
-//------------------------------------------------------------------------------
+import type { CharacterReportRange } from "@flint.fyi/core";
+import {
+	getTSNodeRange,
+	typescriptLanguage,
+	unwrapParenthesizedNode,
+	type AST,
+} from "@flint.fyi/typescript-language";
 
-const astUtils = require("./utils/ast-utils");
+import { ruleCreator } from "./ruleCreator.ts";
+import { countCommentsInRange } from "./utils/countCommentsInRange.ts";
 
-//------------------------------------------------------------------------------
-// Helpers
-//------------------------------------------------------------------------------
-
-/**
- * Determines whether the computed key syntax is unnecessarily used for the given node.
- * In particular, it determines whether removing the square brackets and using the content between them
- * directly as the key (e.g. ['foo'] -> 'foo') would produce valid syntax and preserve the same behavior.
- * Valid non-computed keys are only: identifiers, number literals and string literals.
- * Only literals can preserve the same behavior, with a few exceptions for specific node types:
- * Property
- *   - { ["__proto__"]: foo } defines a property named "__proto__"
- *     { "__proto__": foo } defines object's prototype
- * PropertyDefinition
- *   - class C { ["constructor"]; } defines an instance field named "constructor"
- *     class C { "constructor"; } produces a parsing error
- *   - class C { static ["constructor"]; } defines a static field named "constructor"
- *     class C { static "constructor"; } produces a parsing error
- *   - class C { static ["prototype"]; } produces a runtime error (doesn't break the whole script)
- *     class C { static "prototype"; } produces a parsing error (breaks the whole script)
- * MethodDefinition
- *   - class C { ["constructor"]() {} } defines a prototype method named "constructor"
- *     class C { "constructor"() {} } defines the constructor
- *   - class C { static ["prototype"]() {} } produces a runtime error (doesn't break the whole script)
- *     class C { static "prototype"() {} } produces a parsing error (breaks the whole script)
- * @param {ASTNode} node The node to check. It can be `Property`, `PropertyDefinition` or `MethodDefinition`.
- * @throws {Error} (Unreachable.)
- * @returns {void} `true` if the node has useless computed key.
- */
-function hasUselessComputedKey(node) {
-	if (!node.computed) {
-		return false;
-	}
-
-	const { key } = node;
-
-	if (key.type !== "Literal") {
-		return false;
-	}
-
-	const { value } = key;
-
-	if (typeof value !== "number" && typeof value !== "string") {
-		return false;
-	}
-
-	switch (node.type) {
-		case "Property":
-			if (node.parent.type === "ObjectExpression") {
-				return value !== "__proto__";
-			}
-			return true;
-
-		case "PropertyDefinition":
-			if (node.static) {
-				return value !== "constructor" && value !== "prototype";
-			}
-
-			return value !== "constructor";
-
-		case "MethodDefinition":
-			if (node.static) {
-				return value !== "prototype";
-			}
-
-			return value !== "constructor";
-
-		/* c8 ignore next */
-		default:
-			throw new Error(`Unexpected node type: ${node.type}`);
-	}
+interface RuleOptions {
+	enforceForClassMembers: boolean;
 }
 
-//------------------------------------------------------------------------------
-// Rule Definition
-//------------------------------------------------------------------------------
+/**
+ * Keys that must stay computed in a given construct, because removing the
+ * brackets there would change behavior or produce a syntax error:
+ * - `{ ["__proto__"]: value }` defines a property named `"__proto__"`, while
+ *   `{ "__proto__": value }` sets the object's prototype.
+ * - `class C { ["constructor"]() {} }` defines a method named `"constructor"`,
+ *   while `class C { "constructor"() {} }` declares the class constructor.
+ * - `class C { ["constructor"]; }` and `class C { static ["constructor"]; }`
+ *   define fields named `"constructor"`, while their bracket-less forms are
+ *   syntax errors.
+ * - `class C { static ["prototype"]() {} }` and `static ["prototype"];` are
+ *   runtime errors, while their bracket-less forms are syntax errors.
+ */
+const exemptKeys = {
+	classMember: ["constructor"],
+	objectLiteralMember: ["__proto__"],
+	staticClassField: ["constructor", "prototype"],
+	staticClassMethod: ["prototype"],
+};
 
-/** @type {import('../types').Rule.RuleModule} */
-module.exports = {
-	meta: {
-		type: "suggestion",
+function createFix(
+	range: CharacterReportRange,
+	key: string,
+	sourceFile: AST.SourceFile,
+) {
+	// Comments between the brackets would have nowhere to go once the
+	// brackets are removed, so only report in that case.
+	if (countCommentsInRange(sourceFile.text, range) > 0) {
+		return undefined;
+	}
 
-		defaultOptions: [
-			{
-				enforceForClassMembers: true,
-			},
-		],
+	// Without a space, removing the brackets could merge the key into the
+	// preceding token: `({ get[2]() {} })` must become `({ get 2() {} })`.
+	const needsLeadingSpace =
+		isIdentifierLikeCharacter(sourceFile.text[range.begin - 1]) &&
+		isIdentifierLikeCharacter(key[0]);
 
-		docs: {
-			description:
-				"Disallow unnecessary computed property keys in objects and classes",
-			recommended: false,
-			frozen: true,
-			url: "https://eslint.org/docs/latest/rules/no-useless-computed-key",
-		},
+	return {
+		range,
+		text: needsLeadingSpace ? ` ${key}` : key,
+	};
+}
 
-		schema: [
-			{
-				type: "object",
-				properties: {
-					enforceForClassMembers: {
-						type: "boolean",
-					},
-				},
-				additionalProperties: false,
-			},
-		],
-		fixable: "code",
+function getLiteralKey(name: AST.ComputedPropertyName) {
+	const expression = unwrapParenthesizedNode(name.expression);
 
-		messages: {
-			unnecessarilyComputedProperty:
-				"Unnecessarily computed property [{{property}}] found.",
+	return expression.kind === ts.SyntaxKind.StringLiteral ||
+		expression.kind === ts.SyntaxKind.NumericLiteral
+		? expression
+		: undefined;
+}
+
+function isIdentifierLikeCharacter(character: string | undefined) {
+	return character !== undefined && /[\w$]/u.test(character);
+}
+
+function isStaticMember(
+	member:
+		| AST.GetAccessorDeclaration
+		| AST.MethodDeclaration
+		| AST.PropertyDeclaration
+		| AST.SetAccessorDeclaration,
+) {
+	return (
+		member.modifiers?.some(
+			(modifier) => modifier.kind === ts.SyntaxKind.StaticKeyword,
+		) ?? false
+	);
+}
+
+export default ruleCreator.createRule(typescriptLanguage, {
+	about: {
+		description:
+			"Reports computed property keys that unnecessarily wrap literal strings or numbers.",
+		id: "unnecessaryComputedKeys",
+		presets: ["stylistic", "stylisticStrict"],
+	},
+	messages: {
+		unnecessaryComputedKey: {
+			primary:
+				"This computed key is the literal {{ key }}, so its wrapping brackets serve no purpose.",
+			secondary: [
+				"Computed property keys (`[...]`) allow property names to be derived from dynamic expressions at runtime.",
+				"When the expression is a plain string or number literal, the resulting name is fixed ahead of time, so the computed syntax only adds visual noise.",
+			],
+			suggestions: [
+				'Write the literal directly as the key, such as `{ "name": value }` instead of `{ ["name"]: value }`.',
+			],
 		},
 	},
-	create(context) {
-		const sourceCode = context.sourceCode;
-		const [{ enforceForClassMembers }] = context.options;
+	options: {
+		enforceForClassMembers: z
+			.boolean()
+			.default(true)
+			.describe(
+				"Whether to also check the keys of class fields, methods, and accessors.",
+			),
+	},
+	setup(context) {
+		function checkComputedName(
+			name: AST.PropertyName,
+			exemptions: readonly string[],
+			sourceFile: AST.SourceFile,
+		) {
+			if (name.kind !== ts.SyntaxKind.ComputedPropertyName) {
+				return;
+			}
 
-		/**
-		 * Reports a given node if it violated this rule.
-		 * @param {ASTNode} node The node to check.
-		 * @returns {void}
-		 */
-		function check(node) {
-			if (hasUselessComputedKey(node)) {
-				const { key } = node;
+			const literal = getLiteralKey(name);
+			if (
+				!literal ||
+				(literal.kind === ts.SyntaxKind.StringLiteral &&
+					exemptions.includes(literal.text))
+			) {
+				return;
+			}
 
-				context.report({
-					node,
-					messageId: "unnecessarilyComputedProperty",
-					data: { property: sourceCode.getText(key) },
-					fix(fixer) {
-						const leftSquareBracket = sourceCode.getTokenBefore(
-							key,
-							astUtils.isOpeningBracketToken,
-						);
-						const rightSquareBracket = sourceCode.getTokenAfter(
-							key,
-							astUtils.isClosingBracketToken,
-						);
+			const key = literal.getText(sourceFile);
+			const range = getTSNodeRange(name, sourceFile);
 
-						// If there are comments between the brackets and the property name, don't do a fix.
-						if (
-							sourceCode.commentsExistBetween(
-								leftSquareBracket,
-								rightSquareBracket,
-							)
-						) {
-							return null;
-						}
+			context.report({
+				data: { key },
+				fix: createFix(range, key, sourceFile),
+				message: "unnecessaryComputedKey",
+				range,
+			});
+		}
 
-						const tokenBeforeLeftBracket =
-							sourceCode.getTokenBefore(leftSquareBracket);
-
-						// Insert a space before the key to avoid changing identifiers, e.g. ({ get[2]() {} }) to ({ get2() {} })
-						const needsSpaceBeforeKey =
-							tokenBeforeLeftBracket.range[1] ===
-								leftSquareBracket.range[0] &&
-							!astUtils.canTokensBeAdjacent(
-								tokenBeforeLeftBracket,
-								sourceCode.getFirstToken(key),
-							);
-
-						const replacementKey =
-							(needsSpaceBeforeKey ? " " : "") + key.raw;
-
-						return fixer.replaceTextRange(
-							[
-								leftSquareBracket.range[0],
-								rightSquareBracket.range[1],
-							],
-							replacementKey,
-						);
-					},
-				});
+		function checkObjectOrClassMember(
+			node:
+				| AST.GetAccessorDeclaration
+				| AST.MethodDeclaration
+				| AST.SetAccessorDeclaration,
+			{
+				options,
+				sourceFile,
+			}: { options: RuleOptions; sourceFile: AST.SourceFile },
+		) {
+			if (node.parent.kind === ts.SyntaxKind.ObjectLiteralExpression) {
+				checkComputedName(
+					node.name,
+					exemptKeys.objectLiteralMember,
+					sourceFile,
+				);
+			} else if (
+				options.enforceForClassMembers &&
+				(node.parent.kind === ts.SyntaxKind.ClassDeclaration ||
+					node.parent.kind === ts.SyntaxKind.ClassExpression)
+			) {
+				checkComputedName(
+					node.name,
+					isStaticMember(node)
+						? exemptKeys.staticClassMethod
+						: exemptKeys.classMember,
+					sourceFile,
+				);
 			}
 		}
 
-		/**
-		 * A no-op function to act as placeholder for checking a node when the `enforceForClassMembers` option is `false`.
-		 * @returns {void}
-		 * @private
-		 */
-		function noop() {}
-
 		return {
-			Property: check,
-			MethodDefinition: enforceForClassMembers ? check : noop,
-			PropertyDefinition: enforceForClassMembers ? check : noop,
+			visitors: {
+				BindingElement: (node, { sourceFile }) => {
+					// Destructuring reads a property rather than defining one, so
+					// even keys like "__proto__" are safe to write without brackets.
+					if (node.propertyName) {
+						checkComputedName(node.propertyName, [], sourceFile);
+					}
+				},
+				GetAccessor: checkObjectOrClassMember,
+				MethodDeclaration: checkObjectOrClassMember,
+				PropertyAssignment: (node, { sourceFile }) => {
+					checkComputedName(
+						node.name,
+						exemptKeys.objectLiteralMember,
+						sourceFile,
+					);
+				},
+				PropertyDeclaration: (node, { options, sourceFile }) => {
+					if (options.enforceForClassMembers) {
+						checkComputedName(
+							node.name,
+							isStaticMember(node)
+								? exemptKeys.staticClassField
+								: exemptKeys.classMember,
+							sourceFile,
+						);
+					}
+				},
+				SetAccessor: checkObjectOrClassMember,
+			},
 		};
 	},
-};
+});


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #2223
- [x] That issue was marked as [`status: accepting prs`](https://github.com/flint-fyi/flint/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/flint-fyi/flint/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

> **Draft port** — opening for maintainer review, not asserting merge-readiness.

Implements `ts/unnecessaryComputedKeys`, the flint equivalent of ESLint core's [`no-useless-computed-key`](https://eslint.org/docs/latest/rules/no-useless-computed-key).
Reports computed property keys whose expression is a plain string or number literal — `{ ["name"]: value }` — with a fix that unwraps the brackets, preserving the semantic exemptions where brackets are load-bearing (`__proto__` in object literals, `constructor`/`prototype` in class members).

### Provenance (staged commits)

Ported from [eslint/eslint@8ae1b5b8](https://github.com/eslint/eslint/blob/8ae1b5b856dc031cd6c701d89a4df7da4772cd56/lib/rules/no-useless-computed-key.js) (204 LOC):

1. verbatim upstream copy → 2. flint scaffolding match → 3. implementation.
Diff commits 1→3 to see exactly what the port changed.

### Behavior vs upstream

- **`accessor` class fields are covered** (`class C { accessor ["field"] = 0 }`): ESTree's `AccessorProperty` escapes upstream's three visitor keys; in the TS AST these are `PropertyDeclaration`s and get the same exemptions and option gating. Strict superset.
- **TS type positions are never reported** (e.g. `interface Shape { get ["area"](): number }`): the class branch requires `ClassDeclaration`/`ClassExpression` parents, keeping the rule scoped to runtime constructs upstream can see.
- **Destructuring-assignment `__proto__` is exempted** (`({ ["__proto__"]: target } = source)` is not reported): TS parses assignment patterns as object literals, so the object-literal exemption applies; upstream reports this one. Ordinary destructuring (`const { ["__proto__"]: p } = source;`) reports identically to upstream. Exotic false negative; flagged rather than special-cased.
- **Token-adjacency check simplified**: upstream's `canTokensBeAdjacent` becomes "both neighboring characters are identifier-like" for the fix's space insertion. Verified to reproduce upstream's `output` for every ported fixture (`get[2]` → `get 2`, `get[.2]` → `get.2`, `async*[2]` → `async*2`, …).

Everything else is behavior parity: string/numeric literals only (templates, bigints, negative numbers, identifiers stay computed), parenthesized literals unwrapped, comments between brackets report without a fix, and the full `__proto__`/`constructor`/`prototype` exemption matrix (documented in a comment block preserved from upstream).

### Open question

The `enforceForClassMembers` option (boolean, default `true`) is ported as-is for parity. If flint would rather have zero-config behavior here (always check class members), dropping it is a small follow-up — happy to do either.

### Files

- `packages/ts/src/rules/unnecessaryComputedKeys.ts` — the rule (reuses existing `countCommentsInRange` + `unwrapParenthesizedNode` utilities)
- `packages/ts/src/rules/unnecessaryComputedKeys.test.ts` — 67 invalid cases (snapshot + fixed output each) + 40 valid cases
- `packages/site/src/content/docs/rules/ts/unnecessaryComputedKeys.mdx` — full rule doc
- `packages/ts/src/plugin.ts` — rule registered alphabetically
- `packages/comparisons/src/data.json` — existing entry marked `"status": "implemented"`
- `.changeset/unnecessary-computed-keys.md` — patch changeset

A courtesy note: rule naming for the `unnecessary*` family is under discussion in #2802 — happy to rename if that lands on a different convention.

### Local gates

`eslint --max-warnings 0` · `tsc -b packages/ts` · `vitest` (rule test, 107 passing) · `vitest` (comparisons) · `prettier --check` — all pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
