### PR TITLE
refactor(core): rename `FinalizedFileResults` to `FinalizedFileResult` (See #3007)

### DIFF
--- a/packages/core/src/cache/writeToCache.ts
+++ b/packages/core/src/cache/writeToCache.ts
@@ -20,7 +20,7 @@ export async function writeToCache(
 	const timestamp = Date.now();
 	const globalInvalidations: GlobalInvalidation[] = [];
 
-	for (const [filePath, fileResult] of lintResults.filesResults) {
+	for (const [filePath, fileResult] of lintResults.allFileResults) {
 		if (fileResult.invalidatesCache) {
 			globalInvalidations.push({
 				filePath,
@@ -46,17 +46,19 @@ export async function writeToCache(
 		},
 		files: {
 			...Object.fromEntries(
-				Array.from(lintResults.filesResults).map(([filePath, fileResults]) => [
-					filePath,
-					{
-						...omitEmpty({
-							dependencies: Array.from(fileResults.dependencies).sort(),
-							languageReports: fileResults.languageReports,
-							reports: fileResults.reports,
-						}),
-						timestamp,
-					},
-				]),
+				Array.from(lintResults.allFileResults).map(
+					([filePath, fileResults]) => [
+						filePath,
+						{
+							...omitEmpty({
+								dependencies: Array.from(fileResults.dependencies).sort(),
+								languageReports: fileResults.languageReports,
+								reports: fileResults.reports,
+							}),
+							timestamp,
+						},
+					],
+				),
 			),
 			...(lintResults.cached &&
 				Object.fromEntries(

--- a/packages/core/src/running/runConfig.ts
+++ b/packages/core/src/running/runConfig.ts
@@ -52,7 +52,7 @@ export async function runConfig(
 	const reportsByFilePath = await runRules(rulesFilesAndOptionsByRule, host);
 
 	// 3. For each file path, finalize output using each of its language files
-	const filesResults = new Map(
+	const allFileResults = new Map(
 		Array.from(languageFilesByFilePath).map(([filePath, languageAndFiles]) => [
 			filePath,
 			finalizeFileResults(
@@ -65,10 +65,10 @@ export async function runConfig(
 		]),
 	);
 
-	// 4. Merge cached file results into filesResults
+	// 4. Merge cached file results into allFileResults
 	if (cached) {
 		for (const [filePath, cachedStorage] of cached) {
-			filesResults.set(filePath, {
+			allFileResults.set(filePath, {
 				dependencies: new Set(cachedStorage.dependencies),
 				languageReports: cachedStorage.languageReports ?? [],
 				reports: cachedStorage.reports ?? [],
@@ -78,7 +78,12 @@ export async function runConfig(
 
 	// 5. Write the results to cache, then return them! We did it!
 	const ruleCount = rulesFilesAndOptionsByRule.size;
-	const lintResults = { allFilePaths, cached, filesResults, ruleCount };
+	const lintResults: LintResults = {
+		allFilePaths,
+		allFileResults,
+		cached,
+		ruleCount,
+	};
 
 	if (!skipCacheWrite) {
 		await writeToCache(

--- a/packages/core/src/running/runConfigFixing.ts
+++ b/packages/core/src/running/runConfigFixing.ts
@@ -56,7 +56,7 @@ export async function runConfigFixing(
 		// flint-disable-next-line performance/loopAwaits
 		const fixedFilePaths = await applyChangesToFiles(
 			host,
-			lintResults.filesResults,
+			lintResults.allFileResults,
 			requestedSuggestions,
 		);
 

--- a/packages/core/src/types/linting.ts
+++ b/packages/core/src/types/linting.ts
@@ -11,8 +11,8 @@ export interface FileResults {
 
 export interface LintResults {
 	allFilePaths: Set<string>;
+	allFileResults: Map<string, FinalizedFileResults>;
 	cached: Map<string, FileCacheStorage> | undefined;
-	filesResults: Map<string, FinalizedFileResults>;
 	ruleCount: number;
 }
 


### PR DESCRIPTION
See https://github.com/flint-fyi/flint/pull/3007