### PR TITLE
chore(orb): use mise shims so husky hooks get repo Node.js

### DIFF
--- a/.agents/setup
+++ b/.agents/setup
@@ -2,7 +2,10 @@
 set -euo pipefail
 
 curl https://mise.run | sh
-eval "$(~/.local/bin/mise activate bash)"
+# Use shims instead of `mise activate bash`'s shell functions so the orb's
+# repo-managed Node.js/pnpm propagate to child processes like husky's dash
+# pre-commit hook, which would otherwise hit the orb's older system Node.js.
+eval "$(~/.local/bin/mise activate --shims bash)"
 
 mise settings set idiomatic_version_file_enable_tools node,pnpm
 mise install --yes


### PR DESCRIPTION
## Summary

`.agents/setup` used `eval "$(mise activate bash)``, which defines `node`/`pnpm` as **shell functions**. Shell functions don't propagate to child processes, so husky's `pre-commit` hook (run by `/bin/sh` → dash) fell back to the orb's older system Node.js (v20.9.0) and crashed on APIs it lacks — e.g. `node:util`'s `styleText`, used by lint-staged:

```
SyntaxError: The requested module 'node:util' does not provide an export named 'styleText'
husky - pre-commit script failed (code 1)
```

## Fix

Switch to `mise activate --shims bash`, which prepends the mise shims directory (`~/.local/share/mise/shims`) to `PATH` as real executable symlinks. Those propagate to child processes, so husky's dash hook resolves to the repo-managed Node.js the same as everything else.

Verified on this orb: with the shims on `PATH`, `sh -c 'which node'` resolves to `~/.local/share/mise/shims/node` (v24.18.0) instead of `/usr/local/bin/node` (v20.9.0), and the husky pre-commit hook runs successfully.

## Test plan

- [ ] New orb runs `.agents/setup` without error
- [ ] On the new orb, a commit that triggers the husky `pre-commit` hook succeeds without `--no-verify`