### PR TITLE
refactor(core): rename `FinalizedFileResults` to `FinalizedFileResult`

### DIFF
--- a/packages/core/src/cache/writeToCache.ts
+++ b/packages/core/src/cache/writeToCache.ts
@@ -46,13 +46,13 @@ export async function writeToCache(
 		},
 		files: {
 			...Object.fromEntries(
-				Array.from(lintResults.filesResults).map(([filePath, fileResults]) => [
+				Array.from(lintResults.filesResults).map(([filePath, fileResult]) => [
 					filePath,
 					{
 						...omitEmpty({
-							dependencies: Array.from(fileResults.dependencies).sort(),
-							languageReports: fileResults.languageReports,
-							reports: fileResults.reports,
+							dependencies: Array.from(fileResult.dependencies).sort(),
+							languageReports: fileResult.languageReports,
+							reports: fileResult.reports,
 						}),
 						timestamp,
 					},

--- a/packages/core/src/running/finalizeFileResult.ts
+++ b/packages/core/src/running/finalizeFileResult.ts
@@ -13,7 +13,7 @@ import type { LanguageAndFile } from "./types.ts";
 
 const log = debugForFile(import.meta.filename);
 
-export interface FinalizedFileResults {
+export interface FinalizedFileResult {
 	dependencies: Set<string>;
 	invalidatesCache?: boolean;
 	languageReports: LanguageReport[];
@@ -27,13 +27,13 @@ export interface FinalizedFileResults {
  *   - Reports: from rules reports by file path
  * ...and then disposes of each language file.
  */
-export function finalizeFileResults(
+export function finalizeFileResult(
 	filePath: string,
 	languageAndFiles: LanguageAndFile[],
 	reports: FileReport[],
 	host: LinterHost,
 	skipLanguageReports?: boolean,
-): FinalizedFileResults {
+): FinalizedFileResult {
 	const directivesFilterer = new DirectivesFilterer();
 	const fileDependencies = new Set<string>();
 	const languageReports: LanguageReport[] = [];

--- a/packages/core/src/running/runConfig.ts
+++ b/packages/core/src/running/runConfig.ts
@@ -7,7 +7,7 @@ import type { LintResults } from "../types/linting.ts";
 import type { FileReport } from "../types/reports.ts";
 import type { AnyRule } from "../types/rules.ts";
 import { collectFilesAndOptions } from "./collectFilesAndOptions.ts";
-import { finalizeFileResults } from "./finalizeFileResults.ts";
+import { finalizeFileResult } from "./finalizeFileResult.ts";
 import { runLintRule } from "./runLintRule.ts";
 import type { LanguageFilesWithOptions } from "./types.ts";
 
@@ -55,7 +55,7 @@ export async function runConfig(
 	const filesResults = new Map(
 		Array.from(languageFilesByFilePath).map(([filePath, languageAndFiles]) => [
 			filePath,
-			finalizeFileResults(
+			finalizeFileResult(
 				filePath,
 				languageAndFiles,
 				reportsByFilePath.get(filePath).flat(),

--- a/packages/core/src/types/linting.ts
+++ b/packages/core/src/types/linting.ts
@@ -1,4 +1,4 @@
-import type { FinalizedFileResults } from "../running/finalizeFileResults.ts";
+import type { FinalizedFileResult } from "../running/finalizeFileResult.ts";
 import type { FileCacheStorage } from "./cache.ts";
 import type { LanguageReport } from "./languages.ts";
 import type { FileReport } from "./reports.ts";
@@ -12,7 +12,7 @@ export interface FileResults {
 export interface LintResults {
 	allFilePaths: Set<string>;
 	cached: Map<string, FileCacheStorage> | undefined;
-	filesResults: Map<string, FinalizedFileResults>;
+	filesResults: Map<string, FinalizedFileResult>;
 	ruleCount: number;
 }
 


### PR DESCRIPTION
## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [`status: accepting prs`](https://github.com/flint-fyi/flint/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/flint-fyi/flint/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

`FinalizedFileResults` represents the lint result for a single file, not a collection (the plural name implied that).

🎨