### PR TITLE
refactor(core): rename `filesResults` to `allFileResults` (See #3005)

### DIFF
--- a/packages/core/src/cache/writeToCache.ts
+++ b/packages/core/src/cache/writeToCache.ts
@@ -20,7 +20,7 @@ export async function writeToCache(
 	const timestamp = Date.now();
 	const globalInvalidations: GlobalInvalidation[] = [];
 
-	for (const [filePath, fileResult] of lintResults.filesResults) {
+	for (const [filePath, fileResult] of lintResults.allFileResults) {
 		if (fileResult.invalidatesCache) {
 			globalInvalidations.push({
 				filePath,
@@ -46,17 +46,19 @@ export async function writeToCache(
 		},
 		files: {
 			...Object.fromEntries(
-				Array.from(lintResults.filesResults).map(([filePath, fileResults]) => [
-					filePath,
-					{
-						...omitEmpty({
-							dependencies: Array.from(fileResults.dependencies).sort(),
-							languageReports: fileResults.languageReports,
-							reports: fileResults.reports,
-						}),
-						timestamp,
-					},
-				]),
+				Array.from(lintResults.allFileResults).map(
+					([filePath, fileResults]) => [
+						filePath,
+						{
+							...omitEmpty({
+								dependencies: Array.from(fileResults.dependencies).sort(),
+								languageReports: fileResults.languageReports,
+								reports: fileResults.reports,
+							}),
+							timestamp,
+						},
+					],
+				),
 			),
 		},
 		globalInvalidations,

--- a/packages/core/src/cache/writeToCache.ts
+++ b/packages/core/src/cache/writeToCache.ts
@@ -58,12 +58,6 @@ export async function writeToCache(
 					},
 				]),
 			),
-			...(lintResults.cached &&
-				Object.fromEntries(
-					Array.from(lintResults.cached).filter(([filePath]) =>
-						lintResults.allFilePaths.has(filePath),
-					),
-				)),
 		},
 		globalInvalidations,
 	};

--- a/packages/core/src/running/runConfig.ts
+++ b/packages/core/src/running/runConfig.ts
@@ -78,7 +78,11 @@ export async function runConfig(
 
 	// 5. Write the results to cache, then return them! We did it!
 	const ruleCount = rulesFilesAndOptionsByRule.size;
-	const lintResults: LintResults = { allFilePaths, filesResults, ruleCount };
+	const lintResults: LintResults = {
+		allFilePaths,
+		allFileResults: filesResults,
+		ruleCount,
+	};
 
 	if (!skipCacheWrite) {
 		await writeToCache(

--- a/packages/core/src/running/runConfig.ts
+++ b/packages/core/src/running/runConfig.ts
@@ -78,7 +78,7 @@ export async function runConfig(
 
 	// 5. Write the results to cache, then return them! We did it!
 	const ruleCount = rulesFilesAndOptionsByRule.size;
-	const lintResults = { allFilePaths, cached, filesResults, ruleCount };
+	const lintResults: LintResults = { allFilePaths, filesResults, ruleCount };
 
 	if (!skipCacheWrite) {
 		await writeToCache(

--- a/packages/core/src/running/runConfigFixing.ts
+++ b/packages/core/src/running/runConfigFixing.ts
@@ -56,7 +56,7 @@ export async function runConfigFixing(
 		// flint-disable-next-line performance/loopAwaits
 		const fixedFilePaths = await applyChangesToFiles(
 			host,
-			lintResults.filesResults,
+			lintResults.allFileResults,
 			requestedSuggestions,
 		);
 

--- a/packages/core/src/types/linting.ts
+++ b/packages/core/src/types/linting.ts
@@ -10,7 +10,7 @@ export interface FileResults {
 
 export interface LintResults {
 	allFilePaths: Set<string>;
-	filesResults: Map<string, FinalizedFileResults>;
+	allFileResults: Map<string, FinalizedFileResults>;
 	ruleCount: number;
 }
 

--- a/packages/core/src/types/linting.ts
+++ b/packages/core/src/types/linting.ts
@@ -1,5 +1,4 @@
 import type { FinalizedFileResults } from "../running/finalizeFileResults.ts";
-import type { FileCacheStorage } from "./cache.ts";
 import type { LanguageReport } from "./languages.ts";
 import type { FileReport } from "./reports.ts";
 
@@ -11,7 +10,6 @@ export interface FileResults {
 
 export interface LintResults {
 	allFilePaths: Set<string>;
-	cached: Map<string, FileCacheStorage> | undefined;
 	filesResults: Map<string, FinalizedFileResults>;
 	ruleCount: number;
 }


### PR DESCRIPTION
See #3005 