### PR TITLE
refactor(core): remove redundant cached field from `LintResults`

### DIFF
--- a/packages/core/src/cache/writeToCache.ts
+++ b/packages/core/src/cache/writeToCache.ts
@@ -58,12 +58,6 @@ export async function writeToCache(
 					},
 				]),
 			),
-			...(lintResults.cached &&
-				Object.fromEntries(
-					Array.from(lintResults.cached).filter(([filePath]) =>
-						lintResults.allFilePaths.has(filePath),
-					),
-				)),
 		},
 		globalInvalidations,
 	};

--- a/packages/core/src/running/runConfig.ts
+++ b/packages/core/src/running/runConfig.ts
@@ -78,7 +78,11 @@ export async function runConfig(
 
 	// 5. Write the results to cache, then return them! We did it!
 	const ruleCount = rulesFilesAndOptionsByRule.size;
-	const lintResults = { allFilePaths, cached, filesResults, ruleCount };
+	const lintResults: LintResults = {
+		allFilePaths,
+		filesResults,
+		ruleCount,
+	};
 
 	if (!skipCacheWrite) {
 		await writeToCache(

--- a/packages/core/src/types/linting.ts
+++ b/packages/core/src/types/linting.ts
@@ -1,5 +1,4 @@
 import type { FinalizedFileResults } from "../running/finalizeFileResults.ts";
-import type { FileCacheStorage } from "./cache.ts";
 import type { LanguageReport } from "./languages.ts";
 import type { FileReport } from "./reports.ts";
 
@@ -11,7 +10,6 @@ export interface FileResults {
 
 export interface LintResults {
 	allFilePaths: Set<string>;
-	cached: Map<string, FileCacheStorage> | undefined;
 	filesResults: Map<string, FinalizedFileResults>;
 	ruleCount: number;
 }


### PR DESCRIPTION
## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [`status: accepting prs`](https://github.com/flint-fyi/flint/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/flint-fyi/flint/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

`LintResults.cached` was being spread into the cache file in `writeToCache`, but cached entries are already merged into `filesResults` in `runConfig` before `writeToCache` is called making the spread effectively a no-op. This removes the `cached` field from `LintResults` entirely and simplifies `writeToCache` to only iterate `filesResults`, which is now the single source of truth for all file results.

🚄