### PR TITLE
feat(ts): implement unnecessaryTypeConstraints rule

### DIFF
--- a/.changeset/unnecessary-type-constraints.md
+++ b/.changeset/unnecessary-type-constraints.md
@@ -1,0 +1,5 @@
+---
+"@flint.fyi/ts": patch
+---
+
+Implement the `unnecessaryTypeConstraints` rule.

--- a/packages/comparisons/src/data.json
+++ b/packages/comparisons/src/data.json
@@ -21052,7 +21052,8 @@
 		"flint": {
 			"name": "unnecessaryTypeConstraints",
 			"plugin": "ts",
-			"preset": "logical"
+			"preset": "logical",
+			"status": "implemented"
 		},
 		"oxlint": [
 			{

--- a/packages/site/src/content/docs/rules/ts/unnecessaryTypeConstraints.mdx
+++ b/packages/site/src/content/docs/rules/ts/unnecessaryTypeConstraints.mdx
@@ -1,0 +1,61 @@
+---
+description: 'Disallow unnecessary constraints on generic types.'
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+> 🛑 This file is source code, not the primary documentation location! 🛑
+>
+> See **https://typescript-eslint.io/rules/no-unnecessary-type-constraint** for documentation.
+
+Generic type parameters (`<T>`) in TypeScript may be "constrained" with an [`extends` keyword](https://www.typescriptlang.org/docs/handbook/generics.html#generic-constraints).
+When no `extends` is provided, type parameters default a constraint to `unknown`.
+It is therefore redundant to `extend` from `any` or `unknown`.
+
+## Examples
+
+<Tabs>
+<TabItem value="❌ Incorrect">
+
+```ts
+interface FooAny<T extends any> {}
+
+interface FooUnknown<T extends unknown> {}
+
+type BarAny<T extends any> = {};
+
+type BarUnknown<T extends unknown> = {};
+
+class BazAny<T extends any> {
+  quxAny<U extends any>() {}
+}
+
+const QuuxAny = <T extends any>() => {};
+
+function QuuzAny<T extends any>() {}
+```
+
+</TabItem>
+<TabItem value="✅ Correct">
+
+```ts
+interface Foo<T> {}
+
+type Bar<T> = {};
+
+class Baz<T> {
+  qux<U>() {}
+}
+
+const Quux = <T>() => {};
+
+function Quuz<T>() {}
+```
+
+</TabItem>
+</Tabs>
+
+## When Not To Use It
+
+If you don't care about the specific styles of your type constraints, or never use them in the first place, then you will not need this rule.

--- a/packages/site/src/content/docs/rules/ts/unnecessaryTypeConstraints.mdx
+++ b/packages/site/src/content/docs/rules/ts/unnecessaryTypeConstraints.mdx
@@ -1,61 +1,75 @@
 ---
-description: 'Disallow unnecessary constraints on generic types.'
+description: "Remove `extends any` and `extends unknown` constraints that don't change a generic type parameter."
+title: "unnecessaryTypeConstraints"
+topic: "rules"
 ---
 
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
+import { TabItem, Tabs } from "@astrojs/starlight/components";
+import { RuleEquivalents } from "~/components/RuleEquivalents";
+import RuleSummary from "~/components/RuleSummary.astro";
 
-> 🛑 This file is source code, not the primary documentation location! 🛑
->
-> See **https://typescript-eslint.io/rules/no-unnecessary-type-constraint** for documentation.
+<RuleSummary plugin="ts" rule="unnecessaryTypeConstraints" />
 
-Generic type parameters (`<T>`) in TypeScript may be "constrained" with an [`extends` keyword](https://www.typescriptlang.org/docs/handbook/generics.html#generic-constraints).
+Generic type parameters (`<T>`) in TypeScript may be "constrained" with an [`extends` keyword](https://www.typescriptlang.org/docs/handbook/2/generics.html#generic-constraints).
 When no `extends` is provided, type parameters default a constraint to `unknown`.
-It is therefore redundant to `extend` from `any` or `unknown`.
+Constraining a type parameter to `any` or `unknown` therefore changes nothing: every type is already assignable to both.
+Removing the constraint leaves behavior the same and makes the type parameter easier to read.
 
 ## Examples
 
 <Tabs>
-<TabItem value="❌ Incorrect">
+<TabItem label="❌ Incorrect">
 
 ```ts
-interface FooAny<T extends any> {}
+interface ContainerAny<T extends any> {}
 
-interface FooUnknown<T extends unknown> {}
+interface ContainerUnknown<T extends unknown> {}
 
-type BarAny<T extends any> = {};
+type RecordAny<T extends any> = {};
 
-type BarUnknown<T extends unknown> = {};
+type RecordUnknown<T extends unknown> = {};
 
-class BazAny<T extends any> {
-  quxAny<U extends any>() {}
+class StoreAny<T extends any> {
+	getValue<U extends any>() {}
 }
 
-const QuuxAny = <T extends any>() => {};
+const createStore = <T extends any>() => {};
 
-function QuuzAny<T extends any>() {}
+function createValue<T extends any>() {}
 ```
 
 </TabItem>
-<TabItem value="✅ Correct">
+<TabItem label="✅ Correct">
 
 ```ts
-interface Foo<T> {}
+interface Container<T> {}
 
-type Bar<T> = {};
+type Record<T> = {};
 
-class Baz<T> {
-  qux<U>() {}
+class Store<T> {
+	getValue<U>() {}
 }
 
-const Quux = <T>() => {};
+const createStore = <T>() => {};
 
-function Quuz<T>() {}
+function createValue<T>() {}
 ```
 
 </TabItem>
 </Tabs>
 
+## Options
+
+This rule is not configurable.
+
 ## When Not To Use It
 
 If you don't care about the specific styles of your type constraints, or never use them in the first place, then you will not need this rule.
+
+## Further Reading
+
+- [TypeScript Handbook: Generic Constraints](https://www.typescriptlang.org/docs/handbook/2/generics.html#generic-constraints)
+
+## Equivalents in Other Linters
+
+<RuleEquivalents pluginId="ts" ruleId="unnecessaryTypeConstraints" />

--- a/packages/site/src/content/docs/rules/ts/unnecessaryTypeConstraints.mdx
+++ b/packages/site/src/content/docs/rules/ts/unnecessaryTypeConstraints.mdx
@@ -25,9 +25,9 @@ interface ContainerAny<T extends any> {}
 
 interface ContainerUnknown<T extends unknown> {}
 
-type RecordAny<T extends any> = {};
+type EntryAny<T extends any> = {};
 
-type RecordUnknown<T extends unknown> = {};
+type EntryUnknown<T extends unknown> = {};
 
 class StoreAny<T extends any> {
 	getValue<U extends any>() {}
@@ -44,7 +44,7 @@ function createValue<T extends any>() {}
 ```ts
 interface Container<T> {}
 
-type Record<T> = {};
+type Entry<T> = {};
 
 class Store<T> {
 	getValue<U>() {}

--- a/packages/ts/src/plugin.ts
+++ b/packages/ts/src/plugin.ts
@@ -295,6 +295,7 @@ import unnecessaryMathClamps from "./rules/unnecessaryMathClamps.ts";
 import unnecessaryNumericFractions from "./rules/unnecessaryNumericFractions.ts";
 import unnecessaryRenames from "./rules/unnecessaryRenames.ts";
 import unnecessaryTernaries from "./rules/unnecessaryTernaries.ts";
+import unnecessaryTypeConstraints from "./rules/unnecessaryTypeConstraints.ts";
 import unnecessaryUseStricts from "./rules/unnecessaryUseStricts.ts";
 import unsafeNegations from "./rules/unsafeNegations.ts";
 import variableDeletions from "./rules/variableDeletions.ts";
@@ -609,6 +610,7 @@ export const ts = createPlugin({
 		unnecessaryNumericFractions,
 		unnecessaryRenames,
 		unnecessaryTernaries,
+		unnecessaryTypeConstraints,
 		unnecessaryUseStricts,
 		unsafeNegations,
 		variableDeletions,

--- a/packages/ts/src/rules/unnecessaryTypeConstraints.test.ts
+++ b/packages/ts/src/rules/unnecessaryTypeConstraints.test.ts
@@ -1,0 +1,526 @@
+import { noFormat, RuleTester } from '@typescript-eslint/rule-tester';
+
+import rule from '../../src/rules/no-unnecessary-type-constraint';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('no-unnecessary-type-constraint', rule, {
+  valid: [
+    'function data() {}',
+    'function data<T>() {}',
+    'function data<T, U>() {}',
+    'function data<T extends number>() {}',
+    'function data<T extends number | string>() {}',
+    'function data<T extends any | number>() {}',
+    `
+type TODO = any;
+function data<T extends TODO>() {}
+    `,
+    'const data = () => {};',
+    'const data = <T,>() => {};',
+    'const data = <T, U>() => {};',
+    'const data = <T extends number>() => {};',
+    'const data = <T extends number | string>() => {};',
+  ],
+  invalid: [
+    {
+      code: 'function data<T extends any>() {}',
+      errors: [
+        {
+          column: 15,
+          data: { constraint: 'any', name: 'T' },
+          endColumn: 28,
+          line: 1,
+          messageId: 'unnecessaryConstraint',
+          suggestions: [
+            {
+              data: { constraint: 'any' },
+              messageId: 'removeUnnecessaryConstraint',
+              output: 'function data<T>() {}',
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: 'function data<T extends any, U>() {}',
+      errors: [
+        {
+          column: 15,
+          data: { constraint: 'any', name: 'T' },
+          endColumn: 28,
+          line: 1,
+          messageId: 'unnecessaryConstraint',
+          suggestions: [
+            {
+              data: { constraint: 'any' },
+              messageId: 'removeUnnecessaryConstraint',
+              output: 'function data<T, U>() {}',
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: 'function data<T, U extends any>() {}',
+      errors: [
+        {
+          column: 18,
+          data: { constraint: 'any', name: 'U' },
+          endColumn: 31,
+          line: 1,
+          messageId: 'unnecessaryConstraint',
+          suggestions: [
+            {
+              data: { constraint: 'any' },
+              messageId: 'removeUnnecessaryConstraint',
+              output: 'function data<T, U>() {}',
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: 'function data<T extends any, U extends T>() {}',
+      errors: [
+        {
+          column: 15,
+          data: { constraint: 'any', name: 'T' },
+          endColumn: 28,
+          line: 1,
+          messageId: 'unnecessaryConstraint',
+          suggestions: [
+            {
+              data: { constraint: 'any' },
+              messageId: 'removeUnnecessaryConstraint',
+              output: 'function data<T, U extends T>() {}',
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: 'const data = <T extends any>() => {};',
+      errors: [
+        {
+          column: 15,
+          data: { constraint: 'any', name: 'T' },
+          endColumn: 28,
+          line: 1,
+          messageId: 'unnecessaryConstraint',
+          suggestions: [
+            {
+              data: { constraint: 'any' },
+              messageId: 'removeUnnecessaryConstraint',
+              output: `const data = <T,>() => {};`,
+            },
+          ],
+        },
+      ],
+      languageOptions: {
+        parserOptions: {
+          ecmaFeatures: {
+            jsx: true,
+          },
+        },
+      },
+    },
+    {
+      code: 'const data = <T extends any>() => {};',
+      errors: [
+        {
+          column: 15,
+          data: { constraint: 'any', name: 'T' },
+          endColumn: 28,
+          line: 1,
+          messageId: 'unnecessaryConstraint',
+          suggestions: [
+            {
+              data: { constraint: 'any' },
+              messageId: 'removeUnnecessaryConstraint',
+              output: `const data = <T,>() => {};`,
+            },
+          ],
+        },
+      ],
+      filename: 'file.mts',
+    },
+    {
+      code: 'const data = <T extends any>() => {};',
+      errors: [
+        {
+          column: 15,
+          data: { constraint: 'any', name: 'T' },
+          endColumn: 28,
+          line: 1,
+          messageId: 'unnecessaryConstraint',
+          suggestions: [
+            {
+              data: { constraint: 'any' },
+              messageId: 'removeUnnecessaryConstraint',
+              output: `const data = <T,>() => {};`,
+            },
+          ],
+        },
+      ],
+      filename: 'file.cts',
+    },
+    {
+      code: noFormat`const data = <T extends any,>() => {};`,
+      errors: [
+        {
+          column: 15,
+          data: { constraint: 'any', name: 'T' },
+          endColumn: 28,
+          line: 1,
+          messageId: 'unnecessaryConstraint',
+          suggestions: [
+            {
+              data: { constraint: 'any' },
+              messageId: 'removeUnnecessaryConstraint',
+              output: `const data = <T,>() => {};`,
+            },
+          ],
+        },
+      ],
+      languageOptions: {
+        parserOptions: {
+          ecmaFeatures: {
+            jsx: true,
+          },
+        },
+      },
+    },
+    {
+      code: noFormat`const data = <T extends any, >() => {};`,
+      errors: [
+        {
+          column: 15,
+          data: { constraint: 'any', name: 'T' },
+          endColumn: 28,
+          line: 1,
+          messageId: 'unnecessaryConstraint',
+          suggestions: [
+            {
+              data: { constraint: 'any' },
+              messageId: 'removeUnnecessaryConstraint',
+              output: `const data = <T, >() => {};`,
+            },
+          ],
+        },
+      ],
+      languageOptions: {
+        parserOptions: {
+          ecmaFeatures: {
+            jsx: true,
+          },
+        },
+      },
+    },
+    {
+      code: noFormat`const data = <T extends any ,>() => {};`,
+      errors: [
+        {
+          column: 15,
+          data: { constraint: 'any', name: 'T' },
+          endColumn: 28,
+          line: 1,
+          messageId: 'unnecessaryConstraint',
+          suggestions: [
+            {
+              data: { constraint: 'any' },
+              messageId: 'removeUnnecessaryConstraint',
+              output: `const data = <T ,>() => {};`,
+            },
+          ],
+        },
+      ],
+      languageOptions: {
+        parserOptions: {
+          ecmaFeatures: {
+            jsx: true,
+          },
+        },
+      },
+    },
+    {
+      code: noFormat`const data = <T extends any , >() => {};`,
+      errors: [
+        {
+          column: 15,
+          data: { constraint: 'any', name: 'T' },
+          endColumn: 28,
+          line: 1,
+          messageId: 'unnecessaryConstraint',
+          suggestions: [
+            {
+              data: { constraint: 'any' },
+              messageId: 'removeUnnecessaryConstraint',
+              output: `const data = <T , >() => {};`,
+            },
+          ],
+        },
+      ],
+      languageOptions: {
+        parserOptions: {
+          ecmaFeatures: {
+            jsx: true,
+          },
+        },
+      },
+    },
+    {
+      code: 'const data = <T extends any = unknown>() => {};',
+      errors: [
+        {
+          column: 15,
+          data: { constraint: 'any', name: 'T' },
+          endColumn: 38,
+          line: 1,
+          messageId: 'unnecessaryConstraint',
+          suggestions: [
+            {
+              data: { constraint: 'any' },
+              messageId: 'removeUnnecessaryConstraint',
+              output: 'const data = <T = unknown>() => {};',
+            },
+          ],
+        },
+      ],
+      languageOptions: {
+        parserOptions: {
+          ecmaFeatures: {
+            jsx: true,
+          },
+        },
+      },
+    },
+    {
+      code: 'const data = <T extends any, U extends any>() => {};',
+      errors: [
+        {
+          column: 15,
+          data: { constraint: 'any', name: 'T' },
+          endColumn: 28,
+          line: 1,
+          messageId: 'unnecessaryConstraint',
+          suggestions: [
+            {
+              data: { constraint: 'any' },
+              messageId: 'removeUnnecessaryConstraint',
+              output: `const data = <T, U extends any>() => {};`,
+            },
+          ],
+        },
+        {
+          column: 30,
+          data: { constraint: 'any', name: 'U' },
+          endColumn: 43,
+          line: 1,
+          messageId: 'unnecessaryConstraint',
+          suggestions: [
+            {
+              data: { constraint: 'any' },
+              messageId: 'removeUnnecessaryConstraint',
+              output: `const data = <T extends any, U>() => {};`,
+            },
+          ],
+        },
+      ],
+      languageOptions: {
+        parserOptions: {
+          ecmaFeatures: {
+            jsx: true,
+          },
+        },
+      },
+    },
+    {
+      code: 'function data<T extends unknown>() {}',
+      errors: [
+        {
+          column: 15,
+          data: { constraint: 'unknown', name: 'T' },
+          endColumn: 32,
+          line: 1,
+          messageId: 'unnecessaryConstraint',
+          suggestions: [
+            {
+              data: { constraint: 'unknown' },
+              messageId: 'removeUnnecessaryConstraint',
+              output: 'function data<T>() {}',
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: 'const data = <T extends any>() => {};',
+      errors: [
+        {
+          column: 15,
+          data: { constraint: 'any', name: 'T' },
+          endColumn: 28,
+          line: 1,
+          messageId: 'unnecessaryConstraint',
+          suggestions: [
+            {
+              data: { constraint: 'any' },
+              messageId: 'removeUnnecessaryConstraint',
+              output: 'const data = <T>() => {};',
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: 'const data = <T extends unknown>() => {};',
+      errors: [
+        {
+          column: 15,
+          data: { constraint: 'unknown', name: 'T' },
+          endColumn: 32,
+          line: 1,
+          messageId: 'unnecessaryConstraint',
+          suggestions: [
+            {
+              data: { constraint: 'unknown' },
+              messageId: 'removeUnnecessaryConstraint',
+              output: 'const data = <T>() => {};',
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: 'class Data<T extends unknown> {}',
+      errors: [
+        {
+          column: 12,
+          data: { constraint: 'unknown', name: 'T' },
+          endColumn: 29,
+          line: 1,
+          messageId: 'unnecessaryConstraint',
+          suggestions: [
+            {
+              data: { constraint: 'unknown' },
+              messageId: 'removeUnnecessaryConstraint',
+              output: 'class Data<T> {}',
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: 'const Data = class<T extends unknown> {};',
+      errors: [
+        {
+          column: 20,
+          data: { constraint: 'unknown', name: 'T' },
+          endColumn: 37,
+          line: 1,
+          messageId: 'unnecessaryConstraint',
+          suggestions: [
+            {
+              data: { constraint: 'unknown' },
+              messageId: 'removeUnnecessaryConstraint',
+              output: 'const Data = class<T> {};',
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: `
+class Data {
+  member<T extends unknown>() {}
+}
+      `,
+      errors: [
+        {
+          column: 10,
+          data: { constraint: 'unknown', name: 'T' },
+          endColumn: 27,
+          line: 3,
+          messageId: 'unnecessaryConstraint',
+          suggestions: [
+            {
+              data: { constraint: 'unknown' },
+              messageId: 'removeUnnecessaryConstraint',
+              output: `
+class Data {
+  member<T>() {}
+}
+      `,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: `
+const Data = class {
+  member<T extends unknown>() {}
+};
+      `,
+      errors: [
+        {
+          column: 10,
+          data: { constraint: 'unknown', name: 'T' },
+          endColumn: 27,
+          line: 3,
+          messageId: 'unnecessaryConstraint',
+          suggestions: [
+            {
+              data: { constraint: 'unknown' },
+              messageId: 'removeUnnecessaryConstraint',
+              output: `
+const Data = class {
+  member<T>() {}
+};
+      `,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: 'interface Data<T extends unknown> {}',
+      errors: [
+        {
+          column: 16,
+          data: { constraint: 'unknown', name: 'T' },
+          endColumn: 33,
+          line: 1,
+          messageId: 'unnecessaryConstraint',
+          suggestions: [
+            {
+              data: { constraint: 'unknown' },
+              messageId: 'removeUnnecessaryConstraint',
+              output: 'interface Data<T> {}',
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: 'type Data<T extends unknown> = {};',
+      errors: [
+        {
+          column: 11,
+          data: { constraint: 'unknown', name: 'T' },
+          endColumn: 28,
+          line: 1,
+          messageId: 'unnecessaryConstraint',
+          suggestions: [
+            {
+              data: { constraint: 'unknown' },
+              messageId: 'removeUnnecessaryConstraint',
+              output: 'type Data<T> = {};',
+            },
+          ],
+        },
+      ],
+    },
+  ],
+});

--- a/packages/ts/src/rules/unnecessaryTypeConstraints.test.ts
+++ b/packages/ts/src/rules/unnecessaryTypeConstraints.test.ts
@@ -1,5 +1,5 @@
-import rule from "./unnecessaryTypeConstraints.ts";
 import { ruleTester } from "./ruleTester.ts";
+import rule from "./unnecessaryTypeConstraints.ts";
 
 ruleTester.describe(rule, {
 	invalid: [
@@ -12,6 +12,14 @@ function data<T extends any>() {}
                ~~~~~~~~~~~~
                Constraining the generic type \`T\` to \`any\` does nothing and is unnecessary.
 `,
+			suggestions: [
+				{
+					id: "removeConstraint",
+					updated: `
+function data<T>() {}
+`,
+				},
+			],
 		},
 		{
 			code: `
@@ -22,6 +30,14 @@ function data<T extends any, U>() {}
                ~~~~~~~~~~~~
                Constraining the generic type \`T\` to \`any\` does nothing and is unnecessary.
 `,
+			suggestions: [
+				{
+					id: "removeConstraint",
+					updated: `
+function data<T, U>() {}
+`,
+				},
+			],
 		},
 		{
 			code: `
@@ -32,6 +48,14 @@ function data<T, U extends any>() {}
                   ~~~~~~~~~~~~
                   Constraining the generic type \`U\` to \`any\` does nothing and is unnecessary.
 `,
+			suggestions: [
+				{
+					id: "removeConstraint",
+					updated: `
+function data<T, U>() {}
+`,
+				},
+			],
 		},
 		{
 			code: `
@@ -42,6 +66,14 @@ function data<T extends any, U extends T>() {}
                ~~~~~~~~~~~~
                Constraining the generic type \`T\` to \`any\` does nothing and is unnecessary.
 `,
+			suggestions: [
+				{
+					id: "removeConstraint",
+					updated: `
+function data<T, U extends T>() {}
+`,
+				},
+			],
 		},
 		{
 			code: `
@@ -52,21 +84,172 @@ const data = <T extends any>() => {};
                ~~~~~~~~~~~~
                Constraining the generic type \`T\` to \`any\` does nothing and is unnecessary.
 `,
+			suggestions: [
+				{
+					id: "removeConstraint",
+					updated: `
+const data = <T>() => {};
+`,
+				},
+			],
+		},
+		{
+			code: `
+const data = <T extends any>() => {};
+`,
+			fileName: "file.tsx",
+			snapshot: `
+const data = <T extends any>() => {};
+               ~~~~~~~~~~~~
+               Constraining the generic type \`T\` to \`any\` does nothing and is unnecessary.
+`,
+			suggestions: [
+				{
+					id: "removeConstraint",
+					updated: `
+const data = <T,>() => {};
+`,
+				},
+			],
+		},
+		{
+			code: `
+const data = <T extends any>() => {};
+`,
+			fileName: "file.mts",
+			snapshot: `
+const data = <T extends any>() => {};
+               ~~~~~~~~~~~~
+               Constraining the generic type \`T\` to \`any\` does nothing and is unnecessary.
+`,
+			suggestions: [
+				{
+					id: "removeConstraint",
+					updated: `
+const data = <T,>() => {};
+`,
+				},
+			],
+		},
+		{
+			code: `
+const data = <T extends any>() => {};
+`,
+			fileName: "file.cts",
+			snapshot: `
+const data = <T extends any>() => {};
+               ~~~~~~~~~~~~
+               Constraining the generic type \`T\` to \`any\` does nothing and is unnecessary.
+`,
+			suggestions: [
+				{
+					id: "removeConstraint",
+					updated: `
+const data = <T,>() => {};
+`,
+				},
+			],
+		},
+		{
+			code: `
+const data = <T extends any,>() => {};
+`,
+			fileName: "file.tsx",
+			snapshot: `
+const data = <T extends any,>() => {};
+               ~~~~~~~~~~~~
+               Constraining the generic type \`T\` to \`any\` does nothing and is unnecessary.
+`,
+			suggestions: [
+				{
+					id: "removeConstraint",
+					updated: `
+const data = <T,>() => {};
+`,
+				},
+			],
+		},
+		{
+			code: `
+const data = <T extends any, >() => {};
+`,
+			fileName: "file.tsx",
+			snapshot: `
+const data = <T extends any, >() => {};
+               ~~~~~~~~~~~~
+               Constraining the generic type \`T\` to \`any\` does nothing and is unnecessary.
+`,
+			suggestions: [
+				{
+					id: "removeConstraint",
+					updated: `
+const data = <T, >() => {};
+`,
+				},
+			],
+		},
+		{
+			code: `
+const data = <T extends any ,>() => {};
+`,
+			fileName: "file.tsx",
+			snapshot: `
+const data = <T extends any ,>() => {};
+               ~~~~~~~~~~~~
+               Constraining the generic type \`T\` to \`any\` does nothing and is unnecessary.
+`,
+			suggestions: [
+				{
+					id: "removeConstraint",
+					updated: `
+const data = <T ,>() => {};
+`,
+				},
+			],
+		},
+		{
+			code: `
+const data = <T extends any , >() => {};
+`,
+			fileName: "file.tsx",
+			snapshot: `
+const data = <T extends any , >() => {};
+               ~~~~~~~~~~~~
+               Constraining the generic type \`T\` to \`any\` does nothing and is unnecessary.
+`,
+			suggestions: [
+				{
+					id: "removeConstraint",
+					updated: `
+const data = <T , >() => {};
+`,
+				},
+			],
 		},
 		{
 			code: `
 const data = <T extends any = unknown>() => {};
 `,
+			fileName: "file.tsx",
 			snapshot: `
 const data = <T extends any = unknown>() => {};
                ~~~~~~~~~~~~
                Constraining the generic type \`T\` to \`any\` does nothing and is unnecessary.
 `,
+			suggestions: [
+				{
+					id: "removeConstraint",
+					updated: `
+const data = <T = unknown>() => {};
+`,
+				},
+			],
 		},
 		{
 			code: `
 const data = <T extends any, U extends any>() => {};
 `,
+			fileName: "file.tsx",
 			snapshot: `
 const data = <T extends any, U extends any>() => {};
                ~~~~~~~~~~~~
@@ -74,6 +257,39 @@ const data = <T extends any, U extends any>() => {};
                               ~~~~~~~~~~~~
                               Constraining the generic type \`U\` to \`any\` does nothing and is unnecessary.
 `,
+			suggestions: [
+				{
+					id: "removeConstraint",
+					updated: `
+const data = <T, U extends any>() => {};
+`,
+				},
+				{
+					id: "removeConstraint",
+					updated: `
+const data = <T extends any, U>() => {};
+`,
+				},
+			],
+		},
+		{
+			code: `
+function data<T extends any>() {}
+`,
+			fileName: "file.tsx",
+			snapshot: `
+function data<T extends any>() {}
+               ~~~~~~~~~~~~
+               Constraining the generic type \`T\` to \`any\` does nothing and is unnecessary.
+`,
+			suggestions: [
+				{
+					id: "removeConstraint",
+					updated: `
+function data<T>() {}
+`,
+				},
+			],
 		},
 		{
 			code: `
@@ -84,6 +300,14 @@ function data<T extends unknown>() {}
                ~~~~~~~~~~~~~~~~
                Constraining the generic type \`T\` to \`unknown\` does nothing and is unnecessary.
 `,
+			suggestions: [
+				{
+					id: "removeConstraint",
+					updated: `
+function data<T>() {}
+`,
+				},
+			],
 		},
 		{
 			code: `
@@ -94,6 +318,14 @@ const data = <T extends unknown>() => {};
                ~~~~~~~~~~~~~~~~
                Constraining the generic type \`T\` to \`unknown\` does nothing and is unnecessary.
 `,
+			suggestions: [
+				{
+					id: "removeConstraint",
+					updated: `
+const data = <T>() => {};
+`,
+				},
+			],
 		},
 		{
 			code: `
@@ -104,6 +336,14 @@ class Data<T extends unknown> {}
             ~~~~~~~~~~~~~~~~
             Constraining the generic type \`T\` to \`unknown\` does nothing and is unnecessary.
 `,
+			suggestions: [
+				{
+					id: "removeConstraint",
+					updated: `
+class Data<T> {}
+`,
+				},
+			],
 		},
 		{
 			code: `
@@ -114,6 +354,14 @@ const Data = class<T extends unknown> {};
                     ~~~~~~~~~~~~~~~~
                     Constraining the generic type \`T\` to \`unknown\` does nothing and is unnecessary.
 `,
+			suggestions: [
+				{
+					id: "removeConstraint",
+					updated: `
+const Data = class<T> {};
+`,
+				},
+			],
 		},
 		{
 			code: `
@@ -128,6 +376,16 @@ class Data {
             Constraining the generic type \`T\` to \`unknown\` does nothing and is unnecessary.
 }
 `,
+			suggestions: [
+				{
+					id: "removeConstraint",
+					updated: `
+class Data {
+    member<T>() {}
+}
+`,
+				},
+			],
 		},
 		{
 			code: `
@@ -142,6 +400,16 @@ const Data = class {
             Constraining the generic type \`T\` to \`unknown\` does nothing and is unnecessary.
 };
 `,
+			suggestions: [
+				{
+					id: "removeConstraint",
+					updated: `
+const Data = class {
+    member<T>() {}
+};
+`,
+				},
+			],
 		},
 		{
 			code: `
@@ -152,6 +420,14 @@ interface Data<T extends unknown> {}
                 ~~~~~~~~~~~~~~~~
                 Constraining the generic type \`T\` to \`unknown\` does nothing and is unnecessary.
 `,
+			suggestions: [
+				{
+					id: "removeConstraint",
+					updated: `
+interface Data<T> {}
+`,
+				},
+			],
 		},
 		{
 			code: `
@@ -162,6 +438,50 @@ type Data<T extends unknown> = {};
            ~~~~~~~~~~~~~~~~
            Constraining the generic type \`T\` to \`unknown\` does nothing and is unnecessary.
 `,
+			suggestions: [
+				{
+					id: "removeConstraint",
+					updated: `
+type Data<T> = {};
+`,
+				},
+			],
+		},
+		{
+			code: `
+type Mapper = <T extends any>(value: T) => T;
+`,
+			snapshot: `
+type Mapper = <T extends any>(value: T) => T;
+                ~~~~~~~~~~~~
+                Constraining the generic type \`T\` to \`any\` does nothing and is unnecessary.
+`,
+			suggestions: [
+				{
+					id: "removeConstraint",
+					updated: `
+type Mapper = <T>(value: T) => T;
+`,
+				},
+			],
+		},
+		{
+			code: `
+type Creator = new <T extends unknown>() => T;
+`,
+			snapshot: `
+type Creator = new <T extends unknown>() => T;
+                     ~~~~~~~~~~~~~~~~
+                     Constraining the generic type \`T\` to \`unknown\` does nothing and is unnecessary.
+`,
+			suggestions: [
+				{
+					id: "removeConstraint",
+					updated: `
+type Creator = new <T>() => T;
+`,
+				},
+			],
 		},
 	],
 	valid: [
@@ -180,5 +500,7 @@ function data<T extends TODO>() {}
 		"const data = <T, U>() => {};",
 		"const data = <T extends number>() => {};",
 		"const data = <T extends number | string>() => {};",
+		"type AnyKeys = { [Key in any]: number };",
+		"type Inferred<T> = T extends (infer Element extends any) ? Element : never;",
 	],
 });

--- a/packages/ts/src/rules/unnecessaryTypeConstraints.test.ts
+++ b/packages/ts/src/rules/unnecessaryTypeConstraints.test.ts
@@ -1,526 +1,184 @@
-import { noFormat, RuleTester } from '@typescript-eslint/rule-tester';
+import rule from "./unnecessaryTypeConstraints.ts";
+import { ruleTester } from "./ruleTester.ts";
 
-import rule from '../../src/rules/no-unnecessary-type-constraint';
-
-const ruleTester = new RuleTester();
-
-ruleTester.run('no-unnecessary-type-constraint', rule, {
-  valid: [
-    'function data() {}',
-    'function data<T>() {}',
-    'function data<T, U>() {}',
-    'function data<T extends number>() {}',
-    'function data<T extends number | string>() {}',
-    'function data<T extends any | number>() {}',
-    `
+ruleTester.describe(rule, {
+	invalid: [
+		{
+			code: `
+function data<T extends any>() {}
+`,
+			snapshot: `
+function data<T extends any>() {}
+               ~~~~~~~~~~~~
+               Constraining the generic type \`T\` to \`any\` does nothing and is unnecessary.
+`,
+		},
+		{
+			code: `
+function data<T extends any, U>() {}
+`,
+			snapshot: `
+function data<T extends any, U>() {}
+               ~~~~~~~~~~~~
+               Constraining the generic type \`T\` to \`any\` does nothing and is unnecessary.
+`,
+		},
+		{
+			code: `
+function data<T, U extends any>() {}
+`,
+			snapshot: `
+function data<T, U extends any>() {}
+                  ~~~~~~~~~~~~
+                  Constraining the generic type \`U\` to \`any\` does nothing and is unnecessary.
+`,
+		},
+		{
+			code: `
+function data<T extends any, U extends T>() {}
+`,
+			snapshot: `
+function data<T extends any, U extends T>() {}
+               ~~~~~~~~~~~~
+               Constraining the generic type \`T\` to \`any\` does nothing and is unnecessary.
+`,
+		},
+		{
+			code: `
+const data = <T extends any>() => {};
+`,
+			snapshot: `
+const data = <T extends any>() => {};
+               ~~~~~~~~~~~~
+               Constraining the generic type \`T\` to \`any\` does nothing and is unnecessary.
+`,
+		},
+		{
+			code: `
+const data = <T extends any = unknown>() => {};
+`,
+			snapshot: `
+const data = <T extends any = unknown>() => {};
+               ~~~~~~~~~~~~
+               Constraining the generic type \`T\` to \`any\` does nothing and is unnecessary.
+`,
+		},
+		{
+			code: `
+const data = <T extends any, U extends any>() => {};
+`,
+			snapshot: `
+const data = <T extends any, U extends any>() => {};
+               ~~~~~~~~~~~~
+               Constraining the generic type \`T\` to \`any\` does nothing and is unnecessary.
+                              ~~~~~~~~~~~~
+                              Constraining the generic type \`U\` to \`any\` does nothing and is unnecessary.
+`,
+		},
+		{
+			code: `
+function data<T extends unknown>() {}
+`,
+			snapshot: `
+function data<T extends unknown>() {}
+               ~~~~~~~~~~~~~~~~
+               Constraining the generic type \`T\` to \`unknown\` does nothing and is unnecessary.
+`,
+		},
+		{
+			code: `
+const data = <T extends unknown>() => {};
+`,
+			snapshot: `
+const data = <T extends unknown>() => {};
+               ~~~~~~~~~~~~~~~~
+               Constraining the generic type \`T\` to \`unknown\` does nothing and is unnecessary.
+`,
+		},
+		{
+			code: `
+class Data<T extends unknown> {}
+`,
+			snapshot: `
+class Data<T extends unknown> {}
+            ~~~~~~~~~~~~~~~~
+            Constraining the generic type \`T\` to \`unknown\` does nothing and is unnecessary.
+`,
+		},
+		{
+			code: `
+const Data = class<T extends unknown> {};
+`,
+			snapshot: `
+const Data = class<T extends unknown> {};
+                    ~~~~~~~~~~~~~~~~
+                    Constraining the generic type \`T\` to \`unknown\` does nothing and is unnecessary.
+`,
+		},
+		{
+			code: `
+class Data {
+    member<T extends unknown>() {}
+}
+`,
+			snapshot: `
+class Data {
+    member<T extends unknown>() {}
+            ~~~~~~~~~~~~~~~~
+            Constraining the generic type \`T\` to \`unknown\` does nothing and is unnecessary.
+}
+`,
+		},
+		{
+			code: `
+const Data = class {
+    member<T extends unknown>() {}
+};
+`,
+			snapshot: `
+const Data = class {
+    member<T extends unknown>() {}
+            ~~~~~~~~~~~~~~~~
+            Constraining the generic type \`T\` to \`unknown\` does nothing and is unnecessary.
+};
+`,
+		},
+		{
+			code: `
+interface Data<T extends unknown> {}
+`,
+			snapshot: `
+interface Data<T extends unknown> {}
+                ~~~~~~~~~~~~~~~~
+                Constraining the generic type \`T\` to \`unknown\` does nothing and is unnecessary.
+`,
+		},
+		{
+			code: `
+type Data<T extends unknown> = {};
+`,
+			snapshot: `
+type Data<T extends unknown> = {};
+           ~~~~~~~~~~~~~~~~
+           Constraining the generic type \`T\` to \`unknown\` does nothing and is unnecessary.
+`,
+		},
+	],
+	valid: [
+		"function data() {}",
+		"function data<T>() {}",
+		"function data<T, U>() {}",
+		"function data<T extends number>() {}",
+		"function data<T extends number | string>() {}",
+		"function data<T extends any | number>() {}",
+		`
 type TODO = any;
 function data<T extends TODO>() {}
-    `,
-    'const data = () => {};',
-    'const data = <T,>() => {};',
-    'const data = <T, U>() => {};',
-    'const data = <T extends number>() => {};',
-    'const data = <T extends number | string>() => {};',
-  ],
-  invalid: [
-    {
-      code: 'function data<T extends any>() {}',
-      errors: [
-        {
-          column: 15,
-          data: { constraint: 'any', name: 'T' },
-          endColumn: 28,
-          line: 1,
-          messageId: 'unnecessaryConstraint',
-          suggestions: [
-            {
-              data: { constraint: 'any' },
-              messageId: 'removeUnnecessaryConstraint',
-              output: 'function data<T>() {}',
-            },
-          ],
-        },
-      ],
-    },
-    {
-      code: 'function data<T extends any, U>() {}',
-      errors: [
-        {
-          column: 15,
-          data: { constraint: 'any', name: 'T' },
-          endColumn: 28,
-          line: 1,
-          messageId: 'unnecessaryConstraint',
-          suggestions: [
-            {
-              data: { constraint: 'any' },
-              messageId: 'removeUnnecessaryConstraint',
-              output: 'function data<T, U>() {}',
-            },
-          ],
-        },
-      ],
-    },
-    {
-      code: 'function data<T, U extends any>() {}',
-      errors: [
-        {
-          column: 18,
-          data: { constraint: 'any', name: 'U' },
-          endColumn: 31,
-          line: 1,
-          messageId: 'unnecessaryConstraint',
-          suggestions: [
-            {
-              data: { constraint: 'any' },
-              messageId: 'removeUnnecessaryConstraint',
-              output: 'function data<T, U>() {}',
-            },
-          ],
-        },
-      ],
-    },
-    {
-      code: 'function data<T extends any, U extends T>() {}',
-      errors: [
-        {
-          column: 15,
-          data: { constraint: 'any', name: 'T' },
-          endColumn: 28,
-          line: 1,
-          messageId: 'unnecessaryConstraint',
-          suggestions: [
-            {
-              data: { constraint: 'any' },
-              messageId: 'removeUnnecessaryConstraint',
-              output: 'function data<T, U extends T>() {}',
-            },
-          ],
-        },
-      ],
-    },
-    {
-      code: 'const data = <T extends any>() => {};',
-      errors: [
-        {
-          column: 15,
-          data: { constraint: 'any', name: 'T' },
-          endColumn: 28,
-          line: 1,
-          messageId: 'unnecessaryConstraint',
-          suggestions: [
-            {
-              data: { constraint: 'any' },
-              messageId: 'removeUnnecessaryConstraint',
-              output: `const data = <T,>() => {};`,
-            },
-          ],
-        },
-      ],
-      languageOptions: {
-        parserOptions: {
-          ecmaFeatures: {
-            jsx: true,
-          },
-        },
-      },
-    },
-    {
-      code: 'const data = <T extends any>() => {};',
-      errors: [
-        {
-          column: 15,
-          data: { constraint: 'any', name: 'T' },
-          endColumn: 28,
-          line: 1,
-          messageId: 'unnecessaryConstraint',
-          suggestions: [
-            {
-              data: { constraint: 'any' },
-              messageId: 'removeUnnecessaryConstraint',
-              output: `const data = <T,>() => {};`,
-            },
-          ],
-        },
-      ],
-      filename: 'file.mts',
-    },
-    {
-      code: 'const data = <T extends any>() => {};',
-      errors: [
-        {
-          column: 15,
-          data: { constraint: 'any', name: 'T' },
-          endColumn: 28,
-          line: 1,
-          messageId: 'unnecessaryConstraint',
-          suggestions: [
-            {
-              data: { constraint: 'any' },
-              messageId: 'removeUnnecessaryConstraint',
-              output: `const data = <T,>() => {};`,
-            },
-          ],
-        },
-      ],
-      filename: 'file.cts',
-    },
-    {
-      code: noFormat`const data = <T extends any,>() => {};`,
-      errors: [
-        {
-          column: 15,
-          data: { constraint: 'any', name: 'T' },
-          endColumn: 28,
-          line: 1,
-          messageId: 'unnecessaryConstraint',
-          suggestions: [
-            {
-              data: { constraint: 'any' },
-              messageId: 'removeUnnecessaryConstraint',
-              output: `const data = <T,>() => {};`,
-            },
-          ],
-        },
-      ],
-      languageOptions: {
-        parserOptions: {
-          ecmaFeatures: {
-            jsx: true,
-          },
-        },
-      },
-    },
-    {
-      code: noFormat`const data = <T extends any, >() => {};`,
-      errors: [
-        {
-          column: 15,
-          data: { constraint: 'any', name: 'T' },
-          endColumn: 28,
-          line: 1,
-          messageId: 'unnecessaryConstraint',
-          suggestions: [
-            {
-              data: { constraint: 'any' },
-              messageId: 'removeUnnecessaryConstraint',
-              output: `const data = <T, >() => {};`,
-            },
-          ],
-        },
-      ],
-      languageOptions: {
-        parserOptions: {
-          ecmaFeatures: {
-            jsx: true,
-          },
-        },
-      },
-    },
-    {
-      code: noFormat`const data = <T extends any ,>() => {};`,
-      errors: [
-        {
-          column: 15,
-          data: { constraint: 'any', name: 'T' },
-          endColumn: 28,
-          line: 1,
-          messageId: 'unnecessaryConstraint',
-          suggestions: [
-            {
-              data: { constraint: 'any' },
-              messageId: 'removeUnnecessaryConstraint',
-              output: `const data = <T ,>() => {};`,
-            },
-          ],
-        },
-      ],
-      languageOptions: {
-        parserOptions: {
-          ecmaFeatures: {
-            jsx: true,
-          },
-        },
-      },
-    },
-    {
-      code: noFormat`const data = <T extends any , >() => {};`,
-      errors: [
-        {
-          column: 15,
-          data: { constraint: 'any', name: 'T' },
-          endColumn: 28,
-          line: 1,
-          messageId: 'unnecessaryConstraint',
-          suggestions: [
-            {
-              data: { constraint: 'any' },
-              messageId: 'removeUnnecessaryConstraint',
-              output: `const data = <T , >() => {};`,
-            },
-          ],
-        },
-      ],
-      languageOptions: {
-        parserOptions: {
-          ecmaFeatures: {
-            jsx: true,
-          },
-        },
-      },
-    },
-    {
-      code: 'const data = <T extends any = unknown>() => {};',
-      errors: [
-        {
-          column: 15,
-          data: { constraint: 'any', name: 'T' },
-          endColumn: 38,
-          line: 1,
-          messageId: 'unnecessaryConstraint',
-          suggestions: [
-            {
-              data: { constraint: 'any' },
-              messageId: 'removeUnnecessaryConstraint',
-              output: 'const data = <T = unknown>() => {};',
-            },
-          ],
-        },
-      ],
-      languageOptions: {
-        parserOptions: {
-          ecmaFeatures: {
-            jsx: true,
-          },
-        },
-      },
-    },
-    {
-      code: 'const data = <T extends any, U extends any>() => {};',
-      errors: [
-        {
-          column: 15,
-          data: { constraint: 'any', name: 'T' },
-          endColumn: 28,
-          line: 1,
-          messageId: 'unnecessaryConstraint',
-          suggestions: [
-            {
-              data: { constraint: 'any' },
-              messageId: 'removeUnnecessaryConstraint',
-              output: `const data = <T, U extends any>() => {};`,
-            },
-          ],
-        },
-        {
-          column: 30,
-          data: { constraint: 'any', name: 'U' },
-          endColumn: 43,
-          line: 1,
-          messageId: 'unnecessaryConstraint',
-          suggestions: [
-            {
-              data: { constraint: 'any' },
-              messageId: 'removeUnnecessaryConstraint',
-              output: `const data = <T extends any, U>() => {};`,
-            },
-          ],
-        },
-      ],
-      languageOptions: {
-        parserOptions: {
-          ecmaFeatures: {
-            jsx: true,
-          },
-        },
-      },
-    },
-    {
-      code: 'function data<T extends unknown>() {}',
-      errors: [
-        {
-          column: 15,
-          data: { constraint: 'unknown', name: 'T' },
-          endColumn: 32,
-          line: 1,
-          messageId: 'unnecessaryConstraint',
-          suggestions: [
-            {
-              data: { constraint: 'unknown' },
-              messageId: 'removeUnnecessaryConstraint',
-              output: 'function data<T>() {}',
-            },
-          ],
-        },
-      ],
-    },
-    {
-      code: 'const data = <T extends any>() => {};',
-      errors: [
-        {
-          column: 15,
-          data: { constraint: 'any', name: 'T' },
-          endColumn: 28,
-          line: 1,
-          messageId: 'unnecessaryConstraint',
-          suggestions: [
-            {
-              data: { constraint: 'any' },
-              messageId: 'removeUnnecessaryConstraint',
-              output: 'const data = <T>() => {};',
-            },
-          ],
-        },
-      ],
-    },
-    {
-      code: 'const data = <T extends unknown>() => {};',
-      errors: [
-        {
-          column: 15,
-          data: { constraint: 'unknown', name: 'T' },
-          endColumn: 32,
-          line: 1,
-          messageId: 'unnecessaryConstraint',
-          suggestions: [
-            {
-              data: { constraint: 'unknown' },
-              messageId: 'removeUnnecessaryConstraint',
-              output: 'const data = <T>() => {};',
-            },
-          ],
-        },
-      ],
-    },
-    {
-      code: 'class Data<T extends unknown> {}',
-      errors: [
-        {
-          column: 12,
-          data: { constraint: 'unknown', name: 'T' },
-          endColumn: 29,
-          line: 1,
-          messageId: 'unnecessaryConstraint',
-          suggestions: [
-            {
-              data: { constraint: 'unknown' },
-              messageId: 'removeUnnecessaryConstraint',
-              output: 'class Data<T> {}',
-            },
-          ],
-        },
-      ],
-    },
-    {
-      code: 'const Data = class<T extends unknown> {};',
-      errors: [
-        {
-          column: 20,
-          data: { constraint: 'unknown', name: 'T' },
-          endColumn: 37,
-          line: 1,
-          messageId: 'unnecessaryConstraint',
-          suggestions: [
-            {
-              data: { constraint: 'unknown' },
-              messageId: 'removeUnnecessaryConstraint',
-              output: 'const Data = class<T> {};',
-            },
-          ],
-        },
-      ],
-    },
-    {
-      code: `
-class Data {
-  member<T extends unknown>() {}
-}
-      `,
-      errors: [
-        {
-          column: 10,
-          data: { constraint: 'unknown', name: 'T' },
-          endColumn: 27,
-          line: 3,
-          messageId: 'unnecessaryConstraint',
-          suggestions: [
-            {
-              data: { constraint: 'unknown' },
-              messageId: 'removeUnnecessaryConstraint',
-              output: `
-class Data {
-  member<T>() {}
-}
-      `,
-            },
-          ],
-        },
-      ],
-    },
-    {
-      code: `
-const Data = class {
-  member<T extends unknown>() {}
-};
-      `,
-      errors: [
-        {
-          column: 10,
-          data: { constraint: 'unknown', name: 'T' },
-          endColumn: 27,
-          line: 3,
-          messageId: 'unnecessaryConstraint',
-          suggestions: [
-            {
-              data: { constraint: 'unknown' },
-              messageId: 'removeUnnecessaryConstraint',
-              output: `
-const Data = class {
-  member<T>() {}
-};
-      `,
-            },
-          ],
-        },
-      ],
-    },
-    {
-      code: 'interface Data<T extends unknown> {}',
-      errors: [
-        {
-          column: 16,
-          data: { constraint: 'unknown', name: 'T' },
-          endColumn: 33,
-          line: 1,
-          messageId: 'unnecessaryConstraint',
-          suggestions: [
-            {
-              data: { constraint: 'unknown' },
-              messageId: 'removeUnnecessaryConstraint',
-              output: 'interface Data<T> {}',
-            },
-          ],
-        },
-      ],
-    },
-    {
-      code: 'type Data<T extends unknown> = {};',
-      errors: [
-        {
-          column: 11,
-          data: { constraint: 'unknown', name: 'T' },
-          endColumn: 28,
-          line: 1,
-          messageId: 'unnecessaryConstraint',
-          suggestions: [
-            {
-              data: { constraint: 'unknown' },
-              messageId: 'removeUnnecessaryConstraint',
-              output: 'type Data<T> = {};',
-            },
-          ],
-        },
-      ],
-    },
-  ],
+`,
+		"const data = () => {};",
+		"const data = <T,>() => {};",
+		"const data = <T, U>() => {};",
+		"const data = <T extends number>() => {};",
+		"const data = <T extends number | string>() => {};",
+	],
 });

--- a/packages/ts/src/rules/unnecessaryTypeConstraints.ts
+++ b/packages/ts/src/rules/unnecessaryTypeConstraints.ts
@@ -1,0 +1,118 @@
+import type { TSESLint, TSESTree } from '@typescript-eslint/utils';
+
+import { AST_NODE_TYPES } from '@typescript-eslint/utils';
+import { extname } from 'node:path';
+import * as ts from 'typescript';
+
+import type { MakeRequired } from '../util';
+
+import { createRule } from '../util';
+
+type TypeParameterWithConstraint = MakeRequired<
+  TSESTree.TSTypeParameter,
+  'constraint'
+>;
+
+export default createRule({
+  name: 'no-unnecessary-type-constraint',
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description: 'Disallow unnecessary constraints on generic types',
+      recommended: 'recommended',
+    },
+    hasSuggestions: true,
+    messages: {
+      removeUnnecessaryConstraint:
+        'Remove the unnecessary `{{constraint}}` constraint.',
+      unnecessaryConstraint:
+        'Constraining the generic type `{{name}}` to `{{constraint}}` does nothing and is unnecessary.',
+    },
+    schema: [],
+  },
+  defaultOptions: [],
+  create(context) {
+    // In theory, we could use the type checker for more advanced constraint types...
+    // ...but in practice, these types are rare, and likely not worth requiring type info.
+    // https://github.com/typescript-eslint/typescript-eslint/pull/2516#discussion_r495731858
+    const unnecessaryConstraints = new Map([
+      [AST_NODE_TYPES.TSAnyKeyword, 'any'],
+      [AST_NODE_TYPES.TSUnknownKeyword, 'unknown'],
+    ]);
+
+    function checkRequiresGenericDeclarationDisambiguation(
+      filename: string,
+    ): boolean {
+      const pathExt = extname(filename).toLocaleLowerCase() as ts.Extension;
+      switch (pathExt) {
+        case ts.Extension.Cts:
+        case ts.Extension.Mts:
+        case ts.Extension.Tsx:
+          return true;
+
+        default:
+          return false;
+      }
+    }
+
+    const requiresGenericDeclarationDisambiguation =
+      checkRequiresGenericDeclarationDisambiguation(context.filename);
+
+    const checkNode = (
+      node: TypeParameterWithConstraint,
+      inArrowFunction: boolean,
+    ): void => {
+      const constraint = unnecessaryConstraints.get(node.constraint.type);
+      function shouldAddTrailingComma(): boolean {
+        if (!inArrowFunction || !requiresGenericDeclarationDisambiguation) {
+          return false;
+        }
+        // Only <T>() => {} would need trailing comma
+        return (
+          (node.parent as TSESTree.TSTypeParameterDeclaration).params.length ===
+            1 &&
+          context.sourceCode.getTokensAfter(node)[0].value !== ',' &&
+          !node.default
+        );
+      }
+
+      if (constraint) {
+        context.report({
+          node,
+          messageId: 'unnecessaryConstraint',
+          data: {
+            name: node.name.name,
+            constraint,
+          },
+          suggest: [
+            {
+              messageId: 'removeUnnecessaryConstraint',
+              data: {
+                constraint,
+              },
+              fix(fixer): TSESLint.RuleFix | null {
+                return fixer.replaceTextRange(
+                  [node.name.range[1], node.constraint.range[1]],
+                  shouldAddTrailingComma() ? ',' : '',
+                );
+              },
+            },
+          ],
+        });
+      }
+    };
+
+    return {
+      ':not(ArrowFunctionExpression) > TSTypeParameterDeclaration > TSTypeParameter[constraint]'(
+        node: TypeParameterWithConstraint,
+      ): void {
+        checkNode(node, false);
+      },
+      'ArrowFunctionExpression > TSTypeParameterDeclaration > TSTypeParameter[constraint]'(
+        node: TypeParameterWithConstraint,
+      ): void {
+        checkNode(node, true);
+      },
+    };
+  },
+});

--- a/packages/ts/src/rules/unnecessaryTypeConstraints.ts
+++ b/packages/ts/src/rules/unnecessaryTypeConstraints.ts
@@ -1,8 +1,50 @@
 import ts from "typescript";
 
-import { typescriptLanguage } from "@flint.fyi/typescript-language";
+import { typescriptLanguage, type AST } from "@flint.fyi/typescript-language";
 
 import { ruleCreator } from "./ruleCreator.ts";
+
+// In theory, more complex constraint types could be detected with the type checker...
+// ...but in practice, those types are rare, and likely not worth requiring type info.
+// https://github.com/typescript-eslint/typescript-eslint/pull/2516#discussion_r495731858
+const unnecessaryConstraints = new Map([
+	[ts.SyntaxKind.AnyKeyword, "any"],
+	[ts.SyntaxKind.UnknownKeyword, "unknown"],
+]);
+
+// In these kinds of files, a bare `<T>() => {}` is ambiguous or reserved
+// syntax, so a lone arrow function type parameter needs a trailing comma
+// (`<T,>() => {}`) once its constraint is removed.
+const disambiguationFileExtensions = new Set<string>([
+	ts.Extension.Cts,
+	ts.Extension.Mts,
+	ts.Extension.Tsx,
+]);
+
+function requiresGenericDeclarationDisambiguation(fileName: string) {
+	return disambiguationFileExtensions.has(
+		fileName.slice(fileName.lastIndexOf(".")),
+	);
+}
+
+function shouldAddTrailingComma(
+	node: AST.TypeParameterDeclaration,
+	sourceFile: AST.SourceFile,
+) {
+	if (
+		node.parent.kind !== ts.SyntaxKind.ArrowFunction ||
+		!requiresGenericDeclarationDisambiguation(sourceFile.fileName)
+	) {
+		return false;
+	}
+
+	// Only a lone `<T>() => {}` type parameter would need a trailing comma.
+	return (
+		node.parent.typeParameters?.length === 1 &&
+		!node.parent.typeParameters.hasTrailingComma &&
+		!node.default
+	);
+}
 
 export default ruleCreator.createRule(typescriptLanguage, {
 	about: {
@@ -15,33 +57,53 @@ export default ruleCreator.createRule(typescriptLanguage, {
 			primary:
 				"Constraining the generic type `{{ name }}` to `{{ constraint }}` does nothing and is unnecessary.",
 			secondary: [
-				"Generic type parameters are implicitly constrained to `unknown`, and every type is assignable to both `any` and `unknown`.",
+				"Generic type parameters without an `extends` clause are already implicitly constrained to `unknown`.",
+				"Because every type is assignable to both `any` and `unknown`, writing out either constraint doesn't change which types the parameter accepts.",
 			],
-			suggestions: ["Remove the constraint."],
+			suggestions: [
+				"Remove the `extends` constraint to keep the same behavior with less code.",
+			],
 		},
 	},
 	setup(context) {
 		return {
 			visitors: {
 				TypeParameter: (node, { sourceFile }) => {
+					// Mapped types (`{[Key in Keys]: ...}`) and inferred types
+					// (`infer Element extends Bound`) use their type parameter
+					// nodes for more than declaring a constrained generic type.
 					if (
-						!node.constraint ||
-						(node.constraint.kind !== ts.SyntaxKind.AnyKeyword &&
-							node.constraint.kind !== ts.SyntaxKind.UnknownKeyword)
+						node.parent.kind === ts.SyntaxKind.InferType ||
+						node.parent.kind === ts.SyntaxKind.MappedType ||
+						!node.constraint
 					) {
 						return;
 					}
 
+					const constraint = unnecessaryConstraints.get(node.constraint.kind);
+					if (constraint === undefined) {
+						return;
+					}
+
+					const range = {
+						begin: node.name.getEnd(),
+						end: node.constraint.getEnd(),
+					};
+
 					context.report({
 						data: {
-							constraint: node.constraint.getText(sourceFile),
+							constraint,
 							name: node.name.text,
 						},
 						message: "unnecessaryConstraint",
-						range: {
-							begin: node.name.getEnd(),
-							end: node.constraint.getEnd(),
-						},
+						range,
+						suggestions: [
+							{
+								id: "removeConstraint",
+								range,
+								text: shouldAddTrailingComma(node, sourceFile) ? "," : "",
+							},
+						],
 					});
 				},
 			},

--- a/packages/ts/src/rules/unnecessaryTypeConstraints.ts
+++ b/packages/ts/src/rules/unnecessaryTypeConstraints.ts
@@ -1,118 +1,50 @@
-import type { TSESLint, TSESTree } from '@typescript-eslint/utils';
+import ts from "typescript";
 
-import { AST_NODE_TYPES } from '@typescript-eslint/utils';
-import { extname } from 'node:path';
-import * as ts from 'typescript';
+import { typescriptLanguage } from "@flint.fyi/typescript-language";
 
-import type { MakeRequired } from '../util';
+import { ruleCreator } from "./ruleCreator.ts";
 
-import { createRule } from '../util';
+export default ruleCreator.createRule(typescriptLanguage, {
+	about: {
+		description: "Reports unnecessary constraints on generic type parameters.",
+		id: "unnecessaryTypeConstraints",
+		presets: ["logical", "logicalStrict"],
+	},
+	messages: {
+		unnecessaryConstraint: {
+			primary:
+				"Constraining the generic type `{{ name }}` to `{{ constraint }}` does nothing and is unnecessary.",
+			secondary: [
+				"Generic type parameters are implicitly constrained to `unknown`, and every type is assignable to both `any` and `unknown`.",
+			],
+			suggestions: ["Remove the constraint."],
+		},
+	},
+	setup(context) {
+		return {
+			visitors: {
+				TypeParameter: (node, { sourceFile }) => {
+					if (
+						!node.constraint ||
+						(node.constraint.kind !== ts.SyntaxKind.AnyKeyword &&
+							node.constraint.kind !== ts.SyntaxKind.UnknownKeyword)
+					) {
+						return;
+					}
 
-type TypeParameterWithConstraint = MakeRequired<
-  TSESTree.TSTypeParameter,
-  'constraint'
->;
-
-export default createRule({
-  name: 'no-unnecessary-type-constraint',
-  meta: {
-    type: 'suggestion',
-    docs: {
-      description: 'Disallow unnecessary constraints on generic types',
-      recommended: 'recommended',
-    },
-    hasSuggestions: true,
-    messages: {
-      removeUnnecessaryConstraint:
-        'Remove the unnecessary `{{constraint}}` constraint.',
-      unnecessaryConstraint:
-        'Constraining the generic type `{{name}}` to `{{constraint}}` does nothing and is unnecessary.',
-    },
-    schema: [],
-  },
-  defaultOptions: [],
-  create(context) {
-    // In theory, we could use the type checker for more advanced constraint types...
-    // ...but in practice, these types are rare, and likely not worth requiring type info.
-    // https://github.com/typescript-eslint/typescript-eslint/pull/2516#discussion_r495731858
-    const unnecessaryConstraints = new Map([
-      [AST_NODE_TYPES.TSAnyKeyword, 'any'],
-      [AST_NODE_TYPES.TSUnknownKeyword, 'unknown'],
-    ]);
-
-    function checkRequiresGenericDeclarationDisambiguation(
-      filename: string,
-    ): boolean {
-      const pathExt = extname(filename).toLocaleLowerCase() as ts.Extension;
-      switch (pathExt) {
-        case ts.Extension.Cts:
-        case ts.Extension.Mts:
-        case ts.Extension.Tsx:
-          return true;
-
-        default:
-          return false;
-      }
-    }
-
-    const requiresGenericDeclarationDisambiguation =
-      checkRequiresGenericDeclarationDisambiguation(context.filename);
-
-    const checkNode = (
-      node: TypeParameterWithConstraint,
-      inArrowFunction: boolean,
-    ): void => {
-      const constraint = unnecessaryConstraints.get(node.constraint.type);
-      function shouldAddTrailingComma(): boolean {
-        if (!inArrowFunction || !requiresGenericDeclarationDisambiguation) {
-          return false;
-        }
-        // Only <T>() => {} would need trailing comma
-        return (
-          (node.parent as TSESTree.TSTypeParameterDeclaration).params.length ===
-            1 &&
-          context.sourceCode.getTokensAfter(node)[0].value !== ',' &&
-          !node.default
-        );
-      }
-
-      if (constraint) {
-        context.report({
-          node,
-          messageId: 'unnecessaryConstraint',
-          data: {
-            name: node.name.name,
-            constraint,
-          },
-          suggest: [
-            {
-              messageId: 'removeUnnecessaryConstraint',
-              data: {
-                constraint,
-              },
-              fix(fixer): TSESLint.RuleFix | null {
-                return fixer.replaceTextRange(
-                  [node.name.range[1], node.constraint.range[1]],
-                  shouldAddTrailingComma() ? ',' : '',
-                );
-              },
-            },
-          ],
-        });
-      }
-    };
-
-    return {
-      ':not(ArrowFunctionExpression) > TSTypeParameterDeclaration > TSTypeParameter[constraint]'(
-        node: TypeParameterWithConstraint,
-      ): void {
-        checkNode(node, false);
-      },
-      'ArrowFunctionExpression > TSTypeParameterDeclaration > TSTypeParameter[constraint]'(
-        node: TypeParameterWithConstraint,
-      ): void {
-        checkNode(node, true);
-      },
-    };
-  },
+					context.report({
+						data: {
+							constraint: node.constraint.getText(sourceFile),
+							name: node.name.text,
+						},
+						message: "unnecessaryConstraint",
+						range: {
+							begin: node.name.getEnd(),
+							end: node.constraint.getEnd(),
+						},
+					});
+				},
+			},
+		};
+	},
 });


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #2242
- [x] That issue was marked as [`status: accepting prs`](https://github.com/flint-fyi/flint/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/flint-fyi/flint/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

> **Draft port** — opening for maintainer review, not asserting merge-readiness.

Implements `ts/unnecessaryTypeConstraints`, the flint equivalent of [`@typescript-eslint/no-unnecessary-type-constraint`](https://typescript-eslint.io/rules/no-unnecessary-type-constraint).
Reports generic type parameters constrained to `any` or `unknown` — every type parameter is already implicitly constrained to `unknown`, so these constraints change nothing — with a suggestion that removes the constraint (adding the `<T,>` trailing comma when a lone arrow-function type parameter in a `.cts`/`.mts`/`.tsx` file would otherwise become parse-ambiguous).

### Provenance (staged commits)

Ported from [typescript-eslint/typescript-eslint@4ba3e02e](https://github.com/typescript-eslint/typescript-eslint/blob/4ba3e02e46a3d01c24b030771ec6fc8d52385c61/packages/eslint-plugin/src/rules/no-unnecessary-type-constraint.ts) (118 LOC):

1. verbatim upstream copy → 2. flint scaffolding match → 3. implementation.
Diff commits 1→3 to see exactly what the port changed.

### Behavior vs upstream

- **Targeted report range**: the underline covers the ` extends any`/` extends unknown` span (name end → constraint end) rather than upstream's whole-type-parameter highlight — the removable text is exactly what's marked.
- **Mapped-type and `infer` positions are skipped explicitly**: upstream's `TSTypeParameterDeclaration > TSTypeParameter` selector never sees `{ [K in any]: … }` or `infer U extends any`; flint's `TypeParameter` visitor does, so the rule guards those parents (both covered by valid tests). Same observable behavior as upstream, reached structurally.
- **Extension check via `ts.Extension` set on the source file name** (same `.cts`/`.mts`/`.tsx` set verbatim) and **`NodeArray.hasTrailingComma`** instead of token scanning — the TS AST records what upstream had to lex for.
- **Upstream's extension lowercasing is dropped**: flint's typescript-language rejects non-lowercase-extension files before rules run (verified empirically), so the normalization is unreachable code here.
- **Added coverage beyond upstream's matrix**: function types, constructor types, a tsx *non-arrow* declaration (pins the arrow-only comma logic), and the mapped/`infer` valid cases.

### Files

- `packages/ts/src/rules/unnecessaryTypeConstraints.ts` — the rule (syntactic only, preserving upstream's no-type-checker rationale link)
- `packages/ts/src/rules/unnecessaryTypeConstraints.test.ts` — 24 invalid cases (snapshot + suggestion output each, including per-case `fileName` for the `.cts`/`.mts`/`.tsx` comma matrix) + 14 valid cases
- `packages/site/src/content/docs/rules/ts/unnecessaryTypeConstraints.mdx` — full rule doc
- `packages/ts/src/plugin.ts` — rule registered alphabetically
- `packages/comparisons/src/data.json` — existing entry marked `"status": "implemented"`
- `.changeset/unnecessary-type-constraints.md` — patch changeset

A courtesy note: rule naming for the `unnecessary*` family is under discussion in #2802 — happy to rename if that lands on a different convention.

### Local gates

`eslint --max-warnings 0` · `tsc -b packages/ts` · `vitest` (rule test, 39 passing) · `vitest` (comparisons) · `prettier --check` — all pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
