### PR TITLE
refactor(core): rename `filesResults` to `allFileResults`

### DIFF
--- a/packages/cli/src/presenters/briefPresenterFactory.ts
+++ b/packages/cli/src/presenters/briefPresenterFactory.ts
@@ -48,7 +48,9 @@ export const briefPresenterFactory: PresenterFactory = {
 			},
 			*summarize(summaryContext) {
 				yield* presentSummary(counts, summaryContext);
-				yield* presentLanguageReports(summaryContext.lintResults.filesResults);
+				yield* presentLanguageReports(
+					summaryContext.lintResults.allFileResults,
+				);
 			},
 		};
 	},

--- a/packages/cli/src/presenters/detailed/detailedPresenterFactory.ts
+++ b/packages/cli/src/presenters/detailed/detailedPresenterFactory.ts
@@ -56,7 +56,9 @@ export const detailedPresenterFactory: PresenterFactory = {
 			},
 			*summarize(summaryContext) {
 				yield* presentSummary(counts, summaryContext);
-				yield* presentLanguageReports(summaryContext.lintResults.filesResults);
+				yield* presentLanguageReports(
+					summaryContext.lintResults.allFileResults,
+				);
 			},
 		};
 	},

--- a/packages/cli/src/renderers/interactive/interactiveRendererFactory.ts
+++ b/packages/cli/src/renderers/interactive/interactiveRendererFactory.ts
@@ -49,7 +49,7 @@ export const interactiveRendererFactory: RendererFactory = {
 
 		async function render({ lintResults }: RendererContext) {
 			const filesWithReportResults = Array.from(
-				lintResults.filesResults,
+				lintResults.allFileResults,
 			).filter(([, results]) => results.reports.length);
 
 			const events: Record<string, (() => boolean) | undefined> = {

--- a/packages/cli/src/renderers/singleRendererFactory.ts
+++ b/packages/cli/src/renderers/singleRendererFactory.ts
@@ -15,7 +15,7 @@ export const singleRendererFactory: RendererFactory = {
 			},
 			async render({ duration, formattingResults, lintResults }) {
 				const fileContexts = await Promise.all(
-					lintResults.filesResults
+					lintResults.allFileResults
 						.entries()
 						.map(async ([filePath, fileResults]) => {
 							if (!fileResults.reports.length) {

--- a/packages/cli/src/runCliOnce.ts
+++ b/packages/cli/src/runCliOnce.ts
@@ -93,7 +93,7 @@ export async function runCliOnce(
 		return { exitCode: 1, lintResults };
 	}
 
-	for (const fileResults of lintResults.filesResults.values()) {
+	for (const fileResults of lintResults.allFileResults.values()) {
 		if (fileResults.languageReports.length || fileResults.reports.length) {
 			return { exitCode: 1, lintResults };
 		}

--- a/packages/cli/src/runCliWatch.ts
+++ b/packages/cli/src/runCliWatch.ts
@@ -97,11 +97,11 @@ function shouldRerunForFileChange(
 		return true;
 	}
 
-	if (lintResults.filesResults.has(changedFilePath)) {
+	if (lintResults.allFilePaths.has(changedFilePath)) {
 		return true;
 	}
 
-	for (const fileResult of lintResults.filesResults.values()) {
+	for (const fileResult of lintResults.allFileResults.values()) {
 		if (fileResult.dependencies.has(changedFilePath)) {
 			return true;
 		}

--- a/packages/core/src/cache/writeToCache.ts
+++ b/packages/core/src/cache/writeToCache.ts
@@ -20,7 +20,7 @@ export async function writeToCache(
 	const timestamp = Date.now();
 	const globalInvalidations: GlobalInvalidation[] = [];
 
-	for (const [filePath, fileResult] of lintResults.filesResults) {
+	for (const [filePath, fileResult] of lintResults.allFileResults) {
 		if (fileResult.invalidatesCache) {
 			globalInvalidations.push({
 				filePath,
@@ -46,17 +46,19 @@ export async function writeToCache(
 		},
 		files: {
 			...Object.fromEntries(
-				Array.from(lintResults.filesResults).map(([filePath, fileResults]) => [
-					filePath,
-					{
-						...omitEmpty({
-							dependencies: Array.from(fileResults.dependencies).sort(),
-							languageReports: fileResults.languageReports,
-							reports: fileResults.reports,
-						}),
-						timestamp,
-					},
-				]),
+				Array.from(lintResults.allFileResults).map(
+					([filePath, fileResults]) => [
+						filePath,
+						{
+							...omitEmpty({
+								dependencies: Array.from(fileResults.dependencies).sort(),
+								languageReports: fileResults.languageReports,
+								reports: fileResults.reports,
+							}),
+							timestamp,
+						},
+					],
+				),
 			),
 			...(lintResults.cached &&
 				Object.fromEntries(

--- a/packages/core/src/running/runConfig.ts
+++ b/packages/core/src/running/runConfig.ts
@@ -52,7 +52,7 @@ export async function runConfig(
 	const reportsByFilePath = await runRules(rulesFilesAndOptionsByRule, host);
 
 	// 3. For each file path, finalize output using each of its language files
-	const filesResults = new Map(
+	const allFileResults = new Map(
 		Array.from(languageFilesByFilePath).map(([filePath, languageAndFiles]) => [
 			filePath,
 			finalizeFileResults(
@@ -65,10 +65,10 @@ export async function runConfig(
 		]),
 	);
 
-	// 4. Merge cached file results into filesResults
+	// 4. Merge cached file results into allFileResults
 	if (cached) {
 		for (const [filePath, cachedStorage] of cached) {
-			filesResults.set(filePath, {
+			allFileResults.set(filePath, {
 				dependencies: new Set(cachedStorage.dependencies),
 				languageReports: cachedStorage.languageReports ?? [],
 				reports: cachedStorage.reports ?? [],
@@ -78,7 +78,12 @@ export async function runConfig(
 
 	// 5. Write the results to cache, then return them! We did it!
 	const ruleCount = rulesFilesAndOptionsByRule.size;
-	const lintResults = { allFilePaths, cached, filesResults, ruleCount };
+	const lintResults: LintResults = {
+		allFilePaths,
+		allFileResults,
+		cached,
+		ruleCount,
+	};
 
 	if (!skipCacheWrite) {
 		await writeToCache(

--- a/packages/core/src/running/runConfigFixing.ts
+++ b/packages/core/src/running/runConfigFixing.ts
@@ -56,7 +56,7 @@ export async function runConfigFixing(
 		// flint-disable-next-line performance/loopAwaits
 		const fixedFilePaths = await applyChangesToFiles(
 			host,
-			lintResults.filesResults,
+			lintResults.allFileResults,
 			requestedSuggestions,
 		);
 

--- a/packages/core/src/types/linting.ts
+++ b/packages/core/src/types/linting.ts
@@ -11,8 +11,8 @@ export interface FileResults {
 
 export interface LintResults {
 	allFilePaths: Set<string>;
+	allFileResults: Map<string, FinalizedFileResults>;
 	cached: Map<string, FileCacheStorage> | undefined;
-	filesResults: Map<string, FinalizedFileResults>;
 	ruleCount: number;
 }
 


### PR DESCRIPTION
## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [`status: accepting prs`](https://github.com/flint-fyi/flint/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/flint-fyi/flint/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

`allFileResults` better reflects that the map contains results for every file. This mirrors the existing `allFilePaths` naming on `LintResults`.

The inconsistency caused a double-take when reading the interface for me.

👨‍💻

