### PR TITLE
chore: clean up Amp setup

### DIFF
--- a/.agents/setup
+++ b/.agents/setup
@@ -7,6 +7,7 @@ eval "$(~/.local/bin/mise activate bash)"
 mise settings set idiomatic_version_file_enable_tools node,pnpm
 mise install --yes
 pnpm install --frozen-lockfile
+pnpm --filter=site prebuild
 
 amp_config_dir="$HOME/.config/amp"
 mkdir -p "$amp_config_dir"

--- a/.agents/skills/implementing-lint-rules/SKILL.md
+++ b/.agents/skills/implementing-lint-rules/SKILL.md
@@ -25,9 +25,9 @@ Example: instead of messages like _"Octal escape sequences should not be used in
 
 ## AST Node Handling
 
-When you have an `AST.Expression` or `AST.*Declaration`, check whether nodes are certain types using a comparison like `node.kind === ts.SyntaxKind.BinaryExpression`.
+When you have an `AST.Expression` or `AST.*Declaration`, check whether nodes are certain types using a comparison like `node.kind === SyntaxKind.BinaryExpression`.
 
-When you have a `ts.Node` type, however, you'll have to use `ts.is*` checks such as `ts.isBinaryExpression`, or failing that `tsutils` from `ts-api-utils` to get nice type narrowing.
+When you have a `ts.Node` type, however, you'll have to use `ts.is*` checks such as `ts.isBinaryExpression`, or failing that, `tsutils` from `ts-api-utils` to get nice type narrowing.
 
 Always pass source files to `node.getStart(sourceFile)` - don't just call `node.getStart()`.
 Same with other TypeScript APIs that optionally take in a sourceFile.


### PR DESCRIPTION
## Overview

- Run the site prebuild during orb setup.
- Update the lint-rule skill's AST guidance to match the repository's direct `SyntaxKind` imports.
