### PR TITLE
chore: activate mise in orb shells

### DIFF
--- a/.agents/setup
+++ b/.agents/setup
@@ -9,6 +9,11 @@ eval "$(~/.local/bin/mise activate --shims bash)"
 
 mise settings set idiomatic_version_file_enable_tools node,pnpm
 mise install --yes
+
+cat >> "$HOME/.bash_profile" << EOF_PROFILE
+eval "\$("$HOME/.local/bin/mise" activate --shims bash)"
+EOF_PROFILE
+
 pnpm install --frozen-lockfile
 pnpm --filter=site prebuild
 


### PR DESCRIPTION
## PR Checklist

- [ ] Addresses an existing open issue
- [ ] That issue was marked as `status: accepting prs`
- [x] Relevant setup behavior was verified

## Overview

Persist mise's shims activation in `~/.bash_profile` during orb setup so later login shells use the repository-managed Node.js and pnpm versions.