### PR TITLE
test: run e2e tests in-process instead of spawning the cli

### DIFF
--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -23,6 +23,7 @@
 		"test": "vitest --project e2e"
 	},
 	"devDependencies": {
+		"@flint.fyi/cli": "workspace:^",
 		"@flint.fyi/spelling": "workspace:^",
 		"@flint.fyi/ts": "workspace:^",
 		"@flint.fyi/utils": "workspace:^",

--- a/packages/e2e/tests/utils.ts
+++ b/packages/e2e/tests/utils.ts
@@ -1,5 +1,6 @@
-import { execa } from "execa";
+import util from "node:util";
 
+import { runCli } from "@flint.fyi/cli";
 import { normalizePath } from "@flint.fyi/utils";
 
 declare global {
@@ -35,12 +36,30 @@ export function normalizeOutput(stdout: string, cwd: string): string {
 }
 
 /**
- * Runs the flint CLI with color output enabled.
+ * Runs the flint CLI in-process, capturing its stdout.
+ * Color output comes from the e2e Vitest project's FORCE_COLOR env.
  */
-export function runFlint(cwd: string, args: string[] = []) {
-	return execa({
-		cwd,
-		env: { FORCE_COLOR: "1" },
-		reject: false,
-	})`flint ${args}`;
+export async function runFlint(cwd: string, args: string[] = []) {
+	const previousCwd = process.cwd();
+	const originalWrite = process.stdout.write.bind(process.stdout);
+	const originalLog = console.log;
+	const chunks: string[] = [];
+
+	process.chdir(cwd);
+	process.stdout.write = (chunk) => {
+		chunks.push(String(chunk));
+		return true;
+	};
+	console.log = (...args: unknown[]) => {
+		chunks.push(`${util.format(...args)}\n`);
+	};
+
+	try {
+		const exitCode = await runCli(args);
+		return { exitCode, stdout: chunks.join("") };
+	} finally {
+		process.stdout.write = originalWrite;
+		console.log = originalLog;
+		process.chdir(previousCwd);
+	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -696,6 +696,9 @@ importers:
 
   packages/e2e:
     devDependencies:
+      '@flint.fyi/cli':
+        specifier: workspace:^
+        version: link:../cli
       '@flint.fyi/spelling':
         specifier: workspace:^
         version: link:../spelling

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,6 +1,5 @@
 import { readdirSync } from "node:fs";
 import path from "node:path";
-import { platform } from "node:process";
 
 import { defineConfig } from "vitest/config";
 
@@ -13,6 +12,7 @@ export default defineConfig({
 			(name) => ({
 				test: {
 					clearMocks: true,
+					env: name === "e2e" ? { FORCE_COLOR: "1" } : {},
 					include: ["**/src/**/*.test.ts", "**/tests/**/*.test.ts"],
 					name,
 					root: path.join(import.meta.dirname, "packages", name),
@@ -21,8 +21,7 @@ export default defineConfig({
 						"@flint.fyi/ts-patch/install-patch-hooks",
 					],
 					snapshotSerializers: name === "e2e" ? ["vitest-ansi-serializer"] : [],
-					testTimeout:
-						name === "e2e" ? (platform === "win32" ? 60_000 : 20_000) : 10_000,
+					testTimeout: 10_000,
 				},
 			}),
 		),


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to flint! ❤️‍🔥
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #2729
- [x] That issue was marked as [`status: accepting prs`](https://github.com/flint-fyi/flint/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/flint-fyi/flint/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

<table>
<tr>
 <td>
 Before
 <td>
 After
<tr>
 <td>
<img width="1580" height="922" alt="CleanShot 2026-06-11 at 10 44 35@2x" src="https://github.com/user-attachments/assets/2d99767a-d4cc-4432-86a5-85768096a3b8" />

 <td>
</table>