### PR TITLE
style: use direct SyntaxKind imports

### DIFF
--- a/packages/performance/src/rules/spreadAccumulators.ts
+++ b/packages/performance/src/rules/spreadAccumulators.ts
@@ -1,5 +1,5 @@
 import * as tsutils from "ts-api-utils";
-import ts from "typescript";
+import ts, { SyntaxKind } from "typescript";
 
 import {
 	typescriptLanguage,
@@ -54,7 +54,7 @@ export default ruleCreator.createRule(typescriptLanguage, {
 		function checkAssignmentInLoop(node: ts.Node, sourceFile: AST.SourceFile) {
 			if (
 				ts.isBinaryExpression(node) &&
-				node.operatorToken.kind === ts.SyntaxKind.EqualsToken
+				node.operatorToken.kind === SyntaxKind.EqualsToken
 			) {
 				checkBinaryEqualsExpression(node, sourceFile);
 			}
@@ -89,7 +89,7 @@ export default ruleCreator.createRule(typescriptLanguage, {
 			}
 
 			const firstToken = spreadNode.getFirstToken(sourceFile);
-			if (firstToken?.kind !== ts.SyntaxKind.DotDotDotToken) {
+			if (firstToken?.kind !== SyntaxKind.DotDotDotToken) {
 				return;
 			}
 

--- a/packages/plugin-flint/src/rules/invalidCodeLines.ts
+++ b/packages/plugin-flint/src/rules/invalidCodeLines.ts
@@ -1,4 +1,4 @@
-import ts from "typescript";
+import { SyntaxKind } from "typescript";
 
 import type { FileChange } from "@flint.fyi/core";
 import {
@@ -63,7 +63,7 @@ export default ruleCreator.createRule(typescriptLanguage, {
 			node: ParsedTestCaseCodeNode,
 			sourceFile: AST.SourceFile,
 		) {
-			if (node.kind === ts.SyntaxKind.StringLiteral) {
+			if (node.kind === SyntaxKind.StringLiteral) {
 				return [
 					{
 						range: getTSNodeRange(node, sourceFile),
@@ -73,7 +73,7 @@ export default ruleCreator.createRule(typescriptLanguage, {
 			}
 
 			const template =
-				node.kind === ts.SyntaxKind.TaggedTemplateExpression
+				node.kind === SyntaxKind.TaggedTemplateExpression
 					? node.template
 					: node;
 			const changes: FileChange[] = [];

--- a/packages/plugin-flint/src/rules/testShorthands.ts
+++ b/packages/plugin-flint/src/rules/testShorthands.ts
@@ -1,4 +1,4 @@
-import ts from "typescript";
+import { SyntaxKind } from "typescript";
 
 import type { FileChange } from "@flint.fyi/core";
 import {
@@ -38,14 +38,14 @@ export default ruleCreator.createRule(typescriptLanguage, {
 					for (const testCase of describedCases.valid) {
 						const caseNode = testCase.nodes.case;
 						if (
-							caseNode.kind === ts.SyntaxKind.ObjectLiteralExpression &&
+							caseNode.kind === SyntaxKind.ObjectLiteralExpression &&
 							caseNode.properties.length === 1 &&
-							caseNode.properties[0]?.name?.kind === ts.SyntaxKind.Identifier &&
+							caseNode.properties[0]?.name?.kind === SyntaxKind.Identifier &&
 							caseNode.properties[0].name.text === "code"
 						) {
 							let fix: FileChange | undefined;
 							if (
-								caseNode.properties[0].kind === ts.SyntaxKind.PropertyAssignment
+								caseNode.properties[0].kind === SyntaxKind.PropertyAssignment
 							) {
 								fix = {
 									range: getTSNodeRange(caseNode, sourceFile),

--- a/packages/ts/src/rules/accessorThisRecursion.ts
+++ b/packages/ts/src/rules/accessorThisRecursion.ts
@@ -1,5 +1,5 @@
 import * as tsutils from "ts-api-utils";
-import * as ts from "typescript";
+import ts, { SyntaxKind } from "typescript";
 
 import {
 	typescriptLanguage,
@@ -15,9 +15,9 @@ function getPropertyName(
 	accessor: AST.GetAccessorDeclaration | AST.SetAccessorDeclaration,
 	sourceFile: AST.SourceFile,
 ) {
-	return accessor.name.kind === ts.SyntaxKind.Identifier ||
-		accessor.name.kind === ts.SyntaxKind.StringLiteral ||
-		accessor.name.kind === ts.SyntaxKind.NumericLiteral
+	return accessor.name.kind === SyntaxKind.Identifier ||
+		accessor.name.kind === SyntaxKind.StringLiteral ||
+		accessor.name.kind === SyntaxKind.NumericLiteral
 		? accessor.name.text
 		: accessor.name.getText(sourceFile);
 }
@@ -64,7 +64,7 @@ export default ruleCreator.createRule(typescriptLanguage, {
 			}
 
 			const propertyName = getPropertyName(accessor, sourceFile);
-			const isGetter = accessor.kind === ts.SyntaxKind.GetAccessor;
+			const isGetter = accessor.kind === SyntaxKind.GetAccessor;
 
 			function checkNode(node: ts.Node): void {
 				if (tsutils.isFunctionScopeBoundary(node)) {
@@ -83,7 +83,7 @@ export default ruleCreator.createRule(typescriptLanguage, {
 			) {
 				if (
 					node.name.text !== propertyName ||
-					node.expression.kind !== ts.SyntaxKind.ThisKeyword
+					node.expression.kind !== SyntaxKind.ThisKeyword
 				) {
 					return;
 				}
@@ -99,7 +99,7 @@ export default ruleCreator.createRule(typescriptLanguage, {
 				} else if (
 					ts.isBinaryExpression(node.parent) &&
 					node.parent.left === node &&
-					node.parent.operatorToken.kind === ts.SyntaxKind.EqualsToken
+					node.parent.operatorToken.kind === SyntaxKind.EqualsToken
 				) {
 					context.report({
 						message: "noSetterRecursion",

--- a/packages/ts/src/rules/anyArguments.ts
+++ b/packages/ts/src/rules/anyArguments.ts
@@ -1,5 +1,5 @@
 import * as tsutils from "ts-api-utils";
-import * as ts from "typescript";
+import ts, { SyntaxKind } from "typescript";
 
 import {
 	typescriptLanguage,
@@ -75,7 +75,7 @@ export default ruleCreator.createRule(typescriptLanguage, {
 			for (const argument of node.arguments) {
 				const argumentType = typeChecker.getTypeAtLocation(argument);
 
-				if (argument.kind === ts.SyntaxKind.SpreadElement) {
+				if (argument.kind === SyntaxKind.SpreadElement) {
 					const spreadType = typeChecker.getTypeAtLocation(argument.expression);
 					const anyType = discriminateAnyType(
 						spreadType,
@@ -243,7 +243,7 @@ export default ruleCreator.createRule(typescriptLanguage, {
 					}
 
 					const template = node.template;
-					if (template.kind !== ts.SyntaxKind.TemplateExpression) {
+					if (template.kind !== SyntaxKind.TemplateExpression) {
 						return;
 					}
 

--- a/packages/ts/src/rules/anyAssignments.ts
+++ b/packages/ts/src/rules/anyAssignments.ts
@@ -1,5 +1,5 @@
 import * as tsutils from "ts-api-utils";
-import * as ts from "typescript";
+import ts, { SyntaxKind } from "typescript";
 
 import {
 	typescriptLanguage,
@@ -353,7 +353,7 @@ export default ruleCreator.createRule(typescriptLanguage, {
 			visitors: {
 				ArrayLiteralExpression: (node, { sourceFile, typeChecker }) => {
 					for (const element of node.elements) {
-						if (element.kind !== ts.SyntaxKind.SpreadElement) {
+						if (element.kind !== SyntaxKind.SpreadElement) {
 							continue;
 						}
 
@@ -403,7 +403,7 @@ export default ruleCreator.createRule(typescriptLanguage, {
 						node.initializer,
 					);
 
-					if (node.name.kind === ts.SyntaxKind.ArrayBindingPattern) {
+					if (node.name.kind === SyntaxKind.ArrayBindingPattern) {
 						checkArrayDestructure(
 							node.name,
 							initializerType,
@@ -413,7 +413,7 @@ export default ruleCreator.createRule(typescriptLanguage, {
 						return;
 					}
 
-					if (node.name.kind === ts.SyntaxKind.ObjectBindingPattern) {
+					if (node.name.kind === SyntaxKind.ObjectBindingPattern) {
 						checkObjectDestructure(
 							node.name,
 							initializerType,
@@ -455,9 +455,9 @@ export default ruleCreator.createRule(typescriptLanguage, {
 					let key: string | undefined;
 
 					if (
-						node.name.kind === ts.SyntaxKind.Identifier ||
-						node.name.kind === ts.SyntaxKind.StringLiteral ||
-						node.name.kind === ts.SyntaxKind.NumericLiteral
+						node.name.kind === SyntaxKind.Identifier ||
+						node.name.kind === SyntaxKind.StringLiteral ||
+						node.name.kind === SyntaxKind.NumericLiteral
 					) {
 						key = node.name.text;
 					}
@@ -554,7 +554,7 @@ export default ruleCreator.createRule(typescriptLanguage, {
 						node.initializer,
 					);
 
-					if (node.name.kind === ts.SyntaxKind.ArrayBindingPattern) {
+					if (node.name.kind === SyntaxKind.ArrayBindingPattern) {
 						checkArrayDestructure(
 							node.name,
 							initializerType,
@@ -564,7 +564,7 @@ export default ruleCreator.createRule(typescriptLanguage, {
 						return;
 					}
 
-					if (node.name.kind === ts.SyntaxKind.ObjectBindingPattern) {
+					if (node.name.kind === SyntaxKind.ObjectBindingPattern) {
 						checkObjectDestructure(
 							node.name,
 							initializerType,

--- a/packages/ts/src/rules/arguments.ts
+++ b/packages/ts/src/rules/arguments.ts
@@ -1,4 +1,4 @@
-import * as ts from "typescript";
+import ts, { SyntaxKind } from "typescript";
 
 import {
 	getTSNodeRange,
@@ -51,14 +51,14 @@ export default ruleCreator.createRule(typescriptLanguage, {
 					const { parent } = node;
 
 					if (
-						(parent.kind === ts.SyntaxKind.PropertyAccessExpression ||
-							parent.kind === ts.SyntaxKind.PropertyAssignment ||
-							parent.kind === ts.SyntaxKind.ShorthandPropertyAssignment ||
-							parent.kind === ts.SyntaxKind.Parameter ||
-							parent.kind === ts.SyntaxKind.VariableDeclaration ||
-							parent.kind === ts.SyntaxKind.PropertyDeclaration ||
-							parent.kind === ts.SyntaxKind.BindingElement ||
-							parent.kind === ts.SyntaxKind.PropertySignature) &&
+						(parent.kind === SyntaxKind.PropertyAccessExpression ||
+							parent.kind === SyntaxKind.PropertyAssignment ||
+							parent.kind === SyntaxKind.ShorthandPropertyAssignment ||
+							parent.kind === SyntaxKind.Parameter ||
+							parent.kind === SyntaxKind.VariableDeclaration ||
+							parent.kind === SyntaxKind.PropertyDeclaration ||
+							parent.kind === SyntaxKind.BindingElement ||
+							parent.kind === SyntaxKind.PropertySignature) &&
 						parent.name === node
 					) {
 						return;

--- a/packages/ts/src/rules/arrayFlatMethods.ts
+++ b/packages/ts/src/rules/arrayFlatMethods.ts
@@ -1,4 +1,4 @@
-import * as ts from "typescript";
+import { SyntaxKind } from "typescript";
 
 import {
 	getTSNodeRange,
@@ -13,7 +13,7 @@ import { skipParentheses } from "./utils/skipParentheses.ts";
 
 function isConcatApply(node: AST.CallExpression, typeChecker: Checker) {
 	if (
-		node.expression.kind !== ts.SyntaxKind.PropertyAccessExpression ||
+		node.expression.kind !== SyntaxKind.PropertyAccessExpression ||
 		node.expression.name.text !== "apply"
 	) {
 		return false;
@@ -21,7 +21,7 @@ function isConcatApply(node: AST.CallExpression, typeChecker: Checker) {
 
 	const callExpression = node.expression.expression;
 	if (
-		callExpression.kind !== ts.SyntaxKind.PropertyAccessExpression ||
+		callExpression.kind !== SyntaxKind.PropertyAccessExpression ||
 		callExpression.name.text !== "concat"
 	) {
 		return false;
@@ -31,8 +31,8 @@ function isConcatApply(node: AST.CallExpression, typeChecker: Checker) {
 
 	const isEmptyArrayConcat = isEmptyArrayLiteral(concatObject);
 	const isArrayPrototypeConcat =
-		concatObject.kind === ts.SyntaxKind.PropertyAccessExpression &&
-		concatObject.expression.kind === ts.SyntaxKind.Identifier &&
+		concatObject.kind === SyntaxKind.PropertyAccessExpression &&
+		concatObject.expression.kind === SyntaxKind.Identifier &&
 		concatObject.expression.text === "Array" &&
 		concatObject.name.text === "prototype";
 
@@ -60,7 +60,7 @@ function isConcatApply(node: AST.CallExpression, typeChecker: Checker) {
 
 function isConcatCall(node: AST.CallExpression, typeChecker: Checker) {
 	if (
-		node.expression.kind !== ts.SyntaxKind.PropertyAccessExpression ||
+		node.expression.kind !== SyntaxKind.PropertyAccessExpression ||
 		node.expression.name.text !== "call"
 	) {
 		return false;
@@ -68,7 +68,7 @@ function isConcatCall(node: AST.CallExpression, typeChecker: Checker) {
 
 	const callExpression = node.expression.expression;
 	if (
-		callExpression.kind !== ts.SyntaxKind.PropertyAccessExpression ||
+		callExpression.kind !== SyntaxKind.PropertyAccessExpression ||
 		callExpression.name.text !== "concat"
 	) {
 		return false;
@@ -76,8 +76,8 @@ function isConcatCall(node: AST.CallExpression, typeChecker: Checker) {
 
 	const concatObject = callExpression.expression;
 	if (
-		concatObject.kind !== ts.SyntaxKind.PropertyAccessExpression ||
-		concatObject.expression.kind !== ts.SyntaxKind.Identifier ||
+		concatObject.kind !== SyntaxKind.PropertyAccessExpression ||
+		concatObject.expression.kind !== SyntaxKind.Identifier ||
 		concatObject.expression.text !== "Array" ||
 		concatObject.name.text !== "prototype"
 	) {
@@ -96,7 +96,7 @@ function isConcatCall(node: AST.CallExpression, typeChecker: Checker) {
 
 	// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 	const secondArg = node.arguments[1]!;
-	if (secondArg.kind !== ts.SyntaxKind.SpreadElement) {
+	if (secondArg.kind !== SyntaxKind.SpreadElement) {
 		return false;
 	}
 
@@ -105,7 +105,7 @@ function isConcatCall(node: AST.CallExpression, typeChecker: Checker) {
 
 function isConcatSpread(node: AST.CallExpression, typeChecker: Checker) {
 	if (
-		node.expression.kind !== ts.SyntaxKind.PropertyAccessExpression ||
+		node.expression.kind !== SyntaxKind.PropertyAccessExpression ||
 		node.expression.name.text !== "concat"
 	) {
 		return false;
@@ -121,7 +121,7 @@ function isConcatSpread(node: AST.CallExpression, typeChecker: Checker) {
 	}
 
 	const arg = node.arguments[0];
-	if (arg?.kind !== ts.SyntaxKind.SpreadElement) {
+	if (arg?.kind !== SyntaxKind.SpreadElement) {
 		return false;
 	}
 
@@ -130,7 +130,7 @@ function isConcatSpread(node: AST.CallExpression, typeChecker: Checker) {
 
 function isEmptyArrayLiteral(node: AST.Expression) {
 	return (
-		node.kind === ts.SyntaxKind.ArrayLiteralExpression && !node.elements.length
+		node.kind === SyntaxKind.ArrayLiteralExpression && !node.elements.length
 	);
 }
 
@@ -138,7 +138,7 @@ function isIdentityArrowFunction(node: AST.Expression) {
 	const expression = skipParentheses(node);
 
 	if (
-		expression.kind !== ts.SyntaxKind.ArrowFunction ||
+		expression.kind !== SyntaxKind.ArrowFunction ||
 		expression.parameters.length !== 1
 	) {
 		return false;
@@ -147,19 +147,17 @@ function isIdentityArrowFunction(node: AST.Expression) {
 	// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 	const param = expression.parameters[0]!;
 
-	if (param.name.kind !== ts.SyntaxKind.Identifier) {
+	if (param.name.kind !== SyntaxKind.Identifier) {
 		return false;
 	}
 
 	const body = skipParentheses(expression.body as AST.Expression);
-	return (
-		body.kind === ts.SyntaxKind.Identifier && body.text === param.name.text
-	);
+	return body.kind === SyntaxKind.Identifier && body.text === param.name.text;
 }
 
 function isIdentityFlatMapCall(node: AST.CallExpression, typeChecker: Checker) {
 	if (
-		node.expression.kind !== ts.SyntaxKind.PropertyAccessExpression ||
+		node.expression.kind !== SyntaxKind.PropertyAccessExpression ||
 		node.expression.name.text !== "flatMap" ||
 		node.arguments.length !== 1
 	) {

--- a/packages/ts/src/rules/builtinCoercions.ts
+++ b/packages/ts/src/rules/builtinCoercions.ts
@@ -1,4 +1,4 @@
-import * as ts from "typescript";
+import { SyntaxKind } from "typescript";
 
 import {
 	getTSNodeRange,
@@ -71,10 +71,7 @@ function blockReturnsIdentifier(block: AST.Block, parameterName: string) {
 	}
 
 	const statement = block.statements[0];
-	if (
-		statement?.kind !== ts.SyntaxKind.ReturnStatement ||
-		!statement.expression
-	) {
+	if (statement?.kind !== SyntaxKind.ReturnStatement || !statement.expression) {
 		return false;
 	}
 
@@ -83,11 +80,11 @@ function blockReturnsIdentifier(block: AST.Block, parameterName: string) {
 
 function expressionMatchesName(expression: AST.ConciseBody, name: string) {
 	const unwrapped =
-		expression.kind === ts.SyntaxKind.ParenthesizedExpression
+		expression.kind === SyntaxKind.ParenthesizedExpression
 			? expression.expression
 			: expression;
 
-	return unwrapped.kind === ts.SyntaxKind.Identifier && unwrapped.text === name;
+	return unwrapped.kind === SyntaxKind.Identifier && unwrapped.text === name;
 }
 
 function getCoercionCallName(
@@ -95,8 +92,8 @@ function getCoercionCallName(
 	parameterName: string,
 ): string | undefined {
 	if (
-		expression.kind !== ts.SyntaxKind.CallExpression ||
-		expression.expression.kind !== ts.SyntaxKind.Identifier
+		expression.kind !== SyntaxKind.CallExpression ||
+		expression.expression.kind !== SyntaxKind.Identifier
 	) {
 		return undefined;
 	}
@@ -111,7 +108,7 @@ function getCoercionCallName(
 
 	const argument = expression.arguments[0];
 	if (
-		argument?.kind !== ts.SyntaxKind.Identifier ||
+		argument?.kind !== SyntaxKind.Identifier ||
 		argument.text !== parameterName
 	) {
 		return undefined;
@@ -194,7 +191,7 @@ function getSoleParameterText(
 	}
 
 	const parameter = node.parameters[0];
-	if (parameter?.name.kind !== ts.SyntaxKind.Identifier) {
+	if (parameter?.name.kind !== SyntaxKind.Identifier) {
 		return undefined;
 	}
 
@@ -206,24 +203,21 @@ function getWrappedCoercionFunction(
 	parameterName: string,
 ): string | undefined {
 	if (
-		node.kind === ts.SyntaxKind.ArrowFunction &&
-		node.body.kind !== ts.SyntaxKind.Block
+		node.kind === SyntaxKind.ArrowFunction &&
+		node.body.kind !== SyntaxKind.Block
 	) {
 		return getCoercionCallName(node.body, parameterName);
 	}
 
 	if (
-		node.body.kind !== ts.SyntaxKind.Block ||
+		node.body.kind !== SyntaxKind.Block ||
 		node.body.statements.length !== 1
 	) {
 		return undefined;
 	}
 
 	const statement = node.body.statements[0];
-	if (
-		statement?.kind !== ts.SyntaxKind.ReturnStatement ||
-		!statement.expression
-	) {
+	if (statement?.kind !== SyntaxKind.ReturnStatement || !statement.expression) {
 		return undefined;
 	}
 
@@ -234,9 +228,9 @@ function isArrayMethodCallback(
 	node: AST.ArrowFunction | AST.FunctionExpression,
 ) {
 	return (
-		node.parent.kind === ts.SyntaxKind.CallExpression &&
+		node.parent.kind === SyntaxKind.CallExpression &&
 		node.parent.arguments[0] === node &&
-		node.parent.expression.kind === ts.SyntaxKind.PropertyAccessExpression &&
+		node.parent.expression.kind === SyntaxKind.PropertyAccessExpression &&
 		arrayMethodsWithBooleanCallback.has(node.parent.expression.name.text)
 	);
 }
@@ -246,14 +240,14 @@ function isIdentityFunction(
 	soleParameterText: string,
 ) {
 	if (
-		node.kind === ts.SyntaxKind.ArrowFunction &&
-		node.body.kind !== ts.SyntaxKind.Block
+		node.kind === SyntaxKind.ArrowFunction &&
+		node.body.kind !== SyntaxKind.Block
 	) {
 		return expressionMatchesName(node.body, soleParameterText);
 	}
 
 	return (
-		node.body.kind === ts.SyntaxKind.Block &&
+		node.body.kind === SyntaxKind.Block &&
 		blockReturnsIdentifier(node.body, soleParameterText)
 	);
 }

--- a/packages/ts/src/rules/caughtVariableNames.ts
+++ b/packages/ts/src/rules/caughtVariableNames.ts
@@ -1,4 +1,4 @@
-import * as ts from "typescript";
+import { SyntaxKind } from "typescript";
 
 import { typescriptLanguage } from "@flint.fyi/typescript-language";
 
@@ -31,7 +31,7 @@ export default ruleCreator.createRule(typescriptLanguage, {
 			visitors: {
 				CatchClause: (node, { sourceFile }) => {
 					const variable = node.variableDeclaration;
-					if (variable?.name.kind !== ts.SyntaxKind.Identifier) {
+					if (variable?.name.kind !== SyntaxKind.Identifier) {
 						return;
 					}
 

--- a/packages/ts/src/rules/classFieldDeclarations.ts
+++ b/packages/ts/src/rules/classFieldDeclarations.ts
@@ -1,4 +1,4 @@
-import ts from "typescript";
+import ts, { SyntaxKind } from "typescript";
 
 import {
 	getTSNodeRange,
@@ -9,24 +9,24 @@ import {
 import { ruleCreator } from "./ruleCreator.ts";
 
 function isLiteralValue(node: AST.AnyNode) {
-	if (node.kind === ts.SyntaxKind.PrefixUnaryExpression) {
+	if (node.kind === SyntaxKind.PrefixUnaryExpression) {
 		return isLiteralValue(node.operand);
 	}
 
 	return (
-		node.kind === ts.SyntaxKind.TrueKeyword ||
-		node.kind === ts.SyntaxKind.FalseKeyword ||
-		node.kind === ts.SyntaxKind.NullKeyword ||
+		node.kind === SyntaxKind.TrueKeyword ||
+		node.kind === SyntaxKind.FalseKeyword ||
+		node.kind === SyntaxKind.NullKeyword ||
 		ts.isLiteralExpression(node)
 	);
 }
 
 function isThisLiteralAssignment(node: AST.BinaryExpression) {
 	return (
-		(node.left.kind === ts.SyntaxKind.ElementAccessExpression ||
-			node.left.kind === ts.SyntaxKind.PropertyAccessExpression) &&
-		node.left.kind === ts.SyntaxKind.PropertyAccessExpression &&
-		node.left.expression.kind === ts.SyntaxKind.ThisKeyword &&
+		(node.left.kind === SyntaxKind.ElementAccessExpression ||
+			node.left.kind === SyntaxKind.PropertyAccessExpression) &&
+		node.left.kind === SyntaxKind.PropertyAccessExpression &&
+		node.left.expression.kind === SyntaxKind.ThisKeyword &&
 		isLiteralValue(node.right)
 	);
 }
@@ -54,9 +54,9 @@ export default ruleCreator.createRule(typescriptLanguage, {
 	setup(context) {
 		function checkStatement(node: AST.Statement, sourceFile: AST.SourceFile) {
 			if (
-				node.kind !== ts.SyntaxKind.ExpressionStatement ||
-				node.expression.kind !== ts.SyntaxKind.BinaryExpression ||
-				node.expression.operatorToken.kind !== ts.SyntaxKind.EqualsToken ||
+				node.kind !== SyntaxKind.ExpressionStatement ||
+				node.expression.kind !== SyntaxKind.BinaryExpression ||
+				node.expression.operatorToken.kind !== SyntaxKind.EqualsToken ||
 				!isThisLiteralAssignment(node.expression)
 			) {
 				return;

--- a/packages/ts/src/rules/classMethodsThis.ts
+++ b/packages/ts/src/rules/classMethodsThis.ts
@@ -1,4 +1,4 @@
-import ts from "typescript";
+import ts, { SyntaxKind } from "typescript";
 import { z } from "zod/v4";
 
 import { typescriptLanguage, type AST } from "@flint.fyi/typescript-language";
@@ -21,15 +21,15 @@ function classImplementsSomething(
 ): boolean {
 	return (
 		classNode.heritageClauses?.some(
-			(clause) => clause.token === ts.SyntaxKind.ImplementsKeyword,
+			(clause) => clause.token === SyntaxKind.ImplementsKeyword,
 		) ?? false
 	);
 }
 
 function containsThis(node: ts.Node): boolean {
 	switch (node.kind) {
-		case ts.SyntaxKind.ClassDeclaration:
-		case ts.SyntaxKind.ClassExpression: {
+		case SyntaxKind.ClassDeclaration:
+		case SyntaxKind.ClassExpression: {
 			const classNode = node as ts.ClassDeclaration | ts.ClassExpression;
 			for (const member of classNode.members) {
 				if (
@@ -43,13 +43,13 @@ function containsThis(node: ts.Node): boolean {
 			return false;
 		}
 
-		case ts.SyntaxKind.ClassStaticBlockDeclaration:
-		case ts.SyntaxKind.FunctionDeclaration:
-		case ts.SyntaxKind.FunctionExpression:
+		case SyntaxKind.ClassStaticBlockDeclaration:
+		case SyntaxKind.FunctionDeclaration:
+		case SyntaxKind.FunctionExpression:
 			return false;
 
-		case ts.SyntaxKind.SuperKeyword:
-		case ts.SyntaxKind.ThisKeyword:
+		case SyntaxKind.SuperKeyword:
+		case SyntaxKind.ThisKeyword:
 			return true;
 
 		default:
@@ -66,23 +66,23 @@ function getMemberDisplayName(
 	const name = member.name;
 
 	if (
-		name.kind === ts.SyntaxKind.Identifier ||
-		name.kind === ts.SyntaxKind.StringLiteral ||
-		name.kind === ts.SyntaxKind.NumericLiteral
+		name.kind === SyntaxKind.Identifier ||
+		name.kind === SyntaxKind.StringLiteral ||
+		name.kind === SyntaxKind.NumericLiteral
 	) {
 		return name.text;
 	}
 
-	if (name.kind === ts.SyntaxKind.PrivateIdentifier) {
+	if (name.kind === SyntaxKind.PrivateIdentifier) {
 		return name.text;
 	}
 
-	if (name.kind === ts.SyntaxKind.ComputedPropertyName) {
+	if (name.kind === SyntaxKind.ComputedPropertyName) {
 		const expr = name.expression;
 		if (
-			expr.kind === ts.SyntaxKind.StringLiteral ||
-			expr.kind === ts.SyntaxKind.NoSubstitutionTemplateLiteral ||
-			expr.kind === ts.SyntaxKind.NumericLiteral
+			expr.kind === SyntaxKind.StringLiteral ||
+			expr.kind === SyntaxKind.NoSubstitutionTemplateLiteral ||
+			expr.kind === SyntaxKind.NumericLiteral
 		) {
 			return expr.text;
 		}
@@ -95,13 +95,13 @@ function getMemberDisplayName(
 
 function hasModifier(
 	modifiers: ts.NodeArray<AST.ModifierLike> | undefined,
-	kind: ts.SyntaxKind,
+	kind: SyntaxKind,
 ): boolean {
 	return modifiers?.some((modifier) => modifier.kind === kind) ?? false;
 }
 
 function isPublicMember(member: ClassMember): boolean {
-	if (member.name.kind === ts.SyntaxKind.PrivateIdentifier) {
+	if (member.name.kind === SyntaxKind.PrivateIdentifier) {
 		return false;
 	}
 
@@ -113,8 +113,8 @@ function isPublicMember(member: ClassMember): boolean {
 	if (
 		modifiers.some(
 			(m) =>
-				m.kind === ts.SyntaxKind.PrivateKeyword ||
-				m.kind === ts.SyntaxKind.ProtectedKeyword,
+				m.kind === SyntaxKind.PrivateKeyword ||
+				m.kind === SyntaxKind.ProtectedKeyword,
 		)
 	) {
 		return false;
@@ -128,13 +128,13 @@ function shouldSkipMember(
 	classNode: AST.ClassDeclaration | AST.ClassExpression,
 	options: RuleOptions,
 ): boolean {
-	if (hasModifier(member.modifiers, ts.SyntaxKind.StaticKeyword)) {
+	if (hasModifier(member.modifiers, SyntaxKind.StaticKeyword)) {
 		return true;
 	}
 
 	if (
 		options.ignoreOverrideMethods &&
-		hasModifier(member.modifiers, ts.SyntaxKind.OverrideKeyword)
+		hasModifier(member.modifiers, SyntaxKind.OverrideKeyword)
 	) {
 		return true;
 	}
@@ -252,8 +252,8 @@ export default ruleCreator.createRule(typescriptLanguage, {
 			}
 
 			if (
-				member.initializer.kind !== ts.SyntaxKind.ArrowFunction &&
-				member.initializer.kind !== ts.SyntaxKind.FunctionExpression
+				member.initializer.kind !== SyntaxKind.ArrowFunction &&
+				member.initializer.kind !== SyntaxKind.FunctionExpression
 			) {
 				return;
 			}
@@ -275,16 +275,16 @@ export default ruleCreator.createRule(typescriptLanguage, {
 		) {
 			for (const member of node.members) {
 				switch (member.kind) {
-					case ts.SyntaxKind.GetAccessor:
+					case SyntaxKind.GetAccessor:
 						checkAccessor(member, node, sourceFile, options, "getter");
 						break;
-					case ts.SyntaxKind.MethodDeclaration:
+					case SyntaxKind.MethodDeclaration:
 						checkMethod(member, node, sourceFile, options);
 						break;
-					case ts.SyntaxKind.PropertyDeclaration:
+					case SyntaxKind.PropertyDeclaration:
 						checkPropertyInitializerFunction(member, node, sourceFile, options);
 						break;
-					case ts.SyntaxKind.SetAccessor:
+					case SyntaxKind.SetAccessor:
 						checkAccessor(member, node, sourceFile, options, "setter");
 						break;
 				}

--- a/packages/ts/src/rules/constructorGenericCalls.ts
+++ b/packages/ts/src/rules/constructorGenericCalls.ts
@@ -1,4 +1,4 @@
-import ts from "typescript";
+import ts, { SyntaxKind } from "typescript";
 import { z } from "zod/v4";
 
 import {
@@ -31,9 +31,9 @@ function getTypeArgumentsRange(
 	let end = typeArguments.end;
 
 	for (const child of children) {
-		if (child.kind === ts.SyntaxKind.LessThanToken) {
+		if (child.kind === SyntaxKind.LessThanToken) {
 			begin = child.getStart(sourceFile);
-		} else if (child.kind === ts.SyntaxKind.GreaterThanToken) {
+		} else if (child.kind === SyntaxKind.GreaterThanToken) {
 			end = child.getEnd();
 		}
 	}
@@ -108,8 +108,8 @@ export default ruleCreator.createRule(typescriptLanguage, {
 			const style = options.style;
 
 			if (
-				initializer?.kind !== ts.SyntaxKind.NewExpression ||
-				initializer.expression.kind !== ts.SyntaxKind.Identifier
+				initializer?.kind !== SyntaxKind.NewExpression ||
+				initializer.expression.kind !== SyntaxKind.Identifier
 			) {
 				return;
 			}
@@ -154,7 +154,7 @@ export default ruleCreator.createRule(typescriptLanguage, {
 
 			if (
 				!ts.isTypeReferenceNode(typeAnnotation) ||
-				typeAnnotation.typeName.kind !== ts.SyntaxKind.Identifier ||
+				typeAnnotation.typeName.kind !== SyntaxKind.Identifier ||
 				typeAnnotation.typeName.text !== constructorName ||
 				isBuiltInTypedArray(typeAnnotation.typeName.text) ||
 				!!typeAnnotation.typeArguments !== !initializer.typeArguments

--- a/packages/ts/src/rules/deprecated.ts
+++ b/packages/ts/src/rules/deprecated.ts
@@ -1,4 +1,4 @@
-import * as ts from "typescript";
+import ts, { SyntaxKind } from "typescript";
 
 import {
 	getTSNodeRange,
@@ -113,39 +113,39 @@ export default ruleCreator.createRule(typescriptLanguage, {
 
 		function isDeclarationSite(node: AST.AnyNode) {
 			switch (node.parent.kind) {
-				case ts.SyntaxKind.ArrowFunction:
-				case ts.SyntaxKind.ClassDeclaration:
-				case ts.SyntaxKind.Constructor:
-				case ts.SyntaxKind.EnumDeclaration:
-				case ts.SyntaxKind.EnumMember:
-				case ts.SyntaxKind.FunctionDeclaration:
-				case ts.SyntaxKind.FunctionExpression:
-				case ts.SyntaxKind.GetAccessor:
-				case ts.SyntaxKind.InterfaceDeclaration:
-				case ts.SyntaxKind.MethodDeclaration:
-				case ts.SyntaxKind.MethodSignature:
-				case ts.SyntaxKind.ModuleDeclaration:
-				case ts.SyntaxKind.Parameter:
-				case ts.SyntaxKind.PropertyDeclaration:
-				case ts.SyntaxKind.PropertySignature:
-				case ts.SyntaxKind.SetAccessor:
-				case ts.SyntaxKind.TypeAliasDeclaration:
-				case ts.SyntaxKind.TypeParameter:
-				case ts.SyntaxKind.VariableDeclaration:
+				case SyntaxKind.ArrowFunction:
+				case SyntaxKind.ClassDeclaration:
+				case SyntaxKind.Constructor:
+				case SyntaxKind.EnumDeclaration:
+				case SyntaxKind.EnumMember:
+				case SyntaxKind.FunctionDeclaration:
+				case SyntaxKind.FunctionExpression:
+				case SyntaxKind.GetAccessor:
+				case SyntaxKind.InterfaceDeclaration:
+				case SyntaxKind.MethodDeclaration:
+				case SyntaxKind.MethodSignature:
+				case SyntaxKind.ModuleDeclaration:
+				case SyntaxKind.Parameter:
+				case SyntaxKind.PropertyDeclaration:
+				case SyntaxKind.PropertySignature:
+				case SyntaxKind.SetAccessor:
+				case SyntaxKind.TypeAliasDeclaration:
+				case SyntaxKind.TypeParameter:
+				case SyntaxKind.VariableDeclaration:
 					return node.parent.name === node;
 
-				case ts.SyntaxKind.ExportSpecifier:
+				case SyntaxKind.ExportSpecifier:
 					return node.parent.propertyName === node;
 
-				case ts.SyntaxKind.ImportClause:
-				case ts.SyntaxKind.ImportSpecifier:
-				case ts.SyntaxKind.NamespaceImport:
+				case SyntaxKind.ImportClause:
+				case SyntaxKind.ImportSpecifier:
+				case SyntaxKind.NamespaceImport:
 					return true;
 
-				case ts.SyntaxKind.PropertyAssignment: {
+				case SyntaxKind.PropertyAssignment: {
 					return (
 						node.parent.name === node &&
-						node.parent.name.kind !== ts.SyntaxKind.ComputedPropertyName
+						node.parent.name.kind !== SyntaxKind.ComputedPropertyName
 					);
 				}
 			}
@@ -155,26 +155,26 @@ export default ruleCreator.createRule(typescriptLanguage, {
 			let current: AST.AnyNode = node;
 
 			while (
-				current.parent.kind === ts.SyntaxKind.PropertyAccessExpression &&
+				current.parent.kind === SyntaxKind.PropertyAccessExpression &&
 				current.parent.name === current
 			) {
 				current = current.parent;
 			}
 
 			while (
-				current.parent.kind === ts.SyntaxKind.ElementAccessExpression &&
+				current.parent.kind === SyntaxKind.ElementAccessExpression &&
 				current.parent.argumentExpression === current
 			) {
 				current = current.parent;
 			}
 
 			switch (current.parent.kind) {
-				case ts.SyntaxKind.CallExpression:
-				case ts.SyntaxKind.Decorator:
-				case ts.SyntaxKind.NewExpression:
+				case SyntaxKind.CallExpression:
+				case SyntaxKind.Decorator:
+				case SyntaxKind.NewExpression:
 					return current.parent.expression === current && current.parent;
 
-				case ts.SyntaxKind.TaggedTemplateExpression:
+				case SyntaxKind.TaggedTemplateExpression:
 					return current.parent.tag === current && current.parent;
 			}
 
@@ -203,9 +203,9 @@ export default ruleCreator.createRule(typescriptLanguage, {
 			const symbolDeclarationKind = aliasedSymbol?.declarations?.[0]?.kind;
 
 			if (
-				symbolDeclarationKind !== ts.SyntaxKind.MethodDeclaration &&
-				symbolDeclarationKind !== ts.SyntaxKind.FunctionDeclaration &&
-				symbolDeclarationKind !== ts.SyntaxKind.MethodSignature
+				symbolDeclarationKind !== SyntaxKind.MethodDeclaration &&
+				symbolDeclarationKind !== SyntaxKind.FunctionDeclaration &&
+				symbolDeclarationKind !== SyntaxKind.MethodSignature
 			) {
 				return (
 					searchForDeprecationInAliasesChain(symbol, typeChecker, true) ||
@@ -241,7 +241,7 @@ export default ruleCreator.createRule(typescriptLanguage, {
 			}
 
 			if (
-				node.parent.kind === ts.SyntaxKind.ShorthandPropertyAssignment &&
+				node.parent.kind === SyntaxKind.ShorthandPropertyAssignment &&
 				node.parent.name === node
 			) {
 				const symbol = typeChecker.getSymbolAtLocation(node);
@@ -315,32 +315,32 @@ export default ruleCreator.createRule(typescriptLanguage, {
 			typeChecker: ts.TypeChecker,
 		) {
 			const bindingPattern = node.parent;
-			if (bindingPattern.kind !== ts.SyntaxKind.ObjectBindingPattern) {
+			if (bindingPattern.kind !== SyntaxKind.ObjectBindingPattern) {
 				return;
 			}
 
 			const propertyName = node.propertyName ?? node.name;
-			if (propertyName.kind !== ts.SyntaxKind.Identifier) {
+			if (propertyName.kind !== SyntaxKind.Identifier) {
 				return;
 			}
 
 			const declarationOrPattern = bindingPattern.parent;
 			let objectType: ts.Type | undefined;
 
-			if (declarationOrPattern.kind === ts.SyntaxKind.VariableDeclaration) {
+			if (declarationOrPattern.kind === SyntaxKind.VariableDeclaration) {
 				const initializer = declarationOrPattern.initializer;
 				if (initializer) {
 					objectType = typeChecker.getTypeAtLocation(initializer);
 				}
-			} else if (declarationOrPattern.kind === ts.SyntaxKind.BindingElement) {
+			} else if (declarationOrPattern.kind === SyntaxKind.BindingElement) {
 				const parentInitializer = declarationOrPattern.parent.parent;
-				if (parentInitializer.kind === ts.SyntaxKind.VariableDeclaration) {
+				if (parentInitializer.kind === SyntaxKind.VariableDeclaration) {
 					const init = parentInitializer.initializer;
 					if (init) {
 						const parentType = typeChecker.getTypeAtLocation(init);
 						const parentPropertyName =
 							declarationOrPattern.propertyName ?? declarationOrPattern.name;
-						if (parentPropertyName.kind === ts.SyntaxKind.Identifier) {
+						if (parentPropertyName.kind === SyntaxKind.Identifier) {
 							const prop = parentType.getProperty(parentPropertyName.text);
 							if (prop) {
 								objectType = typeChecker.getTypeOfSymbolAtLocation(
@@ -361,7 +361,7 @@ export default ruleCreator.createRule(typescriptLanguage, {
 						isDeprecatedFromDeclarations(property))
 				) {
 					const reportNode = node.propertyName ?? node.name;
-					if (reportNode.kind === ts.SyntaxKind.Identifier) {
+					if (reportNode.kind === SyntaxKind.Identifier) {
 						context.report({
 							message: "deprecated",
 							range: getTSNodeRange(reportNode, sourceFile),
@@ -377,7 +377,7 @@ export default ruleCreator.createRule(typescriptLanguage, {
 			typeChecker: ts.TypeChecker,
 		) {
 			for (const type of node.types) {
-				if (type.expression.kind === ts.SyntaxKind.Identifier) {
+				if (type.expression.kind === SyntaxKind.Identifier) {
 					const symbol = typeChecker.getSymbolAtLocation(type.expression);
 					if (isDeprecated(symbol, typeChecker)) {
 						context.report({
@@ -396,7 +396,7 @@ export default ruleCreator.createRule(typescriptLanguage, {
 		) {
 			const callExpr = node.parent;
 			if (
-				callExpr.kind !== ts.SyntaxKind.CallExpression ||
+				callExpr.kind !== SyntaxKind.CallExpression ||
 				callExpr.expression !== node
 			) {
 				return;
@@ -431,7 +431,7 @@ export default ruleCreator.createRule(typescriptLanguage, {
 					}
 
 					if (
-						node.parent.kind === ts.SyntaxKind.PropertyAccessExpression &&
+						node.parent.kind === SyntaxKind.PropertyAccessExpression &&
 						node === node.parent.name
 					) {
 						checkNode(node, sourceFile, typeChecker);
@@ -439,7 +439,7 @@ export default ruleCreator.createRule(typescriptLanguage, {
 					}
 
 					if (
-						node.parent.kind === ts.SyntaxKind.QualifiedName &&
+						node.parent.kind === SyntaxKind.QualifiedName &&
 						node === node.parent.right
 					) {
 						checkNode(node, sourceFile, typeChecker);
@@ -447,7 +447,7 @@ export default ruleCreator.createRule(typescriptLanguage, {
 					}
 
 					if (
-						node.parent.kind === ts.SyntaxKind.ElementAccessExpression &&
+						node.parent.kind === SyntaxKind.ElementAccessExpression &&
 						node === node.parent.argumentExpression
 					) {
 						return;
@@ -458,7 +458,7 @@ export default ruleCreator.createRule(typescriptLanguage, {
 
 				PrivateIdentifier: (node, { sourceFile, typeChecker }) => {
 					if (
-						node.parent.kind === ts.SyntaxKind.PropertyAccessExpression &&
+						node.parent.kind === SyntaxKind.PropertyAccessExpression &&
 						node === node.parent.name
 					) {
 						checkNode(node, sourceFile, typeChecker);
@@ -475,7 +475,7 @@ export default ruleCreator.createRule(typescriptLanguage, {
 
 // TODO (#400): Switch to scope analysis
 function isInsideHeritageClause(node: AST.AnyNode) {
-	if (node.kind === ts.SyntaxKind.HeritageClause) {
+	if (node.kind === SyntaxKind.HeritageClause) {
 		return true;
 	}
 
@@ -498,7 +498,7 @@ function isInsideHeritageClause(node: AST.AnyNode) {
 
 // TODO (#400): Switch to scope analysis
 function isInsideImport(node: AST.AnyNode) {
-	if (node.kind === ts.SyntaxKind.ImportDeclaration) {
+	if (node.kind === SyntaxKind.ImportDeclaration) {
 		return true;
 	}
 

--- a/packages/ts/src/rules/destructuringConsistency.ts
+++ b/packages/ts/src/rules/destructuringConsistency.ts
@@ -1,4 +1,4 @@
-import * as ts from "typescript";
+import ts, { SyntaxKind } from "typescript";
 
 import {
 	getScopeManager,
@@ -25,10 +25,10 @@ function isInScope(accessScope: Scope, declarationScope: Scope) {
 // https://github.com/flint-fyi/flint/issues/1298
 function getInitializerKey(node: AST.Expression): string | undefined {
 	switch (node.kind) {
-		case ts.SyntaxKind.Identifier:
+		case SyntaxKind.Identifier:
 			return node.text;
 
-		case ts.SyntaxKind.PropertyAccessExpression: {
+		case SyntaxKind.PropertyAccessExpression: {
 			if (node.questionDotToken) {
 				return undefined;
 			}
@@ -41,28 +41,28 @@ function getInitializerKey(node: AST.Expression): string | undefined {
 			return `${objectKey}.${node.name.text}`;
 		}
 
-		case ts.SyntaxKind.ThisKeyword:
+		case SyntaxKind.ThisKeyword:
 			return "this";
 	}
 }
 
 function isLeftHandSide(node: AST.AnyNode) {
 	switch (node.parent.kind) {
-		case ts.SyntaxKind.BinaryExpression:
+		case SyntaxKind.BinaryExpression:
 			return (
 				node.parent.left === node &&
-				node.parent.operatorToken.kind >= ts.SyntaxKind.FirstAssignment &&
-				node.parent.operatorToken.kind <= ts.SyntaxKind.LastAssignment
+				node.parent.operatorToken.kind >= SyntaxKind.FirstAssignment &&
+				node.parent.operatorToken.kind <= SyntaxKind.LastAssignment
 			);
 
-		case ts.SyntaxKind.DeleteExpression:
+		case SyntaxKind.DeleteExpression:
 			return true;
 
-		case ts.SyntaxKind.PostfixUnaryExpression:
-		case ts.SyntaxKind.PrefixUnaryExpression:
+		case SyntaxKind.PostfixUnaryExpression:
+		case SyntaxKind.PrefixUnaryExpression:
 			return (
-				node.parent.operator === ts.SyntaxKind.PlusPlusToken ||
-				node.parent.operator === ts.SyntaxKind.MinusMinusToken
+				node.parent.operator === SyntaxKind.PlusPlusToken ||
+				node.parent.operator === SyntaxKind.MinusMinusToken
 			);
 
 		default:

--- a/packages/ts/src/rules/errorUnnecessaryCaptureStackTraces.ts
+++ b/packages/ts/src/rules/errorUnnecessaryCaptureStackTraces.ts
@@ -89,9 +89,9 @@ export default ruleCreator.createRule(typescriptLanguage, {
 
 						for (const statement of member.body.statements) {
 							if (
-								statement.kind !== ts.SyntaxKind.ExpressionStatement ||
+								statement.kind !== SyntaxKind.ExpressionStatement ||
 								!(
-									statement.expression.kind === ts.SyntaxKind.CallExpression ||
+									statement.expression.kind === SyntaxKind.CallExpression ||
 									ts.isCallChain(statement.expression)
 								) ||
 								!isCaptureStackTraceCall(statement.expression)

--- a/packages/ts/src/rules/explicitAnys.ts
+++ b/packages/ts/src/rules/explicitAnys.ts
@@ -1,4 +1,4 @@
-import ts from "typescript";
+import { SyntaxKind } from "typescript";
 
 import {
 	getTSNodeRange,
@@ -10,8 +10,8 @@ import { ruleCreator } from "./ruleCreator.ts";
 
 function isNodeWithinKeyofAny(node: AST.AnyKeyword) {
 	return (
-		node.parent.kind === ts.SyntaxKind.TypeOperator &&
-		node.parent.operator === ts.SyntaxKind.KeyOfKeyword
+		node.parent.kind === SyntaxKind.TypeOperator &&
+		node.parent.operator === SyntaxKind.KeyOfKeyword
 	);
 }
 

--- a/packages/ts/src/rules/exportFromImports.ts
+++ b/packages/ts/src/rules/exportFromImports.ts
@@ -1,4 +1,4 @@
-import ts from "typescript";
+import ts, { SyntaxKind } from "typescript";
 
 import {
 	getStaticStringValue,
@@ -104,19 +104,19 @@ export default ruleCreator.createRule(typescriptLanguage, {
 
 					for (const statement of node.statements) {
 						switch (statement.kind) {
-							case ts.SyntaxKind.ExportAssignment:
+							case SyntaxKind.ExportAssignment:
 								if (!statement.isExportEquals) {
 									exportAssignments.push(statement);
 								}
 								break;
 
-							case ts.SyntaxKind.ExportDeclaration:
+							case SyntaxKind.ExportDeclaration:
 								if (!statement.moduleSpecifier) {
 									namedExports.push(statement);
 								}
 								break;
 
-							case ts.SyntaxKind.ImportDeclaration: {
+							case SyntaxKind.ImportDeclaration: {
 								const info = getImportInfo(statement, sourceFile);
 								if (info) {
 									if (info.defaultImport) {

--- a/packages/ts/src/rules/exportUniqueNames.ts
+++ b/packages/ts/src/rules/exportUniqueNames.ts
@@ -1,4 +1,5 @@
-import ts, { SyntaxKind } from "typescript";
+import type ts from "typescript";
+import { SyntaxKind } from "typescript";
 
 import {
 	getTSNodeRange,
@@ -68,7 +69,7 @@ export default ruleCreator.createRule(typescriptLanguage, {
 
 					function checkExportDeclaration(statement: AST.ExportDeclaration) {
 						if (
-							statement.exportClause?.kind === ts.SyntaxKind.NamedExports &&
+							statement.exportClause?.kind === SyntaxKind.NamedExports &&
 							!statement.isTypeOnly
 						) {
 							for (const specifier of statement.exportClause.elements) {
@@ -87,7 +88,7 @@ export default ruleCreator.createRule(typescriptLanguage, {
 						}
 
 						for (const declaration of statement.declarationList.declarations) {
-							if (declaration.name.kind === ts.SyntaxKind.Identifier) {
+							if (declaration.name.kind === SyntaxKind.Identifier) {
 								checkAndReportDuplicate(
 									declaration.name.text,
 									declaration.name,

--- a/packages/ts/src/rules/functionNameMatches.ts
+++ b/packages/ts/src/rules/functionNameMatches.ts
@@ -1,4 +1,4 @@
-import ts from "typescript";
+import { SyntaxKind } from "typescript";
 
 import {
 	getTSNodeRange,
@@ -11,10 +11,10 @@ import { ruleCreator } from "./ruleCreator.ts";
 // TODO: Use a util like getStaticValue
 // https://github.com/flint-fyi/flint/issues/1298
 function getNameText(name: AST.PropertyName) {
-	return name.kind === ts.SyntaxKind.Identifier ||
-		name.kind === ts.SyntaxKind.PrivateIdentifier ||
-		name.kind === ts.SyntaxKind.StringLiteral ||
-		name.kind === ts.SyntaxKind.NumericLiteral
+	return name.kind === SyntaxKind.Identifier ||
+		name.kind === SyntaxKind.PrivateIdentifier ||
+		name.kind === SyntaxKind.StringLiteral ||
+		name.kind === SyntaxKind.NumericLiteral
 		? name.text
 		: undefined;
 }
@@ -58,7 +58,7 @@ export default ruleCreator.createRule(typescriptLanguage, {
 			visitors: {
 				PropertyAssignment: (node, { sourceFile }) => {
 					if (
-						node.initializer.kind !== ts.SyntaxKind.FunctionExpression ||
+						node.initializer.kind !== SyntaxKind.FunctionExpression ||
 						!node.initializer.name
 					) {
 						return;
@@ -83,8 +83,8 @@ export default ruleCreator.createRule(typescriptLanguage, {
 				},
 				PropertyDeclaration: (node, { sourceFile }) => {
 					if (
-						node.initializer?.kind !== ts.SyntaxKind.FunctionExpression ||
-						node.name.kind !== ts.SyntaxKind.Identifier ||
+						node.initializer?.kind !== SyntaxKind.FunctionExpression ||
+						node.name.kind !== SyntaxKind.Identifier ||
 						!node.initializer.name
 					) {
 						return;
@@ -109,9 +109,9 @@ export default ruleCreator.createRule(typescriptLanguage, {
 				},
 				VariableDeclaration: (node, { sourceFile }) => {
 					if (
-						node.initializer?.kind !== ts.SyntaxKind.FunctionExpression ||
+						node.initializer?.kind !== SyntaxKind.FunctionExpression ||
 						!node.initializer.name ||
-						node.name.kind !== ts.SyntaxKind.Identifier
+						node.name.kind !== SyntaxKind.Identifier
 					) {
 						return;
 					}

--- a/packages/ts/src/rules/importEmptyBlocks.ts
+++ b/packages/ts/src/rules/importEmptyBlocks.ts
@@ -1,4 +1,4 @@
-import ts from "typescript";
+import { SyntaxKind } from "typescript";
 
 import {
 	getTSNodeRange,
@@ -38,7 +38,7 @@ export default ruleCreator.createRule(typescriptLanguage, {
 				ImportDeclaration: (node, { sourceFile }) => {
 					if (
 						node.importClause?.namedBindings?.kind !==
-							ts.SyntaxKind.NamedImports ||
+							SyntaxKind.NamedImports ||
 						node.importClause.namedBindings.elements.length
 					) {
 						return;
@@ -60,7 +60,7 @@ export default ruleCreator.createRule(typescriptLanguage, {
 
 					const commaToken = node.importClause
 						.getChildren(sourceFile)
-						.find((child) => child.kind === ts.SyntaxKind.CommaToken);
+						.find((child) => child.kind === SyntaxKind.CommaToken);
 
 					if (!commaToken) {
 						return;

--- a/packages/ts/src/rules/importTypeSideEffects.ts
+++ b/packages/ts/src/rules/importTypeSideEffects.ts
@@ -1,4 +1,4 @@
-import ts, { SyntaxKind } from "typescript";
+import { SyntaxKind } from "typescript";
 
 import {
 	getTSNodeRange,
@@ -41,7 +41,7 @@ export default ruleCreator.createRule(typescriptLanguage, {
 
 					const namedBindings = node.importClause.namedBindings;
 					if (
-						namedBindings?.kind !== ts.SyntaxKind.NamedImports ||
+						namedBindings?.kind !== SyntaxKind.NamedImports ||
 						!namedBindings.elements.length ||
 						namedBindings.elements.some((element) => !element.isTypeOnly)
 					) {

--- a/packages/ts/src/rules/moduleSpecifierLists.ts
+++ b/packages/ts/src/rules/moduleSpecifierLists.ts
@@ -1,4 +1,4 @@
-import * as ts from "typescript";
+import { SyntaxKind } from "typescript";
 
 import {
 	getTSNodeRange,
@@ -15,20 +15,20 @@ function hasNamedBindings(node: AST.ImportDeclaration) {
 	}
 
 	return (
-		namedBindings.kind !== ts.SyntaxKind.NamedImports ||
+		namedBindings.kind !== SyntaxKind.NamedImports ||
 		!!namedBindings.elements.length
 	);
 }
 
 function hasNamespaceImport(node: AST.ImportDeclaration) {
 	const namedBindings = node.importClause?.namedBindings;
-	return namedBindings?.kind === ts.SyntaxKind.NamespaceImport;
+	return namedBindings?.kind === SyntaxKind.NamespaceImport;
 }
 
 function isEmptyNamedImports(node: AST.ImportDeclaration) {
 	const namedBindings = node.importClause?.namedBindings;
 	return (
-		namedBindings?.kind === ts.SyntaxKind.NamedImports &&
+		namedBindings?.kind === SyntaxKind.NamedImports &&
 		!namedBindings.elements.length
 	);
 }
@@ -116,7 +116,7 @@ export default ruleCreator.createRule(typescriptLanguage, {
 					range: getTSNodeRange(node, sourceFile),
 					text: "",
 				},
-				...(importClause.phaseModifier === ts.SyntaxKind.TypeKeyword
+				...(importClause.phaseModifier === SyntaxKind.TypeKeyword
 					? []
 					: [
 							{
@@ -133,7 +133,7 @@ export default ruleCreator.createRule(typescriptLanguage, {
 				ExportDeclaration: (node, { sourceFile }) => {
 					if (
 						node.moduleSpecifier === undefined ||
-						node.exportClause?.kind !== ts.SyntaxKind.NamedExports ||
+						node.exportClause?.kind !== SyntaxKind.NamedExports ||
 						!!node.exportClause.elements.length
 					) {
 						return;

--- a/packages/ts/src/rules/negativeIndexLengthMethods.ts
+++ b/packages/ts/src/rules/negativeIndexLengthMethods.ts
@@ -1,4 +1,4 @@
-import * as ts from "typescript";
+import ts, { SyntaxKind } from "typescript";
 
 import {
 	getTSNodeRange,
@@ -77,8 +77,8 @@ function getNegativeIndexLengthNode(
 	const unwrapped = unwrapParenthesizedNode(node);
 
 	if (
-		unwrapped.kind !== ts.SyntaxKind.BinaryExpression ||
-		unwrapped.operatorToken.kind !== ts.SyntaxKind.MinusToken
+		unwrapped.kind !== SyntaxKind.BinaryExpression ||
+		unwrapped.operatorToken.kind !== SyntaxKind.MinusToken
 	) {
 		return;
 	}
@@ -107,14 +107,14 @@ function isLengthPropertyAccess(
 	sourceFile: AST.SourceFile,
 ): node is AST.PropertyAccessExpression {
 	return (
-		node.kind === ts.SyntaxKind.PropertyAccessExpression &&
+		node.kind === SyntaxKind.PropertyAccessExpression &&
 		node.name.text === "length" &&
 		hasSameTokens(node.expression, target, sourceFile)
 	);
 }
 
 function isPositiveNumericLiteral(node: AST.Expression) {
-	if (node.kind !== ts.SyntaxKind.NumericLiteral) {
+	if (node.kind !== SyntaxKind.NumericLiteral) {
 		return false;
 	}
 
@@ -159,7 +159,7 @@ function isSupportedType(
 
 function isValidPrototypePattern(node: AST.Expression, method: string) {
 	if (
-		node.kind === ts.SyntaxKind.ArrayLiteralExpression &&
+		node.kind === SyntaxKind.ArrayLiteralExpression &&
 		!node.elements.length
 	) {
 		return true;
@@ -167,21 +167,21 @@ function isValidPrototypePattern(node: AST.Expression, method: string) {
 
 	if (
 		method === "slice" &&
-		node.kind === ts.SyntaxKind.StringLiteral &&
+		node.kind === SyntaxKind.StringLiteral &&
 		node.text === ""
 	) {
 		return true;
 	}
 
 	if (
-		node.kind !== ts.SyntaxKind.PropertyAccessExpression ||
+		node.kind !== SyntaxKind.PropertyAccessExpression ||
 		node.name.text !== "prototype"
 	) {
 		return false;
 	}
 
 	const object = node.expression;
-	if (object.kind !== ts.SyntaxKind.Identifier) {
+	if (object.kind !== SyntaxKind.Identifier) {
 		return false;
 	}
 
@@ -189,7 +189,7 @@ function isValidPrototypePattern(node: AST.Expression, method: string) {
 }
 
 function parseCallExpression(node: AST.CallExpression): ParsedCall | undefined {
-	if (node.expression.kind !== ts.SyntaxKind.PropertyAccessExpression) {
+	if (node.expression.kind !== SyntaxKind.PropertyAccessExpression) {
 		return;
 	}
 
@@ -215,12 +215,12 @@ function parsePrototypeCall(
 	node: AST.CallExpression,
 	isApply: boolean,
 ): ParsedCall | undefined {
-	if (node.expression.kind !== ts.SyntaxKind.PropertyAccessExpression) {
+	if (node.expression.kind !== SyntaxKind.PropertyAccessExpression) {
 		return;
 	}
 
 	const callee = node.expression.expression;
-	if (callee.kind !== ts.SyntaxKind.PropertyAccessExpression) {
+	if (callee.kind !== SyntaxKind.PropertyAccessExpression) {
 		return;
 	}
 
@@ -242,13 +242,13 @@ function parsePrototypeCall(
 
 	if (isApply) {
 		const arrayArgument = restArguments[0];
-		if (arrayArgument?.kind !== ts.SyntaxKind.ArrayLiteralExpression) {
+		if (arrayArgument?.kind !== SyntaxKind.ArrayLiteralExpression) {
 			return;
 		}
 
 		const argumentNodes = arrayArgument.elements.filter(
 			(element): element is AST.Expression =>
-				element.kind !== ts.SyntaxKind.SpreadElement,
+				element.kind !== SyntaxKind.SpreadElement,
 		);
 
 		return {

--- a/packages/ts/src/rules/newDefinitions.ts
+++ b/packages/ts/src/rules/newDefinitions.ts
@@ -1,4 +1,4 @@
-import ts from "typescript";
+import { SyntaxKind } from "typescript";
 
 import {
 	getTSNodeRange,
@@ -12,11 +12,11 @@ import { ruleCreator } from "./ruleCreator.ts";
 // https://github.com/JoshuaKGoldberg/flint/issues/400
 function getParentClassName(node: AST.AnyNode): string | undefined {
 	switch (node.parent.kind) {
-		case ts.SyntaxKind.ClassDeclaration:
-		case ts.SyntaxKind.ClassExpression:
+		case SyntaxKind.ClassDeclaration:
+		case SyntaxKind.ClassExpression:
 			return node.parent.name?.text;
 
-		case ts.SyntaxKind.SourceFile:
+		case SyntaxKind.SourceFile:
 			return undefined;
 
 		default:
@@ -30,10 +30,10 @@ function getParentInterface(
 	node: AST.AnyNode,
 ): AST.InterfaceDeclaration | undefined {
 	switch (node.parent.kind) {
-		case ts.SyntaxKind.InterfaceDeclaration:
+		case SyntaxKind.InterfaceDeclaration:
 			return node.parent;
 
-		case ts.SyntaxKind.SourceFile:
+		case SyntaxKind.SourceFile:
 			return undefined;
 
 		default:
@@ -44,8 +44,8 @@ function getParentInterface(
 function getTypeReferenceName(
 	node: AST.TypeNode | undefined,
 ): string | undefined {
-	return node?.kind === ts.SyntaxKind.TypeReference &&
-		node.typeName.kind === ts.SyntaxKind.Identifier
+	return node?.kind === SyntaxKind.TypeReference &&
+		node.typeName.kind === SyntaxKind.Identifier
 		? node.typeName.text
 		: undefined;
 }
@@ -118,9 +118,9 @@ export default ruleCreator.createRule(typescriptLanguage, {
 				MethodDeclaration: (node, { sourceFile }) => {
 					if (
 						node.body ||
-						(node.parent.kind !== ts.SyntaxKind.ClassDeclaration &&
-							node.parent.kind !== ts.SyntaxKind.ClassExpression) ||
-						node.name.kind !== ts.SyntaxKind.Identifier ||
+						(node.parent.kind !== SyntaxKind.ClassDeclaration &&
+							node.parent.kind !== SyntaxKind.ClassExpression) ||
+						node.name.kind !== SyntaxKind.Identifier ||
 						node.name.text !== "new"
 					) {
 						return;
@@ -143,7 +143,7 @@ export default ruleCreator.createRule(typescriptLanguage, {
 				},
 				MethodSignature: (node, { sourceFile }) => {
 					if (
-						node.name.kind !== ts.SyntaxKind.Identifier ||
+						node.name.kind !== SyntaxKind.Identifier ||
 						node.name.text !== "constructor"
 					) {
 						return;

--- a/packages/ts/src/rules/nonNullAssertedNullishCoalesces.ts
+++ b/packages/ts/src/rules/nonNullAssertedNullishCoalesces.ts
@@ -1,5 +1,5 @@
 import * as tsutils from "ts-api-utils";
-import * as ts from "typescript";
+import ts, { SyntaxKind } from "typescript";
 
 import {
 	getTSNodeRange,
@@ -102,16 +102,16 @@ export default ruleCreator.createRule(typescriptLanguage, {
 			visitors: {
 				NonNullExpression: (node, { sourceFile, typeChecker }) => {
 					if (
-						node.parent.kind !== ts.SyntaxKind.BinaryExpression ||
+						node.parent.kind !== SyntaxKind.BinaryExpression ||
 						node.parent.operatorToken.kind !==
-							ts.SyntaxKind.QuestionQuestionToken ||
+							SyntaxKind.QuestionQuestionToken ||
 						node.parent.left !== node
 					) {
 						return;
 					}
 
 					if (
-						node.expression.kind === ts.SyntaxKind.Identifier &&
+						node.expression.kind === SyntaxKind.Identifier &&
 						hasNoAssignmentBeforeNode(
 							node.expression,
 							node,

--- a/packages/ts/src/rules/nonNullableTypeAssertions.ts
+++ b/packages/ts/src/rules/nonNullableTypeAssertions.ts
@@ -1,5 +1,5 @@
 import * as tsutils from "ts-api-utils";
-import ts from "typescript";
+import ts, { SyntaxKind } from "typescript";
 
 import {
 	getTSNodeRange,
@@ -41,20 +41,20 @@ function isConstAssertion(
 	sourceFile: AST.SourceFile,
 ) {
 	return (
-		node.type.kind === ts.SyntaxKind.TypeReference &&
-		node.type.typeName.kind === ts.SyntaxKind.Identifier &&
+		node.type.kind === SyntaxKind.TypeReference &&
+		node.type.typeName.kind === SyntaxKind.Identifier &&
 		node.type.typeName.getText(sourceFile) === "const"
 	);
 }
 
 function needsParentheses(expression: AST.Expression) {
 	switch (expression.kind) {
-		case ts.SyntaxKind.ArrowFunction:
-		case ts.SyntaxKind.AwaitExpression:
-		case ts.SyntaxKind.BinaryExpression:
-		case ts.SyntaxKind.ConditionalExpression:
-		case ts.SyntaxKind.PrefixUnaryExpression:
-		case ts.SyntaxKind.YieldExpression:
+		case SyntaxKind.ArrowFunction:
+		case SyntaxKind.AwaitExpression:
+		case SyntaxKind.BinaryExpression:
+		case SyntaxKind.ConditionalExpression:
+		case SyntaxKind.PrefixUnaryExpression:
+		case SyntaxKind.YieldExpression:
 			return true;
 		default:
 			return false;

--- a/packages/ts/src/rules/nullishCoalescingOperators.ts
+++ b/packages/ts/src/rules/nullishCoalescingOperators.ts
@@ -1,5 +1,5 @@
 import * as tsutils from "ts-api-utils";
-import ts from "typescript";
+import ts, { SyntaxKind } from "typescript";
 import { z } from "zod/v4";
 
 import type { CharacterReportRange } from "@flint.fyi/core";
@@ -35,8 +35,8 @@ function analyzeConditionalForNullish(
 
 	// Simple truthiness check: x ? x : y
 	if (
-		condition.kind === ts.SyntaxKind.Identifier &&
-		whenTrue.kind === ts.SyntaxKind.Identifier &&
+		condition.kind === SyntaxKind.Identifier &&
+		whenTrue.kind === SyntaxKind.Identifier &&
 		condition.text === whenTrue.text
 	) {
 		return {
@@ -49,13 +49,13 @@ function analyzeConditionalForNullish(
 
 	// Negation: !x ? y : x
 	if (
-		condition.kind === ts.SyntaxKind.PrefixUnaryExpression &&
-		condition.operator === ts.SyntaxKind.ExclamationToken
+		condition.kind === SyntaxKind.PrefixUnaryExpression &&
+		condition.operator === SyntaxKind.ExclamationToken
 	) {
 		const operand = condition.operand;
 		if (
-			operand.kind === ts.SyntaxKind.Identifier &&
-			whenFalse.kind === ts.SyntaxKind.Identifier &&
+			operand.kind === SyntaxKind.Identifier &&
+			whenFalse.kind === SyntaxKind.Identifier &&
 			operand.text === whenFalse.text
 		) {
 			return {
@@ -69,7 +69,7 @@ function analyzeConditionalForNullish(
 
 	// Comparison patterns: x !== null ? x : y
 	if (
-		condition.kind === ts.SyntaxKind.BinaryExpression &&
+		condition.kind === SyntaxKind.BinaryExpression &&
 		isNullLikeComparison(condition)
 	) {
 		const { isNegation, value: testValue } =
@@ -99,15 +99,15 @@ function analyzeConditionalForNullish(
 
 	// Logical AND pattern: x !== undefined && x !== null ? x : y
 	if (
-		condition.kind === ts.SyntaxKind.BinaryExpression &&
-		condition.operatorToken.kind === ts.SyntaxKind.AmpersandAmpersandToken
+		condition.kind === SyntaxKind.BinaryExpression &&
+		condition.operatorToken.kind === SyntaxKind.AmpersandAmpersandToken
 	) {
 		const leftIsComparison =
-			condition.left.kind === ts.SyntaxKind.BinaryExpression
+			condition.left.kind === SyntaxKind.BinaryExpression
 				? isNullLikeComparison(condition.left)
 				: false;
 		const rightIsComparison =
-			condition.right.kind === ts.SyntaxKind.BinaryExpression
+			condition.right.kind === SyntaxKind.BinaryExpression
 				? isNullLikeComparison(condition.right)
 				: false;
 
@@ -135,15 +135,15 @@ function analyzeConditionalForNullish(
 
 	// Logical OR pattern: x === undefined || x === null ? y : x
 	if (
-		condition.kind === ts.SyntaxKind.BinaryExpression &&
-		condition.operatorToken.kind === ts.SyntaxKind.BarBarToken
+		condition.kind === SyntaxKind.BinaryExpression &&
+		condition.operatorToken.kind === SyntaxKind.BarBarToken
 	) {
 		const leftIsComparison =
-			condition.left.kind === ts.SyntaxKind.BinaryExpression
+			condition.left.kind === SyntaxKind.BinaryExpression
 				? isNullLikeComparison(condition.left)
 				: false;
 		const rightIsComparison =
-			condition.right.kind === ts.SyntaxKind.BinaryExpression
+			condition.right.kind === SyntaxKind.BinaryExpression
 				? isNullLikeComparison(condition.right)
 				: false;
 
@@ -182,9 +182,9 @@ function consequentMatchesTest(
 	}
 
 	if (
-		consequent.kind === ts.SyntaxKind.PropertyAccessExpression ||
-		consequent.kind === ts.SyntaxKind.ElementAccessExpression ||
-		consequent.kind === ts.SyntaxKind.CallExpression
+		consequent.kind === SyntaxKind.PropertyAccessExpression ||
+		consequent.kind === SyntaxKind.ElementAccessExpression ||
+		consequent.kind === SyntaxKind.CallExpression
 	) {
 		return consequentMatchesTest(consequent.expression, test, sourceFile);
 	}
@@ -195,20 +195,20 @@ function consequentMatchesTest(
 function extractAssignmentFromIfStatement(node: AST.IfStatement) {
 	let assignmentExpr: AST.Expression | undefined;
 
-	if (node.thenStatement.kind === ts.SyntaxKind.Block) {
+	if (node.thenStatement.kind === SyntaxKind.Block) {
 		if (node.thenStatement.statements.length === 1) {
 			const stmt = node.thenStatement.statements[0];
-			if (stmt?.kind === ts.SyntaxKind.ExpressionStatement) {
+			if (stmt?.kind === SyntaxKind.ExpressionStatement) {
 				assignmentExpr = stmt.expression;
 			}
 		}
-	} else if (node.thenStatement.kind === ts.SyntaxKind.ExpressionStatement) {
+	} else if (node.thenStatement.kind === SyntaxKind.ExpressionStatement) {
 		assignmentExpr = node.thenStatement.expression;
 	}
 
 	if (
-		assignmentExpr?.kind !== ts.SyntaxKind.BinaryExpression ||
-		assignmentExpr.operatorToken.kind !== ts.SyntaxKind.EqualsToken
+		assignmentExpr?.kind !== SyntaxKind.BinaryExpression ||
+		assignmentExpr.operatorToken.kind !== SyntaxKind.EqualsToken
 	) {
 		return undefined;
 	}
@@ -221,8 +221,8 @@ function extractValueFromComparison(node: AST.BinaryExpression): {
 	value: AST.Expression | null;
 } {
 	const isNegation =
-		node.operatorToken.kind === ts.SyntaxKind.ExclamationEqualsToken ||
-		node.operatorToken.kind === ts.SyntaxKind.ExclamationEqualsEqualsToken;
+		node.operatorToken.kind === SyntaxKind.ExclamationEqualsToken ||
+		node.operatorToken.kind === SyntaxKind.ExclamationEqualsEqualsToken;
 
 	if (isNullLike(node.left)) {
 		return { isNegation, value: node.right };
@@ -239,13 +239,13 @@ function getComparisonOperator(
 	node: AST.BinaryExpression,
 ): NullishCheckOperator {
 	switch (node.operatorToken.kind) {
-		case ts.SyntaxKind.EqualsEqualsEqualsToken:
+		case SyntaxKind.EqualsEqualsEqualsToken:
 			return "===";
-		case ts.SyntaxKind.EqualsEqualsToken:
+		case SyntaxKind.EqualsEqualsToken:
 			return "==";
-		case ts.SyntaxKind.ExclamationEqualsEqualsToken:
+		case SyntaxKind.ExclamationEqualsEqualsToken:
 			return "!==";
-		case ts.SyntaxKind.ExclamationEqualsToken:
+		case SyntaxKind.ExclamationEqualsToken:
 			return "!=";
 		default:
 			return "";
@@ -254,14 +254,14 @@ function getComparisonOperator(
 
 function getIfStatementNullishCheckValue(node: AST.IfStatement) {
 	switch (node.expression.kind) {
-		case ts.SyntaxKind.BinaryExpression:
+		case SyntaxKind.BinaryExpression:
 			if (isNullLikeComparison(node.expression)) {
 				return extractValueFromComparison(node.expression).value ?? undefined;
 			}
 			return;
 
-		case ts.SyntaxKind.PrefixUnaryExpression:
-			if (node.expression.operator === ts.SyntaxKind.ExclamationToken) {
+		case SyntaxKind.PrefixUnaryExpression:
+			if (node.expression.operator === SyntaxKind.ExclamationToken) {
 				return node.expression.operand;
 			}
 			return;
@@ -285,30 +285,29 @@ function getTypeFlags(type: ts.Type): ts.TypeFlags {
 
 function isConditionalTest(node: AST.AnyNode): boolean {
 	switch (node.parent.kind) {
-		case ts.SyntaxKind.BinaryExpression:
+		case SyntaxKind.BinaryExpression:
 			if (
-				node.parent.operatorToken.kind ===
-					ts.SyntaxKind.AmpersandAmpersandToken ||
-				node.parent.operatorToken.kind === ts.SyntaxKind.BarBarToken
+				node.parent.operatorToken.kind === SyntaxKind.AmpersandAmpersandToken ||
+				node.parent.operatorToken.kind === SyntaxKind.BarBarToken
 			) {
 				return isConditionalTest(node.parent);
 			}
 			return false;
 
-		case ts.SyntaxKind.ConditionalExpression:
+		case SyntaxKind.ConditionalExpression:
 			return node.parent.condition === node || isConditionalTest(node.parent);
 
-		case ts.SyntaxKind.DoStatement:
-		case ts.SyntaxKind.IfStatement:
-		case ts.SyntaxKind.WhileStatement:
+		case SyntaxKind.DoStatement:
+		case SyntaxKind.IfStatement:
+		case SyntaxKind.WhileStatement:
 			return node.parent.expression === node;
 
-		case ts.SyntaxKind.ForStatement:
+		case SyntaxKind.ForStatement:
 			return node.parent.condition === node;
 
-		case ts.SyntaxKind.PrefixUnaryExpression:
+		case SyntaxKind.PrefixUnaryExpression:
 			return (
-				node.parent.operator === ts.SyntaxKind.ExclamationToken &&
+				node.parent.operator === SyntaxKind.ExclamationToken &&
 				isConditionalTest(node.parent)
 			);
 
@@ -356,16 +355,14 @@ function isMixedLogicalExpression(node: AST.BinaryExpression) {
 
 		seen.add(current);
 
-		if (current.kind === ts.SyntaxKind.BinaryExpression) {
-			if (
-				current.operatorToken.kind === ts.SyntaxKind.AmpersandAmpersandToken
-			) {
+		if (current.kind === SyntaxKind.BinaryExpression) {
+			if (current.operatorToken.kind === SyntaxKind.AmpersandAmpersandToken) {
 				return true;
 			}
 
 			if (
-				current.operatorToken.kind === ts.SyntaxKind.BarBarToken ||
-				current.operatorToken.kind === ts.SyntaxKind.BarBarEqualsToken
+				current.operatorToken.kind === SyntaxKind.BarBarToken ||
+				current.operatorToken.kind === SyntaxKind.BarBarEqualsToken
 			) {
 				queue.push(current.parent, current.left, current.right);
 			}
@@ -386,9 +383,9 @@ function isNullishType(type: ts.Type) {
 // https://github.com/flint-fyi/flint/issues/1298
 function isNullLike(node: AST.AnyNode) {
 	switch (node.kind) {
-		case ts.SyntaxKind.Identifier:
+		case SyntaxKind.Identifier:
 			return node.text === "undefined";
-		case ts.SyntaxKind.NullKeyword:
+		case SyntaxKind.NullKeyword:
 			return true;
 		default:
 			return false;
@@ -397,10 +394,10 @@ function isNullLike(node: AST.AnyNode) {
 
 function isNullLikeComparison(node: AST.BinaryExpression) {
 	return (
-		(node.operatorToken.kind === ts.SyntaxKind.EqualsEqualsToken ||
-			node.operatorToken.kind === ts.SyntaxKind.EqualsEqualsEqualsToken ||
-			node.operatorToken.kind === ts.SyntaxKind.ExclamationEqualsToken ||
-			node.operatorToken.kind === ts.SyntaxKind.ExclamationEqualsEqualsToken) &&
+		(node.operatorToken.kind === SyntaxKind.EqualsEqualsToken ||
+			node.operatorToken.kind === SyntaxKind.EqualsEqualsEqualsToken ||
+			node.operatorToken.kind === SyntaxKind.ExclamationEqualsToken ||
+			node.operatorToken.kind === SyntaxKind.ExclamationEqualsEqualsToken) &&
 		(isNullLike(node.left) || isNullLike(node.right))
 	);
 }
@@ -540,12 +537,12 @@ export default ruleCreator.createRule(typescriptLanguage, {
 			sourceFile: AST.SourceFile,
 		) {
 			if (
-				node.kind === ts.SyntaxKind.PropertyAccessExpression ||
-				node.kind === ts.SyntaxKind.ElementAccessExpression
+				node.kind === SyntaxKind.PropertyAccessExpression ||
+				node.kind === SyntaxKind.ElementAccessExpression
 			) {
 				if (hasSameTokens(node.expression, test, sourceFile)) {
 					return {
-						needsDot: node.kind === ts.SyntaxKind.ElementAccessExpression,
+						needsDot: node.kind === SyntaxKind.ElementAccessExpression,
 						pos: node.expression.getEnd(),
 					};
 				}
@@ -555,7 +552,7 @@ export default ruleCreator.createRule(typescriptLanguage, {
 					sourceFile,
 				);
 			}
-			if (node.kind === ts.SyntaxKind.CallExpression) {
+			if (node.kind === SyntaxKind.CallExpression) {
 				return getOptionalChainInsertPosition(
 					node.expression,
 					test,
@@ -614,10 +611,9 @@ export default ruleCreator.createRule(typescriptLanguage, {
 						(options.ignoreConditionalTests && isConditionalTest(node)) ||
 						(options.ignoreMixedLogicalExpressions &&
 							isMixedLogicalExpression(node)) ||
-						![
-							ts.SyntaxKind.BarBarEqualsToken,
-							ts.SyntaxKind.BarBarToken,
-						].includes(node.operatorToken.kind) ||
+						![SyntaxKind.BarBarEqualsToken, SyntaxKind.BarBarToken].includes(
+							node.operatorToken.kind,
+						) ||
 						shouldIgnoreNode(node.left, options.ignorePrimitives, typeChecker)
 					) {
 						return;
@@ -630,7 +626,7 @@ export default ruleCreator.createRule(typescriptLanguage, {
 						fix: {
 							range,
 							text:
-								node.operatorToken.kind === ts.SyntaxKind.BarBarToken
+								node.operatorToken.kind === SyntaxKind.BarBarToken
 									? "??"
 									: "??=",
 						},

--- a/packages/ts/src/rules/numberStaticMethods.ts
+++ b/packages/ts/src/rules/numberStaticMethods.ts
@@ -1,4 +1,4 @@
-import ts from "typescript";
+import ts, { SyntaxKind } from "typescript";
 
 import {
 	getTSNodeRange,
@@ -24,10 +24,10 @@ function isDeclarationName(node: ts.Identifier) {
 
 function isLeftHandSide(node: AST.Identifier) {
 	return (
-		node.parent.kind === ts.SyntaxKind.BinaryExpression &&
+		node.parent.kind === SyntaxKind.BinaryExpression &&
 		node.parent.left === node &&
-		node.parent.operatorToken.kind >= ts.SyntaxKind.FirstAssignment &&
-		node.parent.operatorToken.kind <= ts.SyntaxKind.LastAssignment
+		node.parent.operatorToken.kind >= SyntaxKind.FirstAssignment &&
+		node.parent.operatorToken.kind <= SyntaxKind.LastAssignment
 	);
 }
 

--- a/packages/ts/src/rules/numericErasingOperations.ts
+++ b/packages/ts/src/rules/numericErasingOperations.ts
@@ -1,4 +1,4 @@
-import ts from "typescript";
+import { SyntaxKind } from "typescript";
 
 import {
 	getStaticNumberValue,
@@ -39,8 +39,8 @@ export default ruleCreator.createRule(typescriptLanguage, {
 			visitors: {
 				BinaryExpression: (node, { sourceFile }) => {
 					switch (node.operatorToken.kind) {
-						case ts.SyntaxKind.AmpersandToken:
-						case ts.SyntaxKind.AsteriskToken:
+						case SyntaxKind.AmpersandToken:
+						case SyntaxKind.AsteriskToken:
 							if (isZeroLiteral(node.left) || isZeroLiteral(node.right)) {
 								context.report({
 									message: "erasingOperation",
@@ -49,7 +49,7 @@ export default ruleCreator.createRule(typescriptLanguage, {
 							}
 							break;
 
-						case ts.SyntaxKind.SlashToken:
+						case SyntaxKind.SlashToken:
 							if (isZeroLiteral(node.left) && !isZeroLiteral(node.right)) {
 								context.report({
 									message: "erasingOperation",

--- a/packages/ts/src/rules/propertyAccessNotation.ts
+++ b/packages/ts/src/rules/propertyAccessNotation.ts
@@ -1,4 +1,4 @@
-import ts from "typescript";
+import ts, { SyntaxKind } from "typescript";
 import { z } from "zod/v4";
 
 import {
@@ -67,13 +67,13 @@ function getModifiers(node: null | ts.Node | undefined) {
 // https://github.com/flint-fyi/flint/issues/1298
 function getPropertyKeyText(node: AST.ElementAccessExpression) {
 	switch (node.argumentExpression.kind) {
-		case ts.SyntaxKind.FalseKeyword:
+		case SyntaxKind.FalseKeyword:
 			return "false";
-		case ts.SyntaxKind.NullKeyword:
+		case SyntaxKind.NullKeyword:
 			return "null";
-		case ts.SyntaxKind.StringLiteral:
+		case SyntaxKind.StringLiteral:
 			return node.argumentExpression.text;
-		case ts.SyntaxKind.TrueKeyword:
+		case SyntaxKind.TrueKeyword:
 			return "true";
 		default:
 			return undefined;
@@ -125,7 +125,7 @@ export default ruleCreator.createRule(typescriptLanguage, {
 					.getProperties()
 					.find(
 						(propertySymbol) =>
-							node.argumentExpression.kind === ts.SyntaxKind.StringLiteral &&
+							node.argumentExpression.kind === SyntaxKind.StringLiteral &&
 							(propertySymbol.escapedName as string) ===
 								node.argumentExpression.text,
 					);
@@ -136,8 +136,8 @@ export default ruleCreator.createRule(typescriptLanguage, {
 
 			return {
 				inaccessible:
-					modifierKind === ts.SyntaxKind.PrivateKeyword ||
-					modifierKind === ts.SyntaxKind.ProtectedKeyword,
+					modifierKind === SyntaxKind.PrivateKeyword ||
+					modifierKind === SyntaxKind.ProtectedKeyword,
 				propertySymbol,
 			};
 		}

--- a/packages/ts/src/rules/redundantTypeConstituents.ts
+++ b/packages/ts/src/rules/redundantTypeConstituents.ts
@@ -1,5 +1,5 @@
 import * as tsutils from "ts-api-utils";
-import ts from "typescript";
+import ts, { SyntaxKind } from "typescript";
 
 import {
 	getTSNodeRange,
@@ -108,15 +108,15 @@ function isNodeInsideReturnType(node: AST.AnyNode) {
 
 	while (current) {
 		if (
-			current.kind === ts.SyntaxKind.FunctionDeclaration ||
-			current.kind === ts.SyntaxKind.FunctionExpression ||
-			current.kind === ts.SyntaxKind.ArrowFunction ||
-			current.kind === ts.SyntaxKind.MethodDeclaration ||
-			current.kind === ts.SyntaxKind.MethodSignature ||
-			current.kind === ts.SyntaxKind.FunctionType ||
-			current.kind === ts.SyntaxKind.CallSignature ||
-			current.kind === ts.SyntaxKind.ConstructSignature ||
-			current.kind === ts.SyntaxKind.ConstructorType
+			current.kind === SyntaxKind.FunctionDeclaration ||
+			current.kind === SyntaxKind.FunctionExpression ||
+			current.kind === SyntaxKind.ArrowFunction ||
+			current.kind === SyntaxKind.MethodDeclaration ||
+			current.kind === SyntaxKind.MethodSignature ||
+			current.kind === SyntaxKind.FunctionType ||
+			current.kind === SyntaxKind.CallSignature ||
+			current.kind === SyntaxKind.ConstructSignature ||
+			current.kind === SyntaxKind.ConstructorType
 		) {
 			return !!current.type && isDescendantOf(node, current.type);
 		}

--- a/packages/ts/src/rules/regexAmbiguousInvalidity.ts
+++ b/packages/ts/src/rules/regexAmbiguousInvalidity.ts
@@ -5,7 +5,7 @@ import {
 	type AST as RegExpAST,
 } from "@eslint-community/regexpp";
 import type { CharacterClassElement } from "@eslint-community/regexpp/ast";
-import ts from "typescript";
+import { SyntaxKind } from "typescript";
 
 import {
 	isGlobalDeclarationOfName,
@@ -418,7 +418,7 @@ export default ruleCreator.createRule(typescriptLanguage, {
 			{ program, sourceFile, typeChecker }: TypeScriptFileServices,
 		) {
 			if (
-				node.expression.kind !== ts.SyntaxKind.Identifier ||
+				node.expression.kind !== SyntaxKind.Identifier ||
 				node.expression.text !== "RegExp" ||
 				!isGlobalDeclarationOfName(
 					node.expression,
@@ -434,13 +434,13 @@ export default ruleCreator.createRule(typescriptLanguage, {
 			// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 			const patternArg = node.arguments[0]!;
 
-			if (patternArg.kind !== ts.SyntaxKind.StringLiteral) {
+			if (patternArg.kind !== SyntaxKind.StringLiteral) {
 				return;
 			}
 
 			const flagsArg = node.arguments[1];
 			const flagsText =
-				flagsArg?.kind === ts.SyntaxKind.StringLiteral ? flagsArg.text : "";
+				flagsArg?.kind === SyntaxKind.StringLiteral ? flagsArg.text : "";
 			const flags = parseFlags(flagsText);
 			const issues = checkPatternWithRegexpp(patternArg.text, flags);
 

--- a/packages/ts/src/rules/regexResultArrayGroups.ts
+++ b/packages/ts/src/rules/regexResultArrayGroups.ts
@@ -3,7 +3,7 @@ import type {
 	CapturingGroup,
 	RegExpLiteral,
 } from "@eslint-community/regexpp/ast";
-import ts from "typescript";
+import ts, { SyntaxKind } from "typescript";
 
 import {
 	getTSNodeRange,
@@ -26,14 +26,14 @@ interface NamedCapturingGroup {
 function extractCallExpression(expression: AST.Expression) {
 	const unwrapped = skipParentheses(expression);
 
-	if (unwrapped.kind === ts.SyntaxKind.CallExpression) {
+	if (unwrapped.kind === SyntaxKind.CallExpression) {
 		return unwrapped;
 	}
 
 	if (
-		unwrapped.kind === ts.SyntaxKind.NonNullExpression ||
-		unwrapped.kind === ts.SyntaxKind.AsExpression ||
-		unwrapped.kind === ts.SyntaxKind.TypeAssertionExpression
+		unwrapped.kind === SyntaxKind.NonNullExpression ||
+		unwrapped.kind === SyntaxKind.AsExpression ||
+		unwrapped.kind === SyntaxKind.TypeAssertionExpression
 	) {
 		return extractCallExpression(unwrapped.expression);
 	}
@@ -51,7 +51,7 @@ function findAssignmentsToSymbol(
 	function visit(node: ts.Node) {
 		if (
 			ts.isBinaryExpression(node) &&
-			node.operatorToken.kind === ts.SyntaxKind.EqualsToken &&
+			node.operatorToken.kind === SyntaxKind.EqualsToken &&
 			ts.isIdentifier(node.left)
 		) {
 			const leftSymbol = typeChecker.getSymbolAtLocation(node.left);
@@ -98,7 +98,7 @@ function getNamedGroupsFromExpression(
 ) {
 	const unwrapped = skipParentheses(node);
 
-	if (unwrapped.kind === ts.SyntaxKind.Identifier) {
+	if (unwrapped.kind === SyntaxKind.Identifier) {
 		const symbol = typeChecker.getSymbolAtLocation(unwrapped);
 		if (symbol) {
 			const resolvedSymbol =
@@ -109,7 +109,7 @@ function getNamedGroupsFromExpression(
 		}
 	}
 
-	if (unwrapped.kind === ts.SyntaxKind.CallExpression) {
+	if (unwrapped.kind === SyntaxKind.CallExpression) {
 		const regexInfo = getRegexFromCall(unwrapped, typeChecker, sourceFile);
 		if (regexInfo) {
 			const namedGroups = getNamedCapturingGroups(
@@ -123,9 +123,9 @@ function getNamedGroupsFromExpression(
 	}
 
 	if (
-		unwrapped.kind === ts.SyntaxKind.NonNullExpression ||
-		unwrapped.kind === ts.SyntaxKind.AsExpression ||
-		unwrapped.kind === ts.SyntaxKind.TypeAssertionExpression
+		unwrapped.kind === SyntaxKind.NonNullExpression ||
+		unwrapped.kind === SyntaxKind.AsExpression ||
+		unwrapped.kind === SyntaxKind.TypeAssertionExpression
 	) {
 		return getNamedGroupsFromExpression(
 			unwrapped.expression,
@@ -154,7 +154,7 @@ function getRegexFromExecCall(
 	typeChecker: Checker,
 	sourceFile: AST.SourceFile,
 ) {
-	if (node.expression.kind !== ts.SyntaxKind.PropertyAccessExpression) {
+	if (node.expression.kind !== SyntaxKind.PropertyAccessExpression) {
 		return undefined;
 	}
 
@@ -171,7 +171,7 @@ function getRegexFromMatchAllCall(
 	typeChecker: Checker,
 	sourceFile: AST.SourceFile,
 ) {
-	if (node.expression.kind !== ts.SyntaxKind.PropertyAccessExpression) {
+	if (node.expression.kind !== SyntaxKind.PropertyAccessExpression) {
 		return undefined;
 	}
 
@@ -196,7 +196,7 @@ function getRegexFromMatchCall(
 	sourceFile: AST.SourceFile,
 ) {
 	if (
-		node.expression.kind !== ts.SyntaxKind.PropertyAccessExpression ||
+		node.expression.kind !== SyntaxKind.PropertyAccessExpression ||
 		node.expression.name.text !== "match" ||
 		node.arguments.length !== 1
 	) {
@@ -226,13 +226,13 @@ function getRegexInfoFromExpression(
 ) {
 	const unwrapped = skipParentheses(node);
 
-	if (unwrapped.kind === ts.SyntaxKind.RegularExpressionLiteral) {
+	if (unwrapped.kind === SyntaxKind.RegularExpressionLiteral) {
 		return getRegExpLiteralDetails(unwrapped, { sourceFile });
 	}
 
 	if (
-		unwrapped.kind === ts.SyntaxKind.CallExpression ||
-		unwrapped.kind === ts.SyntaxKind.NewExpression
+		unwrapped.kind === SyntaxKind.CallExpression ||
+		unwrapped.kind === SyntaxKind.NewExpression
 	) {
 		const construction = getRegExpConstruction(unwrapped, {
 			sourceFile,
@@ -246,7 +246,7 @@ function getRegexInfoFromExpression(
 		}
 	}
 
-	if (unwrapped.kind === ts.SyntaxKind.Identifier) {
+	if (unwrapped.kind === SyntaxKind.Identifier) {
 		const symbol = typeChecker.getSymbolAtLocation(unwrapped);
 		if (symbol) {
 			const declarations = symbol.getDeclarations();
@@ -387,7 +387,7 @@ export default ruleCreator.createRule(typescriptLanguage, {
 			visitors: {
 				ElementAccessExpression: (node, { sourceFile, typeChecker }) => {
 					const argument = skipParentheses(node.argumentExpression);
-					if (argument.kind !== ts.SyntaxKind.NumericLiteral) {
+					if (argument.kind !== SyntaxKind.NumericLiteral) {
 						return;
 					}
 

--- a/packages/ts/src/rules/regexTestMethods.ts
+++ b/packages/ts/src/rules/regexTestMethods.ts
@@ -1,4 +1,4 @@
-import ts from "typescript";
+import ts, { SyntaxKind } from "typescript";
 
 import {
 	getTSNodeRange,
@@ -13,10 +13,10 @@ import { isInBooleanContext } from "./utils/isInBooleanContext.ts";
 
 function getRegexFlags(node: AST.Expression, sourceFile: AST.SourceFile) {
 	switch (node.kind) {
-		case ts.SyntaxKind.CallExpression:
-		case ts.SyntaxKind.NewExpression:
+		case SyntaxKind.CallExpression:
+		case SyntaxKind.NewExpression:
 			if (
-				node.expression.kind === ts.SyntaxKind.Identifier &&
+				node.expression.kind === SyntaxKind.Identifier &&
 				node.expression.text === "RegExp" &&
 				node.arguments
 			) {
@@ -26,14 +26,14 @@ function getRegexFlags(node: AST.Expression, sourceFile: AST.SourceFile) {
 
 				const flagsArg = node.arguments[1];
 
-				if (flagsArg?.kind === ts.SyntaxKind.StringLiteral) {
+				if (flagsArg?.kind === SyntaxKind.StringLiteral) {
 					return flagsArg.text;
 				}
 			}
 
 			return undefined;
 
-		case ts.SyntaxKind.RegularExpressionLiteral: {
+		case SyntaxKind.RegularExpressionLiteral: {
 			const text = node.getText(sourceFile);
 			const lastSlash = text.lastIndexOf("/");
 			return lastSlash >= 0 ? text.slice(lastSlash + 1) : "";
@@ -46,11 +46,11 @@ function getRegexFlags(node: AST.Expression, sourceFile: AST.SourceFile) {
 
 function needsParentheses(node: AST.AnyNode) {
 	return !(
-		node.kind === ts.SyntaxKind.Identifier ||
-		node.kind === ts.SyntaxKind.RegularExpressionLiteral ||
-		node.kind === ts.SyntaxKind.ParenthesizedExpression ||
-		node.kind === ts.SyntaxKind.CallExpression ||
-		node.kind === ts.SyntaxKind.NewExpression
+		node.kind === SyntaxKind.Identifier ||
+		node.kind === SyntaxKind.RegularExpressionLiteral ||
+		node.kind === SyntaxKind.ParenthesizedExpression ||
+		node.kind === SyntaxKind.CallExpression ||
+		node.kind === SyntaxKind.NewExpression
 	);
 }
 
@@ -79,7 +79,7 @@ export default ruleCreator.createRule(typescriptLanguage, {
 			visitors: {
 				CallExpression: (node, { program, sourceFile, typeChecker }) => {
 					if (
-						node.expression.kind !== ts.SyntaxKind.PropertyAccessExpression ||
+						node.expression.kind !== SyntaxKind.PropertyAccessExpression ||
 						node.arguments.length !== 1
 					) {
 						return;

--- a/packages/ts/src/rules/restrictedIdentifiers.ts
+++ b/packages/ts/src/rules/restrictedIdentifiers.ts
@@ -1,4 +1,4 @@
-import ts from "typescript";
+import { SyntaxKind } from "typescript";
 import z from "zod/v4";
 
 import {
@@ -42,7 +42,7 @@ export default ruleCreator.createRule(typescriptLanguage, {
 			{ options, sourceFile }: VisitorServices,
 		) {
 			if (
-				node.name?.kind !== ts.SyntaxKind.Identifier ||
+				node.name?.kind !== SyntaxKind.Identifier ||
 				!options.deny?.includes(node.name.text)
 			) {
 				return;

--- a/packages/ts/src/rules/restrictedImports.ts
+++ b/packages/ts/src/rules/restrictedImports.ts
@@ -223,7 +223,7 @@ export default ruleCreator.createRule(typescriptLanguage, {
 					node,
 					{ options, program, sourceFile, typeChecker },
 				) => {
-					if (node.moduleSpecifier?.kind !== ts.SyntaxKind.StringLiteral) {
+					if (node.moduleSpecifier?.kind !== SyntaxKind.StringLiteral) {
 						return;
 					}
 
@@ -231,7 +231,7 @@ export default ruleCreator.createRule(typescriptLanguage, {
 					const topLevelTypeOnly = node.isTypeOnly;
 					const range = getTSNodeRange(node, sourceFile);
 
-					if (node.exportClause?.kind === ts.SyntaxKind.NamedExports) {
+					if (node.exportClause?.kind === SyntaxKind.NamedExports) {
 						for (const element of node.exportClause.elements) {
 							const isTypeOnly = topLevelTypeOnly || element.isTypeOnly;
 							const importedName = element.propertyName
@@ -278,7 +278,7 @@ export default ruleCreator.createRule(typescriptLanguage, {
 					node,
 					{ options, program, sourceFile, typeChecker },
 				) => {
-					if (node.moduleSpecifier.kind !== ts.SyntaxKind.StringLiteral) {
+					if (node.moduleSpecifier.kind !== SyntaxKind.StringLiteral) {
 						return;
 					}
 
@@ -345,7 +345,7 @@ export default ruleCreator.createRule(typescriptLanguage, {
 						return;
 					}
 
-					if (bindings.kind === ts.SyntaxKind.NamedImports) {
+					if (bindings.kind === SyntaxKind.NamedImports) {
 						for (const element of bindings.elements) {
 							const isTypeOnly = topLevelTypeOnly || element.isTypeOnly;
 							const importedName = element.propertyName

--- a/packages/ts/src/rules/singleVariableDeclarations.ts
+++ b/packages/ts/src/rules/singleVariableDeclarations.ts
@@ -1,4 +1,4 @@
-import ts from "typescript";
+import { SyntaxKind } from "typescript";
 
 import {
 	getTSNodeRange,
@@ -27,7 +27,7 @@ export default ruleCreator.createRule(typescriptLanguage, {
 			visitors: {
 				ForStatement: (node, { sourceFile }) => {
 					if (
-						node.initializer?.kind === ts.SyntaxKind.VariableDeclarationList &&
+						node.initializer?.kind === SyntaxKind.VariableDeclarationList &&
 						node.initializer.declarations.length > 1
 					) {
 						context.report({

--- a/packages/ts/src/rules/staticMemberOnlyClasses.ts
+++ b/packages/ts/src/rules/staticMemberOnlyClasses.ts
@@ -1,4 +1,4 @@
-import ts from "typescript";
+import ts, { SyntaxKind } from "typescript";
 
 import {
 	getTSNodeRange,
@@ -16,7 +16,7 @@ function hasDecorators(node: AST.ClassDeclaration | AST.ClassExpression) {
 function hasExtendsClause(node: AST.ClassDeclaration | AST.ClassExpression) {
 	return (
 		node.heritageClauses?.some(
-			(clause) => clause.token === ts.SyntaxKind.ExtendsKeyword,
+			(clause) => clause.token === SyntaxKind.ExtendsKeyword,
 		) ?? false
 	);
 }
@@ -24,7 +24,7 @@ function hasExtendsClause(node: AST.ClassDeclaration | AST.ClassExpression) {
 function hasPrivateConstructor(node: AST.ConstructorDeclaration) {
 	return (
 		node.modifiers?.some(
-			(modifier) => modifier.kind === ts.SyntaxKind.PrivateKeyword,
+			(modifier) => modifier.kind === SyntaxKind.PrivateKeyword,
 		) ?? false
 	);
 }
@@ -33,16 +33,15 @@ function hasStaticModifier(
 	modifiers: ts.NodeArray<AST.ModifierLike> | undefined,
 ) {
 	return (
-		modifiers?.some(
-			(modifier) => modifier.kind === ts.SyntaxKind.StaticKeyword,
-		) ?? false
+		modifiers?.some((modifier) => modifier.kind === SyntaxKind.StaticKeyword) ??
+		false
 	);
 }
 
 function isAbstractClass(node: AST.ClassDeclaration | AST.ClassExpression) {
 	return (
 		node.modifiers?.some(
-			(modifier) => modifier.kind === ts.SyntaxKind.AbstractKeyword,
+			(modifier) => modifier.kind === SyntaxKind.AbstractKeyword,
 		) ?? false
 	);
 }
@@ -89,7 +88,7 @@ export default ruleCreator.createRule(typescriptLanguage, {
 			let hasPrivateConstructorMember = false;
 
 			for (const member of node.members) {
-				if (member.kind === ts.SyntaxKind.Constructor) {
+				if (member.kind === SyntaxKind.Constructor) {
 					if (hasPrivateConstructor(member)) {
 						hasPrivateConstructorMember = true;
 						break;
@@ -102,13 +101,13 @@ export default ruleCreator.createRule(typescriptLanguage, {
 				}
 
 				if (
-					member.kind === ts.SyntaxKind.SemicolonClassElement ||
-					member.kind === ts.SyntaxKind.ClassStaticBlockDeclaration
+					member.kind === SyntaxKind.SemicolonClassElement ||
+					member.kind === SyntaxKind.ClassStaticBlockDeclaration
 				) {
 					continue;
 				}
 
-				if (member.kind === ts.SyntaxKind.IndexSignature) {
+				if (member.kind === SyntaxKind.IndexSignature) {
 					hasNonStaticMember = true;
 					break;
 				}

--- a/packages/ts/src/rules/typeAssertionStyles.ts
+++ b/packages/ts/src/rules/typeAssertionStyles.ts
@@ -1,4 +1,4 @@
-import ts from "typescript";
+import { SyntaxKind } from "typescript";
 
 import {
 	getTSNodeRange,
@@ -10,8 +10,8 @@ import { ruleCreator } from "./ruleCreator.ts";
 
 function isConstAssertion(node: AST.TypeAssertion, sourceFile: AST.SourceFile) {
 	return (
-		node.type.kind === ts.SyntaxKind.TypeReference &&
-		node.type.typeName.kind === ts.SyntaxKind.Identifier &&
+		node.type.kind === SyntaxKind.TypeReference &&
+		node.type.typeName.kind === SyntaxKind.Identifier &&
 		node.type.typeName.getText(sourceFile) === "const"
 	);
 }

--- a/packages/ts/src/rules/typeImports.ts
+++ b/packages/ts/src/rules/typeImports.ts
@@ -55,7 +55,7 @@ function getImportSource(
 	node: AST.ImportDeclaration,
 	sourceFile: AST.SourceFile,
 ) {
-	return node.moduleSpecifier.kind === ts.SyntaxKind.StringLiteral
+	return node.moduleSpecifier.kind === SyntaxKind.StringLiteral
 		? node.moduleSpecifier.text
 		: node.moduleSpecifier.getText(sourceFile);
 }
@@ -74,7 +74,7 @@ function getImportSpecifiers(node: AST.ImportDeclaration) {
 
 	const namedBindings = importClause.namedBindings;
 	if (namedBindings) {
-		if (namedBindings.kind === ts.SyntaxKind.NamespaceImport) {
+		if (namedBindings.kind === SyntaxKind.NamespaceImport) {
 			specifiers.push(namedBindings);
 		} else {
 			specifiers.push(...namedBindings.elements);
@@ -110,7 +110,7 @@ function getTypeImportFix(
 		if (
 			!importClause ||
 			importClause.name ||
-			namedBindings?.kind !== ts.SyntaxKind.NamedImports
+			namedBindings?.kind !== SyntaxKind.NamedImports
 		) {
 			return undefined;
 		}
@@ -137,7 +137,7 @@ function getTypeImportFix(
 		fixStyle === "inline-type-imports" &&
 		importClause &&
 		!importClause.name &&
-		namedBindings?.kind === ts.SyntaxKind.NamedImports
+		namedBindings?.kind === SyntaxKind.NamedImports
 	) {
 		const moduleText = node.moduleSpecifier.getText(sourceFile);
 		const namedText = namedBindings.elements
@@ -212,13 +212,13 @@ function isOnlyTypeReference(node: AST.Identifier) {
 	let parent = node.parent as AST.AnyNode | undefined;
 
 	while (parent) {
-		if (parent.kind === ts.SyntaxKind.HeritageClause) {
+		if (parent.kind === SyntaxKind.HeritageClause) {
 			return parent.token === SyntaxKind.ImplementsKeyword;
 		}
 
 		if (
-			parent.kind === ts.SyntaxKind.TypeAliasDeclaration ||
-			parent.kind === ts.SyntaxKind.InterfaceDeclaration ||
+			parent.kind === SyntaxKind.TypeAliasDeclaration ||
+			parent.kind === SyntaxKind.InterfaceDeclaration ||
 			ts.isTypeParameterDeclaration(parent)
 		) {
 			return true;
@@ -353,7 +353,7 @@ export default ruleCreator.createRule(typescriptLanguage, {
 					if (options.prefer === "no-type-imports") {
 						for (const statement of node.statements) {
 							if (
-								statement.kind !== ts.SyntaxKind.ImportDeclaration ||
+								statement.kind !== SyntaxKind.ImportDeclaration ||
 								!statement.importClause
 							) {
 								continue;
@@ -411,7 +411,7 @@ export default ruleCreator.createRule(typescriptLanguage, {
 
 					for (const statement of node.statements) {
 						if (
-							statement.kind !== ts.SyntaxKind.ImportDeclaration ||
+							statement.kind !== SyntaxKind.ImportDeclaration ||
 							!statement.importClause
 						) {
 							continue;
@@ -445,7 +445,7 @@ export default ruleCreator.createRule(typescriptLanguage, {
 
 					function collectReferences(node: AST.AnyNode) {
 						if (
-							node.kind === ts.SyntaxKind.Identifier &&
+							node.kind === SyntaxKind.Identifier &&
 							!isInImportDeclaration(node)
 						) {
 							const symbol = getReferencedSymbol(typeChecker, node);
@@ -467,7 +467,7 @@ export default ruleCreator.createRule(typescriptLanguage, {
 
 					for (const statement of node.statements) {
 						if (
-							statement.kind !== ts.SyntaxKind.ImportDeclaration ||
+							statement.kind !== SyntaxKind.ImportDeclaration ||
 							!statement.importClause ||
 							isTypeImportDeclaration(statement)
 						) {

--- a/packages/ts/src/rules/unnecessaryBinds.ts
+++ b/packages/ts/src/rules/unnecessaryBinds.ts
@@ -1,4 +1,4 @@
-import ts from "typescript";
+import ts, { SyntaxKind } from "typescript";
 
 import {
 	getTSNodeRange,
@@ -10,7 +10,7 @@ import { ruleCreator } from "./ruleCreator.ts";
 // TODO: This will be more clean when there is a scope manager
 // https://github.com/flint-fyi/flint/issues/400
 function containsThis(node: ts.Node): boolean {
-	if (node.kind === ts.SyntaxKind.ThisKeyword) {
+	if (node.kind === SyntaxKind.ThisKeyword) {
 		return true;
 	}
 
@@ -57,16 +57,16 @@ function isStaticValue(node: ts.Expression): boolean {
 	}
 
 	return (
-		node.kind === ts.SyntaxKind.ThisKeyword ||
-		node.kind === ts.SyntaxKind.SuperKeyword ||
-		node.kind === ts.SyntaxKind.TrueKeyword ||
-		node.kind === ts.SyntaxKind.FalseKeyword ||
-		node.kind === ts.SyntaxKind.NullKeyword ||
+		node.kind === SyntaxKind.ThisKeyword ||
+		node.kind === SyntaxKind.SuperKeyword ||
+		node.kind === SyntaxKind.TrueKeyword ||
+		node.kind === SyntaxKind.FalseKeyword ||
+		node.kind === SyntaxKind.NullKeyword ||
 		ts.isBigIntLiteral(node) ||
 		ts.isNumericLiteral(node) ||
 		ts.isStringLiteral(node) ||
 		ts.isNoSubstitutionTemplateLiteral(node) ||
-		node.kind === ts.SyntaxKind.RegularExpressionLiteral
+		node.kind === SyntaxKind.RegularExpressionLiteral
 	);
 }
 
@@ -113,7 +113,7 @@ export default ruleCreator.createRule(typescriptLanguage, {
 			visitors: {
 				CallExpression(node, { sourceFile }) {
 					if (
-						node.expression.kind !== ts.SyntaxKind.PropertyAccessExpression ||
+						node.expression.kind !== SyntaxKind.PropertyAccessExpression ||
 						node.expression.name.text !== "bind" ||
 						node.arguments.length !== 1
 					) {

--- a/packages/ts/src/rules/unnecessaryEscapes.ts
+++ b/packages/ts/src/rules/unnecessaryEscapes.ts
@@ -1,4 +1,4 @@
-import ts from "typescript";
+import { SyntaxKind } from "typescript";
 
 import {
 	typescriptLanguage,
@@ -152,7 +152,7 @@ export default ruleCreator.createRule(typescriptLanguage, {
 			const fullText = node.getText(sourceFile);
 			let quoteChar: string;
 
-			if (node.kind === ts.SyntaxKind.StringLiteral) {
+			if (node.kind === SyntaxKind.StringLiteral) {
 				quoteChar = fullText.startsWith('"') ? '"' : "'";
 			} else {
 				quoteChar = "`";

--- a/packages/ts/src/rules/unnecessaryUseStricts.ts
+++ b/packages/ts/src/rules/unnecessaryUseStricts.ts
@@ -1,4 +1,4 @@
-import ts from "typescript";
+import ts, { SyntaxKind } from "typescript";
 
 import {
 	getTSNodeRange,
@@ -37,8 +37,8 @@ export default ruleCreator.createRule(typescriptLanguage, {
 					const firstStatement = node.statements[0]!;
 
 					if (
-						firstStatement.kind !== ts.SyntaxKind.ExpressionStatement ||
-						firstStatement.expression.kind !== ts.SyntaxKind.StringLiteral ||
+						firstStatement.kind !== SyntaxKind.ExpressionStatement ||
+						firstStatement.expression.kind !== SyntaxKind.StringLiteral ||
 						firstStatement.expression.text !== "use strict"
 					) {
 						return;

--- a/packages/ts/src/rules/utils/collectAccessorPairs.ts
+++ b/packages/ts/src/rules/utils/collectAccessorPairs.ts
@@ -1,4 +1,5 @@
-import ts from "typescript";
+import type ts from "typescript";
+import { SyntaxKind } from "typescript";
 
 import type { AST } from "@flint.fyi/typescript-language";
 
@@ -20,8 +21,8 @@ export function collectAccessorPairs(
 
 	members.forEach((member, index) => {
 		if (
-			member.kind !== ts.SyntaxKind.GetAccessor &&
-			member.kind !== ts.SyntaxKind.SetAccessor
+			member.kind !== SyntaxKind.GetAccessor &&
+			member.kind !== SyntaxKind.SetAccessor
 		) {
 			return;
 		}
@@ -35,7 +36,7 @@ export function collectAccessorPairs(
 
 		const entry = { index, node: member };
 
-		if (member.kind === ts.SyntaxKind.GetAccessor) {
+		if (member.kind === SyntaxKind.GetAccessor) {
 			pair.getter = entry;
 		} else {
 			pair.setter = entry;
@@ -52,9 +53,9 @@ function getPropertyName(
 	sourceFile: AST.SourceFile,
 ) {
 	if (
-		accessor.name.kind === ts.SyntaxKind.Identifier ||
-		accessor.name.kind === ts.SyntaxKind.StringLiteral ||
-		accessor.name.kind === ts.SyntaxKind.NumericLiteral
+		accessor.name.kind === SyntaxKind.Identifier ||
+		accessor.name.kind === SyntaxKind.StringLiteral ||
+		accessor.name.kind === SyntaxKind.NumericLiteral
 	) {
 		return accessor.name.text;
 	}

--- a/packages/ts/src/rules/utils/countCommentsInRange.ts
+++ b/packages/ts/src/rules/utils/countCommentsInRange.ts
@@ -1,4 +1,4 @@
-import ts from "typescript";
+import ts, { SyntaxKind } from "typescript";
 
 import type { CharacterReportRange } from "@flint.fyi/core";
 
@@ -16,12 +16,12 @@ export function countCommentsInRange(
 
 	for (
 		let token = scanner.scan();
-		token !== ts.SyntaxKind.EndOfFileToken;
+		token !== SyntaxKind.EndOfFileToken;
 		token = scanner.scan()
 	) {
 		if (
-			token === ts.SyntaxKind.SingleLineCommentTrivia ||
-			token === ts.SyntaxKind.MultiLineCommentTrivia
+			token === SyntaxKind.SingleLineCommentTrivia ||
+			token === SyntaxKind.MultiLineCommentTrivia
 		) {
 			count++;
 		}

--- a/packages/ts/src/rules/utils/forEachReturnStatement.ts
+++ b/packages/ts/src/rules/utils/forEachReturnStatement.ts
@@ -1,4 +1,4 @@
-import * as ts from "typescript";
+import ts, { SyntaxKind } from "typescript";
 
 // Copied from typescript https://github.com/microsoft/TypeScript/blob/42b0e3c4630c129ca39ce0df9fff5f0d1b4dd348/src/compiler/utilities.ts#L1335
 // Warning: This has the same semantics as the forEach family of functions,
@@ -11,24 +11,24 @@ export function forEachReturnStatement<T>(
 
 	function traverse(node: ts.Node): T | undefined {
 		switch (node.kind) {
-			case ts.SyntaxKind.Block:
-			case ts.SyntaxKind.CaseBlock:
-			case ts.SyntaxKind.CaseClause:
-			case ts.SyntaxKind.CatchClause:
-			case ts.SyntaxKind.DefaultClause:
-			case ts.SyntaxKind.DoStatement:
-			case ts.SyntaxKind.ForInStatement:
-			case ts.SyntaxKind.ForOfStatement:
-			case ts.SyntaxKind.ForStatement:
-			case ts.SyntaxKind.IfStatement:
-			case ts.SyntaxKind.LabeledStatement:
-			case ts.SyntaxKind.SwitchStatement:
-			case ts.SyntaxKind.TryStatement:
-			case ts.SyntaxKind.WhileStatement:
-			case ts.SyntaxKind.WithStatement:
+			case SyntaxKind.Block:
+			case SyntaxKind.CaseBlock:
+			case SyntaxKind.CaseClause:
+			case SyntaxKind.CatchClause:
+			case SyntaxKind.DefaultClause:
+			case SyntaxKind.DoStatement:
+			case SyntaxKind.ForInStatement:
+			case SyntaxKind.ForOfStatement:
+			case SyntaxKind.ForStatement:
+			case SyntaxKind.IfStatement:
+			case SyntaxKind.LabeledStatement:
+			case SyntaxKind.SwitchStatement:
+			case SyntaxKind.TryStatement:
+			case SyntaxKind.WhileStatement:
+			case SyntaxKind.WithStatement:
 				return ts.forEachChild(node, traverse);
 
-			case ts.SyntaxKind.ReturnStatement:
+			case SyntaxKind.ReturnStatement:
 				return visitor(node as ts.ReturnStatement);
 		}
 

--- a/packages/ts/src/rules/utils/getFunctionName.ts
+++ b/packages/ts/src/rules/utils/getFunctionName.ts
@@ -1,4 +1,4 @@
-import ts from "typescript";
+import { SyntaxKind } from "typescript";
 
 import type { AST } from "@flint.fyi/typescript-language";
 
@@ -11,20 +11,20 @@ export function getFunctionName(
 		| AST.MethodSignature,
 ) {
 	switch (node.kind) {
-		case ts.SyntaxKind.ArrowFunction: {
-			return node.parent.kind === ts.SyntaxKind.VariableDeclaration &&
-				node.parent.name.kind === ts.SyntaxKind.Identifier
+		case SyntaxKind.ArrowFunction: {
+			return node.parent.kind === SyntaxKind.VariableDeclaration &&
+				node.parent.name.kind === SyntaxKind.Identifier
 				? node.parent.name.text
 				: undefined;
 		}
 
-		case ts.SyntaxKind.FunctionDeclaration:
-		case ts.SyntaxKind.FunctionExpression:
+		case SyntaxKind.FunctionDeclaration:
+		case SyntaxKind.FunctionExpression:
 			return node.name?.text;
 
-		case ts.SyntaxKind.MethodDeclaration:
-		case ts.SyntaxKind.MethodSignature:
-			return node.name.kind === ts.SyntaxKind.Identifier
+		case SyntaxKind.MethodDeclaration:
+		case SyntaxKind.MethodSignature:
+			return node.name.kind === SyntaxKind.Identifier
 				? node.name.text
 				: undefined;
 

--- a/packages/ts/src/rules/utils/isBuiltinSymbolLike.ts
+++ b/packages/ts/src/rules/utils/isBuiltinSymbolLike.ts
@@ -1,5 +1,5 @@
 import * as tsutils from "ts-api-utils";
-import * as ts from "typescript";
+import ts from "typescript";
 
 export function isBuiltinSymbolLike(
 	program: ts.Program,

--- a/packages/ts/src/rules/utils/isDirectEqualityCheck.ts
+++ b/packages/ts/src/rules/utils/isDirectEqualityCheck.ts
@@ -1,28 +1,28 @@
-import * as ts from "typescript";
+import { SyntaxKind } from "typescript";
 
 import type { AST } from "@flint.fyi/typescript-language";
 
 export function isDirectEqualityCheck(
 	node: AST.ArrowFunction | AST.FunctionExpression,
-	operators: ts.SyntaxKind[],
+	operators: SyntaxKind[],
 	parameterName: string,
 ) {
 	let body: AST.Expression | undefined;
 
 	switch (node.kind) {
-		case ts.SyntaxKind.ArrowFunction:
+		case SyntaxKind.ArrowFunction:
 			body =
-				node.body.kind === ts.SyntaxKind.Block
+				node.body.kind === SyntaxKind.Block
 					? getDirectReturnExpression(node.body)
 					: node.body;
 			break;
 
-		case ts.SyntaxKind.FunctionExpression:
+		case SyntaxKind.FunctionExpression:
 			body = getDirectReturnExpression(node.body);
 			break;
 	}
 
-	if (body?.kind !== ts.SyntaxKind.BinaryExpression) {
+	if (body?.kind !== SyntaxKind.BinaryExpression) {
 		return undefined;
 	}
 
@@ -33,9 +33,9 @@ export function isDirectEqualityCheck(
 	}
 
 	const isLeftParam =
-		left.kind === ts.SyntaxKind.Identifier && left.text === parameterName;
+		left.kind === SyntaxKind.Identifier && left.text === parameterName;
 	const isRightParam =
-		right.kind === ts.SyntaxKind.Identifier && right.text === parameterName;
+		right.kind === SyntaxKind.Identifier && right.text === parameterName;
 
 	if (isLeftParam && !isRightParam) {
 		return right;
@@ -55,7 +55,7 @@ function getDirectReturnExpression(body: AST.Block) {
 	// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 	const statement = body.statements[0]!;
 
-	return statement.kind === ts.SyntaxKind.ReturnStatement
+	return statement.kind === SyntaxKind.ReturnStatement
 		? statement.expression
 		: undefined;
 }

--- a/packages/ts/src/rules/utils/isInBooleanContext.ts
+++ b/packages/ts/src/rules/utils/isInBooleanContext.ts
@@ -1,43 +1,42 @@
-import ts from "typescript";
+import { SyntaxKind } from "typescript";
 
 import type { AST } from "@flint.fyi/typescript-language";
 
 export function isInBooleanContext(node: AST.AnyNode): boolean {
 	switch (node.parent.kind) {
-		case ts.SyntaxKind.AsExpression:
-		case ts.SyntaxKind.NonNullExpression:
-		case ts.SyntaxKind.ParenthesizedExpression:
+		case SyntaxKind.AsExpression:
+		case SyntaxKind.NonNullExpression:
+		case SyntaxKind.ParenthesizedExpression:
 			return isInBooleanContext(node.parent);
 
-		case ts.SyntaxKind.BinaryExpression: {
+		case SyntaxKind.BinaryExpression: {
 			return (
-				node.parent.operatorToken.kind ===
-					ts.SyntaxKind.AmpersandAmpersandToken ||
-				node.parent.operatorToken.kind === ts.SyntaxKind.BarBarToken
+				node.parent.operatorToken.kind === SyntaxKind.AmpersandAmpersandToken ||
+				node.parent.operatorToken.kind === SyntaxKind.BarBarToken
 			);
 		}
 
 		// TODO: This should make sure the Boolean is the global one...
-		case ts.SyntaxKind.CallExpression: {
+		case SyntaxKind.CallExpression: {
 			return (
-				node.parent.expression.kind === ts.SyntaxKind.Identifier &&
+				node.parent.expression.kind === SyntaxKind.Identifier &&
 				node.parent.expression.text === "Boolean" &&
 				node.parent.arguments.length === 1 &&
 				node.parent.arguments[0] === node
 			);
 		}
 
-		case ts.SyntaxKind.ConditionalExpression:
-		case ts.SyntaxKind.ForStatement:
+		case SyntaxKind.ConditionalExpression:
+		case SyntaxKind.ForStatement:
 			return node.parent.condition === node;
 
-		case ts.SyntaxKind.DoStatement:
-		case ts.SyntaxKind.IfStatement:
-		case ts.SyntaxKind.WhileStatement:
+		case SyntaxKind.DoStatement:
+		case SyntaxKind.IfStatement:
+		case SyntaxKind.WhileStatement:
 			return node.parent.expression === node;
 
-		case ts.SyntaxKind.PrefixUnaryExpression:
-			return node.parent.operator === ts.SyntaxKind.ExclamationToken;
+		case SyntaxKind.PrefixUnaryExpression:
+			return node.parent.operator === SyntaxKind.ExclamationToken;
 
 		default:
 			return false;

--- a/packages/typescript-language/src/directives/parseDirectivesFromTypeScriptFile.ts
+++ b/packages/typescript-language/src/directives/parseDirectivesFromTypeScriptFile.ts
@@ -1,5 +1,5 @@
 import * as tsutils from "ts-api-utils";
-import ts from "typescript";
+import ts, { SyntaxKind } from "typescript";
 
 import {
 	DirectivesCollector,
@@ -89,7 +89,7 @@ function computeNextCodeLine(
 	const kind = scanner.scan();
 
 	// Reaching the end of the file means there are no more lines
-	if (kind === ts.SyntaxKind.EndOfFileToken) {
+	if (kind === SyntaxKind.EndOfFileToken) {
 		return undefined;
 	}
 

--- a/packages/typescript-language/src/language.ts
+++ b/packages/typescript-language/src/language.ts
@@ -2,7 +2,7 @@ import path from "node:path";
 
 import { createProjectService } from "@typescript-eslint/project-service";
 import { debugForFile } from "debug-for-file";
-import * as ts from "typescript";
+import ts, { SyntaxKind } from "typescript";
 
 import {
 	createLanguage,
@@ -35,7 +35,7 @@ export interface TypeScriptFileServices {
 
 const log = debugForFile(import.meta.filename);
 
-export const NodeSyntaxKinds = getFirstEnumValues(ts.SyntaxKind);
+export const NodeSyntaxKinds = getFirstEnumValues(SyntaxKind);
 
 interface GlobalLanguageState {
 	packageVersion: string;

--- a/packages/typescript-language/src/utils/containsGlobalDeclarations.ts
+++ b/packages/typescript-language/src/utils/containsGlobalDeclarations.ts
@@ -1,4 +1,4 @@
-import ts from "typescript";
+import ts, { SyntaxKind } from "typescript";
 
 /**
  * Inspects top-level statements of a TS source file to determine
@@ -25,6 +25,6 @@ export function containsGlobalDeclarations(sourceFileNode: ts.SourceFile) {
 		}
 
 		const modifiers = ts.getModifiers(statement);
-		return modifiers?.some((mod) => mod.kind === ts.SyntaxKind.DeclareKeyword);
+		return modifiers?.some((mod) => mod.kind === SyntaxKind.DeclareKeyword);
 	});
 }

--- a/packages/typescript-language/src/utils/getStaticValue.test.ts
+++ b/packages/typescript-language/src/utils/getStaticValue.test.ts
@@ -1,4 +1,4 @@
-import ts from "typescript";
+import ts, { SyntaxKind } from "typescript";
 import { describe, expect, it } from "vitest";
 
 import type * as AST from "../types/ast.ts";
@@ -89,7 +89,7 @@ function parseExpression(source: string): AST.Expression {
 		ts.ScriptKind.TS,
 	);
 	const statement = sourceFile.statements[0];
-	if (statement?.kind !== ts.SyntaxKind.VariableStatement) {
+	if (statement?.kind !== SyntaxKind.VariableStatement) {
 		throw new Error(`Could not parse expression: ${source}`);
 	}
 

--- a/packages/typescript-language/src/utils/hasSameTokens.ts
+++ b/packages/typescript-language/src/utils/hasSameTokens.ts
@@ -1,4 +1,4 @@
-import ts from "typescript";
+import ts, { SyntaxKind } from "typescript";
 
 import type * as AST from "../types/ast.ts";
 import { unwrapParenthesizedNode } from "./unwrapParenthesizedNode.ts";
@@ -60,7 +60,7 @@ function areSameToken(
 		return nodeA.text === (nodeB as typeof nodeA).text;
 	}
 
-	if (nodeA.kind === ts.SyntaxKind.RegularExpressionLiteral) {
+	if (nodeA.kind === SyntaxKind.RegularExpressionLiteral) {
 		return (
 			sourceFile.text.slice(nodeA.getStart(sourceFile), nodeA.getEnd()) ===
 			sourceFile.text.slice(nodeB.getStart(sourceFile), nodeB.getEnd())

--- a/packages/typescript-language/src/utils/isBuiltinArrayMethod.ts
+++ b/packages/typescript-language/src/utils/isBuiltinArrayMethod.ts
@@ -1,4 +1,5 @@
-import ts from "typescript";
+import type ts from "typescript";
+import { SyntaxKind } from "typescript";
 
 import type { AST, Checker } from "@flint.fyi/typescript-language";
 
@@ -14,11 +15,11 @@ export function isBuiltinArrayMethod(
 	typeChecker: Checker,
 ): node is BuiltInArrayMethodNode {
 	return (
-		node.expression.kind === ts.SyntaxKind.PropertyAccessExpression &&
+		node.expression.kind === SyntaxKind.PropertyAccessExpression &&
 		node.expression.name.text === name &&
 		typeChecker.isArrayType(
 			typeChecker.getTypeAtLocation(node.expression.expression),
 		) &&
-		node.parent.kind !== ts.SyntaxKind.ExpressionStatement
+		node.parent.kind !== SyntaxKind.ExpressionStatement
 	);
 }

--- a/packages/typescript-language/src/utils/isInlineArrayCreation.ts
+++ b/packages/typescript-language/src/utils/isInlineArrayCreation.ts
@@ -1,4 +1,4 @@
-import * as ts from "typescript";
+import ts from "typescript";
 
 const methodsReturningNewArray = new Set([
 	"concat",

--- a/packages/vitest/src/createStatementPaddingRule.ts
+++ b/packages/vitest/src/createStatementPaddingRule.ts
@@ -1,4 +1,4 @@
-import ts from "typescript";
+import ts, { SyntaxKind } from "typescript";
 
 import {
 	getTSNodeRange,
@@ -168,7 +168,7 @@ export function getStatementRootName(statement: AST.AnyNode) {
 		return undefined;
 	}
 
-	if (expression.kind === ts.SyntaxKind.AwaitExpression) {
+	if (expression.kind === SyntaxKind.AwaitExpression) {
 		return getRootIdentifierName(expression.expression);
 	}
 
@@ -176,15 +176,15 @@ export function getStatementRootName(statement: AST.AnyNode) {
 }
 
 function getRootIdentifierName(node: AST.AnyNode): string | undefined {
-	if (node.kind === ts.SyntaxKind.Identifier) {
+	if (node.kind === SyntaxKind.Identifier) {
 		return node.text;
 	}
 
 	if (
-		node.kind === ts.SyntaxKind.CallExpression ||
-		node.kind === ts.SyntaxKind.NonNullExpression ||
-		node.kind === ts.SyntaxKind.ParenthesizedExpression ||
-		node.kind === ts.SyntaxKind.PropertyAccessExpression
+		node.kind === SyntaxKind.CallExpression ||
+		node.kind === SyntaxKind.NonNullExpression ||
+		node.kind === SyntaxKind.ParenthesizedExpression ||
+		node.kind === SyntaxKind.PropertyAccessExpression
 	) {
 		return getRootIdentifierName(node.expression);
 	}
@@ -195,11 +195,11 @@ function getRootIdentifierName(node: AST.AnyNode): string | undefined {
 function getStatementExpression(
 	statement: AST.AnyNode,
 ): AST.AnyNode | undefined {
-	if (statement.kind === ts.SyntaxKind.ExpressionStatement) {
+	if (statement.kind === SyntaxKind.ExpressionStatement) {
 		return statement.expression;
 	}
 
-	if (statement.kind === ts.SyntaxKind.LabeledStatement) {
+	if (statement.kind === SyntaxKind.LabeledStatement) {
 		return getStatementExpression(statement.statement);
 	}
 

--- a/packages/vitest/src/rules/nodeTestImports.ts
+++ b/packages/vitest/src/rules/nodeTestImports.ts
@@ -1,4 +1,4 @@
-import ts from "typescript";
+import { SyntaxKind } from "typescript";
 
 import {
 	getTSNodeRange,
@@ -32,7 +32,7 @@ export default ruleCreator.createRule(typescriptLanguage, {
 			visitors: {
 				ImportDeclaration: (node, { sourceFile }) => {
 					if (
-						node.moduleSpecifier.kind !== ts.SyntaxKind.StringLiteral ||
+						node.moduleSpecifier.kind !== SyntaxKind.StringLiteral ||
 						node.moduleSpecifier.text !== "node:test"
 					) {
 						return;

--- a/packages/vitest/src/utils/parseVitestFunctionCall.ts
+++ b/packages/vitest/src/utils/parseVitestFunctionCall.ts
@@ -1,4 +1,4 @@
-import ts from "typescript";
+import { SyntaxKind } from "typescript";
 
 import type { AST } from "@flint.fyi/typescript-language";
 
@@ -44,18 +44,18 @@ export function parseVitestFunctionCall(node: AST.CallExpression) {
 	}
 
 	switch (node.expression.kind) {
-		case ts.SyntaxKind.CallExpression:
-		case ts.SyntaxKind.TaggedTemplateExpression:
+		case SyntaxKind.CallExpression:
+		case SyntaxKind.TaggedTemplateExpression:
 			return parsedCallee.segments
 				.slice(0, -1)
 				.every((segment) => knownVitestFunctionModifiersSet.has(segment))
 				? parsedCallee
 				: undefined;
 
-		case ts.SyntaxKind.Identifier:
+		case SyntaxKind.Identifier:
 			return parsedCallee;
 
-		case ts.SyntaxKind.PropertyAccessExpression:
+		case SyntaxKind.PropertyAccessExpression:
 			return parsedCallee.segments.every((segment) =>
 				knownVitestFunctionModifiersSet.has(segment),
 			)
@@ -69,17 +69,17 @@ function parseVitestCallee(
 	targetNode?: AST.AnyNode,
 ): undefined | VitestCallee {
 	switch (node.kind) {
-		case ts.SyntaxKind.CallExpression:
+		case SyntaxKind.CallExpression:
 			return parseVitestCallee(node.expression, targetNode);
 
-		case ts.SyntaxKind.Identifier:
+		case SyntaxKind.Identifier:
 			return {
 				name: node.text,
 				segments: [],
 				targetNode: targetNode ?? node,
 			};
 
-		case ts.SyntaxKind.PropertyAccessExpression: {
+		case SyntaxKind.PropertyAccessExpression: {
 			const parsedExpression = parseVitestCallee(node.expression, node);
 
 			return (
@@ -91,7 +91,7 @@ function parseVitestCallee(
 			);
 		}
 
-		case ts.SyntaxKind.TaggedTemplateExpression:
+		case SyntaxKind.TaggedTemplateExpression:
 			return parseVitestCallee(node.tag, targetNode);
 	}
 }


### PR DESCRIPTION
## Overview

This is the final PR in the AST cleanup stack and targets the extensive AST cleanup branch.

It contains only the stylistic TypeScript import and `SyntaxKind` reference cleanup.

Merge after the preceding AST cleanup PR.
