### PR TITLE
chore(deps): update eslint-plugin-unicorn to v72

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -128,3 +128,11 @@ jobs:
         with:
           fail_ci_if_error: true
           use_oidc: true
+
+  check_comps_sort:
+    name: Ensure comparisons data remains sorted
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: ./.github/actions/prepare
+      - run: pnpm run --filter=comparisons sort-data --check

--- a/knip.ts
+++ b/knip.ts
@@ -28,7 +28,7 @@ export default {
 			project: ["src/**/*.ts!"],
 		},
 		"packages/comparisons": {
-			entry: ["src/sort-data.ts!"],
+			entry: ["src/sort-data.ts"],
 			project: ["src/**/*.ts!", "!src/test-utils/*.ts!"],
 		},
 		"packages/css": {

--- a/knip.ts
+++ b/knip.ts
@@ -28,7 +28,7 @@ export default {
 			project: ["src/**/*.ts!"],
 		},
 		"packages/comparisons": {
-			entry: ["src/sort-data.ts"],
+			entry: ["scripts/*.ts"],
 			project: ["src/**/*.ts!", "!src/test-utils/*.ts!"],
 		},
 		"packages/css": {

--- a/packages/comparisons/package.json
+++ b/packages/comparisons/package.json
@@ -71,7 +71,7 @@
 		"eslint-plugin-regexp": "catalog:dev",
 		"eslint-plugin-solid": "0.14.5",
 		"eslint-plugin-svelte": "3.17.1",
-		"eslint-plugin-unicorn": "64.0.0",
+		"eslint-plugin-unicorn": "72.0.0",
 		"eslint-plugin-vue": "10.9.1",
 		"eslint-plugin-yml": "catalog:dev",
 		"markdownlint": "0.41.0",

--- a/packages/comparisons/package.json
+++ b/packages/comparisons/package.json
@@ -40,7 +40,6 @@
 		"@flint.fyi/ts": "workspace:^",
 		"@flint.fyi/vitest": "workspace:^",
 		"@flint.fyi/yaml": "workspace:^",
-		"prettier": "3.8.1",
 		"zod": "^4.3.6"
 	},
 	"devDependencies": {

--- a/packages/comparisons/package.json
+++ b/packages/comparisons/package.json
@@ -22,6 +22,7 @@
 		"dist/"
 	],
 	"scripts": {
+		"sort-data": "node scripts/sort-data.ts",
 		"test": "vitest --project comparisons"
 	},
 	"dependencies": {

--- a/packages/comparisons/scripts/sort-data.ts
+++ b/packages/comparisons/scripts/sort-data.ts
@@ -3,8 +3,7 @@ import path from "node:path";
 import process from "node:process";
 import { isDeepStrictEqual, parseArgs } from "node:util";
 
-import dataOriginal from "./data.json" with { type: "json" };
-import { comparisonsDataSchema } from "./schemas.ts";
+import { comparisons as dataOriginal } from "@flint.fyi/comparisons" with { type: "json" };
 
 const dataFilePath = path.join(import.meta.dirname, "data.json");
 
@@ -20,13 +19,11 @@ const {
 	},
 });
 
-const dataSorted = comparisonsDataSchema
-	.parse(dataOriginal)
-	.toSorted((a, b) =>
-		a.flint.plugin === b.flint.plugin
-			? a.flint.name.localeCompare(b.flint.name)
-			: a.flint.plugin.localeCompare(b.flint.plugin),
-	);
+const dataSorted = dataOriginal.toSorted((a, b) =>
+	a.flint.plugin === b.flint.plugin
+		? a.flint.name.localeCompare(b.flint.name)
+		: a.flint.plugin.localeCompare(b.flint.plugin),
+);
 
 const dirty = !isDeepStrictEqual(dataOriginal, dataSorted);
 

--- a/packages/comparisons/scripts/sort-data.ts
+++ b/packages/comparisons/scripts/sort-data.ts
@@ -1,44 +1,129 @@
+/* eslint perfectionist/sort-objects: ["error", {
+	customGroups: [
+		{
+			groupName: "root",
+			elementNamePattern: "^$",
+		},
+		{
+			groupName: "flint",
+			elementNamePattern: "^flint$",
+		},
+	],
+	groups: ["root" ,"flint", "unknown"],
+}] */
 import fs from "node:fs/promises";
 import path from "node:path";
 import process from "node:process";
-import { isDeepStrictEqual, parseArgs } from "node:util";
+import { parseArgs } from "node:util";
 
-import { comparisons as dataOriginal } from "@flint.fyi/comparisons" with { type: "json" };
+import { comparisonsDataSchema, type Comparison } from "@flint.fyi/comparisons";
+import { jsonCodec } from "@flint.fyi/core";
 
-const dataFilePath = path.join(import.meta.dirname, "data.json");
-
-const {
-	values: { check },
-} = parseArgs({
-	options: {
-		check: {
-			default: false,
-			short: "c",
-			type: "boolean",
-		},
-	},
-});
-
-const dataSorted = dataOriginal.toSorted((a, b) =>
-	a.flint.plugin === b.flint.plugin
-		? a.flint.name.localeCompare(b.flint.name)
-		: a.flint.plugin.localeCompare(b.flint.plugin),
-);
-
-const dirty = !isDeepStrictEqual(dataOriginal, dataSorted);
-
-if (dirty) {
-	if (check) {
-		console.log(`File unsorted: ${dataFilePath}`);
-
-		process.exitCode = 1;
-	} else {
-		console.log(`Writing to: ${dataFilePath}`);
-		await fs.writeFile(
-			dataFilePath,
-			JSON.stringify(dataSorted, null, "	") + "\n",
-		);
-	}
-} else {
-	console.log(`File sorted correctly: ${dataFilePath}`);
+function sortItem(item: Comparison) {
+	return sortKeys(item, orders);
 }
+
+const linterRuleReferenceOrder = ["name", "url"] as const;
+
+const orders = {
+	"": [
+		"flint",
+		"biome",
+		"deno",
+		"eslint",
+		"markdownlint",
+		"oxlint",
+		"stylelint",
+		"notes",
+	],
+	flint: ["name", "plugin", "preset", "status", "strictness"],
+	biome: linterRuleReferenceOrder,
+	deno: linterRuleReferenceOrder,
+	eslint: linterRuleReferenceOrder,
+	markdownlint: linterRuleReferenceOrder,
+	oxlint: linterRuleReferenceOrder,
+	stylelint: linterRuleReferenceOrder,
+};
+
+async function main() {
+	const dataFilePath = path.join(import.meta.dirname, "..", "src", "data.json");
+
+	const {
+		values: { check },
+	} = parseArgs({
+		options: {
+			check: {
+				default: false,
+				short: "c",
+				type: "boolean",
+			},
+		},
+	});
+
+	const original = await fs.readFile(dataFilePath, "utf8");
+
+	const dataOriginal = jsonCodec(comparisonsDataSchema).decode(original);
+
+	const dataSorted = sortList(dataOriginal).map(sortItem);
+
+	const sorted = serialize(dataSorted);
+
+	if (original !== sorted) {
+		if (check) {
+			console.log(`File unsorted: ${dataFilePath}`);
+
+			process.exitCode = 1;
+		} else {
+			console.log(`Writing to: ${dataFilePath}`);
+			await fs.writeFile(dataFilePath, sorted);
+		}
+	} else {
+		console.log(`File sorted correctly: ${dataFilePath}`);
+	}
+}
+
+function serialize(value: unknown): string {
+	return JSON.stringify(value, null, "	") + "\n";
+}
+
+function sortKeys<const T>(
+	value: T,
+	orders: Record<string, readonly string[]>,
+	path = "",
+): T {
+	if (Array.isArray(value)) {
+		return (value as unknown[]).map((v) => sortKeys(v, orders, path)) as T;
+	}
+
+	if (!value || typeof value !== "object") {
+		return value;
+	}
+
+	const order = orders[path];
+	const orderMap = order ? new Map(order.map((k, i) => [k, i])) : undefined;
+
+	return Object.fromEntries(
+		Object.entries(value)
+			.toSorted(([a], [b]) => {
+				if (!orderMap) {
+					return a.localeCompare(b, "en-US");
+				}
+
+				return (
+					(orderMap.get(a) ?? Infinity) - (orderMap.get(b) ?? Infinity) ||
+					a.localeCompare(b, "en-US")
+				);
+			})
+			.map(([k, v]) => [k, sortKeys(v, orders, path ? `${path}.${k}` : k)]),
+	) as T;
+}
+
+function sortList(data: Comparison[]) {
+	return data.toSorted((a, b) =>
+		a.flint.plugin === b.flint.plugin
+			? a.flint.name.localeCompare(b.flint.name, "en-US")
+			: a.flint.plugin.localeCompare(b.flint.plugin, "en-US"),
+	);
+}
+
+await main();

--- a/packages/comparisons/src/comparisons.ts
+++ b/packages/comparisons/src/comparisons.ts
@@ -1,5 +1,5 @@
 import data from "./data.json" with { type: "json" };
-import { comparisonsDataSchema } from "./schemas.ts";
+import { comparisonsDataSchema, type Comparison } from "./schemas.ts";
 
 export type LinterName =
 	| "biome"
@@ -22,6 +22,6 @@ export const linterNames = {
 	stylelint: "Stylelint",
 } as const satisfies Record<LinterName, string>;
 
-const comparisons = comparisonsDataSchema.parse(data);
+const comparisons: Comparison[] = comparisonsDataSchema.parse(data);
 
 export { comparisons };

--- a/packages/comparisons/src/comparisons.ts
+++ b/packages/comparisons/src/comparisons.ts
@@ -1,5 +1,13 @@
 import data from "./data.json" with { type: "json" };
-import type { Comparison, LinterName } from "./schemas.ts";
+import { comparisonsDataSchema } from "./schemas.ts";
+
+export type LinterName =
+	| "biome"
+	| "deno"
+	| "eslint"
+	| "markdownlint"
+	| "oxlint"
+	| "stylelint";
 
 export function getComparisonId(pluginId: string, ruleId: string) {
 	return [pluginId, ruleId].join("/");
@@ -14,6 +22,6 @@ export const linterNames = {
 	stylelint: "Stylelint",
 } as const satisfies Record<LinterName, string>;
 
-const comparisons = data as Comparison[];
+const comparisons = comparisonsDataSchema.parse(data);
 
 export { comparisons };

--- a/packages/comparisons/src/data.json
+++ b/packages/comparisons/src/data.json
@@ -724,6 +724,19 @@
 	},
 	{
 		"flint": {
+			"name": "addEventListenerOptions",
+			"plugin": "browser",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/prefer-add-event-listener-options",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prefer-add-event-listener-options.md"
+			}
+		]
+	},
+	{
+		"flint": {
 			"name": "alerts",
 			"plugin": "browser",
 			"preset": "logical",
@@ -750,6 +763,45 @@
 	},
 	{
 		"flint": {
+			"name": "betterDomTraversing",
+			"plugin": "browser",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/better-dom-traversing",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/better-dom-traversing.md"
+			}
+		]
+	},
+	{
+		"flint": {
+			"name": "blobToFiles",
+			"plugin": "browser",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/no-blob-to-file",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-blob-to-file.md"
+			}
+		]
+	},
+	{
+		"flint": {
+			"name": "canvasToImages",
+			"plugin": "browser",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/no-canvas-to-image",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-canvas-to-image.md"
+			}
+		]
+	},
+	{
+		"flint": {
 			"name": "classListToggles",
 			"plugin": "browser",
 			"preset": "stylistic",
@@ -765,6 +817,19 @@
 			{
 				"name": "unicorn/prefer-classlist-toggle",
 				"url": "https://oxc.rs/docs/guide/usage/linter/rules/unicorn/prefer-classlist-toggle.html"
+			}
+		]
+	},
+	{
+		"flint": {
+			"name": "cssEscapes",
+			"plugin": "browser",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/require-css-escape",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/require-css-escape.md"
 			}
 		]
 	},
@@ -829,6 +894,45 @@
 	},
 	{
 		"flint": {
+			"name": "domNodeDatasets",
+			"plugin": "browser",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/dom-node-dataset",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/dom-node-dataset.md"
+			}
+		]
+	},
+	{
+		"flint": {
+			"name": "domNodeHtmlMethods",
+			"plugin": "browser",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/prefer-dom-node-html-methods",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prefer-dom-node-html-methods.md"
+			}
+		]
+	},
+	{
+		"flint": {
+			"name": "domNodeReplaceChildrenMethods",
+			"plugin": "browser",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/prefer-dom-node-replace-children",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prefer-dom-node-replace-children.md"
+			}
+		]
+	},
+	{
+		"flint": {
 			"name": "eventListenerSubscriptions",
 			"plugin": "browser",
 			"preset": "logical",
@@ -845,6 +949,32 @@
 			{
 				"name": "unicorn/prefer-add-event-listener",
 				"url": "https://oxc.rs/docs/guide/usage/linter/rules/unicorn/prefer-add-event-listener.html"
+			}
+		]
+	},
+	{
+		"flint": {
+			"name": "explicitViewportUnits",
+			"plugin": "browser",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/prefer-explicit-viewport-units",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prefer-explicit-viewport-units.md"
+			}
+		]
+	},
+	{
+		"flint": {
+			"name": "https",
+			"plugin": "browser",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/prefer-https",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prefer-https.md"
 			}
 		]
 	},
@@ -870,6 +1000,32 @@
 	},
 	{
 		"flint": {
+			"name": "incorrectQuerySelectors",
+			"plugin": "browser",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/no-incorrect-query-selector",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-incorrect-query-selector.md"
+			}
+		]
+	},
+	{
+		"flint": {
+			"name": "invalidFileInputAccepts",
+			"plugin": "browser",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/no-invalid-file-input-accept",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-invalid-file-input-accept.md"
+			}
+		]
+	},
+	{
+		"flint": {
 			"name": "keyboardEventKeys",
 			"plugin": "browser",
 			"preset": "logical",
@@ -885,6 +1041,45 @@
 			{
 				"name": "unicorn/prefer-keyboard-event-key",
 				"url": "https://oxc.rs/docs/guide/usage/linter/rules/unicorn/prefer-keyboard-event-key.html"
+			}
+		]
+	},
+	{
+		"flint": {
+			"name": "lateEventControls",
+			"plugin": "browser",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/no-late-event-control",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-late-event-control.md"
+			}
+		]
+	},
+	{
+		"flint": {
+			"name": "locationAssigns",
+			"plugin": "browser",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/prefer-location-assign",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prefer-location-assign.md"
+			}
+		]
+	},
+	{
+		"flint": {
+			"name": "missingLocalResources",
+			"plugin": "browser",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/no-missing-local-resource",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-missing-local-resource.md"
 			}
 		]
 	},
@@ -1028,6 +1223,45 @@
 	},
 	{
 		"flint": {
+			"name": "observerApis",
+			"plugin": "browser",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/prefer-observer-apis",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prefer-observer-apis.md"
+			}
+		]
+	},
+	{
+		"flint": {
+			"name": "passiveEvents",
+			"plugin": "browser",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/require-passive-events",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/require-passive-events.md"
+			}
+		]
+	},
+	{
+		"flint": {
+			"name": "path2dObjects",
+			"plugin": "browser",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/prefer-path2d",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prefer-path2d.md"
+			}
+		]
+	},
+	{
+		"flint": {
 			"name": "removeEventListenerExpressions",
 			"plugin": "browser",
 			"preset": "logical",
@@ -1043,6 +1277,19 @@
 			{
 				"name": "unicorn/no-invalid-remove-event-listener",
 				"url": "https://oxc.rs/docs/guide/usage/linter/rules/unicorn/no-invalid-remove-event-listener.html"
+			}
+		]
+	},
+	{
+		"flint": {
+			"name": "scopedSelectors",
+			"plugin": "browser",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/prefer-scoped-selector",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prefer-scoped-selector.md"
 			}
 		]
 	},
@@ -1069,6 +1316,97 @@
 			{
 				"name": "eslint/no-script-url",
 				"url": "https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-script-url.html"
+			}
+		]
+	},
+	{
+		"flint": {
+			"name": "selectorAsDomNames",
+			"plugin": "browser",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/no-selector-as-dom-name",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-selector-as-dom-name.md"
+			}
+		]
+	},
+	{
+		"flint": {
+			"name": "toggleAttributes",
+			"plugin": "browser",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/prefer-toggle-attribute",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prefer-toggle-attribute.md"
+			}
+		]
+	},
+	{
+		"flint": {
+			"name": "transitionAllDeclarations",
+			"plugin": "browser",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/no-transition-all",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-transition-all.md"
+			}
+		]
+	},
+	{
+		"flint": {
+			"name": "unsafeDomHtml",
+			"plugin": "browser",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/no-unsafe-dom-html",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-unsafe-dom-html.md"
+			}
+		]
+	},
+	{
+		"flint": {
+			"name": "urlCanParseChecks",
+			"plugin": "browser",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/prefer-url-can-parse",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prefer-url-can-parse.md"
+			}
+		]
+	},
+	{
+		"flint": {
+			"name": "urlHrefs",
+			"plugin": "browser",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/prefer-url-href",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prefer-url-href.md"
+			}
+		]
+	},
+	{
+		"flint": {
+			"name": "urlSearchParameters",
+			"plugin": "browser",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/prefer-url-search-parameters",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prefer-url-search-parameters.md"
 			}
 		]
 	},
@@ -9649,6 +9987,19 @@
 	},
 	{
 		"flint": {
+			"name": "exportsInScripts",
+			"plugin": "node",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/no-exports-in-scripts",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-exports-in-scripts.md"
+			}
+		]
+	},
+	{
+		"flint": {
 			"name": "exportsStyle",
 			"plugin": "node",
 			"status": "skipped"
@@ -9878,6 +10229,19 @@
 			{
 				"name": "import/extensions",
 				"url": "https://oxc.rs/docs/guide/usage/linter/rules/import/extensions.html"
+			}
+		]
+	},
+	{
+		"flint": {
+			"name": "jsonFileReadConsistency",
+			"plugin": "node",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/consistent-json-file-read",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/consistent-json-file-read.md"
 			}
 		]
 	},
@@ -10245,6 +10609,19 @@
 			{
 				"name": "n/no-unpublished-require",
 				"url": "https://github.com/eslint-community/eslint-plugin-n/blob/HEAD/docs/rules/no-unpublished-require.md"
+			}
+		]
+	},
+	{
+		"flint": {
+			"name": "unsafeBufferConversions",
+			"plugin": "node",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/no-unsafe-buffer-conversion",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-unsafe-buffer-conversion.md"
 			}
 		]
 	},
@@ -15548,6 +15925,32 @@
 	},
 	{
 		"flint": {
+			"name": "abortSignalAny",
+			"plugin": "ts",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/prefer-abort-signal-any",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prefer-abort-signal-any.md"
+			}
+		]
+	},
+	{
+		"flint": {
+			"name": "abortSignalTimeouts",
+			"plugin": "ts",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/prefer-abort-signal-timeout",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prefer-abort-signal-timeout.md"
+			}
+		]
+	},
+	{
+		"flint": {
 			"name": "accessorPairGroups",
 			"plugin": "ts",
 			"preset": "stylistic",
@@ -15629,6 +16032,32 @@
 			{
 				"name": "unicorn/no-accessor-recursion",
 				"url": "https://oxc.rs/docs/guide/usage/linter/rules/unicorn/no-accessor-recursion.html"
+			}
+		]
+	},
+	{
+		"flint": {
+			"name": "accidentalBitwiseOperators",
+			"plugin": "ts",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/no-accidental-bitwise-operator",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-accidental-bitwise-operator.md"
+			}
+		]
+	},
+	{
+		"flint": {
+			"name": "aggregateErrors",
+			"plugin": "ts",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/prefer-aggregate-error",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prefer-aggregate-error.md"
 			}
 		]
 	},
@@ -15848,6 +16277,19 @@
 	},
 	{
 		"flint": {
+			"name": "arrayConcatInLoops",
+			"plugin": "ts",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/no-array-concat-in-loop",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-array-concat-in-loop.md"
+			}
+		]
+	},
+	{
+		"flint": {
 			"name": "arrayConstructors",
 			"plugin": "ts",
 			"preset": "logical",
@@ -15980,6 +16422,19 @@
 			{
 				"name": "unicorn/consistent-existence-index-check",
 				"url": "https://oxc.rs/docs/guide/usage/linter/rules/unicorn/consistent-existence-index-check.html"
+			}
+		]
+	},
+	{
+		"flint": {
+			"name": "arrayFillWithReferenceTypes",
+			"plugin": "ts",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/no-array-fill-with-reference-type",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-array-fill-with-reference-type.md"
 			}
 		]
 	},
@@ -16119,6 +16574,71 @@
 	},
 	{
 		"flint": {
+			"name": "arrayFromAsyncMethods",
+			"plugin": "ts",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/prefer-array-from-async",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prefer-array-from-async.md"
+			}
+		]
+	},
+	{
+		"flint": {
+			"name": "arrayFromFills",
+			"plugin": "ts",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/no-array-from-fill",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-array-from-fill.md"
+			}
+		]
+	},
+	{
+		"flint": {
+			"name": "arrayFromMaps",
+			"plugin": "ts",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/prefer-array-from-map",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prefer-array-from-map.md"
+			}
+		]
+	},
+	{
+		"flint": {
+			"name": "arrayFromRanges",
+			"plugin": "ts",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/prefer-array-from-range",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prefer-array-from-range.md"
+			}
+		]
+	},
+	{
+		"flint": {
+			"name": "arrayFrontMutations",
+			"plugin": "ts",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/no-array-front-mutation",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-array-front-mutation.md"
+			}
+		]
+	},
+	{
+		"flint": {
 			"name": "arrayIncludes",
 			"plugin": "ts",
 			"preset": "stylistic",
@@ -16212,6 +16732,19 @@
 	},
 	{
 		"flint": {
+			"name": "arrayIterableMethods",
+			"plugin": "ts",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/prefer-array-iterable-methods",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prefer-array-iterable-methods.md"
+			}
+		]
+	},
+	{
+		"flint": {
 			"name": "arrayJoinSeparators",
 			"plugin": "ts",
 			"status": "skipped"
@@ -16226,6 +16759,19 @@
 			{
 				"name": "unicorn/require-array-join-separator",
 				"url": "https://oxc.rs/docs/guide/usage/linter/rules/unicorn/require-array-join-separator.html"
+			}
+		]
+	},
+	{
+		"flint": {
+			"name": "arrayLastMethods",
+			"plugin": "ts",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/prefer-array-last-methods",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prefer-array-last-methods.md"
 			}
 		]
 	},
@@ -16250,10 +16796,6 @@
 			{
 				"name": "@typescript-eslint/prefer-for-of",
 				"url": "https://typescript-eslint.io/rules/prefer-for-of"
-			},
-			{
-				"name": "unicorn/no-array-for-each",
-				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-array-for-each.md"
 			},
 			{
 				"name": "unicorn/no-for-loop",
@@ -16405,6 +16947,19 @@
 	},
 	{
 		"flint": {
+			"name": "arraySlices",
+			"plugin": "ts",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/prefer-array-slice",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prefer-array-slice.md"
+			}
+		]
+	},
+	{
+		"flint": {
 			"name": "arraySliceUnnecessaryEnd",
 			"plugin": "ts",
 			"preset": "stylistic",
@@ -16488,6 +17043,45 @@
 			{
 				"name": "typescript/require-array-sort-compare",
 				"url": "https://oxc.rs/docs/guide/usage/linter/rules/typescript/require-array-sort-compare.html"
+			}
+		]
+	},
+	{
+		"flint": {
+			"name": "arraySortCompares",
+			"plugin": "ts",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/require-array-sort-compare",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/require-array-sort-compare.md"
+			}
+		]
+	},
+	{
+		"flint": {
+			"name": "arraySortMinMaxes",
+			"plugin": "ts",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/no-array-sort-for-min-max",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-array-sort-for-min-max.md"
+			}
+		]
+	},
+	{
+		"flint": {
+			"name": "arraySplices",
+			"plugin": "ts",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/no-array-splice",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-array-splice.md"
 			}
 		]
 	},
@@ -16669,6 +17263,19 @@
 			{
 				"name": "eslint/logical-assignment-operators",
 				"url": "https://oxc.rs/docs/guide/usage/linter/rules/eslint/logical-assignment-operators.html"
+			}
+		]
+	},
+	{
+		"flint": {
+			"name": "asteriskPrefixInDocumentationComments",
+			"plugin": "ts",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/no-asterisk-prefix-in-documentation-comments",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-asterisk-prefix-in-documentation-comments.md"
 			}
 		]
 	},
@@ -16872,6 +17479,19 @@
 	},
 	{
 		"flint": {
+			"name": "awaits",
+			"plugin": "ts",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/prefer-await",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prefer-await.md"
+			}
+		]
+	},
+	{
+		"flint": {
 			"name": "awaitThenable",
 			"plugin": "ts",
 			"preset": "logical"
@@ -16962,6 +17582,19 @@
 	},
 	{
 		"flint": {
+			"name": "blockStatementIifes",
+			"plugin": "ts",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/prefer-block-statement-over-iife",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prefer-block-statement-over-iife.md"
+			}
+		]
+	},
+	{
+		"flint": {
 			"name": "blockStatements",
 			"plugin": "ts",
 			"status": "skipped"
@@ -17001,6 +17634,45 @@
 	},
 	{
 		"flint": {
+			"name": "booleanNameConsistency",
+			"plugin": "ts",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/consistent-boolean-name",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/consistent-boolean-name.md"
+			}
+		]
+	},
+	{
+		"flint": {
+			"name": "booleanReturns",
+			"plugin": "ts",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/prefer-boolean-return",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prefer-boolean-return.md"
+			}
+		]
+	},
+	{
+		"flint": {
+			"name": "booleanSortComparators",
+			"plugin": "ts",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/no-boolean-sort-comparator",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-boolean-sort-comparator.md"
+			}
+		]
+	},
+	{
+		"flint": {
 			"name": "branchCodeDuplicates",
 			"plugin": "ts",
 			"preset": "stylistic",
@@ -17010,6 +17682,19 @@
 			{
 				"name": "oxc/branches-sharing-code",
 				"url": "https://oxc.rs/docs/guide/usage/linter/rules/oxc/branches-sharing-code.html"
+			}
+		]
+	},
+	{
+		"flint": {
+			"name": "breakInNestedLoops",
+			"plugin": "ts",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/no-break-in-nested-loop",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-break-in-nested-loop.md"
 			}
 		]
 	},
@@ -17289,6 +17974,19 @@
 	},
 	{
 		"flint": {
+			"name": "chainedComparisons",
+			"plugin": "ts",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/no-chained-comparison",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-chained-comparison.md"
+			}
+		]
+	},
+	{
+		"flint": {
 			"name": "characterClassElementsOrder",
 			"plugin": "ts"
 		},
@@ -17442,6 +18140,19 @@
 	},
 	{
 		"flint": {
+			"name": "classMemberOrderConsistency",
+			"plugin": "ts",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/consistent-class-member-order",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/consistent-class-member-order.md"
+			}
+		]
+	},
+	{
+		"flint": {
 			"name": "classMethodsThis",
 			"plugin": "ts",
 			"preset": "stylistic",
@@ -17468,6 +18179,32 @@
 			{
 				"name": "eslint/class-methods-use-this",
 				"url": "https://oxc.rs/docs/guide/usage/linter/rules/eslint/class-methods-use-this.html"
+			}
+		]
+	},
+	{
+		"flint": {
+			"name": "classReferenceInStaticMethods",
+			"plugin": "ts",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/class-reference-in-static-methods",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/class-reference-in-static-methods.md"
+			}
+		]
+	},
+	{
+		"flint": {
+			"name": "collectionBracketAccess",
+			"plugin": "ts",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/no-collection-bracket-access",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-collection-bracket-access.md"
 			}
 		]
 	},
@@ -17503,6 +18240,19 @@
 			{
 				"name": "eslint/capitalized-comments",
 				"url": "https://oxc.rs/docs/guide/usage/linter/rules/eslint/capitalized-comments.html"
+			}
+		]
+	},
+	{
+		"flint": {
+			"name": "commentContent",
+			"plugin": "ts",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/comment-content",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/comment-content.md"
 			}
 		]
 	},
@@ -17559,6 +18309,32 @@
 	},
 	{
 		"flint": {
+			"name": "compoundWordConsistency",
+			"plugin": "ts",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/consistent-compound-words",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/consistent-compound-words.md"
+			}
+		]
+	},
+	{
+		"flint": {
+			"name": "computedPropertyExistenceChecks",
+			"plugin": "ts",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/no-computed-property-existence-check",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-computed-property-existence-check.md"
+			}
+		]
+	},
+	{
+		"flint": {
 			"name": "conditionalAssignments",
 			"plugin": "ts",
 			"status": "skipped"
@@ -17588,6 +18364,19 @@
 			}
 		],
 		"notes": "Superseded by unnecessaryConditions."
+	},
+	{
+		"flint": {
+			"name": "conditionalObjectSpreadConsistency",
+			"plugin": "ts",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/consistent-conditional-object-spread",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/consistent-conditional-object-spread.md"
+			}
+		]
 	},
 	{
 		"flint": {
@@ -17644,6 +18433,32 @@
 			{
 				"name": "eslint/yoda",
 				"url": "https://oxc.rs/docs/guide/usage/linter/rules/eslint/yoda.html"
+			}
+		]
+	},
+	{
+		"flint": {
+			"name": "confusingArraySplices",
+			"plugin": "ts",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/no-confusing-array-splice",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-confusing-array-splice.md"
+			}
+		]
+	},
+	{
+		"flint": {
+			"name": "confusingArrayWithCalls",
+			"plugin": "ts",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/no-confusing-array-with",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-confusing-array-with.md"
 			}
 		]
 	},
@@ -17825,6 +18640,19 @@
 	},
 	{
 		"flint": {
+			"name": "constantZeroExpressions",
+			"plugin": "ts",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/no-constant-zero-expression",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-constant-zero-expression.md"
+			}
+		]
+	},
+	{
+		"flint": {
 			"name": "constEnums",
 			"plugin": "ts",
 			"status": "skipped"
@@ -17978,6 +18806,19 @@
 	},
 	{
 		"flint": {
+			"name": "continueStatements",
+			"plugin": "ts",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/prefer-continue",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prefer-continue.md"
+			}
+		]
+	},
+	{
+		"flint": {
 			"name": "dateConstructorClones",
 			"plugin": "ts",
 			"preset": "logical",
@@ -18053,6 +18894,19 @@
 			{
 				"name": "eslint/no-debugger",
 				"url": "https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html"
+			}
+		]
+	},
+	{
+		"flint": {
+			"name": "declarationsBeforeEarlyExits",
+			"plugin": "ts",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/no-declarations-before-early-exit",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-declarations-before-early-exit.md"
 			}
 		]
 	},
@@ -18155,6 +19009,19 @@
 			{
 				"name": "import/no-default-export",
 				"url": "https://oxc.rs/docs/guide/usage/linter/rules/import/no-default-export.html"
+			}
+		]
+	},
+	{
+		"flint": {
+			"name": "defaultExportStyle",
+			"plugin": "ts",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/default-export-style",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/default-export-style.md"
 			}
 		]
 	},
@@ -18325,6 +19192,19 @@
 			{
 				"name": "unicorn/consistent-destructuring",
 				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/consistent-destructuring.md"
+			}
+		]
+	},
+	{
+		"flint": {
+			"name": "directIterations",
+			"plugin": "ts",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/prefer-direct-iteration",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prefer-direct-iteration.md"
 			}
 		]
 	},
@@ -18516,6 +19396,32 @@
 	},
 	{
 		"flint": {
+			"name": "disposes",
+			"plugin": "ts",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/prefer-dispose",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prefer-dispose.md"
+			}
+		]
+	},
+	{
+		"flint": {
+			"name": "doubleComparisons",
+			"plugin": "ts",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/no-double-comparison",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-double-comparison.md"
+			}
+		]
+	},
+	{
+		"flint": {
 			"name": "duplicateArguments",
 			"plugin": "ts",
 			"preset": "javascript",
@@ -18537,6 +19443,58 @@
 			{
 				"name": "no-dupe-args",
 				"url": "https://eslint.org/docs/latest/rules/no-dupe-args"
+			}
+		]
+	},
+	{
+		"flint": {
+			"name": "duplicateIfBranches",
+			"plugin": "ts",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/no-duplicate-if-branches",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-duplicate-if-branches.md"
+			}
+		]
+	},
+	{
+		"flint": {
+			"name": "duplicateLogicalOperands",
+			"plugin": "ts",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/no-duplicate-logical-operands",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-duplicate-logical-operands.md"
+			}
+		]
+	},
+	{
+		"flint": {
+			"name": "duplicateLoops",
+			"plugin": "ts",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/no-duplicate-loops",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-duplicate-loops.md"
+			}
+		]
+	},
+	{
+		"flint": {
+			"name": "duplicateSetValues",
+			"plugin": "ts",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/no-duplicate-set-values",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-duplicate-set-values.md"
 			}
 		]
 	},
@@ -18587,6 +19545,32 @@
 			{
 				"name": "import/no-dynamic-require",
 				"url": "https://oxc.rs/docs/guide/usage/linter/rules/import/no-dynamic-require.html"
+			}
+		]
+	},
+	{
+		"flint": {
+			"name": "earlyReturns",
+			"plugin": "ts",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/prefer-early-return",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prefer-early-return.md"
+			}
+		]
+	},
+	{
+		"flint": {
+			"name": "elseIfBranches",
+			"plugin": "ts",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/prefer-else-if",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prefer-else-if.md"
 			}
 		]
 	},
@@ -19159,6 +20143,19 @@
 	},
 	{
 		"flint": {
+			"name": "errorIsErrors",
+			"plugin": "ts",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/prefer-error-is-error",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prefer-error-is-error.md"
+			}
+		]
+	},
+	{
+		"flint": {
 			"name": "errorMessages",
 			"plugin": "ts",
 			"preset": "logical",
@@ -19181,6 +20178,19 @@
 			{
 				"name": "unicorn/error-message",
 				"url": "https://oxc.rs/docs/guide/usage/linter/rules/unicorn/error-message.html"
+			}
+		]
+	},
+	{
+		"flint": {
+			"name": "errorPropertyAssignments",
+			"plugin": "ts",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/no-error-property-assignment",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-error-property-assignment.md"
 			}
 		]
 	},
@@ -19362,6 +20372,19 @@
 	},
 	{
 		"flint": {
+			"name": "explicitTimerDelays",
+			"plugin": "ts",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/explicit-timer-delay",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/explicit-timer-delay.md"
+			}
+		]
+	},
+	{
+		"flint": {
 			"name": "exponentiationOperators",
 			"plugin": "ts",
 			"preset": "stylistic",
@@ -19407,6 +20430,19 @@
 			{
 				"name": "perfectionist/sort-exports",
 				"url": "https://perfectionist.dev/rules/sort-exports"
+			}
+		]
+	},
+	{
+		"flint": {
+			"name": "exportDecoratorPositionConsistency",
+			"plugin": "ts",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/consistent-export-decorator-position",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/consistent-export-decorator-position.md"
 			}
 		]
 	},
@@ -19662,6 +20698,19 @@
 	},
 	{
 		"flint": {
+			"name": "flatMathMinMaxCalls",
+			"plugin": "ts",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/prefer-flat-math-min-max",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prefer-flat-math-min-max.md"
+			}
+		]
+	},
+	{
+		"flint": {
 			"name": "floatingPromises",
 			"plugin": "ts",
 			"preset": "logical"
@@ -19719,6 +20768,19 @@
 	},
 	{
 		"flint": {
+			"name": "forEachCalls",
+			"plugin": "ts",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/no-for-each",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-for-each.md"
+			}
+		]
+	},
+	{
+		"flint": {
 			"name": "forInArrays",
 			"plugin": "ts",
 			"preset": "logical",
@@ -19771,6 +20833,19 @@
 			{
 				"name": "eslint/guard-for-in",
 				"url": "https://oxc.rs/docs/guide/usage/linter/rules/eslint/guard-for-in.html"
+			}
+		]
+	},
+	{
+		"flint": {
+			"name": "frontmatterFields",
+			"plugin": "ts",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/require-frontmatter-fields",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/require-frontmatter-fields.md"
 			}
 		]
 	},
@@ -19993,6 +21068,19 @@
 	},
 	{
 		"flint": {
+			"name": "functionStyleConsistency",
+			"plugin": "ts",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/consistent-function-style",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/consistent-function-style.md"
+			}
+		]
+	},
+	{
+		"flint": {
 			"name": "functionTypeDeclarations",
 			"plugin": "ts",
 			"preset": "stylistic"
@@ -20045,6 +21133,19 @@
 			{
 				"name": "eslint/require-yield",
 				"url": "https://oxc.rs/docs/guide/usage/linter/rules/eslint/require-yield.html"
+			}
+		]
+	},
+	{
+		"flint": {
+			"name": "getOrInsertComputedMethods",
+			"plugin": "ts",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/prefer-get-or-insert-computed",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prefer-get-or-insert-computed.md"
 			}
 		]
 	},
@@ -20114,6 +21215,19 @@
 	},
 	{
 		"flint": {
+			"name": "globalNumberConstants",
+			"plugin": "ts",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/prefer-global-number-constants",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prefer-global-number-constants.md"
+			}
+		]
+	},
+	{
+		"flint": {
 			"name": "globalObjectCalls",
 			"plugin": "ts",
 			"preset": "javascript",
@@ -20141,6 +21255,19 @@
 			{
 				"name": "eslint/no-obj-calls",
 				"url": "https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-obj-calls.html"
+			}
+		]
+	},
+	{
+		"flint": {
+			"name": "globalObjectPropertyAssignments",
+			"plugin": "ts",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/no-global-object-property-assignment",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-global-object-property-assignment.md"
 			}
 		]
 	},
@@ -20183,6 +21310,32 @@
 	},
 	{
 		"flint": {
+			"name": "groupByMethods",
+			"plugin": "ts",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/prefer-group-by",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prefer-group-by.md"
+			}
+		]
+	},
+	{
+		"flint": {
+			"name": "hasChecks",
+			"plugin": "ts",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/prefer-has-check",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prefer-has-check.md"
+			}
+		]
+	},
+	{
+		"flint": {
 			"name": "heritageClausesOrder",
 			"plugin": "ts",
 			"preset": "sorting"
@@ -20215,6 +21368,32 @@
 	},
 	{
 		"flint": {
+			"name": "hoistingBranchCodes",
+			"plugin": "ts",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/prefer-hoisting-branch-code",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prefer-hoisting-branch-code.md"
+			}
+		]
+	},
+	{
+		"flint": {
+			"name": "identifierImportExportSpecifiers",
+			"plugin": "ts",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/prefer-identifier-import-export-specifiers",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prefer-identifier-import-export-specifiers.md"
+			}
+		]
+	},
+	{
+		"flint": {
 			"name": "identifierMatches",
 			"plugin": "ts",
 			"status": "skipped"
@@ -20229,6 +21408,19 @@
 			{
 				"name": "eslint/id-match",
 				"url": "https://oxc.rs/docs/guide/usage/linter/rules/eslint/id-match.html"
+			}
+		]
+	},
+	{
+		"flint": {
+			"name": "identifierPatternMatches",
+			"plugin": "ts",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/id-match",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/id-match.md"
 			}
 		]
 	},
@@ -20788,6 +21980,45 @@
 	},
 	{
 		"flint": {
+			"name": "impossibleLengthComparisons",
+			"plugin": "ts",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/no-impossible-length-comparison",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-impossible-length-comparison.md"
+			}
+		]
+	},
+	{
+		"flint": {
+			"name": "includesOverRepeatedComparisons",
+			"plugin": "ts",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/prefer-includes-over-repeated-comparisons",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prefer-includes-over-repeated-comparisons.md"
+			}
+		]
+	},
+	{
+		"flint": {
+			"name": "incorrectTemplateStringInterpolations",
+			"plugin": "ts",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/no-incorrect-template-string-interpolation",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-incorrect-template-string-interpolation.md"
+			}
+		]
+	},
+	{
+		"flint": {
 			"name": "indexedObjectTypes",
 			"plugin": "ts",
 			"preset": "stylistic",
@@ -20927,6 +22158,32 @@
 	},
 	{
 		"flint": {
+			"name": "invalidArgumentCounts",
+			"plugin": "ts",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/no-invalid-argument-count",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-invalid-argument-count.md"
+			}
+		]
+	},
+	{
+		"flint": {
+			"name": "invalidCharacterComparisons",
+			"plugin": "ts",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/no-invalid-character-comparison",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-invalid-character-comparison.md"
+			}
+		]
+	},
+	{
+		"flint": {
 			"name": "invalidThis",
 			"plugin": "ts",
 			"preset": "javascript"
@@ -20965,6 +22222,19 @@
 			{
 				"name": "typescript/no-invalid-void-type",
 				"url": "https://oxc.rs/docs/guide/usage/linter/rules/typescript/no-invalid-void-type.html"
+			}
+		]
+	},
+	{
+		"flint": {
+			"name": "invalidWellKnownSymbolMethods",
+			"plugin": "ts",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/no-invalid-well-known-symbol-methods",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-invalid-well-known-symbol-methods.md"
 			}
 		]
 	},
@@ -21047,6 +22317,45 @@
 	},
 	{
 		"flint": {
+			"name": "iterableInConstructors",
+			"plugin": "ts",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/prefer-iterable-in-constructor",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prefer-iterable-in-constructor.md"
+			}
+		]
+	},
+	{
+		"flint": {
+			"name": "iteratorConcats",
+			"plugin": "ts",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/prefer-iterator-concat",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prefer-iterator-concat.md"
+			}
+		]
+	},
+	{
+		"flint": {
+			"name": "iteratorHelpers",
+			"plugin": "ts",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/prefer-iterator-helpers",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prefer-iterator-helpers.md"
+			}
+		]
+	},
+	{
+		"flint": {
 			"name": "iteratorMethodFunctionReferences",
 			"plugin": "ts",
 			"status": "skipped"
@@ -21061,6 +22370,32 @@
 			{
 				"name": "unicorn/no-array-callback-reference",
 				"url": "https://oxc.rs/docs/guide/usage/linter/rules/unicorn/no-array-callback-reference.html"
+			}
+		]
+	},
+	{
+		"flint": {
+			"name": "iteratorToArrayAtEnds",
+			"plugin": "ts",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/prefer-iterator-to-array-at-end",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prefer-iterator-to-array-at-end.md"
+			}
+		]
+	},
+	{
+		"flint": {
+			"name": "iteratorToArrays",
+			"plugin": "ts",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/prefer-iterator-to-array",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prefer-iterator-to-array.md"
 			}
 		]
 	},
@@ -22231,6 +23566,19 @@
 	},
 	{
 		"flint": {
+			"name": "lateCurrentTargetAccess",
+			"plugin": "ts",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/no-late-current-target-access",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-late-current-target-access.md"
+			}
+		]
+	},
+	{
+		"flint": {
 			"name": "literalConstructorWrappers",
 			"plugin": "ts",
 			"preset": "stylistic",
@@ -22252,6 +23600,19 @@
 	},
 	{
 		"flint": {
+			"name": "logicalAssignmentOperators",
+			"plugin": "ts",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/logical-assignment-operators",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/logical-assignment-operators.md"
+			}
+		]
+	},
+	{
+		"flint": {
 			"name": "loopConditionConstants",
 			"plugin": "ts",
 			"status": "skipped"
@@ -22266,6 +23627,19 @@
 			{
 				"name": "eslint/no-unmodified-loop-condition",
 				"url": "https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-unmodified-loop-condition.html"
+			}
+		]
+	},
+	{
+		"flint": {
+			"name": "loopIterableMutations",
+			"plugin": "ts",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/no-loop-iterable-mutation",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-loop-iterable-mutation.md"
 			}
 		]
 	},
@@ -22301,6 +23675,32 @@
 	},
 	{
 		"flint": {
+			"name": "manuallyWrappedComments",
+			"plugin": "ts",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/no-manually-wrapped-comments",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-manually-wrapped-comments.md"
+			}
+		]
+	},
+	{
+		"flint": {
+			"name": "mapFromEntries",
+			"plugin": "ts",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/prefer-map-from-entries",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prefer-map-from-entries.md"
+			}
+		]
+	},
+	{
+		"flint": {
 			"name": "mapsOrder",
 			"plugin": "ts",
 			"preset": "sorting"
@@ -22309,6 +23709,32 @@
 			{
 				"name": "perfectionist/sort-maps",
 				"url": "https://perfectionist.dev/rules/sort-maps"
+			}
+		]
+	},
+	{
+		"flint": {
+			"name": "mathAbs",
+			"plugin": "ts",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/prefer-math-abs",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prefer-math-abs.md"
+			}
+		]
+	},
+	{
+		"flint": {
+			"name": "mathConstants",
+			"plugin": "ts",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/prefer-math-constants",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prefer-math-constants.md"
 			}
 		]
 	},
@@ -22591,6 +24017,19 @@
 	},
 	{
 		"flint": {
+			"name": "maxNestedCalls",
+			"plugin": "ts",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/max-nested-calls",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/max-nested-calls.md"
+			}
+		]
+	},
+	{
+		"flint": {
 			"name": "meaninglessVoidOperators",
 			"plugin": "ts",
 			"preset": "logical",
@@ -22675,6 +24114,19 @@
 	},
 	{
 		"flint": {
+			"name": "minimalTernaries",
+			"plugin": "ts",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/prefer-minimal-ternary",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prefer-minimal-ternary.md"
+			}
+		]
+	},
+	{
+		"flint": {
 			"name": "misleadingShorthandAssignments",
 			"plugin": "ts",
 			"status": "skipped"
@@ -22728,6 +24180,32 @@
 			{
 				"name": "typescript/no-confusing-void-expression",
 				"url": "https://oxc.rs/docs/guide/usage/linter/rules/typescript/no-confusing-void-expression.html"
+			}
+		]
+	},
+	{
+		"flint": {
+			"name": "mismatchedMapKeys",
+			"plugin": "ts",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/no-mismatched-map-key",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-mismatched-map-key.md"
+			}
+		]
+	},
+	{
+		"flint": {
+			"name": "misrefactoredAssignments",
+			"plugin": "ts",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/no-misrefactored-assignment",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-misrefactored-assignment.md"
 			}
 		]
 	},
@@ -22955,6 +24433,19 @@
 	},
 	{
 		"flint": {
+			"name": "multiplePromiseResolverCalls",
+			"plugin": "ts",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/no-multiple-promise-resolver-calls",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-multiple-promise-resolver-calls.md"
+			}
+		]
+	},
+	{
+		"flint": {
 			"name": "namedDefaultExports",
 			"plugin": "ts",
 			"preset": "stylistic",
@@ -23029,6 +24520,19 @@
 			{
 				"name": "import/no-named-export",
 				"url": "https://oxc.rs/docs/guide/usage/linter/rules/import/no-named-export.html"
+			}
+		]
+	},
+	{
+		"flint": {
+			"name": "nameReplacements",
+			"plugin": "ts",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/name-replacements",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/name-replacements.md"
 			}
 		]
 	},
@@ -23187,6 +24691,32 @@
 			}
 		],
 		"notes": "Obsolete for modern runtimes."
+	},
+	{
+		"flint": {
+			"name": "negatedArrayPredicates",
+			"plugin": "ts",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/no-negated-array-predicate",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-negated-array-predicate.md"
+			}
+		]
+	},
+	{
+		"flint": {
+			"name": "negatedComparisons",
+			"plugin": "ts",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/no-negated-comparison",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-negated-comparison.md"
+			}
+		]
 	},
 	{
 		"flint": {
@@ -23376,6 +24906,19 @@
 	},
 	{
 		"flint": {
+			"name": "noAsyncPromiseFinally",
+			"plugin": "ts",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/no-async-promise-finally",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-async-promise-finally.md"
+			}
+		]
+	},
+	{
+		"flint": {
 			"name": "nodeBuiltinImports",
 			"plugin": "ts"
 		},
@@ -23395,6 +24938,19 @@
 			{
 				"name": "import/no-nodejs-modules",
 				"url": "https://oxc.rs/docs/guide/usage/linter/rules/import/no-nodejs-modules.html"
+			}
+		]
+	},
+	{
+		"flint": {
+			"name": "nonFunctionVerbPrefixes",
+			"plugin": "ts",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/no-non-function-verb-prefix",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-non-function-verb-prefix.md"
 			}
 		]
 	},
@@ -23552,6 +25108,45 @@
 	},
 	{
 		"flint": {
+			"name": "nonstandardBuiltinProperties",
+			"plugin": "ts",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/no-nonstandard-builtin-properties",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-nonstandard-builtin-properties.md"
+			}
+		]
+	},
+	{
+		"flint": {
+			"name": "noUnnecessaryFetchOptions",
+			"plugin": "ts",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/no-unnecessary-fetch-options",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-unnecessary-fetch-options.md"
+			}
+		]
+	},
+	{
+		"flint": {
+			"name": "noUnsafePromiseAllSettledValues",
+			"plugin": "ts",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/no-unsafe-promise-all-settled-values",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-unsafe-promise-all-settled-values.md"
+			}
+		]
+	},
+	{
+		"flint": {
 			"name": "nullishCheckStyle",
 			"plugin": "ts",
 			"status": "implemented"
@@ -23617,6 +25212,32 @@
 			{
 				"name": "unicorn/no-null",
 				"url": "https://oxc.rs/docs/guide/usage/linter/rules/unicorn/no-null.html"
+			}
+		]
+	},
+	{
+		"flint": {
+			"name": "numberCoercions",
+			"plugin": "ts",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/prefer-number-coercion",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prefer-number-coercion.md"
+			}
+		]
+	},
+	{
+		"flint": {
+			"name": "numberIsSafeIntegers",
+			"plugin": "ts",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/prefer-number-is-safe-integer",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prefer-number-is-safe-integer.md"
 			}
 		]
 	},
@@ -23910,6 +25531,32 @@
 	},
 	{
 		"flint": {
+			"name": "objectDefineProperties",
+			"plugin": "ts",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/prefer-object-define-properties",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prefer-object-define-properties.md"
+			}
+		]
+	},
+	{
+		"flint": {
+			"name": "objectDestructuringDefaults",
+			"plugin": "ts",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/prefer-object-destructuring-defaults",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prefer-object-destructuring-defaults.md"
+			}
+		]
+	},
+	{
+		"flint": {
 			"name": "objectEntriesMethods",
 			"plugin": "ts",
 			"preset": "stylistic",
@@ -23957,6 +25604,19 @@
 	},
 	{
 		"flint": {
+			"name": "objectIterableMethods",
+			"plugin": "ts",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/prefer-object-iterable-methods",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prefer-object-iterable-methods.md"
+			}
+		]
+	},
+	{
+		"flint": {
 			"name": "objectKeyDuplicates",
 			"plugin": "ts",
 			"preset": "javascript",
@@ -23991,6 +25651,19 @@
 			{
 				"name": "oxc/bad-object-literal-comparison",
 				"url": "https://oxc.rs/docs/guide/usage/linter/rules/oxc/bad-object-literal-comparison.html"
+			}
+		]
+	},
+	{
+		"flint": {
+			"name": "objectMethodsWithCollections",
+			"plugin": "ts",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/no-object-methods-with-collections",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-object-methods-with-collections.md"
 			}
 		]
 	},
@@ -24196,6 +25869,19 @@
 	},
 	{
 		"flint": {
+			"name": "operatorAssignments",
+			"plugin": "ts",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/operator-assignment",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/operator-assignment.md"
+			}
+		]
+	},
+	{
+		"flint": {
 			"name": "operatorAssignmentShorthand",
 			"plugin": "ts",
 			"preset": "stylistic",
@@ -24230,6 +25916,32 @@
 			{
 				"name": "oxc/no-optional-chaining",
 				"url": "https://oxc.rs/docs/guide/usage/linter/rules/oxc/no-optional-chaining.html"
+			}
+		]
+	},
+	{
+		"flint": {
+			"name": "optionalChainingConsistency",
+			"plugin": "ts",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/consistent-optional-chaining",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/consistent-optional-chaining.md"
+			}
+		]
+	},
+	{
+		"flint": {
+			"name": "optionalChainingOnUndeclaredVariables",
+			"plugin": "ts",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/no-optional-chaining-on-undeclared-variable",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-optional-chaining-on-undeclared-variable.md"
 			}
 		]
 	},
@@ -24468,6 +26180,19 @@
 			{
 				"name": "unicorn/no-keyword-prefix",
 				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-keyword-prefix.md"
+			}
+		]
+	},
+	{
+		"flint": {
+			"name": "privateClassFields",
+			"plugin": "ts",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/prefer-private-class-fields",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prefer-private-class-fields.md"
 			}
 		]
 	},
@@ -24905,6 +26630,32 @@
 	},
 	{
 		"flint": {
+			"name": "promiseTryCalls",
+			"plugin": "ts",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/prefer-promise-try",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prefer-promise-try.md"
+			}
+		]
+	},
+	{
+		"flint": {
+			"name": "promiseWithResolvers",
+			"plugin": "ts",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/prefer-promise-with-resolvers",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prefer-promise-with-resolvers.md"
+			}
+		]
+	},
+	{
+		"flint": {
 			"name": "propertyAccessNotation",
 			"plugin": "ts",
 			"preset": "stylistic",
@@ -24949,6 +26700,32 @@
 			{
 				"name": "eslint/no-iterator",
 				"url": "https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-iterator.html"
+			}
+		]
+	},
+	{
+		"flint": {
+			"name": "proxyTrapBooleanReturns",
+			"plugin": "ts",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/require-proxy-trap-boolean-return",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/require-proxy-trap-boolean-return.md"
+			}
+		]
+	},
+	{
+		"flint": {
+			"name": "queueMicrotasks",
+			"plugin": "ts",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/prefer-queue-microtask",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prefer-queue-microtask.md"
 			}
 		]
 	},
@@ -25023,6 +26800,19 @@
 			{
 				"name": "noParametersOnlyUsedInRecursion",
 				"url": "https://biomejs.dev/linter/rules/no-parameters-only-used-in-recursion"
+			}
+		]
+	},
+	{
+		"flint": {
+			"name": "redundantComparisons",
+			"plugin": "ts",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/no-redundant-comparison",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-redundant-comparison.md"
 			}
 		]
 	},
@@ -25864,6 +27654,19 @@
 			{
 				"name": "regexp/no-octal",
 				"url": "https://ota-meshi.github.io/eslint-plugin-regexp/rules/no-octal.html"
+			}
+		]
+	},
+	{
+		"flint": {
+			"name": "regexpEscapes",
+			"plugin": "ts",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/prefer-regexp-escape",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prefer-regexp-escape.md"
 			}
 		]
 	},
@@ -26825,6 +28628,19 @@
 	},
 	{
 		"flint": {
+			"name": "returnedArrayPushes",
+			"plugin": "ts",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/no-return-array-push",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-return-array-push.md"
+			}
+		]
+	},
+	{
+		"flint": {
 			"name": "returnThisTypes",
 			"plugin": "ts",
 			"preset": "logical",
@@ -26957,6 +28773,19 @@
 	},
 	{
 		"flint": {
+			"name": "setMethods",
+			"plugin": "ts",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/prefer-set-methods",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prefer-set-methods.md"
+			}
+		]
+	},
+	{
+		"flint": {
 			"name": "setSizeLengthChecks",
 			"plugin": "ts",
 			"preset": "stylistic",
@@ -27084,6 +28913,19 @@
 	},
 	{
 		"flint": {
+			"name": "shortArrowMethods",
+			"plugin": "ts",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/prefer-short-arrow-method",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prefer-short-arrow-method.md"
+			}
+		]
+	},
+	{
+		"flint": {
 			"name": "shorthandAssignmentRefactors",
 			"plugin": "ts",
 			"preset": "logical"
@@ -27092,6 +28934,19 @@
 			{
 				"name": "noMisrefactoredShorthandAssign",
 				"url": "https://biomejs.dev/linter/rules/no-misrefactored-shorthand-assign"
+			}
+		]
+	},
+	{
+		"flint": {
+			"name": "shorthandPropertyOverrides",
+			"plugin": "ts",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/no-shorthand-property-overrides",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-shorthand-property-overrides.md"
 			}
 		]
 	},
@@ -27118,6 +28973,71 @@
 			{
 				"name": "unicorn/prefer-simple-condition-first",
 				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v64.0.0/docs/rules/prefer-simple-condition-first.md"
+			}
+		]
+	},
+	{
+		"flint": {
+			"name": "simpleSortComparators",
+			"plugin": "ts",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/prefer-simple-sort-comparator",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prefer-simple-sort-comparator.md"
+			}
+		]
+	},
+	{
+		"flint": {
+			"name": "simplifiedConditions",
+			"plugin": "ts",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/prefer-simplified-conditions",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prefer-simplified-conditions.md"
+			}
+		]
+	},
+	{
+		"flint": {
+			"name": "singleArrayPredicates",
+			"plugin": "ts",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/prefer-single-array-predicate",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prefer-single-array-predicate.md"
+			}
+		]
+	},
+	{
+		"flint": {
+			"name": "singleObjectDestructuring",
+			"plugin": "ts",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/prefer-single-object-destructuring",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prefer-single-object-destructuring.md"
+			}
+		]
+	},
+	{
+		"flint": {
+			"name": "singleReplaces",
+			"plugin": "ts",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/prefer-single-replace",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prefer-single-replace.md"
 			}
 		]
 	},
@@ -27202,6 +29122,19 @@
 	},
 	{
 		"flint": {
+			"name": "smallerScopes",
+			"plugin": "ts",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/prefer-smaller-scope",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prefer-smaller-scope.md"
+			}
+		]
+	},
+	{
+		"flint": {
 			"name": "sparseArrays",
 			"plugin": "ts",
 			"preset": "logical",
@@ -27229,6 +29162,19 @@
 			{
 				"name": "eslint/no-sparse-arrays",
 				"url": "https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-sparse-arrays.html"
+			}
+		]
+	},
+	{
+		"flint": {
+			"name": "splitLimits",
+			"plugin": "ts",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/prefer-split-limit",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prefer-split-limit.md"
 			}
 		]
 	},
@@ -27385,6 +29331,32 @@
 	},
 	{
 		"flint": {
+			"name": "stringMatchAlls",
+			"plugin": "ts",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/prefer-string-match-all",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prefer-string-match-all.md"
+			}
+		]
+	},
+	{
+		"flint": {
+			"name": "stringPadStartEnds",
+			"plugin": "ts",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/prefer-string-pad-start-end",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prefer-string-pad-start-end.md"
+			}
+		]
+	},
+	{
+		"flint": {
 			"name": "stringRawEscapes",
 			"plugin": "ts",
 			"status": "skipped"
@@ -27399,6 +29371,19 @@
 			{
 				"name": "unicorn/prefer-string-raw",
 				"url": "https://oxc.rs/docs/guide/usage/linter/rules/unicorn/prefer-string-raw.html"
+			}
+		]
+	},
+	{
+		"flint": {
+			"name": "stringRepeats",
+			"plugin": "ts",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/prefer-string-repeat",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prefer-string-repeat.md"
 			}
 		]
 	},
@@ -27560,6 +29545,19 @@
 			{
 				"name": "unicorn/prefer-structured-clone",
 				"url": "https://oxc.rs/docs/guide/usage/linter/rules/unicorn/prefer-structured-clone.html"
+			}
+		]
+	},
+	{
+		"flint": {
+			"name": "subtractionComparisons",
+			"plugin": "ts",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/no-subtraction-comparison",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-subtraction-comparison.md"
 			}
 		]
 	},
@@ -27732,6 +29730,19 @@
 	},
 	{
 		"flint": {
+			"name": "temporals",
+			"plugin": "ts",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/prefer-temporal",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prefer-temporal.md"
+			}
+		]
+	},
+	{
+		"flint": {
 			"name": "ternaryNesting",
 			"plugin": "ts",
 			"status": "skipped"
@@ -27804,6 +29815,19 @@
 			{
 				"name": "unicorn/text-encoding-identifier-case",
 				"url": "https://oxc.rs/docs/guide/usage/linter/rules/unicorn/text-encoding-identifier-case.html"
+			}
+		]
+	},
+	{
+		"flint": {
+			"name": "thenCatchChains",
+			"plugin": "ts",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/prefer-then-catch",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prefer-then-catch.md"
 			}
 		]
 	},
@@ -27916,6 +29940,19 @@
 	},
 	{
 		"flint": {
+			"name": "thisOutsideOfClass",
+			"plugin": "ts",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/no-this-outside-of-class",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-this-outside-of-class.md"
+			}
+		]
+	},
+	{
+		"flint": {
 			"name": "throwErrors",
 			"plugin": "ts",
 			"preset": "logical",
@@ -27987,6 +30024,19 @@
 	},
 	{
 		"flint": {
+			"name": "topLevelAssignmentInFunctions",
+			"plugin": "ts",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/no-top-level-assignment-in-function",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-top-level-assignment-in-function.md"
+			}
+		]
+	},
+	{
+		"flint": {
 			"name": "topLevelAwaits",
 			"plugin": "ts",
 			"preset": "stylistic",
@@ -28003,6 +30053,19 @@
 			{
 				"name": "unicorn/prefer-top-level-await",
 				"url": "https://oxc.rs/docs/guide/usage/linter/rules/unicorn/prefer-top-level-await.html"
+			}
+		]
+	},
+	{
+		"flint": {
+			"name": "topLevelSideEffects",
+			"plugin": "ts",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/no-top-level-side-effects",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-top-level-side-effects.md"
 			}
 		]
 	},
@@ -28043,6 +30106,19 @@
 			{
 				"name": "no-invalid-triple-slash-references",
 				"url": "https://docs.deno.com/lint/rules/no-invalid-triple-slash-references"
+			}
+		]
+	},
+	{
+		"flint": {
+			"name": "tryComplexity",
+			"plugin": "ts",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/try-complexity",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/try-complexity.md"
 			}
 		]
 	},
@@ -28103,6 +30179,19 @@
 			{
 				"name": "typescript/ban-tslint-comment",
 				"url": "https://oxc.rs/docs/guide/usage/linter/rules/typescript/ban-tslint-comment.html"
+			}
+		]
+	},
+	{
+		"flint": {
+			"name": "tupleLabelConsistency",
+			"plugin": "ts",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/consistent-tuple-labels",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/consistent-tuple-labels.md"
 			}
 		]
 	},
@@ -28266,6 +30355,19 @@
 	},
 	{
 		"flint": {
+			"name": "typeLiteralLasts",
+			"plugin": "ts",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/prefer-type-literal-last",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prefer-type-literal-last.md"
+			}
+		]
+	},
+	{
+		"flint": {
 			"name": "typeofComparisons",
 			"plugin": "ts",
 			"preset": "javascript",
@@ -28293,6 +30395,32 @@
 			{
 				"name": "eslint/valid-typeof",
 				"url": "https://oxc.rs/docs/guide/usage/linter/rules/eslint/valid-typeof.html"
+			}
+		]
+	},
+	{
+		"flint": {
+			"name": "uint8arrayBase64s",
+			"plugin": "ts",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/prefer-uint8array-base64",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prefer-uint8array-base64.md"
+			}
+		]
+	},
+	{
+		"flint": {
+			"name": "unaryMinus",
+			"plugin": "ts",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/prefer-unary-minus",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prefer-unary-minus.md"
 			}
 		]
 	},
@@ -28358,6 +30486,32 @@
 			{
 				"name": "typescript/unbound-method",
 				"url": "https://oxc.rs/docs/guide/usage/linter/rules/typescript/unbound-method.html"
+			}
+		]
+	},
+	{
+		"flint": {
+			"name": "uncalledMethods",
+			"plugin": "ts",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/no-uncalled-method",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-uncalled-method.md"
+			}
+		]
+	},
+	{
+		"flint": {
+			"name": "undeclaredClassMembers",
+			"plugin": "ts",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/no-undeclared-class-members",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-undeclared-class-members.md"
 			}
 		]
 	},
@@ -28493,6 +30647,19 @@
 	},
 	{
 		"flint": {
+			"name": "unicodeCodePointEscapes",
+			"plugin": "ts",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/prefer-unicode-code-point-escapes",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prefer-unicode-code-point-escapes.md"
+			}
+		]
+	},
+	{
+		"flint": {
 			"name": "unifiedSignatures",
 			"plugin": "ts",
 			"preset": "logical",
@@ -28527,6 +30694,19 @@
 			{
 				"name": "perfectionist/sort-union-types",
 				"url": "https://perfectionist.dev/rules/sort-union-types"
+			}
+		]
+	},
+	{
+		"flint": {
+			"name": "unnecessaryArrayFlatMaps",
+			"plugin": "ts",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/no-unnecessary-array-flat-map",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-unnecessary-array-flat-map.md"
 			}
 		]
 	},
@@ -28605,6 +30785,19 @@
 			{
 				"name": "eslint/no-extra-boolean-cast",
 				"url": "https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-extra-boolean-cast.html"
+			}
+		]
+	},
+	{
+		"flint": {
+			"name": "unnecessaryBooleanComparisons",
+			"plugin": "ts",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/no-unnecessary-boolean-comparison",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-unnecessary-boolean-comparison.md"
 			}
 		]
 	},
@@ -28843,6 +31036,19 @@
 	},
 	{
 		"flint": {
+			"name": "unnecessaryGlobalThis",
+			"plugin": "ts",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/no-unnecessary-global-this",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-unnecessary-global-this.md"
+			}
+		]
+	},
+	{
+		"flint": {
 			"name": "unnecessaryIteratorArrays",
 			"plugin": "ts",
 			"preset": "stylistic"
@@ -28927,6 +31133,19 @@
 			{
 				"name": "oxc/bad-min-max-func",
 				"url": "https://oxc.rs/docs/guide/usage/linter/rules/oxc/bad-min-max-func.html"
+			}
+		]
+	},
+	{
+		"flint": {
+			"name": "unnecessaryNestedTernaries",
+			"plugin": "ts",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/no-unnecessary-nested-ternary",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-unnecessary-nested-ternary.md"
 			}
 		]
 	},
@@ -29042,6 +31261,19 @@
 	},
 	{
 		"flint": {
+			"name": "unnecessarySplices",
+			"plugin": "ts",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/no-unnecessary-splice",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-unnecessary-splice.md"
+			}
+		]
+	},
+	{
+		"flint": {
 			"name": "unnecessarySpreads",
 			"plugin": "ts",
 			"preset": "logical"
@@ -29069,6 +31301,19 @@
 			{
 				"name": "noUselessStringRaw",
 				"url": "https://biomejs.dev/linter/rules/no-useless-string-raw"
+			}
+		]
+	},
+	{
+		"flint": {
+			"name": "unnecessaryStringTrims",
+			"plugin": "ts",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/no-unnecessary-string-trim",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-unnecessary-string-trim.md"
 			}
 		]
 	},
@@ -29359,6 +31604,45 @@
 	},
 	{
 		"flint": {
+			"name": "unreadableForOfExpressions",
+			"plugin": "ts",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/no-unreadable-for-of-expression",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-unreadable-for-of-expression.md"
+			}
+		]
+	},
+	{
+		"flint": {
+			"name": "unreadableNewExpressions",
+			"plugin": "ts",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/no-unreadable-new-expression",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-unreadable-new-expression.md"
+			}
+		]
+	},
+	{
+		"flint": {
+			"name": "unreadableObjectDestructuring",
+			"plugin": "ts",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/no-unreadable-object-destructuring",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-unreadable-object-destructuring.md"
+			}
+		]
+	},
+	{
+		"flint": {
 			"name": "unresolvedImports",
 			"plugin": "ts"
 		},
@@ -29491,6 +31775,32 @@
 	},
 	{
 		"flint": {
+			"name": "unsafePropertyKeys",
+			"plugin": "ts",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/no-unsafe-property-key",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-unsafe-property-key.md"
+			}
+		]
+	},
+	{
+		"flint": {
+			"name": "unsafeStringReplacements",
+			"plugin": "ts",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/no-unsafe-string-replacement",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-unsafe-string-replacement.md"
+			}
+		]
+	},
+	{
+		"flint": {
 			"name": "unsafeToString",
 			"plugin": "ts",
 			"preset": "logical"
@@ -29549,6 +31859,19 @@
 			{
 				"name": "typescript/no-unsafe-unary-minus",
 				"url": "https://oxc.rs/docs/guide/usage/linter/rules/typescript/no-unsafe-unary-minus.html"
+			}
+		]
+	},
+	{
+		"flint": {
+			"name": "unusedArrayMethodReturns",
+			"plugin": "ts",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/no-unused-array-method-return",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-unused-array-method-return.md"
 			}
 		]
 	},
@@ -29838,6 +32161,71 @@
 	},
 	{
 		"flint": {
+			"name": "uselessBooleanCasts",
+			"plugin": "ts",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/no-useless-boolean-cast",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-useless-boolean-cast.md"
+			}
+		]
+	},
+	{
+		"flint": {
+			"name": "uselessCoercions",
+			"plugin": "ts",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/no-useless-coercion",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-useless-coercion.md"
+			}
+		]
+	},
+	{
+		"flint": {
+			"name": "uselessCompoundAssignments",
+			"plugin": "ts",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/no-useless-compound-assignment",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-useless-compound-assignment.md"
+			}
+		]
+	},
+	{
+		"flint": {
+			"name": "uselessConcats",
+			"plugin": "ts",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/no-useless-concat",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-useless-concat.md"
+			}
+		]
+	},
+	{
+		"flint": {
+			"name": "uselessContinues",
+			"plugin": "ts",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/no-useless-continue",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-useless-continue.md"
+			}
+		]
+	},
+	{
+		"flint": {
 			"name": "uselessDefaultAssignments",
 			"plugin": "ts",
 			"preset": "logical"
@@ -29852,6 +32240,97 @@
 			{
 				"name": "typescript/no-useless-default-assignment",
 				"url": "https://oxc.rs/docs/guide/usage/linter/rules/typescript/no-useless-default-assignment.html"
+			}
+		]
+	},
+	{
+		"flint": {
+			"name": "uselessDeleteChecks",
+			"plugin": "ts",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/no-useless-delete-check",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-useless-delete-check.md"
+			}
+		]
+	},
+	{
+		"flint": {
+			"name": "uselessElses",
+			"plugin": "ts",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/no-useless-else",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-useless-else.md"
+			}
+		]
+	},
+	{
+		"flint": {
+			"name": "uselessLogicalOperands",
+			"plugin": "ts",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/no-useless-logical-operand",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-useless-logical-operand.md"
+			}
+		]
+	},
+	{
+		"flint": {
+			"name": "uselessOverrides",
+			"plugin": "ts",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/no-useless-override",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-useless-override.md"
+			}
+		]
+	},
+	{
+		"flint": {
+			"name": "uselessRecursions",
+			"plugin": "ts",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/no-useless-recursion",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-useless-recursion.md"
+			}
+		]
+	},
+	{
+		"flint": {
+			"name": "uselessReExports",
+			"plugin": "ts",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/no-useless-re-export",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-useless-re-export.md"
+			}
+		]
+	},
+	{
+		"flint": {
+			"name": "uselessTemplateLiterals",
+			"plugin": "ts",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/no-useless-template-literals",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-useless-template-literals.md"
 			}
 		]
 	},
@@ -30118,6 +32597,19 @@
 	},
 	{
 		"flint": {
+			"name": "whileLoopConditions",
+			"plugin": "ts",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/prefer-while-loop-condition",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prefer-while-loop-condition.md"
+			}
+		]
+	},
+	{
+		"flint": {
 			"name": "whileLoops",
 			"plugin": "ts",
 			"preset": "stylistic",
@@ -30204,6 +32696,19 @@
 			{
 				"name": "typescript/no-wrapper-object-types",
 				"url": "https://oxc.rs/docs/guide/usage/linter/rules/typescript/no-wrapper-object-types.html"
+			}
+		]
+	},
+	{
+		"flint": {
+			"name": "xorAsExponentiations",
+			"plugin": "ts",
+			"status": "skipped"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/no-xor-as-exponentiation",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-xor-as-exponentiation.md"
 			}
 		]
 	},

--- a/packages/comparisons/src/data.json
+++ b/packages/comparisons/src/data.json
@@ -10258,7 +10258,6 @@
 		"flint": {
 			"name": "unsupportedGlobals",
 			"plugin": "node",
-			"preset": "logical",
 			"status": "skipped"
 		}
 	},
@@ -10285,7 +10284,6 @@
 		"flint": {
 			"name": "unsupportedSyntax",
 			"plugin": "node",
-			"preset": "logical",
 			"status": "skipped"
 		}
 	},
@@ -12005,6 +12003,7 @@
 			}
 		],
 		"flint": {
+			"plugin": "qwik",
 			"name": "classlists",
 			"status": "skipped"
 		}
@@ -12017,6 +12016,7 @@
 			}
 		],
 		"flint": {
+			"plugin": "qwik",
 			"name": "lexicalScopes",
 			"status": "skipped"
 		}
@@ -12029,6 +12029,7 @@
 			}
 		],
 		"flint": {
+			"plugin": "qwik",
 			"name": "loaderLocations",
 			"status": "skipped"
 		}
@@ -12041,6 +12042,7 @@
 			}
 		],
 		"flint": {
+			"plugin": "qwik",
 			"name": "methodUsages",
 			"status": "skipped"
 		}
@@ -12053,6 +12055,7 @@
 			}
 		],
 		"flint": {
+			"plugin": "qwik",
 			"name": "visibleTasks",
 			"status": "skipped"
 		}
@@ -16838,9 +16841,7 @@
 		"flint": {
 			"name": "awaitInsidePromiseMethods",
 			"plugin": "ts",
-			"preset": "logical",
-			"status": "skipped",
-			"strictness": "strict"
+			"status": "skipped"
 		},
 		"notes": "Superseded by awaitThenable.",
 		"oxlint": [
@@ -16975,8 +16976,7 @@
 		"flint": {
 			"name": "blockStatements",
 			"plugin": "ts",
-			"status": "skipped",
-			"strictness": "strict"
+			"status": "skipped"
 		},
 		"notes": "Superseded by prettier-plugin-curly",
 		"oxlint": [
@@ -17070,8 +17070,7 @@
 		"flint": {
 			"name": "builtinPrototypeMethodAccesses",
 			"plugin": "ts",
-			"status": "skipped",
-			"strictness": "strict"
+			"status": "skipped"
 		},
 		"oxlint": [
 			{
@@ -24632,7 +24631,6 @@
 		"flint": {
 			"name": "promiseExecutorReturns",
 			"plugin": "ts",
-			"preset": "logical",
 			"status": "skipped"
 		},
 		"notes": "Superseded by awaitThenable.",
@@ -24653,7 +24651,6 @@
 		"flint": {
 			"name": "promiseFinallyReturns",
 			"plugin": "ts",
-			"preset": "logical",
 			"status": "skipped"
 		},
 		"notes": "Largely covered by returnVoidSafety.",
@@ -24971,8 +24968,7 @@
 		"flint": {
 			"name": "readonlyClassProperties",
 			"plugin": "ts",
-			"status": "skipped",
-			"strictness": "strict"
+			"status": "skipped"
 		},
 		"notes": "Better suited to a functional/immutable-focused plugin.",
 		"oxlint": [
@@ -25186,7 +25182,7 @@
 			"plugin": "ts",
 			"status": "skipped"
 		},
-		"notes": "Superseded by other regex cleanliness rules"
+		"notes": "Superseded by other regex cleanliness rules."
 	},
 	{
 		"biome": [
@@ -30936,7 +30932,7 @@
 			}
 		],
 		"flint": {
-			"name": "maxiumumDescribesPerFile",
+			"name": "maximumDescribesPerFile",
 			"plugin": "vitest",
 			"status": "skipped"
 		},

--- a/packages/comparisons/src/data.json
+++ b/packages/comparisons/src/data.json
@@ -1,31 +1,5 @@
 [
 	{
-		"biome": [
-			{
-				"name": "noDrizzleDeleteWithoutWhere",
-				"url": "https://biomejs.dev/linter/rules/no-drizzle-delete-without-where"
-			}
-		],
-		"flint": {
-			"name": "deleteWhereClauses",
-			"plugin": "drizzle",
-			"status": "skipped"
-		}
-	},
-	{
-		"biome": [
-			{
-				"name": "noDrizzleUpdateWithoutWhere",
-				"url": "https://biomejs.dev/linter/rules/no-drizzle-update-without-where"
-			}
-		],
-		"flint": {
-			"name": "updateWhereClauses",
-			"plugin": "drizzle",
-			"status": "skipped"
-		}
-	},
-	{
 		"eslint": [
 			{
 				"name": "astro/jsx-a11y/no-access-key",
@@ -978,6 +952,12 @@
 		]
 	},
 	{
+		"biome": [
+			{
+				"name": "useDomQuerySelector",
+				"url": "https://biomejs.dev/linter/rules/use-dom-query-selector"
+			}
+		],
 		"eslint": [
 			{
 				"name": "unicorn/prefer-query-selector",
@@ -995,12 +975,6 @@
 			{
 				"name": "unicorn/prefer-query-selector",
 				"url": "https://oxc.rs/docs/guide/usage/linter/rules/unicorn/prefer-query-selector.html"
-			}
-		],
-		"biome": [
-			{
-				"name": "useDomQuerySelector",
-				"url": "https://biomejs.dev/linter/rules/use-dom-query-selector"
 			}
 		]
 	},
@@ -1026,6 +1000,12 @@
 		]
 	},
 	{
+		"biome": [
+			{
+				"name": "useDomNodeTextContent",
+				"url": "https://biomejs.dev/linter/rules/use-dom-node-text-content"
+			}
+		],
 		"eslint": [
 			{
 				"name": "unicorn/prefer-dom-node-text-content",
@@ -1043,12 +1023,6 @@
 			{
 				"name": "unicorn/prefer-dom-node-text-content",
 				"url": "https://oxc.rs/docs/guide/usage/linter/rules/unicorn/prefer-dom-node-text-content.html"
-			}
-		],
-		"biome": [
-			{
-				"name": "useDomNodeTextContent",
-				"url": "https://biomejs.dev/linter/rules/use-dom-node-text-content"
 			}
 		]
 	},
@@ -1198,6 +1172,12 @@
 		]
 	},
 	{
+		"biome": [
+			{
+				"name": "noInvalidPositionAtImportRule",
+				"url": "https://biomejs.dev/linter/rules/no-invalid-position-at-import-rule"
+			}
+		],
 		"eslint": [
 			{
 				"name": "css/no-invalid-at-rule-placement",
@@ -1213,12 +1193,6 @@
 			{
 				"name": "no-invalid-position-at-import-rule",
 				"url": "https://stylelint.io/user-guide/rules/no-invalid-position-at-import-rule"
-			}
-		],
-		"biome": [
-			{
-				"name": "noInvalidPositionAtImportRule",
-				"url": "https://biomejs.dev/linter/rules/no-invalid-position-at-import-rule"
 			}
 		]
 	},
@@ -1257,17 +1231,17 @@
 				"url": "https://biomejs.dev/linter/rules/no-unknown-at-rules"
 			}
 		],
-		"flint": {
-			"name": "atRuleValidity",
-			"plugin": "css",
-			"preset": "logical"
-		},
 		"eslint": [
 			{
 				"name": "css/no-invalid-at-rules",
 				"url": "https://github.com/eslint/css/blob/main/docs/rules/no-invalid-at-rules.md"
 			}
 		],
+		"flint": {
+			"name": "atRuleValidity",
+			"plugin": "css",
+			"preset": "logical"
+		},
 		"stylelint": [
 			{
 				"name": "at-rule-descriptor-no-unknown",
@@ -1302,6 +1276,12 @@
 		]
 	},
 	{
+		"biome": [
+			{
+				"name": "useBaseline",
+				"url": "https://biomejs.dev/linter/rules/use-baseline"
+			}
+		],
 		"eslint": [
 			{
 				"name": "css/use-baseline",
@@ -1312,13 +1292,7 @@
 			"name": "baselineFeatures",
 			"plugin": "css",
 			"preset": "logical"
-		},
-		"biome": [
-			{
-				"name": "useBaseline",
-				"url": "https://biomejs.dev/linter/rules/use-baseline"
-			}
-		]
+		}
 	},
 	{
 		"biome": [
@@ -1561,6 +1535,12 @@
 		]
 	},
 	{
+		"biome": [
+			{
+				"name": "noMissingVarFunction",
+				"url": "https://biomejs.dev/linter/rules/no-missing-var-function"
+			}
+		],
 		"flint": {
 			"name": "customPropertyVarFunctionPresence",
 			"plugin": "css",
@@ -1570,12 +1550,6 @@
 			{
 				"name": "custom-property-no-missing-var-function",
 				"url": "https://stylelint.io/user-guide/rules/custom-property-no-missing-var-function"
-			}
-		],
-		"biome": [
-			{
-				"name": "noMissingVarFunction",
-				"url": "https://biomejs.dev/linter/rules/no-missing-var-function"
 			}
 		]
 	},
@@ -1607,6 +1581,12 @@
 		]
 	},
 	{
+		"biome": [
+			{
+				"name": "noDuplicateProperties",
+				"url": "https://biomejs.dev/linter/rules/no-duplicate-properties"
+			}
+		],
 		"flint": {
 			"name": "declarationPropertyDuplicates",
 			"plugin": "css",
@@ -1616,12 +1596,6 @@
 			{
 				"name": "declaration-block-no-duplicate-properties",
 				"url": "https://stylelint.io/user-guide/rules/declaration-block-no-duplicate-properties"
-			}
-		],
-		"biome": [
-			{
-				"name": "noDuplicateProperties",
-				"url": "https://biomejs.dev/linter/rules/no-duplicate-properties"
 			}
 		]
 	},
@@ -1660,13 +1634,13 @@
 			"plugin": "css",
 			"status": "skipped"
 		},
+		"notes": "Overly opinionated.",
 		"stylelint": [
 			{
 				"name": "declaration-property-max-values",
 				"url": "https://stylelint.io/user-guide/rules/declaration-property-max-values"
 			}
-		],
-		"notes": "Overly opinionated."
+		]
 	},
 	{
 		"flint": {
@@ -1685,6 +1659,12 @@
 		]
 	},
 	{
+		"biome": [
+			{
+				"name": "noDescendingSpecificity",
+				"url": "https://biomejs.dev/linter/rules/no-descending-specificity"
+			}
+		],
 		"flint": {
 			"name": "descendingSpecificity",
 			"plugin": "css",
@@ -1695,12 +1675,6 @@
 			{
 				"name": "no-descending-specificity",
 				"url": "https://stylelint.io/user-guide/rules/no-descending-specificity"
-			}
-		],
-		"biome": [
-			{
-				"name": "noDescendingSpecificity",
-				"url": "https://biomejs.dev/linter/rules/no-descending-specificity"
 			}
 		]
 	},
@@ -1731,6 +1705,12 @@
 		]
 	},
 	{
+		"biome": [
+			{
+				"name": "noEmptyBlock",
+				"url": "https://biomejs.dev/linter/rules/no-empty-block"
+			}
+		],
 		"eslint": [
 			{
 				"name": "css/no-empty-blocks",
@@ -1746,12 +1726,6 @@
 			{
 				"name": "block-no-empty",
 				"url": "https://stylelint.io/user-guide/rules/block-no-empty"
-			}
-		],
-		"biome": [
-			{
-				"name": "noEmptyBlock",
-				"url": "https://biomejs.dev/linter/rules/no-empty-block"
 			}
 		]
 	},
@@ -1769,6 +1743,12 @@
 		]
 	},
 	{
+		"biome": [
+			{
+				"name": "noEmptySource",
+				"url": "https://biomejs.dev/linter/rules/no-empty-source"
+			}
+		],
 		"flint": {
 			"name": "emptySources",
 			"plugin": "css",
@@ -1778,12 +1758,6 @@
 			{
 				"name": "no-empty-source",
 				"url": "https://stylelint.io/user-guide/rules/no-empty-source"
-			}
-		],
-		"biome": [
-			{
-				"name": "noEmptySource",
-				"url": "https://biomejs.dev/linter/rules/no-empty-source"
 			}
 		]
 	},
@@ -1802,6 +1776,12 @@
 		"notes": "Overly opinionated."
 	},
 	{
+		"biome": [
+			{
+				"name": "useGenericFontNames",
+				"url": "https://biomejs.dev/linter/rules/use-generic-font-names"
+			}
+		],
 		"eslint": [
 			{
 				"name": "css/font-family-fallbacks",
@@ -1818,15 +1798,15 @@
 				"name": "font-family-no-missing-generic-family-keyword",
 				"url": "https://stylelint.io/user-guide/rules/font-family-no-missing-generic-family-keyword"
 			}
-		],
-		"biome": [
-			{
-				"name": "useGenericFontNames",
-				"url": "https://biomejs.dev/linter/rules/use-generic-font-names"
-			}
 		]
 	},
 	{
+		"biome": [
+			{
+				"name": "noDuplicateFontNames",
+				"url": "https://biomejs.dev/linter/rules/no-duplicate-font-names"
+			}
+		],
 		"flint": {
 			"name": "fontFamilyNameDuplicates",
 			"plugin": "css",
@@ -1836,12 +1816,6 @@
 			{
 				"name": "font-family-no-duplicate-names",
 				"url": "https://stylelint.io/user-guide/rules/font-family-no-duplicate-names"
-			}
-		],
-		"biome": [
-			{
-				"name": "noDuplicateFontNames",
-				"url": "https://biomejs.dev/linter/rules/no-duplicate-font-names"
 			}
 		]
 	},
@@ -2058,6 +2032,16 @@
 		]
 	},
 	{
+		"biome": [
+			{
+				"name": "noImportantInKeyframe",
+				"url": "https://biomejs.dev/linter/rules/no-important-in-keyframe"
+			},
+			{
+				"name": "noImportantStyles",
+				"url": "https://biomejs.dev/linter/rules/no-important-styles"
+			}
+		],
 		"eslint": [
 			{
 				"name": "css/no-important",
@@ -2070,6 +2054,7 @@
 			"preset": "logical",
 			"strictness": "strict"
 		},
+		"notes": "Stylelint splits !important declarations in keyframes into a separate rule.",
 		"stylelint": [
 			{
 				"name": "declaration-no-important",
@@ -2078,17 +2063,6 @@
 			{
 				"name": "keyframe-declaration-no-important",
 				"url": "https://stylelint.io/user-guide/rules/keyframe-declaration-no-important"
-			}
-		],
-		"notes": "Stylelint splits !important declarations in keyframes into a separate rule.",
-		"biome": [
-			{
-				"name": "noImportantInKeyframe",
-				"url": "https://biomejs.dev/linter/rules/no-important-in-keyframe"
-			},
-			{
-				"name": "noImportantStyles",
-				"url": "https://biomejs.dev/linter/rules/no-important-styles"
 			}
 		]
 	},
@@ -2107,6 +2081,12 @@
 		}
 	},
 	{
+		"biome": [
+			{
+				"name": "noDuplicateAtImportRules",
+				"url": "https://biomejs.dev/linter/rules/no-duplicate-at-import-rules"
+			}
+		],
 		"eslint": [
 			{
 				"name": "css/no-duplicate-imports",
@@ -2122,12 +2102,6 @@
 			{
 				"name": "no-duplicate-at-import-rules",
 				"url": "https://stylelint.io/user-guide/rules/no-duplicate-at-import-rules"
-			}
-		],
-		"biome": [
-			{
-				"name": "noDuplicateAtImportRules",
-				"url": "https://biomejs.dev/linter/rules/no-duplicate-at-import-rules"
 			}
 		]
 	},
@@ -2190,17 +2164,17 @@
 				"url": "https://biomejs.dev/linter/rules/no-duplicate-selectors-keyframe-block"
 			}
 		],
-		"flint": {
-			"name": "keyframeSelectorDuplicates",
-			"plugin": "css",
-			"preset": "logical"
-		},
 		"eslint": [
 			{
 				"name": "css/no-duplicate-keyframe-selectors",
 				"url": "https://github.com/eslint/css/blob/main/docs/rules/no-duplicate-keyframe-selectors.md"
 			}
 		],
+		"flint": {
+			"name": "keyframeSelectorDuplicates",
+			"plugin": "css",
+			"preset": "logical"
+		},
 		"stylelint": [
 			{
 				"name": "keyframe-block-no-duplicate-selectors",
@@ -2272,6 +2246,12 @@
 		}
 	},
 	{
+		"biome": [
+			{
+				"name": "noInvalidDirectionInLinearGradient",
+				"url": "https://biomejs.dev/linter/rules/no-invalid-direction-in-linear-gradient"
+			}
+		],
 		"flint": {
 			"name": "linearGradientDirectionValidity",
 			"plugin": "css",
@@ -2281,12 +2261,6 @@
 			{
 				"name": "function-linear-gradient-no-nonstandard-direction",
 				"url": "https://stylelint.io/user-guide/rules/function-linear-gradient-no-nonstandard-direction"
-			}
-		],
-		"biome": [
-			{
-				"name": "noInvalidDirectionInLinearGradient",
-				"url": "https://biomejs.dev/linter/rules/no-invalid-direction-in-linear-gradient"
 			}
 		]
 	},
@@ -2454,13 +2428,13 @@
 			"plugin": "css",
 			"status": "skipped"
 		},
+		"notes": "Overly opinionated.",
 		"stylelint": [
 			{
 				"name": "time-min-milliseconds",
 				"url": "https://stylelint.io/user-guide/rules/time-min-milliseconds"
 			}
-		],
-		"notes": "Overly opinionated."
+		]
 	},
 	{
 		"eslint": [
@@ -2482,6 +2456,12 @@
 		]
 	},
 	{
+		"biome": [
+			{
+				"name": "noInvalidGridAreas",
+				"url": "https://biomejs.dev/linter/rules/no-invalid-grid-areas"
+			}
+		],
 		"eslint": [
 			{
 				"name": "css/no-invalid-named-grid-areas",
@@ -2497,12 +2477,6 @@
 			{
 				"name": "named-grid-areas-no-invalid",
 				"url": "https://stylelint.io/user-guide/rules/named-grid-areas-no-invalid"
-			}
-		],
-		"biome": [
-			{
-				"name": "noInvalidGridAreas",
-				"url": "https://biomejs.dev/linter/rules/no-invalid-grid-areas"
 			}
 		]
 	},
@@ -2537,13 +2511,13 @@
 			"plugin": "css",
 			"status": "skipped"
 		},
+		"notes": "Overly opinionated.",
 		"stylelint": [
 			{
 				"name": "max-nesting-depth",
 				"url": "https://stylelint.io/user-guide/rules/max-nesting-depth"
 			}
-		],
-		"notes": "Overly opinionated."
+		]
 	},
 	{
 		"flint": {
@@ -2577,13 +2551,13 @@
 			"plugin": "css",
 			"status": "skipped"
 		},
+		"notes": "Overly opinionated.",
 		"stylelint": [
 			{
 				"name": "number-max-precision",
 				"url": "https://stylelint.io/user-guide/rules/number-max-precision"
 			}
-		],
-		"notes": "Overly opinionated."
+		]
 	},
 	{
 		"eslint": [
@@ -2672,17 +2646,17 @@
 				"url": "https://biomejs.dev/linter/rules/no-unknown-property"
 			}
 		],
-		"flint": {
-			"name": "propertyValidity",
-			"plugin": "css",
-			"preset": "logical"
-		},
 		"eslint": [
 			{
 				"name": "css/no-invalid-properties",
 				"url": "https://github.com/eslint/css/blob/main/docs/rules/no-invalid-properties.md"
 			}
 		],
+		"flint": {
+			"name": "propertyValidity",
+			"plugin": "css",
+			"preset": "logical"
+		},
 		"stylelint": [
 			{
 				"name": "declaration-property-value-no-unknown",
@@ -3008,6 +2982,12 @@
 		]
 	},
 	{
+		"biome": [
+			{
+				"name": "noUnmatchableAnbSelector",
+				"url": "https://biomejs.dev/linter/rules/no-unmatchable-anb-selector"
+			}
+		],
 		"eslint": [
 			{
 				"name": "css/no-unmatchable-selectors",
@@ -3023,12 +3003,6 @@
 			{
 				"name": "selector-anb-no-unmatchable",
 				"url": "https://stylelint.io/user-guide/rules/selector-anb-no-unmatchable"
-			}
-		],
-		"biome": [
-			{
-				"name": "noUnmatchableAnbSelector",
-				"url": "https://biomejs.dev/linter/rules/no-unmatchable-anb-selector"
 			}
 		]
 	},
@@ -3114,13 +3088,13 @@
 			"plugin": "css",
 			"status": "skipped"
 		},
+		"notes": "Overly opinionated.",
 		"stylelint": [
 			{
 				"name": "selector-max-specificity",
 				"url": "https://stylelint.io/user-guide/rules/selector-max-specificity"
 			}
-		],
-		"notes": "Overly opinionated."
+		]
 	},
 	{
 		"flint": {
@@ -3136,6 +3110,12 @@
 		]
 	},
 	{
+		"biome": [
+			{
+				"name": "noUnknownTypeSelector",
+				"url": "https://biomejs.dev/linter/rules/no-unknown-type-selector"
+			}
+		],
 		"flint": {
 			"name": "selectorTypeValidity",
 			"plugin": "css",
@@ -3145,12 +3125,6 @@
 			{
 				"name": "selector-type-no-unknown",
 				"url": "https://stylelint.io/user-guide/rules/selector-type-no-unknown"
-			}
-		],
-		"biome": [
-			{
-				"name": "noUnknownTypeSelector",
-				"url": "https://biomejs.dev/linter/rules/no-unknown-type-selector"
 			}
 		]
 	},
@@ -3225,15 +3199,21 @@
 			"plugin": "css",
 			"status": "skipped"
 		},
+		"notes": "Overly opinionated.",
 		"stylelint": [
 			{
 				"name": "declaration-block-single-line-max-declarations",
 				"url": "https://stylelint.io/user-guide/rules/declaration-block-single-line-max-declarations"
 			}
-		],
-		"notes": "Overly opinionated."
+		]
 	},
 	{
+		"biome": [
+			{
+				"name": "noUselessEscapeInString",
+				"url": "https://biomejs.dev/linter/rules/no-useless-escape-in-string"
+			}
+		],
 		"flint": {
 			"name": "stringValidity",
 			"plugin": "css",
@@ -3243,12 +3223,6 @@
 			{
 				"name": "string-no-newline",
 				"url": "https://stylelint.io/user-guide/rules/string-no-newline"
-			}
-		],
-		"biome": [
-			{
-				"name": "noUselessEscapeInString",
-				"url": "https://biomejs.dev/linter/rules/no-useless-escape-in-string"
 			}
 		]
 	},
@@ -3434,6 +3408,12 @@
 		}
 	},
 	{
+		"biome": [
+			{
+				"name": "noIrregularWhitespace",
+				"url": "https://biomejs.dev/linter/rules/no-irregular-whitespace"
+			}
+		],
 		"flint": {
 			"name": "whitespaceValidity",
 			"plugin": "css",
@@ -3443,12 +3423,6 @@
 			{
 				"name": "no-irregular-whitespace",
 				"url": "https://stylelint.io/user-guide/rules/no-irregular-whitespace"
-			}
-		],
-		"biome": [
-			{
-				"name": "noIrregularWhitespace",
-				"url": "https://biomejs.dev/linter/rules/no-irregular-whitespace"
 			}
 		]
 	},
@@ -3470,6 +3444,32 @@
 				"url": "https://stylelint.io/user-guide/rules/length-zero-no-unit"
 			}
 		]
+	},
+	{
+		"biome": [
+			{
+				"name": "noDrizzleDeleteWithoutWhere",
+				"url": "https://biomejs.dev/linter/rules/no-drizzle-delete-without-where"
+			}
+		],
+		"flint": {
+			"name": "deleteWhereClauses",
+			"plugin": "drizzle",
+			"status": "skipped"
+		}
+	},
+	{
+		"biome": [
+			{
+				"name": "noDrizzleUpdateWithoutWhere",
+				"url": "https://biomejs.dev/linter/rules/no-drizzle-update-without-where"
+			}
+		],
+		"flint": {
+			"name": "updateWhereClauses",
+			"plugin": "drizzle",
+			"status": "skipped"
+		}
 	},
 	{
 		"eslint": [
@@ -3760,8 +3760,8 @@
 			"name": "pluginRuleOrdering",
 			"plugin": "flint",
 			"preset": "stylistic",
-			"strictness": "strict",
-			"status": "implemented"
+			"status": "implemented",
+			"strictness": "strict"
 		}
 	},
 	{
@@ -4215,715 +4215,6 @@
 		}
 	},
 	{
-		"eslint": [
-			{
-				"name": "jsonc/array-bracket-newline",
-				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/array-bracket-newline.html"
-			}
-		],
-		"flint": {
-			"name": "arrayBracketNewlines",
-			"plugin": "json",
-			"status": "skipped"
-		},
-		"notes": "Formatting rule."
-	},
-	{
-		"eslint": [
-			{
-				"name": "jsonc/array-bracket-spacing",
-				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/array-bracket-spacing.html"
-			}
-		],
-		"flint": {
-			"name": "arrayBracketSpaces",
-			"plugin": "json",
-			"status": "skipped"
-		},
-		"notes": "Formatting rule."
-	},
-	{
-		"eslint": [
-			{
-				"name": "jsonc/array-element-newline",
-				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/array-element-newline.html"
-			}
-		],
-		"flint": {
-			"name": "arrayElementNewlines",
-			"plugin": "json",
-			"status": "skipped"
-		},
-		"notes": "Formatting rule."
-	},
-	{
-		"eslint": [
-			{
-				"name": "jsonc/sort-array-values",
-				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/sort-array-values.html"
-			}
-		],
-		"flint": {
-			"name": "arrayElementsSorting",
-			"plugin": "json",
-			"status": "skipped"
-		}
-	},
-	{
-		"eslint": [
-			{
-				"name": "jsonc/auto",
-				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/auto.html"
-			}
-		],
-		"flint": {
-			"name": "automaticJsoncRules",
-			"plugin": "json",
-			"preset": "config"
-		}
-	},
-	{
-		"eslint": [
-			{
-				"name": "jsonc/no-bigint-literals",
-				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/no-bigint-literals.html"
-			}
-		],
-		"flint": {
-			"name": "bigintLiterals",
-			"plugin": "json",
-			"status": "skipped"
-		},
-		"notes": "Generally handled by parsers."
-	},
-	{
-		"eslint": [
-			{
-				"name": "jsonc/no-binary-expression",
-				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/no-binary-expression.html"
-			}
-		],
-		"flint": {
-			"name": "binaryExpressions",
-			"plugin": "json",
-			"status": "skipped"
-		},
-		"notes": "Generally handled by parsers."
-	},
-	{
-		"eslint": [
-			{
-				"name": "jsonc/no-binary-numeric-literals",
-				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/no-binary-numeric-literals.html"
-			}
-		],
-		"flint": {
-			"name": "binaryNumericLiterals",
-			"plugin": "json",
-			"status": "skipped"
-		},
-		"notes": "Generally handled by parsers."
-	},
-	{
-		"eslint": [
-			{
-				"name": "jsonc/comma-style",
-				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/comma-style.html"
-			}
-		],
-		"flint": {
-			"name": "commaStyles",
-			"plugin": "json",
-			"status": "skipped"
-		},
-		"notes": "Formatting rule."
-	},
-	{
-		"eslint": [
-			{
-				"name": "jsonc/no-comments",
-				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/no-comments.html"
-			}
-		],
-		"flint": {
-			"name": "comments",
-			"plugin": "json",
-			"status": "skipped"
-		},
-		"notes": "Generally handled by parsers."
-	},
-	{
-		"eslint": [
-			{
-				"name": "json/no-duplicate-keys",
-				"url": "https://github.com/eslint/json/tree/main/docs/rules/no-duplicate-keys.md"
-			}
-		],
-		"flint": {
-			"name": "duplicateKeys",
-			"plugin": "json",
-			"preset": "logical"
-		}
-	},
-	{
-		"eslint": [
-			{
-				"name": "jsonc/no-floating-decimal",
-				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/no-floating-decimal.html"
-			}
-		],
-		"flint": {
-			"name": "floatingDecimals",
-			"plugin": "json",
-			"status": "skipped"
-		},
-		"notes": "Generally handled by parsers."
-	},
-	{
-		"eslint": [
-			{
-				"name": "jsonc/no-hexadecimal-numeric-literals",
-				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/no-hexadecimal-numeric-literals.html"
-			}
-		],
-		"flint": {
-			"name": "hexadecimalNumericLiterals",
-			"plugin": "json",
-			"status": "skipped"
-		},
-		"notes": "Generally handled by parsers."
-	},
-	{
-		"eslint": [
-			{
-				"name": "jsonc/no-escape-sequence-in-identifier",
-				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/no-escape-sequence-in-identifier.html"
-			}
-		],
-		"flint": {
-			"name": "identifierEscapeSequences",
-			"plugin": "json",
-			"status": "skipped"
-		},
-		"notes": "Generally handled by parsers."
-	},
-	{
-		"eslint": [
-			{
-				"name": "jsonc/no-number-props",
-				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/no-number-props.html"
-			}
-		],
-		"flint": {
-			"name": "identifierNumbers",
-			"plugin": "json",
-			"status": "skipped"
-		},
-		"notes": "Generally handled by parsers."
-	},
-	{
-		"eslint": [
-			{
-				"name": "jsonc/indent",
-				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/indent.html"
-			}
-		],
-		"flint": {
-			"name": "indentation",
-			"plugin": "json",
-			"status": "skipped"
-		},
-		"notes": "Formatting rule."
-	},
-	{
-		"eslint": [
-			{
-				"name": "jsonc/no-infinity",
-				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/no-infinity.html"
-			}
-		],
-		"flint": {
-			"name": "infinity",
-			"plugin": "json",
-			"status": "skipped"
-		},
-		"notes": "Generally handled by parsers."
-	},
-	{
-		"eslint": [
-			{
-				"name": "jsonc/no-irregular-whitespace",
-				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/no-irregular-whitespace.html"
-			}
-		],
-		"flint": {
-			"name": "irregularWhitespace",
-			"plugin": "json",
-			"status": "skipped"
-		},
-		"notes": "Formatting rule."
-	},
-	{
-		"eslint": [
-			{
-				"name": "json/sort-keys",
-				"url": "https://github.com/eslint/json/blob/HEAD/docs/rules/sort-keys.md"
-			},
-			{
-				"name": "jsonc/sort-keys",
-				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/sort-keys.html"
-			}
-		],
-		"flint": {
-			"name": "jsonKeysOrder",
-			"plugin": "json",
-			"preset": "sorting"
-		}
-	},
-	{
-		"eslint": [
-			{
-				"name": "jsonc/key-name-casing",
-				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/key-name-casing.html"
-			}
-		],
-		"flint": {
-			"name": "keyCasing",
-			"plugin": "json",
-			"status": "skipped"
-		}
-	},
-	{
-		"eslint": [
-			{
-				"name": "json/no-empty-keys",
-				"url": "https://github.com/eslint/json/blob/HEAD/docs/rules/no-empty-keys.md"
-			}
-		],
-		"flint": {
-			"name": "keyContents",
-			"plugin": "json",
-			"status": "skipped"
-		},
-		"biome": [
-			{
-				"name": "noEmptyObjectKeys",
-				"url": "https://biomejs.dev/linter/rules/no-empty-object-keys"
-			}
-		]
-	},
-	{
-		"deno": [
-			{
-				"name": "no-dupe-keys",
-				"url": "https://docs.deno.com/lint/rules/no-dupe-keys"
-			}
-		],
-		"eslint": [
-			{
-				"name": "jsonc/no-dupe-keys",
-				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/no-dupe-keys.html"
-			}
-		],
-		"flint": {
-			"name": "keyDuplicates",
-			"plugin": "json",
-			"preset": "logical",
-			"status": "implemented"
-		}
-	},
-	{
-		"eslint": [
-			{
-				"name": "json/no-unnormalized-keys",
-				"url": "https://github.com/eslint/json/blob/HEAD/docs/rules/no-unnormalized-keys.md"
-			}
-		],
-		"flint": {
-			"name": "keyNormalization",
-			"plugin": "json",
-			"preset": "logical",
-			"status": "implemented"
-		}
-	},
-	{
-		"eslint": [
-			{
-				"name": "jsonc/key-spacing",
-				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/key-spacing.html"
-			}
-		],
-		"flint": {
-			"name": "keySpaces",
-			"plugin": "json",
-			"status": "skipped"
-		},
-		"notes": "Formatting rule."
-	},
-	{
-		"eslint": [
-			{
-				"name": "jsonc/no-octal",
-				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/no-octal.html"
-			}
-		],
-		"flint": {
-			"name": "legacyOctalLiterals",
-			"plugin": "json",
-			"preset": "logical"
-		}
-	},
-	{
-		"eslint": [
-			{
-				"name": "jsonc/no-multi-str",
-				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/no-multi-str.html"
-			}
-		],
-		"flint": {
-			"name": "multilineStrings",
-			"plugin": "json",
-			"preset": "logical"
-		}
-	},
-	{
-		"eslint": [
-			{
-				"name": "jsonc/no-nan",
-				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/no-nan.html"
-			}
-		],
-		"flint": {
-			"name": "nan",
-			"plugin": "json",
-			"status": "skipped"
-		},
-		"notes": "Generally handled by parsers."
-	},
-	{
-		"eslint": [
-			{
-				"name": "jsonc/valid-json-number",
-				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/valid-json-number.html"
-			}
-		],
-		"flint": {
-			"name": "numbers",
-			"plugin": "json",
-			"status": "skipped"
-		},
-		"notes": "Generally handled by parsers."
-	},
-	{
-		"eslint": [
-			{
-				"name": "jsonc/no-numeric-separators",
-				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/no-numeric-separators.html"
-			}
-		],
-		"flint": {
-			"name": "numericSeparators",
-			"plugin": "json",
-			"status": "skipped"
-		},
-		"notes": "Generally handled by parsers."
-	},
-	{
-		"eslint": [
-			{
-				"name": "jsonc/object-curly-newline",
-				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/object-curly-newline.html"
-			}
-		],
-		"flint": {
-			"name": "objectCurlyNewlines",
-			"plugin": "json",
-			"status": "skipped"
-		},
-		"notes": "Formatting rule."
-	},
-	{
-		"eslint": [
-			{
-				"name": "jsonc/object-curly-spacing",
-				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/object-curly-spacing.html"
-			}
-		],
-		"flint": {
-			"name": "objectCurlySpaces",
-			"plugin": "json",
-			"status": "skipped"
-		},
-		"notes": "Formatting rule."
-	},
-	{
-		"eslint": [
-			{
-				"name": "jsonc/object-property-newline",
-				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/object-property-newline.html"
-			}
-		],
-		"flint": {
-			"name": "objectPropertyNewlines",
-			"plugin": "json",
-			"status": "skipped"
-		},
-		"notes": "Formatting rule."
-	},
-	{
-		"eslint": [
-			{
-				"name": "jsonc/no-octal-escape",
-				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/no-octal-escape.html"
-			}
-		],
-		"flint": {
-			"name": "octalEscapeSequences",
-			"plugin": "json",
-			"status": "skipped"
-		},
-		"notes": "Generally handled by parsers."
-	},
-	{
-		"eslint": [
-			{
-				"name": "jsonc/no-octal-escape",
-				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/no-octal-escape.html"
-			}
-		],
-		"flint": {
-			"name": "octalLiterals",
-			"plugin": "json",
-			"status": "skipped"
-		},
-		"notes": "Generally handled by parsers."
-	},
-	{
-		"eslint": [
-			{
-				"name": "jsonc/no-octal-numeric-literals",
-				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/no-octal-numeric-literals.html"
-			}
-		],
-		"flint": {
-			"name": "octalNumericLiterals",
-			"plugin": "json",
-			"status": "skipped"
-		},
-		"notes": "Generally handled by parsers."
-	},
-	{
-		"eslint": [
-			{
-				"name": "jsonc/no-parenthesized",
-				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/no-parenthesized.html"
-			}
-		],
-		"flint": {
-			"name": "parentheses",
-			"plugin": "json",
-			"status": "skipped"
-		},
-		"notes": "Generally handled by parsers."
-	},
-	{
-		"eslint": [
-			{
-				"name": "jsonc/no-plus-sign",
-				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/no-plus-sign.html"
-			}
-		],
-		"flint": {
-			"name": "plusOperators",
-			"plugin": "json",
-			"status": "skipped"
-		},
-		"notes": "Generally handled by parsers."
-	},
-	{
-		"eslint": [
-			{
-				"name": "jsonc/quote-props",
-				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/quote-props.html"
-			}
-		],
-		"flint": {
-			"name": "propertyQuotes",
-			"plugin": "json",
-			"status": "skipped"
-		},
-		"notes": "Formatting rule."
-	},
-	{
-		"eslint": [
-			{
-				"name": "jsonc/no-regexp-literals",
-				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/no-regexp-literals.html"
-			}
-		],
-		"flint": {
-			"name": "regexLiterals",
-			"plugin": "json",
-			"preset": "logical"
-		}
-	},
-	{
-		"eslint": [
-			{
-				"name": "jsonc/no-sparse-arrays",
-				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/no-sparse-arrays.html"
-			}
-		],
-		"flint": {
-			"name": "sparseArrays",
-			"plugin": "json",
-			"preset": "logical"
-		}
-	},
-	{
-		"eslint": [
-			{
-				"name": "jsonc/quotes",
-				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/quotes.html"
-			}
-		],
-		"flint": {
-			"name": "stringQuotes",
-			"plugin": "json",
-			"status": "skipped"
-		},
-		"notes": "Formatting rule."
-	},
-	{
-		"eslint": [
-			{
-				"name": "jsonc/no-template-literals",
-				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/no-template-literals.html"
-			}
-		],
-		"flint": {
-			"name": "templateLiterals",
-			"plugin": "json",
-			"status": "skipped"
-		},
-		"notes": "Generally handled by parsers."
-	},
-	{
-		"eslint": [
-			{
-				"name": "json/top-level-interop",
-				"url": "https://github.com/eslint/json/blob/HEAD/docs/rules/top-level-interop.md"
-			}
-		],
-		"flint": {
-			"name": "topLevelInteroperability",
-			"plugin": "json",
-			"status": "skipped"
-		},
-		"biome": [
-			{
-				"name": "noTopLevelLiterals",
-				"url": "https://biomejs.dev/linter/rules/no-top-level-literals"
-			}
-		]
-	},
-	{
-		"eslint": [
-			{
-				"name": "jsonc/comma-dangle",
-				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/comma-dangle.html"
-			}
-		],
-		"flint": {
-			"name": "trailingCommas",
-			"plugin": "json",
-			"status": "skipped"
-		},
-		"notes": "Formatting rule."
-	},
-	{
-		"eslint": [
-			{
-				"name": "jsonc/space-unary-ops",
-				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/space-unary-ops.html"
-			}
-		],
-		"flint": {
-			"name": "unaryOperatorSpaces",
-			"plugin": "json",
-			"status": "skipped"
-		},
-		"notes": "Formatting rule."
-	},
-	{
-		"eslint": [
-			{
-				"name": "jsonc/no-undefined-value",
-				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/no-undefined-value.html"
-			}
-		],
-		"flint": {
-			"name": "undefined",
-			"plugin": "json",
-			"status": "skipped"
-		},
-		"notes": "Generally handled by parsers."
-	},
-	{
-		"eslint": [
-			{
-				"name": "jsonc/no-unicode-codepoint-escapes",
-				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/no-unicode-codepoint-escapes.html"
-			}
-		],
-		"flint": {
-			"name": "unicodeCodepointEscapes",
-			"plugin": "json",
-			"status": "skipped"
-		},
-		"notes": "Generally handled by parsers."
-	},
-	{
-		"eslint": [
-			{
-				"name": "jsonc/no-useless-escape",
-				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/no-useless-escape.html"
-			}
-		],
-		"flint": {
-			"name": "unnecessaryEscapes",
-			"plugin": "json",
-			"preset": "stylistic"
-		}
-	},
-	{
-		"eslint": [
-			{
-				"name": "json/no-unsafe-values",
-				"url": "https://github.com/eslint/json/blob/HEAD/docs/rules/no-unsafe-values.md"
-			}
-		],
-		"flint": {
-			"name": "valueSafety",
-			"plugin": "json",
-			"preset": "logical",
-			"status": "implemented"
-		}
-	},
-	{
-		"eslint": [
-			{
-				"name": "jsonc/vue-custom-block/no-parsing-error",
-				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/vue-custom-block/no-parsing-error.html"
-			}
-		],
-		"flint": {
-			"name": "vueCustomBlockParsingErrors",
-			"plugin": "json",
-			"preset": "logical"
-		}
-	},
-	{
 		"flint": {
 			"name": "afterAllPaddingLines",
 			"plugin": "jest",
@@ -5224,6 +4515,19 @@
 	},
 	{
 		"flint": {
+			"name": "jestGlobalImports",
+			"plugin": "jest",
+			"status": "skipped"
+		},
+		"oxlint": [
+			{
+				"name": "jest/prefer-importing-jest-globals",
+				"url": "https://oxc.rs/docs/guide/usage/linter/rules/jest/prefer-importing-jest-globals.html"
+			}
+		]
+	},
+	{
+		"flint": {
 			"name": "maximumExpects",
 			"plugin": "jest",
 			"status": "skipped"
@@ -5315,19 +4619,6 @@
 	},
 	{
 		"flint": {
-			"name": "restrictedMatchers",
-			"plugin": "jest",
-			"status": "skipped"
-		},
-		"oxlint": [
-			{
-				"name": "jest/no-restricted-matchers",
-				"url": "https://oxc.rs/docs/guide/usage/linter/rules/jest/no-restricted-matchers.html"
-			}
-		]
-	},
-	{
-		"flint": {
 			"name": "restrictedJestMethods",
 			"plugin": "jest",
 			"status": "skipped"
@@ -5336,6 +4627,19 @@
 			{
 				"name": "jest/no-restricted-jest-methods",
 				"url": "https://oxc.rs/docs/guide/usage/linter/rules/jest/no-restricted-jest-methods.html"
+			}
+		]
+	},
+	{
+		"flint": {
+			"name": "restrictedMatchers",
+			"plugin": "jest",
+			"status": "skipped"
+		},
+		"oxlint": [
+			{
+				"name": "jest/no-restricted-matchers",
+				"url": "https://oxc.rs/docs/guide/usage/linter/rules/jest/no-restricted-matchers.html"
 			}
 		]
 	},
@@ -5691,17 +4995,713 @@
 		]
 	},
 	{
+		"eslint": [
+			{
+				"name": "jsonc/array-bracket-newline",
+				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/array-bracket-newline.html"
+			}
+		],
 		"flint": {
-			"name": "jestGlobalImports",
-			"plugin": "jest",
+			"name": "arrayBracketNewlines",
+			"plugin": "json",
 			"status": "skipped"
 		},
-		"oxlint": [
+		"notes": "Formatting rule."
+	},
+	{
+		"eslint": [
 			{
-				"name": "jest/prefer-importing-jest-globals",
-				"url": "https://oxc.rs/docs/guide/usage/linter/rules/jest/prefer-importing-jest-globals.html"
+				"name": "jsonc/array-bracket-spacing",
+				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/array-bracket-spacing.html"
 			}
-		]
+		],
+		"flint": {
+			"name": "arrayBracketSpaces",
+			"plugin": "json",
+			"status": "skipped"
+		},
+		"notes": "Formatting rule."
+	},
+	{
+		"eslint": [
+			{
+				"name": "jsonc/array-element-newline",
+				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/array-element-newline.html"
+			}
+		],
+		"flint": {
+			"name": "arrayElementNewlines",
+			"plugin": "json",
+			"status": "skipped"
+		},
+		"notes": "Formatting rule."
+	},
+	{
+		"eslint": [
+			{
+				"name": "jsonc/sort-array-values",
+				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/sort-array-values.html"
+			}
+		],
+		"flint": {
+			"name": "arrayElementsSorting",
+			"plugin": "json",
+			"status": "skipped"
+		}
+	},
+	{
+		"eslint": [
+			{
+				"name": "jsonc/auto",
+				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/auto.html"
+			}
+		],
+		"flint": {
+			"name": "automaticJsoncRules",
+			"plugin": "json",
+			"preset": "config"
+		}
+	},
+	{
+		"eslint": [
+			{
+				"name": "jsonc/no-bigint-literals",
+				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/no-bigint-literals.html"
+			}
+		],
+		"flint": {
+			"name": "bigintLiterals",
+			"plugin": "json",
+			"status": "skipped"
+		},
+		"notes": "Generally handled by parsers."
+	},
+	{
+		"eslint": [
+			{
+				"name": "jsonc/no-binary-expression",
+				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/no-binary-expression.html"
+			}
+		],
+		"flint": {
+			"name": "binaryExpressions",
+			"plugin": "json",
+			"status": "skipped"
+		},
+		"notes": "Generally handled by parsers."
+	},
+	{
+		"eslint": [
+			{
+				"name": "jsonc/no-binary-numeric-literals",
+				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/no-binary-numeric-literals.html"
+			}
+		],
+		"flint": {
+			"name": "binaryNumericLiterals",
+			"plugin": "json",
+			"status": "skipped"
+		},
+		"notes": "Generally handled by parsers."
+	},
+	{
+		"eslint": [
+			{
+				"name": "jsonc/comma-style",
+				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/comma-style.html"
+			}
+		],
+		"flint": {
+			"name": "commaStyles",
+			"plugin": "json",
+			"status": "skipped"
+		},
+		"notes": "Formatting rule."
+	},
+	{
+		"eslint": [
+			{
+				"name": "jsonc/no-comments",
+				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/no-comments.html"
+			}
+		],
+		"flint": {
+			"name": "comments",
+			"plugin": "json",
+			"status": "skipped"
+		},
+		"notes": "Generally handled by parsers."
+	},
+	{
+		"eslint": [
+			{
+				"name": "json/no-duplicate-keys",
+				"url": "https://github.com/eslint/json/tree/main/docs/rules/no-duplicate-keys.md"
+			}
+		],
+		"flint": {
+			"name": "duplicateKeys",
+			"plugin": "json",
+			"preset": "logical"
+		}
+	},
+	{
+		"eslint": [
+			{
+				"name": "jsonc/no-floating-decimal",
+				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/no-floating-decimal.html"
+			}
+		],
+		"flint": {
+			"name": "floatingDecimals",
+			"plugin": "json",
+			"status": "skipped"
+		},
+		"notes": "Generally handled by parsers."
+	},
+	{
+		"eslint": [
+			{
+				"name": "jsonc/no-hexadecimal-numeric-literals",
+				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/no-hexadecimal-numeric-literals.html"
+			}
+		],
+		"flint": {
+			"name": "hexadecimalNumericLiterals",
+			"plugin": "json",
+			"status": "skipped"
+		},
+		"notes": "Generally handled by parsers."
+	},
+	{
+		"eslint": [
+			{
+				"name": "jsonc/no-escape-sequence-in-identifier",
+				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/no-escape-sequence-in-identifier.html"
+			}
+		],
+		"flint": {
+			"name": "identifierEscapeSequences",
+			"plugin": "json",
+			"status": "skipped"
+		},
+		"notes": "Generally handled by parsers."
+	},
+	{
+		"eslint": [
+			{
+				"name": "jsonc/no-number-props",
+				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/no-number-props.html"
+			}
+		],
+		"flint": {
+			"name": "identifierNumbers",
+			"plugin": "json",
+			"status": "skipped"
+		},
+		"notes": "Generally handled by parsers."
+	},
+	{
+		"eslint": [
+			{
+				"name": "jsonc/indent",
+				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/indent.html"
+			}
+		],
+		"flint": {
+			"name": "indentation",
+			"plugin": "json",
+			"status": "skipped"
+		},
+		"notes": "Formatting rule."
+	},
+	{
+		"eslint": [
+			{
+				"name": "jsonc/no-infinity",
+				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/no-infinity.html"
+			}
+		],
+		"flint": {
+			"name": "infinity",
+			"plugin": "json",
+			"status": "skipped"
+		},
+		"notes": "Generally handled by parsers."
+	},
+	{
+		"eslint": [
+			{
+				"name": "jsonc/no-irregular-whitespace",
+				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/no-irregular-whitespace.html"
+			}
+		],
+		"flint": {
+			"name": "irregularWhitespace",
+			"plugin": "json",
+			"status": "skipped"
+		},
+		"notes": "Formatting rule."
+	},
+	{
+		"eslint": [
+			{
+				"name": "json/sort-keys",
+				"url": "https://github.com/eslint/json/blob/HEAD/docs/rules/sort-keys.md"
+			},
+			{
+				"name": "jsonc/sort-keys",
+				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/sort-keys.html"
+			}
+		],
+		"flint": {
+			"name": "jsonKeysOrder",
+			"plugin": "json",
+			"preset": "sorting"
+		}
+	},
+	{
+		"eslint": [
+			{
+				"name": "jsonc/key-name-casing",
+				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/key-name-casing.html"
+			}
+		],
+		"flint": {
+			"name": "keyCasing",
+			"plugin": "json",
+			"status": "skipped"
+		}
+	},
+	{
+		"biome": [
+			{
+				"name": "noEmptyObjectKeys",
+				"url": "https://biomejs.dev/linter/rules/no-empty-object-keys"
+			}
+		],
+		"eslint": [
+			{
+				"name": "json/no-empty-keys",
+				"url": "https://github.com/eslint/json/blob/HEAD/docs/rules/no-empty-keys.md"
+			}
+		],
+		"flint": {
+			"name": "keyContents",
+			"plugin": "json",
+			"status": "skipped"
+		}
+	},
+	{
+		"deno": [
+			{
+				"name": "no-dupe-keys",
+				"url": "https://docs.deno.com/lint/rules/no-dupe-keys"
+			}
+		],
+		"eslint": [
+			{
+				"name": "jsonc/no-dupe-keys",
+				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/no-dupe-keys.html"
+			}
+		],
+		"flint": {
+			"name": "keyDuplicates",
+			"plugin": "json",
+			"preset": "logical",
+			"status": "implemented"
+		}
+	},
+	{
+		"eslint": [
+			{
+				"name": "json/no-unnormalized-keys",
+				"url": "https://github.com/eslint/json/blob/HEAD/docs/rules/no-unnormalized-keys.md"
+			}
+		],
+		"flint": {
+			"name": "keyNormalization",
+			"plugin": "json",
+			"preset": "logical",
+			"status": "implemented"
+		}
+	},
+	{
+		"eslint": [
+			{
+				"name": "jsonc/key-spacing",
+				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/key-spacing.html"
+			}
+		],
+		"flint": {
+			"name": "keySpaces",
+			"plugin": "json",
+			"status": "skipped"
+		},
+		"notes": "Formatting rule."
+	},
+	{
+		"eslint": [
+			{
+				"name": "jsonc/no-octal",
+				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/no-octal.html"
+			}
+		],
+		"flint": {
+			"name": "legacyOctalLiterals",
+			"plugin": "json",
+			"preset": "logical"
+		}
+	},
+	{
+		"eslint": [
+			{
+				"name": "jsonc/no-multi-str",
+				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/no-multi-str.html"
+			}
+		],
+		"flint": {
+			"name": "multilineStrings",
+			"plugin": "json",
+			"preset": "logical"
+		}
+	},
+	{
+		"eslint": [
+			{
+				"name": "jsonc/no-nan",
+				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/no-nan.html"
+			}
+		],
+		"flint": {
+			"name": "nan",
+			"plugin": "json",
+			"status": "skipped"
+		},
+		"notes": "Generally handled by parsers."
+	},
+	{
+		"eslint": [
+			{
+				"name": "jsonc/valid-json-number",
+				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/valid-json-number.html"
+			}
+		],
+		"flint": {
+			"name": "numbers",
+			"plugin": "json",
+			"status": "skipped"
+		},
+		"notes": "Generally handled by parsers."
+	},
+	{
+		"eslint": [
+			{
+				"name": "jsonc/no-numeric-separators",
+				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/no-numeric-separators.html"
+			}
+		],
+		"flint": {
+			"name": "numericSeparators",
+			"plugin": "json",
+			"status": "skipped"
+		},
+		"notes": "Generally handled by parsers."
+	},
+	{
+		"eslint": [
+			{
+				"name": "jsonc/object-curly-newline",
+				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/object-curly-newline.html"
+			}
+		],
+		"flint": {
+			"name": "objectCurlyNewlines",
+			"plugin": "json",
+			"status": "skipped"
+		},
+		"notes": "Formatting rule."
+	},
+	{
+		"eslint": [
+			{
+				"name": "jsonc/object-curly-spacing",
+				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/object-curly-spacing.html"
+			}
+		],
+		"flint": {
+			"name": "objectCurlySpaces",
+			"plugin": "json",
+			"status": "skipped"
+		},
+		"notes": "Formatting rule."
+	},
+	{
+		"eslint": [
+			{
+				"name": "jsonc/object-property-newline",
+				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/object-property-newline.html"
+			}
+		],
+		"flint": {
+			"name": "objectPropertyNewlines",
+			"plugin": "json",
+			"status": "skipped"
+		},
+		"notes": "Formatting rule."
+	},
+	{
+		"eslint": [
+			{
+				"name": "jsonc/no-octal-escape",
+				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/no-octal-escape.html"
+			}
+		],
+		"flint": {
+			"name": "octalEscapeSequences",
+			"plugin": "json",
+			"status": "skipped"
+		},
+		"notes": "Generally handled by parsers."
+	},
+	{
+		"eslint": [
+			{
+				"name": "jsonc/no-octal-escape",
+				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/no-octal-escape.html"
+			}
+		],
+		"flint": {
+			"name": "octalLiterals",
+			"plugin": "json",
+			"status": "skipped"
+		},
+		"notes": "Generally handled by parsers."
+	},
+	{
+		"eslint": [
+			{
+				"name": "jsonc/no-octal-numeric-literals",
+				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/no-octal-numeric-literals.html"
+			}
+		],
+		"flint": {
+			"name": "octalNumericLiterals",
+			"plugin": "json",
+			"status": "skipped"
+		},
+		"notes": "Generally handled by parsers."
+	},
+	{
+		"eslint": [
+			{
+				"name": "jsonc/no-parenthesized",
+				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/no-parenthesized.html"
+			}
+		],
+		"flint": {
+			"name": "parentheses",
+			"plugin": "json",
+			"status": "skipped"
+		},
+		"notes": "Generally handled by parsers."
+	},
+	{
+		"eslint": [
+			{
+				"name": "jsonc/no-plus-sign",
+				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/no-plus-sign.html"
+			}
+		],
+		"flint": {
+			"name": "plusOperators",
+			"plugin": "json",
+			"status": "skipped"
+		},
+		"notes": "Generally handled by parsers."
+	},
+	{
+		"eslint": [
+			{
+				"name": "jsonc/quote-props",
+				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/quote-props.html"
+			}
+		],
+		"flint": {
+			"name": "propertyQuotes",
+			"plugin": "json",
+			"status": "skipped"
+		},
+		"notes": "Formatting rule."
+	},
+	{
+		"eslint": [
+			{
+				"name": "jsonc/no-regexp-literals",
+				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/no-regexp-literals.html"
+			}
+		],
+		"flint": {
+			"name": "regexLiterals",
+			"plugin": "json",
+			"preset": "logical"
+		}
+	},
+	{
+		"eslint": [
+			{
+				"name": "jsonc/no-sparse-arrays",
+				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/no-sparse-arrays.html"
+			}
+		],
+		"flint": {
+			"name": "sparseArrays",
+			"plugin": "json",
+			"preset": "logical"
+		}
+	},
+	{
+		"eslint": [
+			{
+				"name": "jsonc/quotes",
+				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/quotes.html"
+			}
+		],
+		"flint": {
+			"name": "stringQuotes",
+			"plugin": "json",
+			"status": "skipped"
+		},
+		"notes": "Formatting rule."
+	},
+	{
+		"eslint": [
+			{
+				"name": "jsonc/no-template-literals",
+				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/no-template-literals.html"
+			}
+		],
+		"flint": {
+			"name": "templateLiterals",
+			"plugin": "json",
+			"status": "skipped"
+		},
+		"notes": "Generally handled by parsers."
+	},
+	{
+		"biome": [
+			{
+				"name": "noTopLevelLiterals",
+				"url": "https://biomejs.dev/linter/rules/no-top-level-literals"
+			}
+		],
+		"eslint": [
+			{
+				"name": "json/top-level-interop",
+				"url": "https://github.com/eslint/json/blob/HEAD/docs/rules/top-level-interop.md"
+			}
+		],
+		"flint": {
+			"name": "topLevelInteroperability",
+			"plugin": "json",
+			"status": "skipped"
+		}
+	},
+	{
+		"eslint": [
+			{
+				"name": "jsonc/comma-dangle",
+				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/comma-dangle.html"
+			}
+		],
+		"flint": {
+			"name": "trailingCommas",
+			"plugin": "json",
+			"status": "skipped"
+		},
+		"notes": "Formatting rule."
+	},
+	{
+		"eslint": [
+			{
+				"name": "jsonc/space-unary-ops",
+				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/space-unary-ops.html"
+			}
+		],
+		"flint": {
+			"name": "unaryOperatorSpaces",
+			"plugin": "json",
+			"status": "skipped"
+		},
+		"notes": "Formatting rule."
+	},
+	{
+		"eslint": [
+			{
+				"name": "jsonc/no-undefined-value",
+				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/no-undefined-value.html"
+			}
+		],
+		"flint": {
+			"name": "undefined",
+			"plugin": "json",
+			"status": "skipped"
+		},
+		"notes": "Generally handled by parsers."
+	},
+	{
+		"eslint": [
+			{
+				"name": "jsonc/no-unicode-codepoint-escapes",
+				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/no-unicode-codepoint-escapes.html"
+			}
+		],
+		"flint": {
+			"name": "unicodeCodepointEscapes",
+			"plugin": "json",
+			"status": "skipped"
+		},
+		"notes": "Generally handled by parsers."
+	},
+	{
+		"eslint": [
+			{
+				"name": "jsonc/no-useless-escape",
+				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/no-useless-escape.html"
+			}
+		],
+		"flint": {
+			"name": "unnecessaryEscapes",
+			"plugin": "json",
+			"preset": "stylistic"
+		}
+	},
+	{
+		"eslint": [
+			{
+				"name": "json/no-unsafe-values",
+				"url": "https://github.com/eslint/json/blob/HEAD/docs/rules/no-unsafe-values.md"
+			}
+		],
+		"flint": {
+			"name": "valueSafety",
+			"plugin": "json",
+			"preset": "logical",
+			"status": "implemented"
+		}
+	},
+	{
+		"eslint": [
+			{
+				"name": "jsonc/vue-custom-block/no-parsing-error",
+				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/vue-custom-block/no-parsing-error.html"
+			}
+		],
+		"flint": {
+			"name": "vueCustomBlockParsingErrors",
+			"plugin": "json",
+			"preset": "logical"
+		}
 	},
 	{
 		"eslint": [
@@ -5718,6 +5718,12 @@
 		"notes": "Deprecated."
 	},
 	{
+		"biome": [
+			{
+				"name": "noAccessKey",
+				"url": "https://biomejs.dev/linter/rules/no-access-key"
+			}
+		],
 		"eslint": [
 			{
 				"name": "jsx-a11y/no-access-key",
@@ -5734,12 +5740,6 @@
 			{
 				"name": "jsx-a11y/no-access-key",
 				"url": "https://oxc.rs/docs/guide/usage/linter/rules/jsx_a11y/no-access-key.html"
-			}
-		],
-		"biome": [
-			{
-				"name": "noAccessKey",
-				"url": "https://biomejs.dev/linter/rules/no-access-key"
 			}
 		]
 	},
@@ -5784,6 +5784,12 @@
 		]
 	},
 	{
+		"biome": [
+			{
+				"name": "noAmbiguousAnchorText",
+				"url": "https://biomejs.dev/linter/rules/no-ambiguous-anchor-text"
+			}
+		],
 		"eslint": [
 			{
 				"name": "jsx-a11y/anchor-ambiguous-text",
@@ -5801,12 +5807,6 @@
 			{
 				"name": "jsx-a11y/anchor-ambiguous-text",
 				"url": "https://oxc.rs/docs/guide/usage/linter/rules/jsx-a11y/anchor-ambiguous-text.html"
-			}
-		],
-		"biome": [
-			{
-				"name": "noAmbiguousAnchorText",
-				"url": "https://biomejs.dev/linter/rules/no-ambiguous-anchor-text"
 			}
 		]
 	},
@@ -6702,6 +6702,12 @@
 		]
 	},
 	{
+		"biome": [
+			{
+				"name": "noJsxPropsBind",
+				"url": "https://biomejs.dev/linter/rules/no-jsx-props-bind"
+			}
+		],
 		"eslint": [
 			{
 				"name": "react/jsx-no-bind",
@@ -6713,13 +6719,7 @@
 			"plugin": "jsx",
 			"status": "skipped"
 		},
-		"notes": "Overly opinionated.",
-		"biome": [
-			{
-				"name": "noJsxPropsBind",
-				"url": "https://biomejs.dev/linter/rules/no-jsx-props-bind"
-			}
-		]
+		"notes": "Overly opinionated."
 	},
 	{
 		"eslint": [
@@ -7102,6 +7102,12 @@
 		"notes": "Overly opinionated."
 	},
 	{
+		"biome": [
+			{
+				"name": "noJsxLiterals",
+				"url": "https://biomejs.dev/linter/rules/no-jsx-literals"
+			}
+		],
 		"eslint": [
 			{
 				"name": "react/jsx-no-literals",
@@ -7113,13 +7119,7 @@
 			"plugin": "jsx",
 			"status": "skipped"
 		},
-		"notes": "Overly opinionated.",
-		"biome": [
-			{
-				"name": "noJsxLiterals",
-				"url": "https://biomejs.dev/linter/rules/no-jsx-literals"
-			}
-		]
+		"notes": "Overly opinionated."
 	},
 	{
 		"eslint": [
@@ -7491,6 +7491,12 @@
 		]
 	},
 	{
+		"biome": [
+			{
+				"name": "noLeakedRender",
+				"url": "https://biomejs.dev/linter/rules/no-leaked-render"
+			}
+		],
 		"eslint": [
 			{
 				"name": "react/jsx-no-leaked-render",
@@ -7502,13 +7508,7 @@
 			"plugin": "jsx",
 			"preset": "logical",
 			"strictness": "strict"
-		},
-		"biome": [
-			{
-				"name": "noLeakedRender",
-				"url": "https://biomejs.dev/linter/rules/no-leaked-render"
-			}
-		]
+		}
 	},
 	{
 		"eslint": [
@@ -9550,8 +9550,8 @@
 			"name": "consoleSpaces",
 			"plugin": "node",
 			"preset": "stylistic",
-			"strictness": "strict",
-			"status": "implemented"
+			"status": "implemented",
+			"strictness": "strict"
 		},
 		"oxlint": [
 			{
@@ -9686,8 +9686,8 @@
 			"name": "filePathsFromImportMeta",
 			"plugin": "node",
 			"preset": "stylistic",
-			"strictness": "strict",
-			"status": "implemented"
+			"status": "implemented",
+			"strictness": "strict"
 		},
 		"oxlint": [
 			{
@@ -10622,6 +10622,12 @@
 		}
 	},
 	{
+		"biome": [
+			{
+				"name": "noDuplicateDependencies",
+				"url": "https://biomejs.dev/linter/rules/no-duplicate-dependencies"
+			}
+		],
 		"eslint": [
 			{
 				"name": "package-json/unique-dependencies",
@@ -10633,13 +10639,7 @@
 			"plugin": "package-json",
 			"preset": "logical",
 			"status": "implemented"
-		},
-		"biome": [
-			{
-				"name": "noDuplicateDependencies",
-				"url": "https://biomejs.dev/linter/rules/no-duplicate-dependencies"
-			}
-		]
+		}
 	},
 	{
 		"eslint": [
@@ -10651,8 +10651,8 @@
 		"flint": {
 			"name": "descriptionPresence",
 			"plugin": "package-json",
-			"status": "implemented",
-			"preset": "logical"
+			"preset": "logical",
+			"status": "implemented"
 		}
 	},
 	{
@@ -10801,8 +10801,8 @@
 		"flint": {
 			"name": "exportsPresence",
 			"plugin": "package-json",
-			"status": "implemented",
-			"preset": "logical"
+			"preset": "logical",
+			"status": "implemented"
 		}
 	},
 	{
@@ -11020,8 +11020,8 @@
 		"flint": {
 			"name": "licensePresence",
 			"plugin": "package-json",
-			"status": "implemented",
-			"preset": "logical"
+			"preset": "logical",
+			"status": "implemented"
 		}
 	},
 	{
@@ -11156,8 +11156,8 @@
 		"flint": {
 			"name": "namePresence",
 			"plugin": "package-json",
-			"status": "implemented",
-			"preset": "logical"
+			"preset": "logical",
+			"status": "implemented"
 		}
 	},
 	{
@@ -11468,8 +11468,8 @@
 		"flint": {
 			"name": "repositoryPresence",
 			"plugin": "package-json",
-			"status": "implemented",
-			"preset": "logical"
+			"preset": "logical",
+			"status": "implemented"
 		}
 	},
 	{
@@ -11515,6 +11515,12 @@
 		}
 	},
 	{
+		"biome": [
+			{
+				"name": "useRequiredScripts",
+				"url": "https://biomejs.dev/linter/rules/use-required-scripts"
+			}
+		],
 		"eslint": [
 			{
 				"name": "package-json/require-scripts",
@@ -11525,13 +11531,7 @@
 			"name": "scriptsPresence",
 			"plugin": "package-json",
 			"status": "implemented"
-		},
-		"biome": [
-			{
-				"name": "useRequiredScripts",
-				"url": "https://biomejs.dev/linter/rules/use-required-scripts"
-			}
-		]
+		}
 	},
 	{
 		"eslint": [
@@ -11557,8 +11557,8 @@
 		"flint": {
 			"name": "sideEffectsPresence",
 			"plugin": "package-json",
-			"status": "implemented",
-			"preset": "logical"
+			"preset": "logical",
+			"status": "implemented"
 		}
 	},
 	{
@@ -11597,8 +11597,8 @@
 		"flint": {
 			"name": "typePresence",
 			"plugin": "package-json",
-			"status": "implemented",
-			"preset": "logical"
+			"preset": "logical",
+			"status": "implemented"
 		}
 	},
 	{
@@ -11638,8 +11638,8 @@
 		"flint": {
 			"name": "versionPresence",
 			"plugin": "package-json",
-			"status": "implemented",
-			"preset": "logical"
+			"preset": "logical",
+			"status": "implemented"
 		}
 	},
 	{
@@ -12003,8 +12003,8 @@
 			}
 		],
 		"flint": {
-			"plugin": "qwik",
 			"name": "classlists",
+			"plugin": "qwik",
 			"status": "skipped"
 		}
 	},
@@ -12016,8 +12016,8 @@
 			}
 		],
 		"flint": {
-			"plugin": "qwik",
 			"name": "lexicalScopes",
+			"plugin": "qwik",
 			"status": "skipped"
 		}
 	},
@@ -12029,8 +12029,8 @@
 			}
 		],
 		"flint": {
-			"plugin": "qwik",
 			"name": "loaderLocations",
+			"plugin": "qwik",
 			"status": "skipped"
 		}
 	},
@@ -12042,8 +12042,8 @@
 			}
 		],
 		"flint": {
-			"plugin": "qwik",
 			"name": "methodUsages",
+			"plugin": "qwik",
 			"status": "skipped"
 		}
 	},
@@ -12055,8 +12055,8 @@
 			}
 		],
 		"flint": {
-			"plugin": "qwik",
 			"name": "visibleTasks",
+			"plugin": "qwik",
 			"status": "skipped"
 		}
 	},
@@ -12393,6 +12393,12 @@
 		]
 	},
 	{
+		"biome": [
+			{
+				"name": "noComponentHookFactories",
+				"url": "https://biomejs.dev/linter/rules/no-component-hook-factories"
+			}
+		],
 		"eslint": [
 			{
 				"name": "react-hooks/component-hook-factories",
@@ -12403,13 +12409,7 @@
 			"name": "componentHookFactories",
 			"plugin": "react",
 			"preset": "logical"
-		},
-		"biome": [
-			{
-				"name": "noComponentHookFactories",
-				"url": "https://biomejs.dev/linter/rules/no-component-hook-factories"
-			}
-		]
+		}
 	},
 	{
 		"eslint": [
@@ -12948,6 +12948,12 @@
 		}
 	},
 	{
+		"biome": [
+			{
+				"name": "useReactFunctionComponents",
+				"url": "https://biomejs.dev/linter/rules/use-react-function-components"
+			}
+		],
 		"eslint": [
 			{
 				"name": "react/function-component-definition",
@@ -12958,13 +12964,7 @@
 			"name": "functionComponentDefinitions",
 			"plugin": "react",
 			"preset": "stylistic"
-		},
-		"biome": [
-			{
-				"name": "useReactFunctionComponents",
-				"url": "https://biomejs.dev/linter/rules/use-react-function-components"
-			}
-		]
+		}
 	},
 	{
 		"eslint": [
@@ -13211,17 +13211,17 @@
 				"url": "https://biomejs.dev/linter/rules/no-nested-component-definitions"
 			}
 		],
-		"flint": {
-			"name": "nestedComponentDefinitions",
-			"plugin": "react",
-			"preset": "logical"
-		},
 		"eslint": [
 			{
 				"name": "@eslint-react/no-nested-component-definitions",
 				"url": "https://eslint-react.xyz/docs/rules/no-nested-component-definitions"
 			}
-		]
+		],
+		"flint": {
+			"name": "nestedComponentDefinitions",
+			"plugin": "react",
+			"preset": "logical"
+		}
 	},
 	{
 		"eslint": [
@@ -14197,6 +14197,12 @@
 		}
 	},
 	{
+		"biome": [
+			{
+				"name": "useSolidForComponent",
+				"url": "https://biomejs.dev/linter/rules/use-solid-for-component"
+			}
+		],
 		"eslint": [
 			{
 				"name": "solid/prefer-for",
@@ -14207,13 +14213,7 @@
 			"name": "forMaps",
 			"plugin": "solid",
 			"preset": "logical"
-		},
-		"biome": [
-			{
-				"name": "useSolidForComponent",
-				"url": "https://biomejs.dev/linter/rules/use-solid-for-component"
-			}
-		]
+		}
 	},
 	{
 		"eslint": [
@@ -14243,6 +14243,12 @@
 		}
 	},
 	{
+		"biome": [
+			{
+				"name": "noScriptUrl",
+				"url": "https://biomejs.dev/linter/rules/no-script-url"
+			}
+		],
 		"eslint": [
 			{
 				"name": "solid/jsx-no-script-url",
@@ -14254,15 +14260,15 @@
 			"plugin": "solid",
 			"status": "skipped"
 		},
-		"notes": "Superseded by jsx plugin's scriptUrls rule.",
-		"biome": [
-			{
-				"name": "noScriptUrl",
-				"url": "https://biomejs.dev/linter/rules/no-script-url"
-			}
-		]
+		"notes": "Superseded by jsx plugin's scriptUrls rule."
 	},
 	{
+		"biome": [
+			{
+				"name": "noSolidDestructuredProps",
+				"url": "https://biomejs.dev/linter/rules/no-solid-destructured-props"
+			}
+		],
 		"eslint": [
 			{
 				"name": "solid/no-destructure",
@@ -14273,13 +14279,7 @@
 			"name": "propDestructures",
 			"plugin": "solid",
 			"preset": "logical"
-		},
-		"biome": [
-			{
-				"name": "noSolidDestructuredProps",
-				"url": "https://biomejs.dev/linter/rules/no-solid-destructured-props"
-			}
-		]
+		}
 	},
 	{
 		"eslint": [
@@ -14322,6 +14322,12 @@
 		}
 	},
 	{
+		"biome": [
+			{
+				"name": "noReactSpecificProps",
+				"url": "https://biomejs.dev/linter/rules/no-react-specific-props"
+			}
+		],
 		"eslint": [
 			{
 				"name": "solid/no-react-specific-props",
@@ -14332,13 +14338,7 @@
 			"name": "reactLikeProps",
 			"plugin": "solid",
 			"preset": "javascript"
-		},
-		"biome": [
-			{
-				"name": "noReactSpecificProps",
-				"url": "https://biomejs.dev/linter/rules/no-react-specific-props"
-			}
-		]
+		}
 	},
 	{
 		"eslint": [
@@ -14889,6 +14889,12 @@
 		}
 	},
 	{
+		"biome": [
+			{
+				"name": "noInlineStyles",
+				"url": "https://biomejs.dev/linter/rules/no-inline-styles"
+			}
+		],
 		"eslint": [
 			{
 				"name": "svelte/no-inline-styles",
@@ -14900,13 +14906,7 @@
 			"plugin": "svelte",
 			"preset": "logical",
 			"strictness": "strict"
-		},
-		"biome": [
-			{
-				"name": "noInlineStyles",
-				"url": "https://biomejs.dev/linter/rules/no-inline-styles"
-			}
-		]
+		}
 	},
 	{
 		"eslint": [
@@ -16377,6 +16377,12 @@
 		]
 	},
 	{
+		"biome": [
+			{
+				"name": "useReduceTypeParameter",
+				"url": "https://biomejs.dev/linter/rules/use-reduce-type-parameter"
+			}
+		],
 		"eslint": [
 			{
 				"name": "@typescript-eslint/prefer-reduce-type-parameter",
@@ -16394,12 +16400,6 @@
 			{
 				"name": "typescript/prefer-reduce-type-parameter",
 				"url": "https://oxc.rs/docs/guide/usage/linter/rules/typescript/prefer-reduce-type-parameter.html"
-			}
-		],
-		"biome": [
-			{
-				"name": "useReduceTypeParameter",
-				"url": "https://biomejs.dev/linter/rules/use-reduce-type-parameter"
 			}
 		]
 	},
@@ -16428,6 +16428,12 @@
 		]
 	},
 	{
+		"biome": [
+			{
+				"name": "useArraySome",
+				"url": "https://biomejs.dev/linter/rules/use-array-some"
+			}
+		],
 		"eslint": [
 			{
 				"name": "unicorn/prefer-array-some",
@@ -16446,12 +16452,6 @@
 				"name": "unicorn/prefer-array-some",
 				"url": "https://oxc.rs/docs/guide/usage/linter/rules/unicorn/prefer-array-some.html"
 			}
-		],
-		"biome": [
-			{
-				"name": "useArraySome",
-				"url": "https://biomejs.dev/linter/rules/use-array-some"
-			}
 		]
 	},
 	{
@@ -16467,6 +16467,12 @@
 		}
 	},
 	{
+		"biome": [
+			{
+				"name": "useArraySortCompare",
+				"url": "https://biomejs.dev/linter/rules/use-array-sort-compare"
+			}
+		],
 		"eslint": [
 			{
 				"name": "@typescript-eslint/require-array-sort-compare",
@@ -16482,12 +16488,6 @@
 			{
 				"name": "typescript/require-array-sort-compare",
 				"url": "https://oxc.rs/docs/guide/usage/linter/rules/typescript/require-array-sort-compare.html"
-			}
-		],
-		"biome": [
-			{
-				"name": "useArraySortCompare",
-				"url": "https://biomejs.dev/linter/rules/use-array-sort-compare"
 			}
 		]
 	},
@@ -16871,6 +16871,12 @@
 		]
 	},
 	{
+		"biome": [
+			{
+				"name": "useAwaitThenable",
+				"url": "https://biomejs.dev/linter/rules/use-await-thenable"
+			}
+		],
 		"eslint": [
 			{
 				"name": "@typescript-eslint/await-thenable",
@@ -16895,15 +16901,15 @@
 				"name": "unicorn/no-unnecessary-await",
 				"url": "https://oxc.rs/docs/guide/usage/linter/rules/unicorn/no-unnecessary-await.html"
 			}
-		],
-		"biome": [
-			{
-				"name": "useAwaitThenable",
-				"url": "https://biomejs.dev/linter/rules/use-await-thenable"
-			}
 		]
 	},
 	{
+		"biome": [
+			{
+				"name": "noBarrelFile",
+				"url": "https://biomejs.dev/linter/rules/no-barrel-file"
+			}
+		],
 		"flint": {
 			"name": "barrelFiles",
 			"plugin": "ts",
@@ -16913,12 +16919,6 @@
 			{
 				"name": "oxc/no-barrel-file",
 				"url": "https://oxc.rs/docs/guide/usage/linter/rules/oxc/no-barrel-file.html"
-			}
-		],
-		"biome": [
-			{
-				"name": "noBarrelFile",
-				"url": "https://biomejs.dev/linter/rules/no-barrel-file"
 			}
 		]
 	},
@@ -18267,6 +18267,12 @@
 		]
 	},
 	{
+		"biome": [
+			{
+				"name": "noDeprecatedImports",
+				"url": "https://biomejs.dev/linter/rules/no-deprecated-imports"
+			}
+		],
 		"eslint": [
 			{
 				"name": "import/no-deprecated",
@@ -18276,13 +18282,7 @@
 		"flint": {
 			"name": "deprecatedImports",
 			"plugin": "ts"
-		},
-		"biome": [
-			{
-				"name": "noDeprecatedImports",
-				"url": "https://biomejs.dev/linter/rules/no-deprecated-imports"
-			}
-		]
+		}
 	},
 	{
 		"biome": [
@@ -18768,6 +18768,12 @@
 		]
 	},
 	{
+		"biome": [
+			{
+				"name": "noEmptySource",
+				"url": "https://biomejs.dev/linter/rules/no-empty-source"
+			}
+		],
 		"eslint": [
 			{
 				"name": "unicorn/no-empty-file",
@@ -18785,12 +18791,6 @@
 			{
 				"name": "unicorn/no-empty-file",
 				"url": "https://oxc.rs/docs/guide/usage/linter/rules/unicorn/no-empty-file.html"
-			}
-		],
-		"biome": [
-			{
-				"name": "noEmptySource",
-				"url": "https://biomejs.dev/linter/rules/no-empty-source"
 			}
 		]
 	},
@@ -18998,8 +18998,8 @@
 			"name": "enumMemberLiterals",
 			"plugin": "ts",
 			"preset": "logical",
-			"strictness": "strict",
-			"status": "implemented"
+			"status": "implemented",
+			"strictness": "strict"
 		},
 		"oxlint": [
 			{
@@ -19054,6 +19054,12 @@
 		}
 	},
 	{
+		"biome": [
+			{
+				"name": "useConsistentEnumValueType",
+				"url": "https://biomejs.dev/linter/rules/use-consistent-enum-value-type"
+			}
+		],
 		"eslint": [
 			{
 				"name": "@typescript-eslint/no-mixed-enums",
@@ -19071,15 +19077,15 @@
 				"name": "typescript/no-mixed-enums",
 				"url": "https://oxc.rs/docs/guide/usage/linter/rules/typescript/no-mixed-enums.html"
 			}
-		],
-		"biome": [
-			{
-				"name": "useConsistentEnumValueType",
-				"url": "https://biomejs.dev/linter/rules/use-consistent-enum-value-type"
-			}
 		]
 	},
 	{
+		"biome": [
+			{
+				"name": "noDuplicateEnumValues",
+				"url": "https://biomejs.dev/linter/rules/no-duplicate-enum-values"
+			}
+		],
 		"eslint": [
 			{
 				"name": "@typescript-eslint/no-duplicate-enum-values",
@@ -19096,12 +19102,6 @@
 			{
 				"name": "typescript/no-duplicate-enum-values",
 				"url": "https://oxc.rs/docs/guide/usage/linter/rules/typescript/no-duplicate-enum-values.html"
-			}
-		],
-		"biome": [
-			{
-				"name": "noDuplicateEnumValues",
-				"url": "https://biomejs.dev/linter/rules/no-duplicate-enum-values"
 			}
 		]
 	},
@@ -19471,6 +19471,12 @@
 		]
 	},
 	{
+		"biome": [
+			{
+				"name": "useExportsLast",
+				"url": "https://biomejs.dev/linter/rules/use-exports-last"
+			}
+		],
 		"eslint": [
 			{
 				"name": "import/exports-last",
@@ -19487,12 +19493,6 @@
 			{
 				"name": "import/exports-last",
 				"url": "https://oxc.rs/docs/guide/usage/linter/rules/import/exports-last.html"
-			}
-		],
-		"biome": [
-			{
-				"name": "useExportsLast",
-				"url": "https://biomejs.dev/linter/rules/use-exports-last"
 			}
 		]
 	},
@@ -19648,10 +19648,10 @@
 			}
 		],
 		"flint": {
-			"status": "implemented",
 			"name": "finallyStatementSafety",
 			"plugin": "ts",
-			"preset": "logical"
+			"preset": "logical",
+			"status": "implemented"
 		},
 		"oxlint": [
 			{
@@ -19718,6 +19718,12 @@
 		]
 	},
 	{
+		"biome": [
+			{
+				"name": "noForIn",
+				"url": "https://biomejs.dev/linter/rules/no-for-in"
+			}
+		],
 		"eslint": [
 			{
 				"name": "@typescript-eslint/no-for-in-array",
@@ -19734,12 +19740,6 @@
 			{
 				"name": "typescript/no-for-in-array",
 				"url": "https://oxc.rs/docs/guide/usage/linter/rules/typescript/no-for-in-array.html"
-			}
-		],
-		"biome": [
-			{
-				"name": "noForIn",
-				"url": "https://biomejs.dev/linter/rules/no-for-in"
 			}
 		]
 	},
@@ -20145,6 +20145,12 @@
 		]
 	},
 	{
+		"biome": [
+			{
+				"name": "useGlobalThis",
+				"url": "https://biomejs.dev/linter/rules/use-global-this"
+			}
+		],
 		"deno": [
 			{
 				"name": "no-window",
@@ -20172,12 +20178,6 @@
 			{
 				"name": "unicorn/prefer-global-this",
 				"url": "https://oxc.rs/docs/guide/usage/linter/rules/unicorn/prefer-global-this.html"
-			}
-		],
-		"biome": [
-			{
-				"name": "useGlobalThis",
-				"url": "https://biomejs.dev/linter/rules/use-global-this"
 			}
 		]
 	},
@@ -20536,6 +20536,12 @@
 		}
 	},
 	{
+		"biome": [
+			{
+				"name": "noUndeclaredDependencies",
+				"url": "https://biomejs.dev/linter/rules/no-undeclared-dependencies"
+			}
+		],
 		"eslint": [
 			{
 				"name": "import/no-extraneous-dependencies",
@@ -20551,15 +20557,15 @@
 			"plugin": "ts",
 			"preset": "none"
 		},
-		"notes": "Superseded by Knip.",
-		"biome": [
-			{
-				"name": "noUndeclaredDependencies",
-				"url": "https://biomejs.dev/linter/rules/no-undeclared-dependencies"
-			}
-		]
+		"notes": "Superseded by Knip."
 	},
 	{
+		"biome": [
+			{
+				"name": "useImportsFirst",
+				"url": "https://biomejs.dev/linter/rules/use-imports-first"
+			}
+		],
 		"eslint": [
 			{
 				"name": "import/first",
@@ -20576,12 +20582,6 @@
 			{
 				"name": "import/first",
 				"url": "https://oxc.rs/docs/guide/usage/linter/rules/import/first.html"
-			}
-		],
-		"biome": [
-			{
-				"name": "useImportsFirst",
-				"url": "https://biomejs.dev/linter/rules/use-imports-first"
 			}
 		]
 	},
@@ -20606,6 +20606,12 @@
 		]
 	},
 	{
+		"biome": [
+			{
+				"name": "noUnresolvedImports",
+				"url": "https://biomejs.dev/linter/rules/no-unresolved-imports"
+			}
+		],
 		"eslint": [
 			{
 				"name": "import/named",
@@ -20622,12 +20628,6 @@
 			{
 				"name": "import/named",
 				"url": "https://oxc.rs/docs/guide/usage/linter/rules/import/named.html"
-			}
-		],
-		"biome": [
-			{
-				"name": "noUnresolvedImports",
-				"url": "https://biomejs.dev/linter/rules/no-unresolved-imports"
 			}
 		]
 	},
@@ -21111,6 +21111,12 @@
 		}
 	},
 	{
+		"biome": [
+			{
+				"name": "useSingleJsDocAsterisk",
+				"url": "https://biomejs.dev/linter/rules/use-single-js-doc-asterisk"
+			}
+		],
 		"eslint": [
 			{
 				"name": "jsdoc/no-multi-asterisks",
@@ -21126,13 +21132,7 @@
 			"plugin": "ts",
 			"preset": "stylistic",
 			"strictness": "strict"
-		},
-		"biome": [
-			{
-				"name": "useSingleJsDocAsterisk",
-				"url": "https://biomejs.dev/linter/rules/use-single-js-doc-asterisk"
-			}
-		]
+		}
 	},
 	{
 		"eslint": [
@@ -22334,6 +22334,12 @@
 		]
 	},
 	{
+		"biome": [
+			{
+				"name": "useMathMinMax",
+				"url": "https://biomejs.dev/linter/rules/use-math-min-max"
+			}
+		],
 		"eslint": [
 			{
 				"name": "unicorn/prefer-math-min-max",
@@ -22349,12 +22355,6 @@
 			{
 				"name": "unicorn/prefer-math-min-max",
 				"url": "https://oxc.rs/docs/guide/usage/linter/rules/unicorn/prefer-math-min-max.html"
-			}
-		],
-		"biome": [
-			{
-				"name": "useMathMinMax",
-				"url": "https://biomejs.dev/linter/rules/use-math-min-max"
 			}
 		]
 	},
@@ -23943,10 +23943,10 @@
 			}
 		],
 		"flint": {
-			"status": "implemented",
 			"name": "objectHasOwns",
 			"plugin": "ts",
-			"preset": "stylistic"
+			"preset": "stylistic",
+			"status": "implemented"
 		},
 		"oxlint": [
 			{
@@ -24409,6 +24409,12 @@
 		]
 	},
 	{
+		"biome": [
+			{
+				"name": "noUnsafePlusOperands",
+				"url": "https://biomejs.dev/linter/rules/no-unsafe-plus-operands"
+			}
+		],
 		"eslint": [
 			{
 				"name": "@typescript-eslint/restrict-plus-operands",
@@ -24424,12 +24430,6 @@
 			{
 				"name": "typescript/restrict-plus-operands",
 				"url": "https://oxc.rs/docs/guide/usage/linter/rules/typescript/restrict-plus-operands.html"
-			}
-		],
-		"biome": [
-			{
-				"name": "noUnsafePlusOperands",
-				"url": "https://biomejs.dev/linter/rules/no-unsafe-plus-operands"
 			}
 		]
 	},
@@ -24718,6 +24718,12 @@
 		]
 	},
 	{
+		"biome": [
+			{
+				"name": "noNestedPromises",
+				"url": "https://biomejs.dev/linter/rules/no-nested-promises"
+			}
+		],
 		"eslint": [
 			{
 				"name": "promise/no-nesting",
@@ -24734,12 +24740,6 @@
 			{
 				"name": "promise/no-nesting",
 				"url": "https://oxc.rs/docs/guide/usage/linter/rules/promise/no-nesting.html"
-			}
-		],
-		"biome": [
-			{
-				"name": "noNestedPromises",
-				"url": "https://biomejs.dev/linter/rules/no-nested-promises"
 			}
 		]
 	},
@@ -26025,6 +26025,12 @@
 		}
 	},
 	{
+		"biome": [
+			{
+				"name": "useRegexpTest",
+				"url": "https://biomejs.dev/linter/rules/use-regexp-test"
+			}
+		],
 		"eslint": [
 			{
 				"name": "regexp/prefer-regexp-test",
@@ -26045,12 +26051,6 @@
 			{
 				"name": "unicorn/prefer-regexp-test",
 				"url": "https://oxc.rs/docs/guide/usage/linter/rules/unicorn/prefer-regexp-test.html"
-			}
-		],
-		"biome": [
-			{
-				"name": "useRegexpTest",
-				"url": "https://biomejs.dev/linter/rules/use-regexp-test"
 			}
 		]
 	},
@@ -29490,6 +29490,12 @@
 		]
 	},
 	{
+		"biome": [
+			{
+				"name": "noBaseToString",
+				"url": "https://biomejs.dev/linter/rules/no-base-to-string"
+			}
+		],
 		"eslint": [
 			{
 				"name": "@typescript-eslint/no-base-to-string",
@@ -29505,12 +29511,6 @@
 			{
 				"name": "typescript/no-base-to-string",
 				"url": "https://oxc.rs/docs/guide/usage/linter/rules/typescript/no-base-to-string.html"
-			}
-		],
-		"biome": [
-			{
-				"name": "noBaseToString",
-				"url": "https://biomejs.dev/linter/rules/no-base-to-string"
 			}
 		]
 	},
@@ -29553,6 +29553,12 @@
 		]
 	},
 	{
+		"biome": [
+			{
+				"name": "noUselessCatchBinding",
+				"url": "https://biomejs.dev/linter/rules/no-useless-catch-binding"
+			}
+		],
 		"eslint": [
 			{
 				"name": "unicorn/prefer-optional-catch-binding",
@@ -29569,12 +29575,6 @@
 			{
 				"name": "unicorn/prefer-optional-catch-binding",
 				"url": "https://oxc.rs/docs/guide/usage/linter/rules/unicorn/prefer-optional-catch-binding.html"
-			}
-		],
-		"biome": [
-			{
-				"name": "noUselessCatchBinding",
-				"url": "https://biomejs.dev/linter/rules/no-useless-catch-binding"
 			}
 		]
 	},
@@ -30513,6 +30513,12 @@
 		]
 	},
 	{
+		"biome": [
+			{
+				"name": "noDoneCallback",
+				"url": "https://biomejs.dev/linter/rules/no-done-callback"
+			}
+		],
 		"eslint": [
 			{
 				"name": "vitest/no-done-callback",
@@ -30523,13 +30529,7 @@
 			"name": "doneCallbacks",
 			"plugin": "vitest"
 		},
-		"notes": "Deprecated.",
-		"biome": [
-			{
-				"name": "noDoneCallback",
-				"url": "https://biomejs.dev/linter/rules/no-done-callback"
-			}
-		]
+		"notes": "Deprecated."
 	},
 	{
 		"eslint": [
@@ -30881,6 +30881,26 @@
 	{
 		"eslint": [
 			{
+				"name": "vitest/require-top-level-describe",
+				"url": "https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/require-top-level-describe.md"
+			}
+		],
+		"flint": {
+			"name": "maximumDescribesPerFile",
+			"plugin": "vitest",
+			"status": "skipped"
+		},
+		"notes": "Overly opinionated.",
+		"oxlint": [
+			{
+				"name": "vitest/require-top-level-describe",
+				"url": "https://oxc.rs/docs/guide/usage/linter/rules/vitest/require-top-level-describe.html"
+			}
+		]
+	},
+	{
+		"eslint": [
+			{
 				"name": "vitest/max-expects",
 				"url": "https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/max-expects.md"
 			}
@@ -30921,26 +30941,6 @@
 			{
 				"name": "vitest/max-nested-describe",
 				"url": "https://oxc.rs/docs/guide/usage/linter/rules/vitest/max-nested-describe.html"
-			}
-		]
-	},
-	{
-		"eslint": [
-			{
-				"name": "vitest/require-top-level-describe",
-				"url": "https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/require-top-level-describe.md"
-			}
-		],
-		"flint": {
-			"name": "maximumDescribesPerFile",
-			"plugin": "vitest",
-			"status": "skipped"
-		},
-		"notes": "Overly opinionated.",
-		"oxlint": [
-			{
-				"name": "vitest/require-top-level-describe",
-				"url": "https://oxc.rs/docs/guide/usage/linter/rules/vitest/require-top-level-describe.html"
 			}
 		]
 	},
@@ -31910,6 +31910,12 @@
 		"notes": "Formatting rule."
 	},
 	{
+		"biome": [
+			{
+				"name": "useVueHyphenatedAttributes",
+				"url": "https://biomejs.dev/linter/rules/use-vue-hyphenated-attributes"
+			}
+		],
 		"eslint": [
 			{
 				"name": "vue/attribute-hyphenation",
@@ -31920,13 +31926,7 @@
 			"name": "attributeNameCasing",
 			"plugin": "vue",
 			"preset": "stylistic"
-		},
-		"biome": [
-			{
-				"name": "useVueHyphenatedAttributes",
-				"url": "https://biomejs.dev/linter/rules/use-vue-hyphenated-attributes"
-			}
-		]
+		}
 	},
 	{
 		"eslint": [
@@ -31990,6 +31990,12 @@
 		]
 	},
 	{
+		"biome": [
+			{
+				"name": "useVueValidVBind",
+				"url": "https://biomejs.dev/linter/rules/use-vue-valid-v-bind"
+			}
+		],
 		"eslint": [
 			{
 				"name": "vue/valid-v-bind",
@@ -32000,15 +32006,15 @@
 			"name": "bindDirectiveValidity",
 			"plugin": "vue",
 			"preset": "logical"
-		},
-		"biome": [
-			{
-				"name": "useVueValidVBind",
-				"url": "https://biomejs.dev/linter/rules/use-vue-valid-v-bind"
-			}
-		]
+		}
 	},
 	{
+		"biome": [
+			{
+				"name": "useVueConsistentVBindStyle",
+				"url": "https://biomejs.dev/linter/rules/use-vue-consistent-v-bind-style"
+			}
+		],
 		"eslint": [
 			{
 				"name": "vue/v-bind-style",
@@ -32019,13 +32025,7 @@
 			"name": "bindStyles",
 			"plugin": "vue",
 			"preset": "stylistic"
-		},
-		"biome": [
-			{
-				"name": "useVueConsistentVBindStyle",
-				"url": "https://biomejs.dev/linter/rules/use-vue-consistent-v-bind-style"
-			}
-		]
+		}
 	},
 	{
 		"eslint": [
@@ -32227,6 +32227,12 @@
 		}
 	},
 	{
+		"biome": [
+			{
+				"name": "useVueValidVCloak",
+				"url": "https://biomejs.dev/linter/rules/use-vue-valid-v-cloak"
+			}
+		],
 		"eslint": [
 			{
 				"name": "vue/valid-v-cloak",
@@ -32237,13 +32243,7 @@
 			"name": "cloakDirectiveValidity",
 			"plugin": "vue",
 			"preset": "logical"
-		},
-		"biome": [
-			{
-				"name": "useVueValidVCloak",
-				"url": "https://biomejs.dev/linter/rules/use-vue-valid-v-cloak"
-			}
-		]
+		}
 	},
 	{
 		"eslint": [
@@ -32492,6 +32492,12 @@
 		]
 	},
 	{
+		"biome": [
+			{
+				"name": "useVueMultiWordComponentNames",
+				"url": "https://biomejs.dev/linter/rules/use-vue-multi-word-component-names"
+			}
+		],
 		"eslint": [
 			{
 				"name": "vue/multi-word-component-names",
@@ -32502,13 +32508,7 @@
 			"name": "componentNames",
 			"plugin": "vue",
 			"preset": "stylistic"
-		},
-		"biome": [
-			{
-				"name": "useVueMultiWordComponentNames",
-				"url": "https://biomejs.dev/linter/rules/use-vue-multi-word-component-names"
-			}
-		]
+		}
 	},
 	{
 		"eslint": [
@@ -32807,6 +32807,12 @@
 		]
 	},
 	{
+		"biome": [
+			{
+				"name": "useVueDefineMacrosOrder",
+				"url": "https://biomejs.dev/linter/rules/use-vue-define-macros-order"
+			}
+		],
 		"eslint": [
 			{
 				"name": "vue/define-macros-order",
@@ -32817,13 +32823,7 @@
 			"name": "defineMacrosOrder",
 			"plugin": "vue",
 			"preset": "sorting"
-		},
-		"biome": [
-			{
-				"name": "useVueDefineMacrosOrder",
-				"url": "https://biomejs.dev/linter/rules/use-vue-define-macros-order"
-			}
-		]
+		}
 	},
 	{
 		"eslint": [
@@ -33224,6 +33224,12 @@
 		"notes": "Superseded by deprecated."
 	},
 	{
+		"biome": [
+			{
+				"name": "noVueVOnNumberValues",
+				"url": "https://biomejs.dev/linter/rules/no-vue-v-on-number-values"
+			}
+		],
 		"eslint": [
 			{
 				"name": "vue/no-deprecated-v-on-number-modifiers",
@@ -33235,13 +33241,7 @@
 			"plugin": "vue",
 			"status": "skipped"
 		},
-		"notes": "Superseded by deprecated.",
-		"biome": [
-			{
-				"name": "noVueVOnNumberValues",
-				"url": "https://biomejs.dev/linter/rules/no-vue-v-on-number-values"
-			}
-		]
+		"notes": "Superseded by deprecated."
 	},
 	{
 		"eslint": [
@@ -33310,6 +33310,12 @@
 		}
 	},
 	{
+		"biome": [
+			{
+				"name": "noDuplicateAttributes",
+				"url": "https://biomejs.dev/linter/rules/no-duplicate-attributes"
+			}
+		],
 		"eslint": [
 			{
 				"name": "vue/no-duplicate-attributes",
@@ -33320,13 +33326,7 @@
 			"name": "duplicateAttributes",
 			"plugin": "vue",
 			"preset": "logical"
-		},
-		"biome": [
-			{
-				"name": "noDuplicateAttributes",
-				"url": "https://biomejs.dev/linter/rules/no-duplicate-attributes"
-			}
-		]
+		}
 	},
 	{
 		"eslint": [
@@ -33355,6 +33355,12 @@
 		}
 	},
 	{
+		"biome": [
+			{
+				"name": "useVueValidVElse",
+				"url": "https://biomejs.dev/linter/rules/use-vue-valid-v-else"
+			}
+		],
 		"eslint": [
 			{
 				"name": "vue/valid-v-else",
@@ -33365,15 +33371,15 @@
 			"name": "elseDirectiveValidity",
 			"plugin": "vue",
 			"preset": "logical"
-		},
-		"biome": [
-			{
-				"name": "useVueValidVElse",
-				"url": "https://biomejs.dev/linter/rules/use-vue-valid-v-else"
-			}
-		]
+		}
 	},
 	{
+		"biome": [
+			{
+				"name": "useVueValidVElseIf",
+				"url": "https://biomejs.dev/linter/rules/use-vue-valid-v-else-if"
+			}
+		],
 		"eslint": [
 			{
 				"name": "vue/valid-v-else-if",
@@ -33384,13 +33390,7 @@
 			"name": "elseIfDirectiveValidity",
 			"plugin": "vue",
 			"preset": "logical"
-		},
-		"biome": [
-			{
-				"name": "useVueValidVElseIf",
-				"url": "https://biomejs.dev/linter/rules/use-vue-valid-v-else-if"
-			}
-		]
+		}
 	},
 	{
 		"eslint": [
@@ -33522,6 +33522,12 @@
 		}
 	},
 	{
+		"biome": [
+			{
+				"name": "useVueVForKey",
+				"url": "https://biomejs.dev/linter/rules/use-vue-v-for-key"
+			}
+		],
 		"eslint": [
 			{
 				"name": "vue/require-v-for-key",
@@ -33532,13 +33538,7 @@
 			"name": "forBindKeys",
 			"plugin": "vue",
 			"preset": "logical"
-		},
-		"biome": [
-			{
-				"name": "useVueVForKey",
-				"url": "https://biomejs.dev/linter/rules/use-vue-v-for-key"
-			}
-		]
+		}
 	},
 	{
 		"eslint": [
@@ -33554,6 +33554,12 @@
 		}
 	},
 	{
+		"biome": [
+			{
+				"name": "useVueValidVFor",
+				"url": "https://biomejs.dev/linter/rules/use-vue-valid-v-for"
+			}
+		],
 		"eslint": [
 			{
 				"name": "vue/valid-v-for",
@@ -33564,13 +33570,7 @@
 			"name": "forDirectiveValidity",
 			"plugin": "vue",
 			"preset": "logical"
-		},
-		"biome": [
-			{
-				"name": "useVueValidVFor",
-				"url": "https://biomejs.dev/linter/rules/use-vue-valid-v-for"
-			}
-		]
+		}
 	},
 	{
 		"eslint": [
@@ -33587,6 +33587,12 @@
 		"notes": "Formatting rule."
 	},
 	{
+		"biome": [
+			{
+				"name": "useVueValidVHtml",
+				"url": "https://biomejs.dev/linter/rules/use-vue-valid-v-html"
+			}
+		],
 		"eslint": [
 			{
 				"name": "vue/valid-v-html",
@@ -33597,13 +33603,7 @@
 			"name": "htmlDirectiveValidity",
 			"plugin": "vue",
 			"preset": "logical"
-		},
-		"biome": [
-			{
-				"name": "useVueValidVHtml",
-				"url": "https://biomejs.dev/linter/rules/use-vue-valid-v-html"
-			}
-		]
+		}
 	},
 	{
 		"eslint": [
@@ -33634,6 +33634,12 @@
 		"notes": "Formatting rule."
 	},
 	{
+		"biome": [
+			{
+				"name": "useVueValidVIf",
+				"url": "https://biomejs.dev/linter/rules/use-vue-valid-v-if"
+			}
+		],
 		"eslint": [
 			{
 				"name": "vue/valid-v-if",
@@ -33644,13 +33650,7 @@
 			"name": "ifDirectiveValidity",
 			"plugin": "vue",
 			"preset": "logical"
-		},
-		"biome": [
-			{
-				"name": "useVueValidVIf",
-				"url": "https://biomejs.dev/linter/rules/use-vue-valid-v-if"
-			}
-		]
+		}
 	},
 	{
 		"eslint": [
@@ -33747,6 +33747,12 @@
 		}
 	},
 	{
+		"biome": [
+			{
+				"name": "noVueDuplicateKeys",
+				"url": "https://biomejs.dev/linter/rules/no-vue-duplicate-keys"
+			}
+		],
 		"eslint": [
 			{
 				"name": "vue/no-dupe-keys",
@@ -33757,13 +33763,7 @@
 			"name": "keyDuplicates",
 			"plugin": "vue",
 			"preset": "logical"
-		},
-		"biome": [
-			{
-				"name": "noVueDuplicateKeys",
-				"url": "https://biomejs.dev/linter/rules/no-vue-duplicate-keys"
-			}
-		]
+		}
 	},
 	{
 		"eslint": [
@@ -34165,6 +34165,12 @@
 		}
 	},
 	{
+		"biome": [
+			{
+				"name": "useVueValidVOnce",
+				"url": "https://biomejs.dev/linter/rules/use-vue-valid-v-once"
+			}
+		],
 		"eslint": [
 			{
 				"name": "vue/valid-v-once",
@@ -34175,15 +34181,15 @@
 			"name": "onceDirectiveValidity",
 			"plugin": "vue",
 			"preset": "logical"
-		},
-		"biome": [
-			{
-				"name": "useVueValidVOnce",
-				"url": "https://biomejs.dev/linter/rules/use-vue-valid-v-once"
-			}
-		]
+		}
 	},
 	{
+		"biome": [
+			{
+				"name": "useVueValidVOn",
+				"url": "https://biomejs.dev/linter/rules/use-vue-valid-v-on"
+			}
+		],
 		"eslint": [
 			{
 				"name": "vue/valid-v-on",
@@ -34194,13 +34200,7 @@
 			"name": "onDirectiveValidity",
 			"plugin": "vue",
 			"preset": "logical"
-		},
-		"biome": [
-			{
-				"name": "useVueValidVOn",
-				"url": "https://biomejs.dev/linter/rules/use-vue-valid-v-on"
-			}
-		]
+		}
 	},
 	{
 		"eslint": [
@@ -34216,6 +34216,12 @@
 		}
 	},
 	{
+		"biome": [
+			{
+				"name": "useVueConsistentVOnStyle",
+				"url": "https://biomejs.dev/linter/rules/use-vue-consistent-v-on-style"
+			}
+		],
 		"eslint": [
 			{
 				"name": "vue/v-on-style",
@@ -34226,13 +34232,7 @@
 			"name": "onEventStyles",
 			"plugin": "vue",
 			"preset": "stylistic"
-		},
-		"biome": [
-			{
-				"name": "useVueConsistentVOnStyle",
-				"url": "https://biomejs.dev/linter/rules/use-vue-consistent-v-on-style"
-			}
-		]
+		}
 	},
 	{
 		"eslint": [
@@ -34343,6 +34343,12 @@
 		}
 	},
 	{
+		"biome": [
+			{
+				"name": "useVueValidVPre",
+				"url": "https://biomejs.dev/linter/rules/use-vue-valid-v-pre"
+			}
+		],
 		"eslint": [
 			{
 				"name": "vue/valid-v-pre",
@@ -34353,13 +34359,7 @@
 			"name": "preDirectiveValidity",
 			"plugin": "vue",
 			"preset": "logical"
-		},
-		"biome": [
-			{
-				"name": "useVueValidVPre",
-				"url": "https://biomejs.dev/linter/rules/use-vue-valid-v-pre"
-			}
-		]
+		}
 	},
 	{
 		"eslint": [
@@ -34523,6 +34523,12 @@
 		}
 	},
 	{
+		"biome": [
+			{
+				"name": "noVueRefAsOperand",
+				"url": "https://biomejs.dev/linter/rules/no-vue-ref-as-operand"
+			}
+		],
 		"eslint": [
 			{
 				"name": "vue/no-ref-as-operand",
@@ -34533,13 +34539,7 @@
 			"name": "refOperands",
 			"plugin": "vue",
 			"preset": "logical"
-		},
-		"biome": [
-			{
-				"name": "noVueRefAsOperand",
-				"url": "https://biomejs.dev/linter/rules/no-vue-ref-as-operand"
-			}
-		]
+		}
 	},
 	{
 		"eslint": [
@@ -34789,6 +34789,12 @@
 		}
 	},
 	{
+		"biome": [
+			{
+				"name": "noVueSetupPropsReactivityLoss",
+				"url": "https://biomejs.dev/linter/rules/no-vue-setup-props-reactivity-loss"
+			}
+		],
 		"eslint": [
 			{
 				"name": "vue/no-setup-props-reactivity-loss",
@@ -34799,13 +34805,7 @@
 			"name": "setupPropsReactivityLoss",
 			"plugin": "vue",
 			"preset": "logical"
-		},
-		"biome": [
-			{
-				"name": "noVueSetupPropsReactivityLoss",
-				"url": "https://biomejs.dev/linter/rules/no-vue-setup-props-reactivity-loss"
-			}
-		]
+		}
 	},
 	{
 		"eslint": [
@@ -34966,6 +34966,12 @@
 		}
 	},
 	{
+		"biome": [
+			{
+				"name": "noInlineStyles",
+				"url": "https://biomejs.dev/linter/rules/no-inline-styles"
+			}
+		],
 		"eslint": [
 			{
 				"name": "vue/no-static-inline-styles",
@@ -34976,13 +34982,7 @@
 			"name": "staticInlineStyles",
 			"plugin": "vue",
 			"preset": "stylistic"
-		},
-		"biome": [
-			{
-				"name": "noInlineStyles",
-				"url": "https://biomejs.dev/linter/rules/no-inline-styles"
-			}
-		]
+		}
 	},
 	{
 		"eslint": [
@@ -34998,6 +34998,12 @@
 		}
 	},
 	{
+		"biome": [
+			{
+				"name": "useScopedStyles",
+				"url": "https://biomejs.dev/linter/rules/use-scoped-styles"
+			}
+		],
 		"eslint": [
 			{
 				"name": "vue/enforce-style-attribute",
@@ -35008,13 +35014,7 @@
 			"name": "styleAttributes",
 			"plugin": "vue",
 			"preset": "logical"
-		},
-		"biome": [
-			{
-				"name": "useScopedStyles",
-				"url": "https://biomejs.dev/linter/rules/use-scoped-styles"
-			}
-		]
+		}
 	},
 	{
 		"eslint": [
@@ -35136,6 +35136,12 @@
 		}
 	},
 	{
+		"biome": [
+			{
+				"name": "useVueValidTemplateRoot",
+				"url": "https://biomejs.dev/linter/rules/use-vue-valid-template-root"
+			}
+		],
 		"eslint": [
 			{
 				"name": "vue/valid-template-root",
@@ -35146,13 +35152,7 @@
 			"name": "templateRootValidity",
 			"plugin": "vue",
 			"preset": "logical"
-		},
-		"biome": [
-			{
-				"name": "useVueValidTemplateRoot",
-				"url": "https://biomejs.dev/linter/rules/use-vue-valid-template-root"
-			}
-		]
+		}
 	},
 	{
 		"eslint": [
@@ -35234,6 +35234,12 @@
 		}
 	},
 	{
+		"biome": [
+			{
+				"name": "useVueValidVText",
+				"url": "https://biomejs.dev/linter/rules/use-vue-valid-v-text"
+			}
+		],
 		"eslint": [
 			{
 				"name": "vue/valid-v-text",
@@ -35244,13 +35250,7 @@
 			"name": "textDirectiveValidity",
 			"plugin": "vue",
 			"preset": "logical"
-		},
-		"biome": [
-			{
-				"name": "useVueValidVText",
-				"url": "https://biomejs.dev/linter/rules/use-vue-valid-v-text"
-			}
-		]
+		}
 	},
 	{
 		"eslint": [
@@ -35563,6 +35563,12 @@
 		}
 	},
 	{
+		"biome": [
+			{
+				"name": "noVueVIfWithVFor",
+				"url": "https://biomejs.dev/linter/rules/no-vue-v-if-with-v-for"
+			}
+		],
 		"eslint": [
 			{
 				"name": "vue/no-use-v-if-with-v-for",
@@ -35573,13 +35579,7 @@
 			"name": "vIfsWithVFors",
 			"plugin": "vue",
 			"preset": "logical"
-		},
-		"biome": [
-			{
-				"name": "noVueVIfWithVFor",
-				"url": "https://biomejs.dev/linter/rules/no-vue-v-if-with-v-for"
-			}
-		]
+		}
 	},
 	{
 		"eslint": [
@@ -35722,10 +35722,10 @@
 			}
 		],
 		"flint": {
-			"status": "implemented",
 			"name": "emptyDocuments",
 			"plugin": "yaml",
-			"preset": "logical"
+			"preset": "logical",
+			"status": "implemented"
 		}
 	},
 	{

--- a/packages/comparisons/src/data.json
+++ b/packages/comparisons/src/data.json
@@ -725,8 +725,7 @@
 	{
 		"flint": {
 			"name": "addEventListenerOptions",
-			"plugin": "browser",
-			"status": "skipped"
+			"plugin": "browser"
 		},
 		"eslint": [
 			{
@@ -764,8 +763,7 @@
 	{
 		"flint": {
 			"name": "betterDomTraversing",
-			"plugin": "browser",
-			"status": "skipped"
+			"plugin": "browser"
 		},
 		"eslint": [
 			{
@@ -777,8 +775,7 @@
 	{
 		"flint": {
 			"name": "blobToFiles",
-			"plugin": "browser",
-			"status": "skipped"
+			"plugin": "browser"
 		},
 		"eslint": [
 			{
@@ -790,8 +787,7 @@
 	{
 		"flint": {
 			"name": "canvasToImages",
-			"plugin": "browser",
-			"status": "skipped"
+			"plugin": "browser"
 		},
 		"eslint": [
 			{
@@ -823,8 +819,7 @@
 	{
 		"flint": {
 			"name": "cssEscapes",
-			"plugin": "browser",
-			"status": "skipped"
+			"plugin": "browser"
 		},
 		"eslint": [
 			{
@@ -894,22 +889,8 @@
 	},
 	{
 		"flint": {
-			"name": "domNodeDatasets",
-			"plugin": "browser",
-			"status": "skipped"
-		},
-		"eslint": [
-			{
-				"name": "unicorn/dom-node-dataset",
-				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/dom-node-dataset.md"
-			}
-		]
-	},
-	{
-		"flint": {
 			"name": "domNodeHtmlMethods",
-			"plugin": "browser",
-			"status": "skipped"
+			"plugin": "browser"
 		},
 		"eslint": [
 			{
@@ -921,8 +902,7 @@
 	{
 		"flint": {
 			"name": "domNodeReplaceChildrenMethods",
-			"plugin": "browser",
-			"status": "skipped"
+			"plugin": "browser"
 		},
 		"eslint": [
 			{
@@ -955,8 +935,7 @@
 	{
 		"flint": {
 			"name": "explicitViewportUnits",
-			"plugin": "browser",
-			"status": "skipped"
+			"plugin": "browser"
 		},
 		"eslint": [
 			{
@@ -968,8 +947,7 @@
 	{
 		"flint": {
 			"name": "https",
-			"plugin": "browser",
-			"status": "skipped"
+			"plugin": "browser"
 		},
 		"eslint": [
 			{
@@ -1001,8 +979,7 @@
 	{
 		"flint": {
 			"name": "incorrectQuerySelectors",
-			"plugin": "browser",
-			"status": "skipped"
+			"plugin": "browser"
 		},
 		"eslint": [
 			{
@@ -1014,8 +991,7 @@
 	{
 		"flint": {
 			"name": "invalidFileInputAccepts",
-			"plugin": "browser",
-			"status": "skipped"
+			"plugin": "browser"
 		},
 		"eslint": [
 			{
@@ -1046,9 +1022,20 @@
 	},
 	{
 		"flint": {
+			"name": "lateCurrentTargetAccess",
+			"plugin": "browser"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/no-late-current-target-access",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-late-current-target-access.md"
+			}
+		]
+	},
+	{
+		"flint": {
 			"name": "lateEventControls",
-			"plugin": "browser",
-			"status": "skipped"
+			"plugin": "browser"
 		},
 		"eslint": [
 			{
@@ -1060,8 +1047,7 @@
 	{
 		"flint": {
 			"name": "locationAssigns",
-			"plugin": "browser",
-			"status": "skipped"
+			"plugin": "browser"
 		},
 		"eslint": [
 			{
@@ -1073,8 +1059,7 @@
 	{
 		"flint": {
 			"name": "missingLocalResources",
-			"plugin": "browser",
-			"status": "skipped"
+			"plugin": "browser"
 		},
 		"eslint": [
 			{
@@ -1116,6 +1101,10 @@
 			{
 				"name": "unicorn/prefer-dom-node-dataset",
 				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prefer-dom-node-dataset.md"
+			},
+			{
+				"name": "unicorn/dom-node-dataset",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/dom-node-dataset.md"
 			}
 		],
 		"oxlint": [
@@ -1224,8 +1213,7 @@
 	{
 		"flint": {
 			"name": "observerApis",
-			"plugin": "browser",
-			"status": "skipped"
+			"plugin": "browser"
 		},
 		"eslint": [
 			{
@@ -1237,8 +1225,7 @@
 	{
 		"flint": {
 			"name": "passiveEvents",
-			"plugin": "browser",
-			"status": "skipped"
+			"plugin": "browser"
 		},
 		"eslint": [
 			{
@@ -1250,8 +1237,7 @@
 	{
 		"flint": {
 			"name": "path2dObjects",
-			"plugin": "browser",
-			"status": "skipped"
+			"plugin": "browser"
 		},
 		"eslint": [
 			{
@@ -1283,8 +1269,7 @@
 	{
 		"flint": {
 			"name": "scopedSelectors",
-			"plugin": "browser",
-			"status": "skipped"
+			"plugin": "browser"
 		},
 		"eslint": [
 			{
@@ -1322,8 +1307,7 @@
 	{
 		"flint": {
 			"name": "selectorAsDomNames",
-			"plugin": "browser",
-			"status": "skipped"
+			"plugin": "browser"
 		},
 		"eslint": [
 			{
@@ -1335,8 +1319,7 @@
 	{
 		"flint": {
 			"name": "toggleAttributes",
-			"plugin": "browser",
-			"status": "skipped"
+			"plugin": "browser"
 		},
 		"eslint": [
 			{
@@ -1348,8 +1331,7 @@
 	{
 		"flint": {
 			"name": "transitionAllDeclarations",
-			"plugin": "browser",
-			"status": "skipped"
+			"plugin": "browser"
 		},
 		"eslint": [
 			{
@@ -1361,8 +1343,7 @@
 	{
 		"flint": {
 			"name": "unsafeDomHtml",
-			"plugin": "browser",
-			"status": "skipped"
+			"plugin": "browser"
 		},
 		"eslint": [
 			{
@@ -1374,8 +1355,7 @@
 	{
 		"flint": {
 			"name": "urlCanParseChecks",
-			"plugin": "browser",
-			"status": "skipped"
+			"plugin": "browser"
 		},
 		"eslint": [
 			{
@@ -1387,8 +1367,7 @@
 	{
 		"flint": {
 			"name": "urlHrefs",
-			"plugin": "browser",
-			"status": "skipped"
+			"plugin": "browser"
 		},
 		"eslint": [
 			{
@@ -1400,8 +1379,7 @@
 	{
 		"flint": {
 			"name": "urlSearchParameters",
-			"plugin": "browser",
-			"status": "skipped"
+			"plugin": "browser"
 		},
 		"eslint": [
 			{
@@ -8611,6 +8589,18 @@
 	},
 	{
 		"flint": {
+			"name": "frontmatterFields",
+			"plugin": "md"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/require-frontmatter-fields",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/require-frontmatter-fields.md"
+			}
+		]
+	},
+	{
+		"flint": {
 			"name": "hardTabs",
 			"plugin": "md",
 			"status": "skipped"
@@ -9988,8 +9978,7 @@
 	{
 		"flint": {
 			"name": "exportsInScripts",
-			"plugin": "node",
-			"status": "skipped"
+			"plugin": "node"
 		},
 		"eslint": [
 			{
@@ -10615,8 +10604,7 @@
 	{
 		"flint": {
 			"name": "unsafeBufferConversions",
-			"plugin": "node",
-			"status": "skipped"
+			"plugin": "node"
 		},
 		"eslint": [
 			{
@@ -12051,6 +12039,42 @@
 			{
 				"name": "package-json/valid-workspaces",
 				"url": "https://eslint-plugin-package-json.dev/rules/valid-properties/valid-workspaces"
+			}
+		]
+	},
+	{
+		"flint": {
+			"name": "arrayConcatInLoops",
+			"plugin": "performance"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/no-array-concat-in-loop",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-array-concat-in-loop.md"
+			}
+		]
+	},
+	{
+		"flint": {
+			"name": "arrayFrontMutations",
+			"plugin": "performance"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/no-array-front-mutation",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-array-front-mutation.md"
+			}
+		]
+	},
+	{
+		"flint": {
+			"name": "arraySortMinMaxes",
+			"plugin": "performance"
+		},
+		"eslint": [
+			{
+				"name": "unicorn/no-array-sort-for-min-max",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-array-sort-for-min-max.md"
 			}
 		]
 	},
@@ -15926,8 +15950,7 @@
 	{
 		"flint": {
 			"name": "abortSignalAny",
-			"plugin": "ts",
-			"status": "skipped"
+			"plugin": "ts"
 		},
 		"eslint": [
 			{
@@ -15939,8 +15962,7 @@
 	{
 		"flint": {
 			"name": "abortSignalTimeouts",
-			"plugin": "ts",
-			"status": "skipped"
+			"plugin": "ts"
 		},
 		"eslint": [
 			{
@@ -16037,22 +16059,8 @@
 	},
 	{
 		"flint": {
-			"name": "accidentalBitwiseOperators",
-			"plugin": "ts",
-			"status": "skipped"
-		},
-		"eslint": [
-			{
-				"name": "unicorn/no-accidental-bitwise-operator",
-				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-accidental-bitwise-operator.md"
-			}
-		]
-	},
-	{
-		"flint": {
 			"name": "aggregateErrors",
-			"plugin": "ts",
-			"status": "skipped"
+			"plugin": "ts"
 		},
 		"eslint": [
 			{
@@ -16277,19 +16285,6 @@
 	},
 	{
 		"flint": {
-			"name": "arrayConcatInLoops",
-			"plugin": "ts",
-			"status": "skipped"
-		},
-		"eslint": [
-			{
-				"name": "unicorn/no-array-concat-in-loop",
-				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-array-concat-in-loop.md"
-			}
-		]
-	},
-	{
-		"flint": {
 			"name": "arrayConstructors",
 			"plugin": "ts",
 			"preset": "logical",
@@ -16428,8 +16423,7 @@
 	{
 		"flint": {
 			"name": "arrayFillWithReferenceTypes",
-			"plugin": "ts",
-			"status": "skipped"
+			"plugin": "ts"
 		},
 		"eslint": [
 			{
@@ -16575,8 +16569,7 @@
 	{
 		"flint": {
 			"name": "arrayFromAsyncMethods",
-			"plugin": "ts",
-			"status": "skipped"
+			"plugin": "ts"
 		},
 		"eslint": [
 			{
@@ -16588,8 +16581,7 @@
 	{
 		"flint": {
 			"name": "arrayFromFills",
-			"plugin": "ts",
-			"status": "skipped"
+			"plugin": "ts"
 		},
 		"eslint": [
 			{
@@ -16601,8 +16593,7 @@
 	{
 		"flint": {
 			"name": "arrayFromMaps",
-			"plugin": "ts",
-			"status": "skipped"
+			"plugin": "ts"
 		},
 		"eslint": [
 			{
@@ -16614,26 +16605,12 @@
 	{
 		"flint": {
 			"name": "arrayFromRanges",
-			"plugin": "ts",
-			"status": "skipped"
+			"plugin": "ts"
 		},
 		"eslint": [
 			{
 				"name": "unicorn/prefer-array-from-range",
 				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prefer-array-from-range.md"
-			}
-		]
-	},
-	{
-		"flint": {
-			"name": "arrayFrontMutations",
-			"plugin": "ts",
-			"status": "skipped"
-		},
-		"eslint": [
-			{
-				"name": "unicorn/no-array-front-mutation",
-				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-array-front-mutation.md"
 			}
 		]
 	},
@@ -16733,8 +16710,7 @@
 	{
 		"flint": {
 			"name": "arrayIterableMethods",
-			"plugin": "ts",
-			"status": "skipped"
+			"plugin": "ts"
 		},
 		"eslint": [
 			{
@@ -16765,8 +16741,7 @@
 	{
 		"flint": {
 			"name": "arrayLastMethods",
-			"plugin": "ts",
-			"status": "skipped"
+			"plugin": "ts"
 		},
 		"eslint": [
 			{
@@ -16800,6 +16775,10 @@
 			{
 				"name": "unicorn/no-for-loop",
 				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-for-loop.md"
+			},
+			{
+				"name": "unicorn/no-for-each",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-for-each.md"
 			}
 		],
 		"oxlint": [
@@ -16948,8 +16927,7 @@
 	{
 		"flint": {
 			"name": "arraySlices",
-			"plugin": "ts",
-			"status": "skipped"
+			"plugin": "ts"
 		},
 		"eslint": [
 			{
@@ -17037,6 +17015,10 @@
 			{
 				"name": "@typescript-eslint/require-array-sort-compare",
 				"url": "https://typescript-eslint.io/rules/require-array-sort-compare"
+			},
+			{
+				"name": "unicorn/require-array-sort-compare",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/require-array-sort-compare.md"
 			}
 		],
 		"oxlint": [
@@ -17048,35 +17030,8 @@
 	},
 	{
 		"flint": {
-			"name": "arraySortCompares",
-			"plugin": "ts",
-			"status": "skipped"
-		},
-		"eslint": [
-			{
-				"name": "unicorn/require-array-sort-compare",
-				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/require-array-sort-compare.md"
-			}
-		]
-	},
-	{
-		"flint": {
-			"name": "arraySortMinMaxes",
-			"plugin": "ts",
-			"status": "skipped"
-		},
-		"eslint": [
-			{
-				"name": "unicorn/no-array-sort-for-min-max",
-				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-array-sort-for-min-max.md"
-			}
-		]
-	},
-	{
-		"flint": {
 			"name": "arraySplices",
-			"plugin": "ts",
-			"status": "skipped"
+			"plugin": "ts"
 		},
 		"eslint": [
 			{
@@ -17257,25 +17212,16 @@
 			{
 				"name": "logical-assignment-operators",
 				"url": "https://eslint.org/docs/latest/rules/logical-assignment-operators"
+			},
+			{
+				"name": "unicorn/logical-assignment-operators",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/logical-assignment-operators.md"
 			}
 		],
 		"oxlint": [
 			{
 				"name": "eslint/logical-assignment-operators",
 				"url": "https://oxc.rs/docs/guide/usage/linter/rules/eslint/logical-assignment-operators.html"
-			}
-		]
-	},
-	{
-		"flint": {
-			"name": "asteriskPrefixInDocumentationComments",
-			"plugin": "ts",
-			"status": "skipped"
-		},
-		"eslint": [
-			{
-				"name": "unicorn/no-asterisk-prefix-in-documentation-comments",
-				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-asterisk-prefix-in-documentation-comments.md"
 			}
 		]
 	},
@@ -17479,19 +17425,6 @@
 	},
 	{
 		"flint": {
-			"name": "awaits",
-			"plugin": "ts",
-			"status": "skipped"
-		},
-		"eslint": [
-			{
-				"name": "unicorn/prefer-await",
-				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prefer-await.md"
-			}
-		]
-	},
-	{
-		"flint": {
 			"name": "awaitThenable",
 			"plugin": "ts",
 			"preset": "logical"
@@ -17548,6 +17481,16 @@
 			"plugin": "ts",
 			"status": "skipped"
 		},
+		"eslint": [
+			{
+				"name": "unicorn/no-accidental-bitwise-operator",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-accidental-bitwise-operator.md"
+			},
+			{
+				"name": "unicorn/no-xor-as-exponentiation",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-xor-as-exponentiation.md"
+			}
+		],
 		"oxlint": [
 			{
 				"name": "oxc/bad-bitwise-operator",
@@ -17583,8 +17526,7 @@
 	{
 		"flint": {
 			"name": "blockStatementIifes",
-			"plugin": "ts",
-			"status": "skipped"
+			"plugin": "ts"
 		},
 		"eslint": [
 			{
@@ -17648,8 +17590,7 @@
 	{
 		"flint": {
 			"name": "booleanReturns",
-			"plugin": "ts",
-			"status": "skipped"
+			"plugin": "ts"
 		},
 		"eslint": [
 			{
@@ -17661,8 +17602,7 @@
 	{
 		"flint": {
 			"name": "booleanSortComparators",
-			"plugin": "ts",
-			"status": "skipped"
+			"plugin": "ts"
 		},
 		"eslint": [
 			{
@@ -17678,6 +17618,16 @@
 			"preset": "stylistic",
 			"strictness": "strict"
 		},
+		"eslint": [
+			{
+				"name": "unicorn/no-duplicate-if-branches",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-duplicate-if-branches.md"
+			},
+			{
+				"name": "unicorn/prefer-hoisting-branch-code",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prefer-hoisting-branch-code.md"
+			}
+		],
 		"oxlint": [
 			{
 				"name": "oxc/branches-sharing-code",
@@ -17688,8 +17638,7 @@
 	{
 		"flint": {
 			"name": "breakInNestedLoops",
-			"plugin": "ts",
-			"status": "skipped"
+			"plugin": "ts"
 		},
 		"eslint": [
 			{
@@ -17974,19 +17923,6 @@
 	},
 	{
 		"flint": {
-			"name": "chainedComparisons",
-			"plugin": "ts",
-			"status": "skipped"
-		},
-		"eslint": [
-			{
-				"name": "unicorn/no-chained-comparison",
-				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-chained-comparison.md"
-			}
-		]
-	},
-	{
-		"flint": {
 			"name": "characterClassElementsOrder",
 			"plugin": "ts"
 		},
@@ -18004,6 +17940,12 @@
 			"preset": "logical",
 			"status": "implemented"
 		},
+		"eslint": [
+			{
+				"name": "unicorn/no-invalid-character-comparison",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-invalid-character-comparison.md"
+			}
+		],
 		"oxlint": [
 			{
 				"name": "oxc/bad-char-at-comparison",
@@ -18140,19 +18082,6 @@
 	},
 	{
 		"flint": {
-			"name": "classMemberOrderConsistency",
-			"plugin": "ts",
-			"status": "skipped"
-		},
-		"eslint": [
-			{
-				"name": "unicorn/consistent-class-member-order",
-				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/consistent-class-member-order.md"
-			}
-		]
-	},
-	{
-		"flint": {
 			"name": "classMethodsThis",
 			"plugin": "ts",
 			"preset": "stylistic",
@@ -18185,8 +18114,7 @@
 	{
 		"flint": {
 			"name": "classReferenceInStaticMethods",
-			"plugin": "ts",
-			"status": "skipped"
+			"plugin": "ts"
 		},
 		"eslint": [
 			{
@@ -18198,8 +18126,7 @@
 	{
 		"flint": {
 			"name": "collectionBracketAccess",
-			"plugin": "ts",
-			"status": "skipped"
+			"plugin": "ts"
 		},
 		"eslint": [
 			{
@@ -18299,6 +18226,12 @@
 			"plugin": "ts",
 			"status": "skipped"
 		},
+		"eslint": [
+			{
+				"name": "unicorn/no-chained-comparison",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-chained-comparison.md"
+			}
+		],
 		"oxlint": [
 			{
 				"name": "oxc/bad-comparison-sequence",
@@ -18323,8 +18256,7 @@
 	{
 		"flint": {
 			"name": "computedPropertyExistenceChecks",
-			"plugin": "ts",
-			"status": "skipped"
+			"plugin": "ts"
 		},
 		"eslint": [
 			{
@@ -18439,8 +18371,7 @@
 	{
 		"flint": {
 			"name": "confusingArraySplices",
-			"plugin": "ts",
-			"status": "skipped"
+			"plugin": "ts"
 		},
 		"eslint": [
 			{
@@ -18452,8 +18383,7 @@
 	{
 		"flint": {
 			"name": "confusingArrayWithCalls",
-			"plugin": "ts",
-			"status": "skipped"
+			"plugin": "ts"
 		},
 		"eslint": [
 			{
@@ -18596,6 +18526,10 @@
 			{
 				"name": "no-constant-binary-expression",
 				"url": "https://eslint.org/docs/latest/rules/no-constant-binary-expression"
+			},
+			{
+				"name": "unicorn/no-useless-logical-operand",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-useless-logical-operand.md"
 			}
 		],
 		"oxlint": [
@@ -18637,19 +18571,6 @@
 			}
 		],
 		"notes": "Superseded by unnecessaryConditions."
-	},
-	{
-		"flint": {
-			"name": "constantZeroExpressions",
-			"plugin": "ts",
-			"status": "skipped"
-		},
-		"eslint": [
-			{
-				"name": "unicorn/no-constant-zero-expression",
-				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-constant-zero-expression.md"
-			}
-		]
 	},
 	{
 		"flint": {
@@ -18807,8 +18728,7 @@
 	{
 		"flint": {
 			"name": "continueStatements",
-			"plugin": "ts",
-			"status": "skipped"
+			"plugin": "ts"
 		},
 		"eslint": [
 			{
@@ -18900,8 +18820,7 @@
 	{
 		"flint": {
 			"name": "declarationsBeforeEarlyExits",
-			"plugin": "ts",
-			"status": "skipped"
+			"plugin": "ts"
 		},
 		"eslint": [
 			{
@@ -19198,8 +19117,7 @@
 	{
 		"flint": {
 			"name": "directIterations",
-			"plugin": "ts",
-			"status": "skipped"
+			"plugin": "ts"
 		},
 		"eslint": [
 			{
@@ -19397,26 +19315,12 @@
 	{
 		"flint": {
 			"name": "disposes",
-			"plugin": "ts",
-			"status": "skipped"
+			"plugin": "ts"
 		},
 		"eslint": [
 			{
 				"name": "unicorn/prefer-dispose",
 				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prefer-dispose.md"
-			}
-		]
-	},
-	{
-		"flint": {
-			"name": "doubleComparisons",
-			"plugin": "ts",
-			"status": "skipped"
-		},
-		"eslint": [
-			{
-				"name": "unicorn/no-double-comparison",
-				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-double-comparison.md"
 			}
 		]
 	},
@@ -19448,22 +19352,8 @@
 	},
 	{
 		"flint": {
-			"name": "duplicateIfBranches",
-			"plugin": "ts",
-			"status": "skipped"
-		},
-		"eslint": [
-			{
-				"name": "unicorn/no-duplicate-if-branches",
-				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-duplicate-if-branches.md"
-			}
-		]
-	},
-	{
-		"flint": {
 			"name": "duplicateLogicalOperands",
-			"plugin": "ts",
-			"status": "skipped"
+			"plugin": "ts"
 		},
 		"eslint": [
 			{
@@ -19475,8 +19365,7 @@
 	{
 		"flint": {
 			"name": "duplicateLoops",
-			"plugin": "ts",
-			"status": "skipped"
+			"plugin": "ts"
 		},
 		"eslint": [
 			{
@@ -19488,8 +19377,7 @@
 	{
 		"flint": {
 			"name": "duplicateSetValues",
-			"plugin": "ts",
-			"status": "skipped"
+			"plugin": "ts"
 		},
 		"eslint": [
 			{
@@ -19551,8 +19439,7 @@
 	{
 		"flint": {
 			"name": "earlyReturns",
-			"plugin": "ts",
-			"status": "skipped"
+			"plugin": "ts"
 		},
 		"eslint": [
 			{
@@ -19564,8 +19451,7 @@
 	{
 		"flint": {
 			"name": "elseIfBranches",
-			"plugin": "ts",
-			"status": "skipped"
+			"plugin": "ts"
 		},
 		"eslint": [
 			{
@@ -19618,6 +19504,10 @@
 			{
 				"name": "no-else-return",
 				"url": "https://eslint.org/docs/latest/rules/no-else-return"
+			},
+			{
+				"name": "unicorn/no-useless-else",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-useless-else.md"
 			}
 		],
 		"oxlint": [
@@ -20144,8 +20034,7 @@
 	{
 		"flint": {
 			"name": "errorIsErrors",
-			"plugin": "ts",
-			"status": "skipped"
+			"plugin": "ts"
 		},
 		"eslint": [
 			{
@@ -20184,8 +20073,7 @@
 	{
 		"flint": {
 			"name": "errorPropertyAssignments",
-			"plugin": "ts",
-			"status": "skipped"
+			"plugin": "ts"
 		},
 		"eslint": [
 			{
@@ -20699,8 +20587,7 @@
 	{
 		"flint": {
 			"name": "flatMathMinMaxCalls",
-			"plugin": "ts",
-			"status": "skipped"
+			"plugin": "ts"
 		},
 		"eslint": [
 			{
@@ -20768,19 +20655,6 @@
 	},
 	{
 		"flint": {
-			"name": "forEachCalls",
-			"plugin": "ts",
-			"status": "skipped"
-		},
-		"eslint": [
-			{
-				"name": "unicorn/no-for-each",
-				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-for-each.md"
-			}
-		]
-	},
-	{
-		"flint": {
 			"name": "forInArrays",
 			"plugin": "ts",
 			"preset": "logical",
@@ -20833,19 +20707,6 @@
 			{
 				"name": "eslint/guard-for-in",
 				"url": "https://oxc.rs/docs/guide/usage/linter/rules/eslint/guard-for-in.html"
-			}
-		]
-	},
-	{
-		"flint": {
-			"name": "frontmatterFields",
-			"plugin": "ts",
-			"status": "skipped"
-		},
-		"eslint": [
-			{
-				"name": "unicorn/require-frontmatter-fields",
-				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/require-frontmatter-fields.md"
 			}
 		]
 	},
@@ -20937,6 +20798,10 @@
 			{
 				"name": "func-style",
 				"url": "https://eslint.org/docs/latest/rules/func-style"
+			},
+			{
+				"name": "unicorn/consistent-function-style",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/consistent-function-style.md"
 			}
 		],
 		"oxlint": [
@@ -21068,19 +20933,6 @@
 	},
 	{
 		"flint": {
-			"name": "functionStyleConsistency",
-			"plugin": "ts",
-			"status": "skipped"
-		},
-		"eslint": [
-			{
-				"name": "unicorn/consistent-function-style",
-				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/consistent-function-style.md"
-			}
-		]
-	},
-	{
-		"flint": {
 			"name": "functionTypeDeclarations",
 			"plugin": "ts",
 			"preset": "stylistic"
@@ -21139,8 +20991,7 @@
 	{
 		"flint": {
 			"name": "getOrInsertComputedMethods",
-			"plugin": "ts",
-			"status": "skipped"
+			"plugin": "ts"
 		},
 		"eslint": [
 			{
@@ -21216,8 +21067,7 @@
 	{
 		"flint": {
 			"name": "globalNumberConstants",
-			"plugin": "ts",
-			"status": "skipped"
+			"plugin": "ts"
 		},
 		"eslint": [
 			{
@@ -21261,8 +21111,7 @@
 	{
 		"flint": {
 			"name": "globalObjectPropertyAssignments",
-			"plugin": "ts",
-			"status": "skipped"
+			"plugin": "ts"
 		},
 		"eslint": [
 			{
@@ -21311,8 +21160,7 @@
 	{
 		"flint": {
 			"name": "groupByMethods",
-			"plugin": "ts",
-			"status": "skipped"
+			"plugin": "ts"
 		},
 		"eslint": [
 			{
@@ -21324,8 +21172,7 @@
 	{
 		"flint": {
 			"name": "hasChecks",
-			"plugin": "ts",
-			"status": "skipped"
+			"plugin": "ts"
 		},
 		"eslint": [
 			{
@@ -21357,6 +21204,10 @@
 			{
 				"name": "unicorn/no-hex-escape",
 				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-hex-escape.md"
+			},
+			{
+				"name": "unicorn/prefer-unicode-code-point-escapes",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prefer-unicode-code-point-escapes.md"
 			}
 		],
 		"oxlint": [
@@ -21368,22 +21219,8 @@
 	},
 	{
 		"flint": {
-			"name": "hoistingBranchCodes",
-			"plugin": "ts",
-			"status": "skipped"
-		},
-		"eslint": [
-			{
-				"name": "unicorn/prefer-hoisting-branch-code",
-				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prefer-hoisting-branch-code.md"
-			}
-		]
-	},
-	{
-		"flint": {
 			"name": "identifierImportExportSpecifiers",
-			"plugin": "ts",
-			"status": "skipped"
+			"plugin": "ts"
 		},
 		"eslint": [
 			{
@@ -21402,25 +21239,16 @@
 			{
 				"name": "id-match",
 				"url": "https://eslint.org/docs/latest/rules/id-match"
+			},
+			{
+				"name": "unicorn/id-match",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/id-match.md"
 			}
 		],
 		"oxlint": [
 			{
 				"name": "eslint/id-match",
 				"url": "https://oxc.rs/docs/guide/usage/linter/rules/eslint/id-match.html"
-			}
-		]
-	},
-	{
-		"flint": {
-			"name": "identifierPatternMatches",
-			"plugin": "ts",
-			"status": "skipped"
-		},
-		"eslint": [
-			{
-				"name": "unicorn/id-match",
-				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/id-match.md"
 			}
 		]
 	},
@@ -21980,40 +21808,13 @@
 	},
 	{
 		"flint": {
-			"name": "impossibleLengthComparisons",
-			"plugin": "ts",
-			"status": "skipped"
-		},
-		"eslint": [
-			{
-				"name": "unicorn/no-impossible-length-comparison",
-				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-impossible-length-comparison.md"
-			}
-		]
-	},
-	{
-		"flint": {
 			"name": "includesOverRepeatedComparisons",
-			"plugin": "ts",
-			"status": "skipped"
+			"plugin": "ts"
 		},
 		"eslint": [
 			{
 				"name": "unicorn/prefer-includes-over-repeated-comparisons",
 				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prefer-includes-over-repeated-comparisons.md"
-			}
-		]
-	},
-	{
-		"flint": {
-			"name": "incorrectTemplateStringInterpolations",
-			"plugin": "ts",
-			"status": "skipped"
-		},
-		"eslint": [
-			{
-				"name": "unicorn/no-incorrect-template-string-interpolation",
-				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-incorrect-template-string-interpolation.md"
 			}
 		]
 	},
@@ -22159,26 +21960,12 @@
 	{
 		"flint": {
 			"name": "invalidArgumentCounts",
-			"plugin": "ts",
-			"status": "skipped"
+			"plugin": "ts"
 		},
 		"eslint": [
 			{
 				"name": "unicorn/no-invalid-argument-count",
 				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-invalid-argument-count.md"
-			}
-		]
-	},
-	{
-		"flint": {
-			"name": "invalidCharacterComparisons",
-			"plugin": "ts",
-			"status": "skipped"
-		},
-		"eslint": [
-			{
-				"name": "unicorn/no-invalid-character-comparison",
-				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-invalid-character-comparison.md"
 			}
 		]
 	},
@@ -22196,6 +21983,10 @@
 			{
 				"name": "@typescript-eslint/no-invalid-this",
 				"url": "https://typescript-eslint.io/rules/no-invalid-this"
+			},
+			{
+				"name": "unicorn/no-this-outside-of-class",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-this-outside-of-class.md"
 			}
 		]
 	},
@@ -22228,8 +22019,7 @@
 	{
 		"flint": {
 			"name": "invalidWellKnownSymbolMethods",
-			"plugin": "ts",
-			"status": "skipped"
+			"plugin": "ts"
 		},
 		"eslint": [
 			{
@@ -22318,8 +22108,7 @@
 	{
 		"flint": {
 			"name": "iterableInConstructors",
-			"plugin": "ts",
-			"status": "skipped"
+			"plugin": "ts"
 		},
 		"eslint": [
 			{
@@ -22331,8 +22120,7 @@
 	{
 		"flint": {
 			"name": "iteratorConcats",
-			"plugin": "ts",
-			"status": "skipped"
+			"plugin": "ts"
 		},
 		"eslint": [
 			{
@@ -22344,8 +22132,7 @@
 	{
 		"flint": {
 			"name": "iteratorHelpers",
-			"plugin": "ts",
-			"status": "skipped"
+			"plugin": "ts"
 		},
 		"eslint": [
 			{
@@ -22376,8 +22163,7 @@
 	{
 		"flint": {
 			"name": "iteratorToArrayAtEnds",
-			"plugin": "ts",
-			"status": "skipped"
+			"plugin": "ts"
 		},
 		"eslint": [
 			{
@@ -22389,8 +22175,7 @@
 	{
 		"flint": {
 			"name": "iteratorToArrays",
-			"plugin": "ts",
-			"status": "skipped"
+			"plugin": "ts"
 		},
 		"eslint": [
 			{
@@ -22466,6 +22251,10 @@
 			{
 				"name": "jsdoc/require-asterisk-prefix",
 				"url": "https://github.com/gajus/eslint-plugin-jsdoc/blob/HEAD/docs/rules/require-asterisk-prefix.md"
+			},
+			{
+				"name": "unicorn/no-asterisk-prefix-in-documentation-comments",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-asterisk-prefix-in-documentation-comments.md"
 			}
 		]
 	},
@@ -23566,19 +23355,6 @@
 	},
 	{
 		"flint": {
-			"name": "lateCurrentTargetAccess",
-			"plugin": "ts",
-			"status": "skipped"
-		},
-		"eslint": [
-			{
-				"name": "unicorn/no-late-current-target-access",
-				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-late-current-target-access.md"
-			}
-		]
-	},
-	{
-		"flint": {
 			"name": "literalConstructorWrappers",
 			"plugin": "ts",
 			"preset": "stylistic",
@@ -23597,19 +23373,6 @@
 			}
 		],
 		"notes": "Will apply to all literals, not just bigint"
-	},
-	{
-		"flint": {
-			"name": "logicalAssignmentOperators",
-			"plugin": "ts",
-			"status": "skipped"
-		},
-		"eslint": [
-			{
-				"name": "unicorn/logical-assignment-operators",
-				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/logical-assignment-operators.md"
-			}
-		]
 	},
 	{
 		"flint": {
@@ -23633,8 +23396,7 @@
 	{
 		"flint": {
 			"name": "loopIterableMutations",
-			"plugin": "ts",
-			"status": "skipped"
+			"plugin": "ts"
 		},
 		"eslint": [
 			{
@@ -23689,8 +23451,7 @@
 	{
 		"flint": {
 			"name": "mapFromEntries",
-			"plugin": "ts",
-			"status": "skipped"
+			"plugin": "ts"
 		},
 		"eslint": [
 			{
@@ -23715,26 +23476,12 @@
 	{
 		"flint": {
 			"name": "mathAbs",
-			"plugin": "ts",
-			"status": "skipped"
+			"plugin": "ts"
 		},
 		"eslint": [
 			{
 				"name": "unicorn/prefer-math-abs",
 				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prefer-math-abs.md"
-			}
-		]
-	},
-	{
-		"flint": {
-			"name": "mathConstants",
-			"plugin": "ts",
-			"status": "skipped"
-		},
-		"eslint": [
-			{
-				"name": "unicorn/prefer-math-constants",
-				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prefer-math-constants.md"
 			}
 		]
 	},
@@ -24083,6 +23830,10 @@
 			{
 				"name": "@typescript-eslint/member-ordering",
 				"url": "https://typescript-eslint.io/rules/member-ordering"
+			},
+			{
+				"name": "unicorn/consistent-class-member-order",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/consistent-class-member-order.md"
 			}
 		],
 		"notes": "Superseded by sorting plugin rules."
@@ -24115,8 +23866,7 @@
 	{
 		"flint": {
 			"name": "minimalTernaries",
-			"plugin": "ts",
-			"status": "skipped"
+			"plugin": "ts"
 		},
 		"eslint": [
 			{
@@ -24130,7 +23880,13 @@
 			"name": "misleadingShorthandAssignments",
 			"plugin": "ts",
 			"status": "skipped"
-		}
+		},
+		"eslint": [
+			{
+				"name": "unicorn/no-misrefactored-assignment",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-misrefactored-assignment.md"
+			}
+		]
 	},
 	{
 		"flint": {
@@ -24186,26 +23942,12 @@
 	{
 		"flint": {
 			"name": "mismatchedMapKeys",
-			"plugin": "ts",
-			"status": "skipped"
+			"plugin": "ts"
 		},
 		"eslint": [
 			{
 				"name": "unicorn/no-mismatched-map-key",
 				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-mismatched-map-key.md"
-			}
-		]
-	},
-	{
-		"flint": {
-			"name": "misrefactoredAssignments",
-			"plugin": "ts",
-			"status": "skipped"
-		},
-		"eslint": [
-			{
-				"name": "unicorn/no-misrefactored-assignment",
-				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-misrefactored-assignment.md"
 			}
 		]
 	},
@@ -24428,19 +24170,6 @@
 			{
 				"name": "unicorn/prefer-switch",
 				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prefer-switch.md"
-			}
-		]
-	},
-	{
-		"flint": {
-			"name": "multiplePromiseResolverCalls",
-			"plugin": "ts",
-			"status": "skipped"
-		},
-		"eslint": [
-			{
-				"name": "unicorn/no-multiple-promise-resolver-calls",
-				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-multiple-promise-resolver-calls.md"
 			}
 		]
 	},
@@ -24695,8 +24424,7 @@
 	{
 		"flint": {
 			"name": "negatedArrayPredicates",
-			"plugin": "ts",
-			"status": "skipped"
+			"plugin": "ts"
 		},
 		"eslint": [
 			{
@@ -24708,8 +24436,7 @@
 	{
 		"flint": {
 			"name": "negatedComparisons",
-			"plugin": "ts",
-			"status": "skipped"
+			"plugin": "ts"
 		},
 		"eslint": [
 			{
@@ -24907,8 +24634,7 @@
 	{
 		"flint": {
 			"name": "noAsyncPromiseFinally",
-			"plugin": "ts",
-			"status": "skipped"
+			"plugin": "ts"
 		},
 		"eslint": [
 			{
@@ -24944,8 +24670,7 @@
 	{
 		"flint": {
 			"name": "nonFunctionVerbPrefixes",
-			"plugin": "ts",
-			"status": "skipped"
+			"plugin": "ts"
 		},
 		"eslint": [
 			{
@@ -25109,8 +24834,7 @@
 	{
 		"flint": {
 			"name": "nonstandardBuiltinProperties",
-			"plugin": "ts",
-			"status": "skipped"
+			"plugin": "ts"
 		},
 		"eslint": [
 			{
@@ -25122,8 +24846,7 @@
 	{
 		"flint": {
 			"name": "noUnnecessaryFetchOptions",
-			"plugin": "ts",
-			"status": "skipped"
+			"plugin": "ts"
 		},
 		"eslint": [
 			{
@@ -25135,8 +24858,7 @@
 	{
 		"flint": {
 			"name": "noUnsafePromiseAllSettledValues",
-			"plugin": "ts",
-			"status": "skipped"
+			"plugin": "ts"
 		},
 		"eslint": [
 			{
@@ -25218,8 +24940,7 @@
 	{
 		"flint": {
 			"name": "numberCoercions",
-			"plugin": "ts",
-			"status": "skipped"
+			"plugin": "ts"
 		},
 		"eslint": [
 			{
@@ -25231,8 +24952,7 @@
 	{
 		"flint": {
 			"name": "numberIsSafeIntegers",
-			"plugin": "ts",
-			"status": "skipped"
+			"plugin": "ts"
 		},
 		"eslint": [
 			{
@@ -25340,6 +25060,12 @@
 				"url": "https://biomejs.dev/linter/rules/no-approximative-numeric-constant"
 			}
 		],
+		"eslint": [
+			{
+				"name": "unicorn/prefer-math-constants",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prefer-math-constants.md"
+			}
+		],
 		"oxlint": [
 			{
 				"name": "oxc/approx-constant",
@@ -25354,6 +25080,12 @@
 			"preset": "logical",
 			"status": "implemented"
 		},
+		"eslint": [
+			{
+				"name": "unicorn/no-constant-zero-expression",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-constant-zero-expression.md"
+			}
+		],
 		"oxlint": [
 			{
 				"name": "oxc/erasing-op",
@@ -25532,8 +25264,7 @@
 	{
 		"flint": {
 			"name": "objectDefineProperties",
-			"plugin": "ts",
-			"status": "skipped"
+			"plugin": "ts"
 		},
 		"eslint": [
 			{
@@ -25545,8 +25276,7 @@
 	{
 		"flint": {
 			"name": "objectDestructuringDefaults",
-			"plugin": "ts",
-			"status": "skipped"
+			"plugin": "ts"
 		},
 		"eslint": [
 			{
@@ -25605,8 +25335,7 @@
 	{
 		"flint": {
 			"name": "objectIterableMethods",
-			"plugin": "ts",
-			"status": "skipped"
+			"plugin": "ts"
 		},
 		"eslint": [
 			{
@@ -25657,8 +25386,7 @@
 	{
 		"flint": {
 			"name": "objectMethodsWithCollections",
-			"plugin": "ts",
-			"status": "skipped"
+			"plugin": "ts"
 		},
 		"eslint": [
 			{
@@ -25869,19 +25597,6 @@
 	},
 	{
 		"flint": {
-			"name": "operatorAssignments",
-			"plugin": "ts",
-			"status": "skipped"
-		},
-		"eslint": [
-			{
-				"name": "unicorn/operator-assignment",
-				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/operator-assignment.md"
-			}
-		]
-	},
-	{
-		"flint": {
 			"name": "operatorAssignmentShorthand",
 			"plugin": "ts",
 			"preset": "stylistic",
@@ -25897,6 +25612,10 @@
 			{
 				"name": "operator-assignment",
 				"url": "https://eslint.org/docs/latest/rules/operator-assignment"
+			},
+			{
+				"name": "unicorn/operator-assignment",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/operator-assignment.md"
 			}
 		],
 		"oxlint": [
@@ -25922,26 +25641,12 @@
 	{
 		"flint": {
 			"name": "optionalChainingConsistency",
-			"plugin": "ts",
-			"status": "skipped"
+			"plugin": "ts"
 		},
 		"eslint": [
 			{
 				"name": "unicorn/consistent-optional-chaining",
 				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/consistent-optional-chaining.md"
-			}
-		]
-	},
-	{
-		"flint": {
-			"name": "optionalChainingOnUndeclaredVariables",
-			"plugin": "ts",
-			"status": "skipped"
-		},
-		"eslint": [
-			{
-				"name": "unicorn/no-optional-chaining-on-undeclared-variable",
-				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-optional-chaining-on-undeclared-variable.md"
 			}
 		]
 	},
@@ -26186,8 +25891,7 @@
 	{
 		"flint": {
 			"name": "privateClassFields",
-			"plugin": "ts",
-			"status": "skipped"
+			"plugin": "ts"
 		},
 		"eslint": [
 			{
@@ -26266,6 +25970,10 @@
 			{
 				"name": "promise/prefer-await-to-then",
 				"url": "https://github.com/eslint-community/eslint-plugin-promise/blob/HEAD/docs/rules/prefer-await-to-then.md"
+			},
+			{
+				"name": "unicorn/prefer-await",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prefer-await.md"
 			}
 		],
 		"oxlint": [
@@ -26297,6 +26005,10 @@
 			{
 				"name": "promise/prefer-catch",
 				"url": "https://github.com/eslint-community/eslint-plugin-promise/blob/HEAD/docs/rules/prefer-catch.md"
+			},
+			{
+				"name": "unicorn/prefer-then-catch",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prefer-then-catch.md"
 			}
 		],
 		"oxlint": [
@@ -26433,6 +26145,10 @@
 			{
 				"name": "promise/no-multiple-resolved",
 				"url": "https://github.com/eslint-community/eslint-plugin-promise/blob/main/docs/rules/no-multiple-resolved.md"
+			},
+			{
+				"name": "unicorn/no-multiple-promise-resolver-calls",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-multiple-promise-resolver-calls.md"
 			}
 		],
 		"oxlint": [
@@ -26631,8 +26347,7 @@
 	{
 		"flint": {
 			"name": "promiseTryCalls",
-			"plugin": "ts",
-			"status": "skipped"
+			"plugin": "ts"
 		},
 		"eslint": [
 			{
@@ -26644,8 +26359,7 @@
 	{
 		"flint": {
 			"name": "promiseWithResolvers",
-			"plugin": "ts",
-			"status": "skipped"
+			"plugin": "ts"
 		},
 		"eslint": [
 			{
@@ -26706,8 +26420,7 @@
 	{
 		"flint": {
 			"name": "proxyTrapBooleanReturns",
-			"plugin": "ts",
-			"status": "skipped"
+			"plugin": "ts"
 		},
 		"eslint": [
 			{
@@ -26719,8 +26432,7 @@
 	{
 		"flint": {
 			"name": "queueMicrotasks",
-			"plugin": "ts",
-			"status": "skipped"
+			"plugin": "ts"
 		},
 		"eslint": [
 			{
@@ -26800,19 +26512,6 @@
 			{
 				"name": "noParametersOnlyUsedInRecursion",
 				"url": "https://biomejs.dev/linter/rules/no-parameters-only-used-in-recursion"
-			}
-		]
-	},
-	{
-		"flint": {
-			"name": "redundantComparisons",
-			"plugin": "ts",
-			"status": "skipped"
-		},
-		"eslint": [
-			{
-				"name": "unicorn/no-redundant-comparison",
-				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-redundant-comparison.md"
 			}
 		]
 	},
@@ -27660,8 +27359,7 @@
 	{
 		"flint": {
 			"name": "regexpEscapes",
-			"plugin": "ts",
-			"status": "skipped"
+			"plugin": "ts"
 		},
 		"eslint": [
 			{
@@ -28629,8 +28327,7 @@
 	{
 		"flint": {
 			"name": "returnedArrayPushes",
-			"plugin": "ts",
-			"status": "skipped"
+			"plugin": "ts"
 		},
 		"eslint": [
 			{
@@ -28774,8 +28471,7 @@
 	{
 		"flint": {
 			"name": "setMethods",
-			"plugin": "ts",
-			"status": "skipped"
+			"plugin": "ts"
 		},
 		"eslint": [
 			{
@@ -28940,8 +28636,7 @@
 	{
 		"flint": {
 			"name": "shorthandPropertyOverrides",
-			"plugin": "ts",
-			"status": "skipped"
+			"plugin": "ts"
 		},
 		"eslint": [
 			{
@@ -28979,8 +28674,7 @@
 	{
 		"flint": {
 			"name": "simpleSortComparators",
-			"plugin": "ts",
-			"status": "skipped"
+			"plugin": "ts"
 		},
 		"eslint": [
 			{
@@ -28992,8 +28686,7 @@
 	{
 		"flint": {
 			"name": "simplifiedConditions",
-			"plugin": "ts",
-			"status": "skipped"
+			"plugin": "ts"
 		},
 		"eslint": [
 			{
@@ -29005,8 +28698,7 @@
 	{
 		"flint": {
 			"name": "singleArrayPredicates",
-			"plugin": "ts",
-			"status": "skipped"
+			"plugin": "ts"
 		},
 		"eslint": [
 			{
@@ -29018,8 +28710,7 @@
 	{
 		"flint": {
 			"name": "singleObjectDestructuring",
-			"plugin": "ts",
-			"status": "skipped"
+			"plugin": "ts"
 		},
 		"eslint": [
 			{
@@ -29031,8 +28722,7 @@
 	{
 		"flint": {
 			"name": "singleReplaces",
-			"plugin": "ts",
-			"status": "skipped"
+			"plugin": "ts"
 		},
 		"eslint": [
 			{
@@ -29123,8 +28813,7 @@
 	{
 		"flint": {
 			"name": "smallerScopes",
-			"plugin": "ts",
-			"status": "skipped"
+			"plugin": "ts"
 		},
 		"eslint": [
 			{
@@ -29168,8 +28857,7 @@
 	{
 		"flint": {
 			"name": "splitLimits",
-			"plugin": "ts",
-			"status": "skipped"
+			"plugin": "ts"
 		},
 		"eslint": [
 			{
@@ -29332,8 +29020,7 @@
 	{
 		"flint": {
 			"name": "stringMatchAlls",
-			"plugin": "ts",
-			"status": "skipped"
+			"plugin": "ts"
 		},
 		"eslint": [
 			{
@@ -29345,8 +29032,7 @@
 	{
 		"flint": {
 			"name": "stringPadStartEnds",
-			"plugin": "ts",
-			"status": "skipped"
+			"plugin": "ts"
 		},
 		"eslint": [
 			{
@@ -29377,8 +29063,7 @@
 	{
 		"flint": {
 			"name": "stringRepeats",
-			"plugin": "ts",
-			"status": "skipped"
+			"plugin": "ts"
 		},
 		"eslint": [
 			{
@@ -29492,6 +29177,10 @@
 			{
 				"name": "no-template-curly-in-string",
 				"url": "https://eslint.org/docs/latest/rules/no-template-curly-in-string"
+			},
+			{
+				"name": "unicorn/no-incorrect-template-string-interpolation",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-incorrect-template-string-interpolation.md"
 			}
 		],
 		"oxlint": [
@@ -29551,8 +29240,7 @@
 	{
 		"flint": {
 			"name": "subtractionComparisons",
-			"plugin": "ts",
-			"status": "skipped"
+			"plugin": "ts"
 		},
 		"eslint": [
 			{
@@ -29731,8 +29419,7 @@
 	{
 		"flint": {
 			"name": "temporals",
-			"plugin": "ts",
-			"status": "skipped"
+			"plugin": "ts"
 		},
 		"eslint": [
 			{
@@ -29815,19 +29502,6 @@
 			{
 				"name": "unicorn/text-encoding-identifier-case",
 				"url": "https://oxc.rs/docs/guide/usage/linter/rules/unicorn/text-encoding-identifier-case.html"
-			}
-		]
-	},
-	{
-		"flint": {
-			"name": "thenCatchChains",
-			"plugin": "ts",
-			"status": "skipped"
-		},
-		"eslint": [
-			{
-				"name": "unicorn/prefer-then-catch",
-				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prefer-then-catch.md"
 			}
 		]
 	},
@@ -29940,19 +29614,6 @@
 	},
 	{
 		"flint": {
-			"name": "thisOutsideOfClass",
-			"plugin": "ts",
-			"status": "skipped"
-		},
-		"eslint": [
-			{
-				"name": "unicorn/no-this-outside-of-class",
-				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-this-outside-of-class.md"
-			}
-		]
-	},
-	{
-		"flint": {
 			"name": "throwErrors",
 			"plugin": "ts",
 			"preset": "logical",
@@ -30025,8 +29686,7 @@
 	{
 		"flint": {
 			"name": "topLevelAssignmentInFunctions",
-			"plugin": "ts",
-			"status": "skipped"
+			"plugin": "ts"
 		},
 		"eslint": [
 			{
@@ -30059,8 +29719,7 @@
 	{
 		"flint": {
 			"name": "topLevelSideEffects",
-			"plugin": "ts",
-			"status": "skipped"
+			"plugin": "ts"
 		},
 		"eslint": [
 			{
@@ -30185,8 +29844,7 @@
 	{
 		"flint": {
 			"name": "tupleLabelConsistency",
-			"plugin": "ts",
-			"status": "skipped"
+			"plugin": "ts"
 		},
 		"eslint": [
 			{
@@ -30291,6 +29949,10 @@
 			{
 				"name": "@typescript-eslint/sort-type-constituents",
 				"url": "https://typescript-eslint.io/rules/sort-type-constituents"
+			},
+			{
+				"name": "unicorn/prefer-type-literal-last",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prefer-type-literal-last.md"
 			}
 		]
 	},
@@ -30355,19 +30017,6 @@
 	},
 	{
 		"flint": {
-			"name": "typeLiteralLasts",
-			"plugin": "ts",
-			"status": "skipped"
-		},
-		"eslint": [
-			{
-				"name": "unicorn/prefer-type-literal-last",
-				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prefer-type-literal-last.md"
-			}
-		]
-	},
-	{
-		"flint": {
 			"name": "typeofComparisons",
 			"plugin": "ts",
 			"preset": "javascript",
@@ -30401,8 +30050,7 @@
 	{
 		"flint": {
 			"name": "uint8arrayBase64s",
-			"plugin": "ts",
-			"status": "skipped"
+			"plugin": "ts"
 		},
 		"eslint": [
 			{
@@ -30414,8 +30062,7 @@
 	{
 		"flint": {
 			"name": "unaryMinus",
-			"plugin": "ts",
-			"status": "skipped"
+			"plugin": "ts"
 		},
 		"eslint": [
 			{
@@ -30492,8 +30139,7 @@
 	{
 		"flint": {
 			"name": "uncalledMethods",
-			"plugin": "ts",
-			"status": "skipped"
+			"plugin": "ts"
 		},
 		"eslint": [
 			{
@@ -30505,8 +30151,7 @@
 	{
 		"flint": {
 			"name": "undeclaredClassMembers",
-			"plugin": "ts",
-			"status": "skipped"
+			"plugin": "ts"
 		},
 		"eslint": [
 			{
@@ -30597,6 +30242,10 @@
 			{
 				"name": "no-undef",
 				"url": "https://eslint.org/docs/latest/rules/no-undef"
+			},
+			{
+				"name": "unicorn/no-optional-chaining-on-undeclared-variable",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-optional-chaining-on-undeclared-variable.md"
 			}
 		],
 		"oxlint": [
@@ -30647,19 +30296,6 @@
 	},
 	{
 		"flint": {
-			"name": "unicodeCodePointEscapes",
-			"plugin": "ts",
-			"status": "skipped"
-		},
-		"eslint": [
-			{
-				"name": "unicorn/prefer-unicode-code-point-escapes",
-				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prefer-unicode-code-point-escapes.md"
-			}
-		]
-	},
-	{
-		"flint": {
 			"name": "unifiedSignatures",
 			"plugin": "ts",
 			"preset": "logical",
@@ -30700,8 +30336,7 @@
 	{
 		"flint": {
 			"name": "unnecessaryArrayFlatMaps",
-			"plugin": "ts",
-			"status": "skipped"
+			"plugin": "ts"
 		},
 		"eslint": [
 			{
@@ -30779,25 +30414,16 @@
 			{
 				"name": "no-extra-boolean-cast",
 				"url": "https://eslint.org/docs/latest/rules/no-extra-boolean-cast"
+			},
+			{
+				"name": "unicorn/no-useless-boolean-cast",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-useless-boolean-cast.md"
 			}
 		],
 		"oxlint": [
 			{
 				"name": "eslint/no-extra-boolean-cast",
 				"url": "https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-extra-boolean-cast.html"
-			}
-		]
-	},
-	{
-		"flint": {
-			"name": "unnecessaryBooleanComparisons",
-			"plugin": "ts",
-			"status": "skipped"
-		},
-		"eslint": [
-			{
-				"name": "unicorn/no-unnecessary-boolean-comparison",
-				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-unnecessary-boolean-comparison.md"
 			}
 		]
 	},
@@ -30869,6 +30495,18 @@
 			{
 				"name": "no-self-compare",
 				"url": "https://eslint.org/docs/latest/rules/no-self-compare"
+			},
+			{
+				"name": "unicorn/no-double-comparison",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-double-comparison.md"
+			},
+			{
+				"name": "unicorn/no-impossible-length-comparison",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-impossible-length-comparison.md"
+			},
+			{
+				"name": "unicorn/no-redundant-comparison",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-redundant-comparison.md"
 			}
 		],
 		"oxlint": [
@@ -30928,6 +30566,10 @@
 			{
 				"name": "no-useless-concat",
 				"url": "https://eslint.org/docs/latest/rules/no-useless-concat"
+			},
+			{
+				"name": "unicorn/no-useless-concat",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-useless-concat.md"
 			}
 		],
 		"oxlint": [
@@ -31002,6 +30644,12 @@
 				"name": "noUselessContinue",
 				"url": "https://biomejs.dev/linter/rules/no-useless-continue"
 			}
+		],
+		"eslint": [
+			{
+				"name": "unicorn/no-useless-continue",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-useless-continue.md"
+			}
 		]
 	},
 	{
@@ -31037,8 +30685,7 @@
 	{
 		"flint": {
 			"name": "unnecessaryGlobalThis",
-			"plugin": "ts",
-			"status": "skipped"
+			"plugin": "ts"
 		},
 		"eslint": [
 			{
@@ -31107,6 +30754,10 @@
 			{
 				"name": "@typescript-eslint/no-unnecessary-boolean-literal-compare",
 				"url": "https://typescript-eslint.io/rules/no-unnecessary-boolean-literal-compare"
+			},
+			{
+				"name": "unicorn/no-unnecessary-boolean-comparison",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-unnecessary-boolean-comparison.md"
 			}
 		],
 		"oxlint": [
@@ -31139,8 +30790,7 @@
 	{
 		"flint": {
 			"name": "unnecessaryNestedTernaries",
-			"plugin": "ts",
-			"status": "skipped"
+			"plugin": "ts"
 		},
 		"eslint": [
 			{
@@ -31262,8 +30912,7 @@
 	{
 		"flint": {
 			"name": "unnecessarySplices",
-			"plugin": "ts",
-			"status": "skipped"
+			"plugin": "ts"
 		},
 		"eslint": [
 			{
@@ -31307,8 +30956,7 @@
 	{
 		"flint": {
 			"name": "unnecessaryStringTrims",
-			"plugin": "ts",
-			"status": "skipped"
+			"plugin": "ts"
 		},
 		"eslint": [
 			{
@@ -31337,6 +30985,10 @@
 			{
 				"name": "@typescript-eslint/no-unnecessary-template-expression",
 				"url": "https://typescript-eslint.io/rules/no-unnecessary-template-expression"
+			},
+			{
+				"name": "unicorn/no-useless-template-literals",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-useless-template-literals.md"
 			}
 		],
 		"oxlint": [
@@ -31491,6 +31143,10 @@
 			{
 				"name": "@typescript-eslint/no-unnecessary-type-conversion",
 				"url": "https://typescript-eslint.io/rules/no-unnecessary-type-conversion"
+			},
+			{
+				"name": "unicorn/no-useless-coercion",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-useless-coercion.md"
 			}
 		],
 		"oxlint": [
@@ -31605,8 +31261,7 @@
 	{
 		"flint": {
 			"name": "unreadableForOfExpressions",
-			"plugin": "ts",
-			"status": "skipped"
+			"plugin": "ts"
 		},
 		"eslint": [
 			{
@@ -31618,8 +31273,7 @@
 	{
 		"flint": {
 			"name": "unreadableNewExpressions",
-			"plugin": "ts",
-			"status": "skipped"
+			"plugin": "ts"
 		},
 		"eslint": [
 			{
@@ -31631,8 +31285,7 @@
 	{
 		"flint": {
 			"name": "unreadableObjectDestructuring",
-			"plugin": "ts",
-			"status": "skipped"
+			"plugin": "ts"
 		},
 		"eslint": [
 			{
@@ -31776,8 +31429,7 @@
 	{
 		"flint": {
 			"name": "unsafePropertyKeys",
-			"plugin": "ts",
-			"status": "skipped"
+			"plugin": "ts"
 		},
 		"eslint": [
 			{
@@ -31789,8 +31441,7 @@
 	{
 		"flint": {
 			"name": "unsafeStringReplacements",
-			"plugin": "ts",
-			"status": "skipped"
+			"plugin": "ts"
 		},
 		"eslint": [
 			{
@@ -31865,8 +31516,7 @@
 	{
 		"flint": {
 			"name": "unusedArrayMethodReturns",
-			"plugin": "ts",
-			"status": "skipped"
+			"plugin": "ts"
 		},
 		"eslint": [
 			{
@@ -32161,66 +31811,13 @@
 	},
 	{
 		"flint": {
-			"name": "uselessBooleanCasts",
-			"plugin": "ts",
-			"status": "skipped"
-		},
-		"eslint": [
-			{
-				"name": "unicorn/no-useless-boolean-cast",
-				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-useless-boolean-cast.md"
-			}
-		]
-	},
-	{
-		"flint": {
-			"name": "uselessCoercions",
-			"plugin": "ts",
-			"status": "skipped"
-		},
-		"eslint": [
-			{
-				"name": "unicorn/no-useless-coercion",
-				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-useless-coercion.md"
-			}
-		]
-	},
-	{
-		"flint": {
 			"name": "uselessCompoundAssignments",
-			"plugin": "ts",
-			"status": "skipped"
+			"plugin": "ts"
 		},
 		"eslint": [
 			{
 				"name": "unicorn/no-useless-compound-assignment",
 				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-useless-compound-assignment.md"
-			}
-		]
-	},
-	{
-		"flint": {
-			"name": "uselessConcats",
-			"plugin": "ts",
-			"status": "skipped"
-		},
-		"eslint": [
-			{
-				"name": "unicorn/no-useless-concat",
-				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-useless-concat.md"
-			}
-		]
-	},
-	{
-		"flint": {
-			"name": "uselessContinues",
-			"plugin": "ts",
-			"status": "skipped"
-		},
-		"eslint": [
-			{
-				"name": "unicorn/no-useless-continue",
-				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-useless-continue.md"
 			}
 		]
 	},
@@ -32246,8 +31843,7 @@
 	{
 		"flint": {
 			"name": "uselessDeleteChecks",
-			"plugin": "ts",
-			"status": "skipped"
+			"plugin": "ts"
 		},
 		"eslint": [
 			{
@@ -32258,35 +31854,8 @@
 	},
 	{
 		"flint": {
-			"name": "uselessElses",
-			"plugin": "ts",
-			"status": "skipped"
-		},
-		"eslint": [
-			{
-				"name": "unicorn/no-useless-else",
-				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-useless-else.md"
-			}
-		]
-	},
-	{
-		"flint": {
-			"name": "uselessLogicalOperands",
-			"plugin": "ts",
-			"status": "skipped"
-		},
-		"eslint": [
-			{
-				"name": "unicorn/no-useless-logical-operand",
-				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-useless-logical-operand.md"
-			}
-		]
-	},
-	{
-		"flint": {
 			"name": "uselessOverrides",
-			"plugin": "ts",
-			"status": "skipped"
+			"plugin": "ts"
 		},
 		"eslint": [
 			{
@@ -32298,8 +31867,7 @@
 	{
 		"flint": {
 			"name": "uselessRecursions",
-			"plugin": "ts",
-			"status": "skipped"
+			"plugin": "ts"
 		},
 		"eslint": [
 			{
@@ -32311,26 +31879,12 @@
 	{
 		"flint": {
 			"name": "uselessReExports",
-			"plugin": "ts",
-			"status": "skipped"
+			"plugin": "ts"
 		},
 		"eslint": [
 			{
 				"name": "unicorn/no-useless-re-export",
 				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-useless-re-export.md"
-			}
-		]
-	},
-	{
-		"flint": {
-			"name": "uselessTemplateLiterals",
-			"plugin": "ts",
-			"status": "skipped"
-		},
-		"eslint": [
-			{
-				"name": "unicorn/no-useless-template-literals",
-				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-useless-template-literals.md"
 			}
 		]
 	},
@@ -32597,19 +32151,6 @@
 	},
 	{
 		"flint": {
-			"name": "whileLoopConditions",
-			"plugin": "ts",
-			"status": "skipped"
-		},
-		"eslint": [
-			{
-				"name": "unicorn/prefer-while-loop-condition",
-				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prefer-while-loop-condition.md"
-			}
-		]
-	},
-	{
-		"flint": {
 			"name": "whileLoops",
 			"plugin": "ts",
 			"preset": "stylistic",
@@ -32619,6 +32160,12 @@
 			{
 				"name": "useWhile",
 				"url": "https://biomejs.dev/linter/rules/use-while"
+			}
+		],
+		"eslint": [
+			{
+				"name": "unicorn/prefer-while-loop-condition",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prefer-while-loop-condition.md"
 			}
 		]
 	},
@@ -32696,19 +32243,6 @@
 			{
 				"name": "typescript/no-wrapper-object-types",
 				"url": "https://oxc.rs/docs/guide/usage/linter/rules/typescript/no-wrapper-object-types.html"
-			}
-		]
-	},
-	{
-		"flint": {
-			"name": "xorAsExponentiations",
-			"plugin": "ts",
-			"status": "skipped"
-		},
-		"eslint": [
-			{
-				"name": "unicorn/no-xor-as-exponentiation",
-				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-xor-as-exponentiation.md"
 			}
 		]
 	},

--- a/packages/comparisons/src/data.json
+++ b/packages/comparisons/src/data.json
@@ -1,728 +1,734 @@
 [
 	{
+		"flint": {
+			"name": "accessKeys",
+			"plugin": "astro",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "astro/jsx-a11y/no-access-key",
 				"url": "https://ota-meshi.github.io/eslint-plugin-astro/rules/jsx-a11y/no-access-key"
 			}
-		],
-		"flint": {
-			"name": "accessKeys",
-			"plugin": "astro",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "altTexts",
+			"plugin": "astro",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "astro/jsx-a11y/alt-text",
 				"url": "https://ota-meshi.github.io/eslint-plugin-astro/rules/jsx-a11y/alt-text"
 			}
-		],
-		"flint": {
-			"name": "altTexts",
-			"plugin": "astro",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "anchorAmbiguousText",
+			"plugin": "astro",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "astro/jsx-a11y/anchor-ambiguous-text",
 				"url": "https://ota-meshi.github.io/eslint-plugin-astro/rules/jsx-a11y/anchor-ambiguous-text"
 			}
-		],
-		"flint": {
-			"name": "anchorAmbiguousText",
-			"plugin": "astro",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "anchorContent",
+			"plugin": "astro",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "astro/jsx-a11y/anchor-has-content",
 				"url": "https://ota-meshi.github.io/eslint-plugin-astro/rules/jsx-a11y/anchor-has-content"
 			}
-		],
-		"flint": {
-			"name": "anchorContent",
-			"plugin": "astro",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "anchorValidity",
+			"plugin": "astro",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "astro/jsx-a11y/anchor-is-valid",
 				"url": "https://ota-meshi.github.io/eslint-plugin-astro/rules/jsx-a11y/anchor-is-valid"
 			}
-		],
-		"flint": {
-			"name": "anchorValidity",
-			"plugin": "astro",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "ariaActiveDescendantTabIndex",
+			"plugin": "astro",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "astro/jsx-a11y/aria-activedescendant-has-tabindex",
 				"url": "https://ota-meshi.github.io/eslint-plugin-astro/rules/jsx-a11y/aria-activedescendant-has-tabindex"
 			}
-		],
-		"flint": {
-			"name": "ariaActiveDescendantTabIndex",
-			"plugin": "astro",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "ariaHiddenFocusables",
+			"plugin": "astro",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "astro/jsx-a11y/no-aria-hidden-on-focusable",
 				"url": "https://ota-meshi.github.io/eslint-plugin-astro/rules/jsx-a11y/no-aria-hidden-on-focusable"
 			}
-		],
-		"flint": {
-			"name": "ariaHiddenFocusables",
-			"plugin": "astro",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "ariaProps",
+			"plugin": "astro",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "astro/jsx-a11y/aria-props",
 				"url": "https://ota-meshi.github.io/eslint-plugin-astro/rules/jsx-a11y/aria-props"
 			}
-		],
-		"flint": {
-			"name": "ariaProps",
-			"plugin": "astro",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "ariaPropTypes",
+			"plugin": "astro",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "astro/jsx-a11y/aria-proptypes",
 				"url": "https://ota-meshi.github.io/eslint-plugin-astro/rules/jsx-a11y/aria-proptypes"
 			}
-		],
-		"flint": {
-			"name": "ariaPropTypes",
-			"plugin": "astro",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "ariaRoleValidity",
+			"plugin": "astro",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "astro/jsx-a11y/aria-role",
 				"url": "https://ota-meshi.github.io/eslint-plugin-astro/rules/jsx-a11y/aria-role"
 			}
-		],
-		"flint": {
-			"name": "ariaRoleValidity",
-			"plugin": "astro",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "ariaUnsupportedElements",
+			"plugin": "astro",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "astro/jsx-a11y/aria-unsupported-elements",
 				"url": "https://ota-meshi.github.io/eslint-plugin-astro/rules/jsx-a11y/aria-unsupported-elements"
 			}
-		],
-		"flint": {
-			"name": "ariaUnsupportedElements",
-			"plugin": "astro",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "attributesOrder",
+			"plugin": "astro",
+			"preset": "sorting"
+		},
 		"eslint": [
 			{
 				"name": "astro/sort-attributes",
 				"url": "https://ota-meshi.github.io/eslint-plugin-astro/rules/sort-attributes"
 			}
-		],
-		"flint": {
-			"name": "attributesOrder",
-			"plugin": "astro",
-			"preset": "sorting"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "autocomplete",
+			"plugin": "astro",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "astro/jsx-a11y/autocomplete-valid",
 				"url": "https://ota-meshi.github.io/eslint-plugin-astro/rules/jsx-a11y/autocomplete-valid"
 			}
-		],
-		"flint": {
-			"name": "autocomplete",
-			"plugin": "astro",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "autoFocusProps",
+			"plugin": "astro",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "astro/jsx-a11y/no-autofocus",
 				"url": "https://ota-meshi.github.io/eslint-plugin-astro/rules/jsx-a11y/no-autofocus"
 			}
-		],
-		"flint": {
-			"name": "autoFocusProps",
-			"plugin": "astro",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "classListDirectiveObjects",
+			"plugin": "astro",
+			"preset": "stylistic"
+		},
 		"eslint": [
 			{
 				"name": "astro/prefer-object-class-list",
 				"url": "https://ota-meshi.github.io/eslint-plugin-astro/rules/prefer-object-class-list"
 			}
-		],
-		"flint": {
-			"name": "classListDirectiveObjects",
-			"plugin": "astro",
-			"preset": "stylistic"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "classListDirectives",
+			"plugin": "astro",
+			"preset": "stylistic"
+		},
 		"eslint": [
 			{
 				"name": "astro/prefer-class-list-directive",
 				"url": "https://ota-meshi.github.io/eslint-plugin-astro/rules/prefer-class-list-directive"
 			}
-		],
-		"flint": {
-			"name": "classListDirectives",
-			"plugin": "astro",
-			"preset": "stylistic"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "classListDirectiveSplits",
+			"plugin": "astro",
+			"preset": "stylistic"
+		},
 		"eslint": [
 			{
 				"name": "astro/prefer-split-class-list",
 				"url": "https://ota-meshi.github.io/eslint-plugin-astro/rules/prefer-split-class-list"
 			}
-		],
-		"flint": {
-			"name": "classListDirectiveSplits",
-			"plugin": "astro",
-			"preset": "stylistic"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "clickEventKeyEvents",
+			"plugin": "astro",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "astro/jsx-a11y/click-events-have-key-events",
 				"url": "https://ota-meshi.github.io/eslint-plugin-astro/rules/jsx-a11y/click-events-have-key-events"
 			}
-		],
-		"flint": {
-			"name": "clickEventKeyEvents",
-			"plugin": "astro",
-			"preset": "logical"
-		}
+		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "astro/missing-client-only-directive-value",
-				"url": "https://ota-meshi.github.io/eslint-plugin-astro/rules/missing-client-only-directive-value"
-			}
-		],
 		"flint": {
 			"name": "clientOnlyDirectiveValues",
 			"plugin": "astro",
 			"preset": "logical",
 			"status": "implemented"
-		}
+		},
+		"eslint": [
+			{
+				"name": "astro/missing-client-only-directive-value",
+				"url": "https://ota-meshi.github.io/eslint-plugin-astro/rules/missing-client-only-directive-value"
+			}
+		]
 	},
 	{
+		"flint": {
+			"name": "compiles",
+			"plugin": "astro",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "astro/valid-compile",
 				"url": "https://ota-meshi.github.io/eslint-plugin-astro/rules/valid-compile"
 			}
 		],
-		"flint": {
-			"name": "compiles",
-			"plugin": "astro",
-			"status": "skipped"
-		},
 		"notes": "Handled by the Astro compiler."
 	},
 	{
+		"flint": {
+			"name": "componentFileExports",
+			"plugin": "astro",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "astro/no-exports-from-components",
 				"url": "https://ota-meshi.github.io/eslint-plugin-astro/rules/no-exports-from-components"
 			}
-		],
-		"flint": {
-			"name": "componentFileExports",
-			"plugin": "astro",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "controlAssociatedLabels",
+			"plugin": "astro",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "astro/jsx-a11y/control-has-associated-label",
 				"url": "https://ota-meshi.github.io/eslint-plugin-astro/rules/jsx-a11y/control-has-associated-label"
 			}
-		],
-		"flint": {
-			"name": "controlAssociatedLabels",
-			"plugin": "astro",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "deprecatedAstroCanonicalURL",
+			"plugin": "astro",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "astro/no-deprecated-astro-canonicalurl",
 				"url": "https://ota-meshi.github.io/eslint-plugin-astro/rules/no-deprecated-astro-canonicalurl"
 			}
 		],
-		"flint": {
-			"name": "deprecatedAstroCanonicalURL",
-			"plugin": "astro",
-			"status": "skipped"
-		},
 		"notes": "Superseded by deprecated."
 	},
 	{
+		"flint": {
+			"name": "deprecatedAstroFetchContent",
+			"plugin": "astro",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "astro/no-deprecated-astro-fetchcontent",
 				"url": "https://ota-meshi.github.io/eslint-plugin-astro/rules/no-deprecated-astro-fetchcontent"
 			}
 		],
-		"flint": {
-			"name": "deprecatedAstroFetchContent",
-			"plugin": "astro",
-			"status": "skipped"
-		},
 		"notes": "Superseded by deprecated."
 	},
 	{
+		"flint": {
+			"name": "deprecatedAstroResolve",
+			"plugin": "astro",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "astro/no-deprecated-astro-resolve",
 				"url": "https://ota-meshi.github.io/eslint-plugin-astro/rules/no-deprecated-astro-resolve"
 			}
 		],
-		"flint": {
-			"name": "deprecatedAstroResolve",
-			"plugin": "astro",
-			"status": "skipped"
-		},
 		"notes": "Superseded by deprecated."
 	},
 	{
+		"flint": {
+			"name": "deprecatedGetEntryBySlug",
+			"plugin": "astro",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "astro/no-deprecated-getentrybyslug",
 				"url": "https://ota-meshi.github.io/eslint-plugin-astro/rules/no-deprecated-getentrybyslug"
 			}
 		],
-		"flint": {
-			"name": "deprecatedGetEntryBySlug",
-			"plugin": "astro",
-			"status": "skipped"
-		},
 		"notes": "Superseded by deprecated."
 	},
 	{
+		"flint": {
+			"name": "distractingElements",
+			"plugin": "astro",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "astro/jsx-a11y/no-distracting-elements",
 				"url": "https://ota-meshi.github.io/eslint-plugin-astro/rules/jsx-a11y/no-distracting-elements"
 			}
-		],
-		"flint": {
-			"name": "distractingElements",
-			"plugin": "astro",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "headingContents",
+			"plugin": "astro",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "astro/jsx-a11y/heading-has-content",
 				"url": "https://ota-meshi.github.io/eslint-plugin-astro/rules/jsx-a11y/heading-has-content"
 			}
-		],
-		"flint": {
-			"name": "headingContents",
-			"plugin": "astro",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "htmlLangs",
+			"plugin": "astro",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "astro/jsx-a11y/html-has-lang",
 				"url": "https://ota-meshi.github.io/eslint-plugin-astro/rules/jsx-a11y/html-has-lang"
 			}
-		],
-		"flint": {
-			"name": "htmlLangs",
-			"plugin": "astro",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "iframeTitles",
+			"plugin": "astro",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "astro/jsx-a11y/iframe-has-title",
 				"url": "https://ota-meshi.github.io/eslint-plugin-astro/rules/jsx-a11y/iframe-has-title"
 			}
-		],
-		"flint": {
-			"name": "iframeTitles",
-			"plugin": "astro",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "imageAltRedundancy",
+			"plugin": "astro",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "astro/jsx-a11y/img-redundant-alt",
 				"url": "https://ota-meshi.github.io/eslint-plugin-astro/rules/jsx-a11y/img-redundant-alt"
 			}
-		],
-		"flint": {
-			"name": "imageAltRedundancy",
-			"plugin": "astro",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "interactiveElementRoles",
+			"plugin": "astro",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "astro/jsx-a11y/no-interactive-element-to-noninteractive-role",
 				"url": "https://ota-meshi.github.io/eslint-plugin-astro/rules/jsx-a11y/no-interactive-element-to-noninteractive-role"
 			}
-		],
-		"flint": {
-			"name": "interactiveElementRoles",
-			"plugin": "astro",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "interactiveElementsFocusable",
+			"plugin": "astro",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "astro/jsx-a11y/interactive-supports-focus",
 				"url": "https://ota-meshi.github.io/eslint-plugin-astro/rules/jsx-a11y/interactive-supports-focus"
 			}
-		],
-		"flint": {
-			"name": "interactiveElementsFocusable",
-			"plugin": "astro",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "labelAssociatedControls",
+			"plugin": "astro",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "astro/jsx-a11y/label-has-associated-control",
 				"url": "https://ota-meshi.github.io/eslint-plugin-astro/rules/jsx-a11y/label-has-associated-control"
 			}
-		],
-		"flint": {
-			"name": "labelAssociatedControls",
-			"plugin": "astro",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "langValidity",
+			"plugin": "astro",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "astro/jsx-a11y/lang",
 				"url": "https://ota-meshi.github.io/eslint-plugin-astro/rules/jsx-a11y/lang"
 			}
-		],
-		"flint": {
-			"name": "langValidity",
-			"plugin": "astro",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "mediaCaptions",
+			"plugin": "astro",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "astro/jsx-a11y/media-has-caption",
 				"url": "https://ota-meshi.github.io/eslint-plugin-astro/rules/jsx-a11y/media-has-caption"
 			}
-		],
-		"flint": {
-			"name": "mediaCaptions",
-			"plugin": "astro",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "mouseEventKeyEvents",
+			"plugin": "astro",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "astro/jsx-a11y/mouse-events-have-key-events",
 				"url": "https://ota-meshi.github.io/eslint-plugin-astro/rules/jsx-a11y/mouse-events-have-key-events"
 			}
-		],
-		"flint": {
-			"name": "mouseEventKeyEvents",
-			"plugin": "astro",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "nonInteractiveElementInteractions",
+			"plugin": "astro",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "astro/jsx-a11y/no-noninteractive-element-interactions",
 				"url": "https://ota-meshi.github.io/eslint-plugin-astro/rules/jsx-a11y/no-noninteractive-element-interactions"
 			}
-		],
-		"flint": {
-			"name": "nonInteractiveElementInteractions",
-			"plugin": "astro",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "nonInteractiveElementRoles",
+			"plugin": "astro",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "astro/jsx-a11y/no-noninteractive-element-to-interactive-role",
 				"url": "https://ota-meshi.github.io/eslint-plugin-astro/rules/jsx-a11y/no-noninteractive-element-to-interactive-role"
 			}
-		],
-		"flint": {
-			"name": "nonInteractiveElementRoles",
-			"plugin": "astro",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "nonInteractiveElementTabIndexes",
+			"plugin": "astro",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "astro/jsx-a11y/no-noninteractive-tabindex",
 				"url": "https://ota-meshi.github.io/eslint-plugin-astro/rules/jsx-a11y/no-noninteractive-tabindex"
 			}
-		],
-		"flint": {
-			"name": "nonInteractiveElementTabIndexes",
-			"plugin": "astro",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "prerenderExportsOutsidePages",
+			"plugin": "astro",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "astro/no-prerender-export-outside-pages",
 				"url": "https://ota-meshi.github.io/eslint-plugin-astro/rules/no-prerender-export-outside-pages"
 			}
-		],
-		"flint": {
-			"name": "prerenderExportsOutsidePages",
-			"plugin": "astro",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "roleRedundancies",
+			"plugin": "astro",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "astro/jsx-a11y/no-redundant-roles",
 				"url": "https://ota-meshi.github.io/eslint-plugin-astro/rules/jsx-a11y/no-redundant-roles"
 			}
-		],
-		"flint": {
-			"name": "roleRedundancies",
-			"plugin": "astro",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "roleRequiredAriaProps",
+			"plugin": "astro",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "astro/jsx-a11y/role-has-required-aria-props",
 				"url": "https://ota-meshi.github.io/eslint-plugin-astro/rules/jsx-a11y/role-has-required-aria-props"
 			}
-		],
-		"flint": {
-			"name": "roleRequiredAriaProps",
-			"plugin": "astro",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "roleSupportedAriaProps",
+			"plugin": "astro",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "astro/jsx-a11y/role-supports-aria-props",
 				"url": "https://ota-meshi.github.io/eslint-plugin-astro/rules/jsx-a11y/role-supports-aria-props"
 			}
-		],
-		"flint": {
-			"name": "roleSupportedAriaProps",
-			"plugin": "astro",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "roleTags",
+			"plugin": "astro",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "astro/jsx-a11y/prefer-tag-over-role",
 				"url": "https://ota-meshi.github.io/eslint-plugin-astro/rules/jsx-a11y/prefer-tag-over-role"
 			}
-		],
-		"flint": {
-			"name": "roleTags",
-			"plugin": "astro",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "scopeProps",
+			"plugin": "astro",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "astro/jsx-a11y/scope",
 				"url": "https://ota-meshi.github.io/eslint-plugin-astro/rules/jsx-a11y/scope"
 			}
-		],
-		"flint": {
-			"name": "scopeProps",
-			"plugin": "astro",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "semicolons",
+			"plugin": "astro",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "astro/semi",
 				"url": "https://ota-meshi.github.io/eslint-plugin-astro/rules/semi"
 			}
 		],
-		"flint": {
-			"name": "semicolons",
-			"plugin": "astro",
-			"status": "skipped"
-		},
 		"notes": "Formatting rule."
 	},
 	{
+		"flint": {
+			"name": "setDirectiveChildContentConflicts",
+			"plugin": "astro",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "astro/no-conflict-set-directives",
 				"url": "https://ota-meshi.github.io/eslint-plugin-astro/rules/no-conflict-set-directives"
 			}
-		],
-		"flint": {
-			"name": "setDirectiveChildContentConflicts",
-			"plugin": "astro",
-			"preset": "logical"
-		}
+		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "astro/no-set-html-directive",
-				"url": "https://ota-meshi.github.io/eslint-plugin-astro/rules/no-set-html-directive"
-			}
-		],
 		"flint": {
 			"name": "setHtmlDirectives",
 			"plugin": "astro",
 			"preset": "security",
 			"status": "implemented"
-		}
+		},
+		"eslint": [
+			{
+				"name": "astro/no-set-html-directive",
+				"url": "https://ota-meshi.github.io/eslint-plugin-astro/rules/no-set-html-directive"
+			}
+		]
 	},
 	{
+		"flint": {
+			"name": "setTextDirectives",
+			"plugin": "astro",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "astro/no-set-text-directive",
 				"url": "https://ota-meshi.github.io/eslint-plugin-astro/rules/no-set-text-directive"
 			}
-		],
-		"flint": {
-			"name": "setTextDirectives",
-			"plugin": "astro",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "staticElementInteractions",
+			"plugin": "astro",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "astro/jsx-a11y/no-static-element-interactions",
 				"url": "https://ota-meshi.github.io/eslint-plugin-astro/rules/jsx-a11y/no-static-element-interactions"
 			}
-		],
-		"flint": {
-			"name": "staticElementInteractions",
-			"plugin": "astro",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "tabIndexPositiveValues",
+			"plugin": "astro",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "astro/jsx-a11y/tabindex-no-positive",
 				"url": "https://ota-meshi.github.io/eslint-plugin-astro/rules/jsx-a11y/tabindex-no-positive"
 			}
-		],
-		"flint": {
-			"name": "tabIndexPositiveValues",
-			"plugin": "astro",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "unsafeInlineScripts",
+			"plugin": "astro",
+			"preset": "security"
+		},
 		"eslint": [
 			{
 				"name": "astro/no-unsafe-inline-scripts",
 				"url": "https://ota-meshi.github.io/eslint-plugin-astro/rules/no-unsafe-inline-scripts"
 			}
-		],
-		"flint": {
-			"name": "unsafeInlineScripts",
-			"plugin": "astro",
-			"preset": "security"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "unusedCssSelectors",
+			"plugin": "astro",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "astro/no-unused-css-selector",
 				"url": "https://ota-meshi.github.io/eslint-plugin-astro/rules/no-unused-css-selector"
 			}
-		],
-		"flint": {
-			"name": "unusedCssSelectors",
-			"plugin": "astro",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "unusedStyleDefineVars",
+			"plugin": "astro",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "astro/no-unused-define-vars-in-style",
 				"url": "https://ota-meshi.github.io/eslint-plugin-astro/rules/no-unused-define-vars-in-style"
 			}
-		],
-		"flint": {
-			"name": "unusedStyleDefineVars",
-			"plugin": "astro",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "alerts",
+			"plugin": "browser",
+			"preset": "logical",
+			"status": "implemented"
+		},
 		"biome": [
 			{
 				"name": "noAlert",
@@ -735,12 +741,6 @@
 				"url": "https://eslint.org/docs/latest/rules/no-alert"
 			}
 		],
-		"flint": {
-			"name": "alerts",
-			"plugin": "browser",
-			"preset": "logical",
-			"status": "implemented"
-		},
 		"oxlint": [
 			{
 				"name": "eslint/no-alert",
@@ -749,18 +749,18 @@
 		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "unicorn/prefer-classlist-toggle",
-				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prefer-classlist-toggle.md"
-			}
-		],
 		"flint": {
 			"name": "classListToggles",
 			"plugin": "browser",
 			"preset": "stylistic",
 			"status": "implemented"
 		},
+		"eslint": [
+			{
+				"name": "unicorn/prefer-classlist-toggle",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prefer-classlist-toggle.md"
+			}
+		],
 		"oxlint": [
 			{
 				"name": "unicorn/prefer-classlist-toggle",
@@ -769,6 +769,13 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "documentCookies",
+			"plugin": "browser",
+			"preset": "logical",
+			"status": "implemented",
+			"strictness": "strict"
+		},
 		"biome": [
 			{
 				"name": "noDocumentCookie",
@@ -781,13 +788,6 @@
 				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-document-cookie.md"
 			}
 		],
-		"flint": {
-			"name": "documentCookies",
-			"plugin": "browser",
-			"preset": "logical",
-			"status": "implemented",
-			"strictness": "strict"
-		},
 		"oxlint": [
 			{
 				"name": "unicorn/no-document-cookie",
@@ -796,20 +796,26 @@
 		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "sdl/no-document-domain",
-				"url": "https://github.com/microsoft/eslint-plugin-sdl/blob/main/docs/rules/no-document-domain.md"
-			}
-		],
 		"flint": {
 			"name": "documentDomains",
 			"plugin": "browser",
 			"preset": "logical",
 			"status": "implemented"
-		}
+		},
+		"eslint": [
+			{
+				"name": "sdl/no-document-domain",
+				"url": "https://github.com/microsoft/eslint-plugin-sdl/blob/main/docs/rules/no-document-domain.md"
+			}
+		]
 	},
 	{
+		"flint": {
+			"name": "documentWrites",
+			"plugin": "browser",
+			"preset": "logical",
+			"status": "implemented"
+		},
 		"eslint": [
 			{
 				"name": "document-write/no-document-write",
@@ -819,21 +825,9 @@
 				"name": "sdl/no-document-write",
 				"url": "https://github.com/microsoft/eslint-plugin-sdl/blob/main/docs/rules/no-document-write.md"
 			}
-		],
-		"flint": {
-			"name": "documentWrites",
-			"plugin": "browser",
-			"preset": "logical",
-			"status": "implemented"
-		}
+		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "unicorn/prefer-add-event-listener",
-				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prefer-add-event-listener.md"
-			}
-		],
 		"flint": {
 			"name": "eventListenerSubscriptions",
 			"plugin": "browser",
@@ -841,6 +835,12 @@
 			"status": "implemented",
 			"strictness": "strict"
 		},
+		"eslint": [
+			{
+				"name": "unicorn/prefer-add-event-listener",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prefer-add-event-listener.md"
+			}
+		],
 		"oxlint": [
 			{
 				"name": "unicorn/prefer-add-event-listener",
@@ -849,18 +849,18 @@
 		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "no-implicit-globals",
-				"url": "https://eslint.org/docs/latest/rules/no-implicit-globals"
-			}
-		],
 		"flint": {
 			"name": "implicitGlobals",
 			"plugin": "browser",
 			"preset": "logical",
 			"status": "implemented"
 		},
+		"eslint": [
+			{
+				"name": "no-implicit-globals",
+				"url": "https://eslint.org/docs/latest/rules/no-implicit-globals"
+			}
+		],
 		"oxlint": [
 			{
 				"name": "eslint/no-implicit-globals",
@@ -869,18 +869,18 @@
 		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "unicorn/prefer-keyboard-event-key",
-				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prefer-keyboard-event-key.md"
-			}
-		],
 		"flint": {
 			"name": "keyboardEventKeys",
 			"plugin": "browser",
 			"preset": "logical",
 			"status": "implemented"
 		},
+		"eslint": [
+			{
+				"name": "unicorn/prefer-keyboard-event-key",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prefer-keyboard-event-key.md"
+			}
+		],
 		"oxlint": [
 			{
 				"name": "unicorn/prefer-keyboard-event-key",
@@ -889,12 +889,6 @@
 		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "unicorn/prefer-dom-node-append",
-				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prefer-dom-node-append.md"
-			}
-		],
 		"flint": {
 			"name": "nodeAppendMethods",
 			"plugin": "browser",
@@ -902,6 +896,12 @@
 			"status": "implemented",
 			"strictness": "strict"
 		},
+		"eslint": [
+			{
+				"name": "unicorn/prefer-dom-node-append",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prefer-dom-node-append.md"
+			}
+		],
 		"oxlint": [
 			{
 				"name": "unicorn/prefer-dom-node-append",
@@ -910,12 +910,6 @@
 		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "unicorn/prefer-dom-node-dataset",
-				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prefer-dom-node-dataset.md"
-			}
-		],
 		"flint": {
 			"name": "nodeDatasetAttributes",
 			"plugin": "browser",
@@ -923,6 +917,12 @@
 			"status": "implemented",
 			"strictness": "strict"
 		},
+		"eslint": [
+			{
+				"name": "unicorn/prefer-dom-node-dataset",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prefer-dom-node-dataset.md"
+			}
+		],
 		"oxlint": [
 			{
 				"name": "unicorn/prefer-dom-node-dataset",
@@ -931,12 +931,6 @@
 		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "unicorn/prefer-modern-dom-apis",
-				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prefer-modern-dom-apis.md"
-			}
-		],
 		"flint": {
 			"name": "nodeModificationMethods",
 			"plugin": "browser",
@@ -944,6 +938,12 @@
 			"status": "implemented",
 			"strictness": "strict"
 		},
+		"eslint": [
+			{
+				"name": "unicorn/prefer-modern-dom-apis",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prefer-modern-dom-apis.md"
+			}
+		],
 		"oxlint": [
 			{
 				"name": "unicorn/prefer-modern-dom-apis",
@@ -952,6 +952,13 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "nodeQueryMethods",
+			"plugin": "browser",
+			"preset": "stylistic",
+			"status": "implemented",
+			"strictness": "strict"
+		},
 		"biome": [
 			{
 				"name": "useDomQuerySelector",
@@ -964,13 +971,6 @@
 				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prefer-query-selector.md"
 			}
 		],
-		"flint": {
-			"name": "nodeQueryMethods",
-			"plugin": "browser",
-			"preset": "stylistic",
-			"status": "implemented",
-			"strictness": "strict"
-		},
 		"oxlint": [
 			{
 				"name": "unicorn/prefer-query-selector",
@@ -979,12 +979,6 @@
 		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "unicorn/prefer-dom-node-remove",
-				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prefer-dom-node-remove.md"
-			}
-		],
 		"flint": {
 			"name": "nodeRemoveMethods",
 			"plugin": "browser",
@@ -992,6 +986,12 @@
 			"status": "implemented",
 			"strictness": "strict"
 		},
+		"eslint": [
+			{
+				"name": "unicorn/prefer-dom-node-remove",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prefer-dom-node-remove.md"
+			}
+		],
 		"oxlint": [
 			{
 				"name": "unicorn/prefer-dom-node-remove",
@@ -1000,6 +1000,13 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "nodeTextContents",
+			"plugin": "browser",
+			"preset": "logical",
+			"status": "implemented",
+			"strictness": "strict"
+		},
 		"biome": [
 			{
 				"name": "useDomNodeTextContent",
@@ -1012,13 +1019,6 @@
 				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prefer-dom-node-text-content.md"
 			}
 		],
-		"flint": {
-			"name": "nodeTextContents",
-			"plugin": "browser",
-			"preset": "logical",
-			"status": "implemented",
-			"strictness": "strict"
-		},
 		"oxlint": [
 			{
 				"name": "unicorn/prefer-dom-node-text-content",
@@ -1027,18 +1027,18 @@
 		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "unicorn/no-invalid-remove-event-listener",
-				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-invalid-remove-event-listener.md"
-			}
-		],
 		"flint": {
 			"name": "removeEventListenerExpressions",
 			"plugin": "browser",
 			"preset": "logical",
 			"status": "implemented"
 		},
+		"eslint": [
+			{
+				"name": "unicorn/no-invalid-remove-event-listener",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-invalid-remove-event-listener.md"
+			}
+		],
 		"oxlint": [
 			{
 				"name": "unicorn/no-invalid-remove-event-listener",
@@ -1047,6 +1047,12 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "scriptUrls",
+			"plugin": "browser",
+			"preset": "logical",
+			"status": "implemented"
+		},
 		"biome": [
 			{
 				"name": "noScriptUrl",
@@ -1059,12 +1065,6 @@
 				"url": "https://eslint.org/docs/latest/rules/no-script-url"
 			}
 		],
-		"flint": {
-			"name": "scriptUrls",
-			"plugin": "browser",
-			"preset": "logical",
-			"status": "implemented"
-		},
 		"oxlint": [
 			{
 				"name": "eslint/no-script-url",
@@ -1073,18 +1073,18 @@
 		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "unicorn/require-post-message-target-origin",
-				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/require-post-message-target-origin.md"
-			}
-		],
 		"flint": {
 			"name": "windowMessagingTargetOrigin",
 			"plugin": "browser",
 			"preset": "logical",
 			"status": "implemented"
 		},
+		"eslint": [
+			{
+				"name": "unicorn/require-post-message-target-origin",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/require-post-message-target-origin.md"
+			}
+		],
 		"oxlint": [
 			{
 				"name": "unicorn/require-post-message-target-origin",
@@ -1106,17 +1106,17 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "anbSelectorMatchability",
+			"plugin": "css",
+			"preset": "logical"
+		},
 		"biome": [
 			{
 				"name": "noUnmatchableAnbSelector",
 				"url": "https://biomejs.dev/linter/rules/no-unmatchable-anb-selector"
 			}
-		],
-		"flint": {
-			"name": "anbSelectorMatchability",
-			"plugin": "css",
-			"preset": "logical"
-		}
+		]
 	},
 	{
 		"flint": {
@@ -1163,15 +1163,20 @@
 			"plugin": "css",
 			"status": "skipped"
 		},
-		"notes": "Formatting rule.",
 		"stylelint": [
 			{
 				"name": "at-rule-empty-line-before",
 				"url": "https://stylelint.io/user-guide/rules/at-rule-empty-line-before"
 			}
-		]
+		],
+		"notes": "Formatting rule."
 	},
 	{
+		"flint": {
+			"name": "atRulePlacements",
+			"plugin": "css",
+			"preset": "logical"
+		},
 		"biome": [
 			{
 				"name": "noInvalidPositionAtImportRule",
@@ -1184,11 +1189,6 @@
 				"url": "https://github.com/eslint/css/blob/main/docs/rules/no-invalid-at-rule-placement.md"
 			}
 		],
-		"flint": {
-			"name": "atRulePlacements",
-			"plugin": "css",
-			"preset": "logical"
-		},
 		"stylelint": [
 			{
 				"name": "no-invalid-position-at-import-rule",
@@ -1225,6 +1225,11 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "atRuleValidity",
+			"plugin": "css",
+			"preset": "logical"
+		},
 		"biome": [
 			{
 				"name": "noUnknownAtRules",
@@ -1237,11 +1242,6 @@
 				"url": "https://github.com/eslint/css/blob/main/docs/rules/no-invalid-at-rules.md"
 			}
 		],
-		"flint": {
-			"name": "atRuleValidity",
-			"plugin": "css",
-			"preset": "logical"
-		},
 		"stylelint": [
 			{
 				"name": "at-rule-descriptor-no-unknown",
@@ -1276,6 +1276,11 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "baselineFeatures",
+			"plugin": "css",
+			"preset": "logical"
+		},
 		"biome": [
 			{
 				"name": "useBaseline",
@@ -1287,39 +1292,34 @@
 				"name": "css/use-baseline",
 				"url": "https://github.com/eslint/css/blob/main/docs/rules/use-baseline.md"
 			}
-		],
-		"flint": {
-			"name": "baselineFeatures",
-			"plugin": "css",
-			"preset": "logical"
-		}
+		]
 	},
 	{
-		"biome": [
-			{
-				"name": "useBaseline",
-				"url": "https://biomejs.dev/linter/rules/use-baseline"
-			}
-		],
 		"flint": {
 			"name": "baselineSupport",
 			"plugin": "css",
 			"preset": "logical",
 			"strictness": "strict"
-		}
+		},
+		"biome": [
+			{
+				"name": "useBaseline",
+				"url": "https://biomejs.dev/linter/rules/use-baseline"
+			}
+		]
 	},
 	{
+		"flint": {
+			"name": "blockContents",
+			"plugin": "css",
+			"preset": "stylistic"
+		},
 		"biome": [
 			{
 				"name": "noEmptyBlock",
 				"url": "https://biomejs.dev/linter/rules/no-empty-block"
 			}
-		],
-		"flint": {
-			"name": "blockContents",
-			"plugin": "css",
-			"preset": "stylistic"
-		}
+		]
 	},
 	{
 		"flint": {
@@ -1335,31 +1335,31 @@
 		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "css/use-layers",
-				"url": "https://github.com/eslint/css/blob/main/docs/rules/use-layers.md"
-			}
-		],
 		"flint": {
 			"name": "cascadeLayers",
 			"plugin": "css",
 			"preset": "logical",
 			"strictness": "strict"
-		}
+		},
+		"eslint": [
+			{
+				"name": "css/use-layers",
+				"url": "https://github.com/eslint/css/blob/main/docs/rules/use-layers.md"
+			}
+		]
 	},
 	{
+		"flint": {
+			"name": "colorAlphaRedundancy",
+			"plugin": "css",
+			"preset": "stylistic"
+		},
 		"eslint": [
 			{
 				"name": "css/no-useless-color-alpha",
 				"url": "https://ota-meshi.github.io/eslint-plugin-css/rules/no-useless-color-alpha.html"
 			}
-		],
-		"flint": {
-			"name": "colorAlphaRedundancy",
-			"plugin": "css",
-			"preset": "stylistic"
-		}
+		]
 	},
 	{
 		"flint": {
@@ -1393,13 +1393,13 @@
 			"plugin": "css",
 			"status": "skipped"
 		},
-		"notes": "Formatting rule.",
 		"stylelint": [
 			{
 				"name": "comment-empty-line-before",
 				"url": "https://stylelint.io/user-guide/rules/comment-empty-line-before"
 			}
-		]
+		],
+		"notes": "Formatting rule."
 	},
 	{
 		"flint": {
@@ -1419,13 +1419,13 @@
 			"plugin": "css",
 			"status": "skipped"
 		},
-		"notes": "Formatting rule.",
 		"stylelint": [
 			{
 				"name": "comment-whitespace-inside",
 				"url": "https://stylelint.io/user-guide/rules/comment-whitespace-inside"
 			}
-		]
+		],
+		"notes": "Formatting rule."
 	},
 	{
 		"flint": {
@@ -1477,17 +1477,17 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "customPropertyDuplicates",
+			"plugin": "css",
+			"preset": "logical"
+		},
 		"biome": [
 			{
 				"name": "noDuplicateCustomProperties",
 				"url": "https://biomejs.dev/linter/rules/no-duplicate-custom-properties"
 			}
 		],
-		"flint": {
-			"name": "customPropertyDuplicates",
-			"plugin": "css",
-			"preset": "logical"
-		},
 		"stylelint": [
 			{
 				"name": "declaration-block-no-duplicate-custom-properties",
@@ -1501,13 +1501,13 @@
 			"plugin": "css",
 			"status": "skipped"
 		},
-		"notes": "Formatting rule.",
 		"stylelint": [
 			{
 				"name": "custom-property-empty-line-before",
 				"url": "https://stylelint.io/user-guide/rules/custom-property-empty-line-before"
 			}
-		]
+		],
+		"notes": "Formatting rule."
 	},
 	{
 		"flint": {
@@ -1535,17 +1535,17 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "customPropertyVarFunctionPresence",
+			"plugin": "css",
+			"preset": "logical"
+		},
 		"biome": [
 			{
 				"name": "noMissingVarFunction",
 				"url": "https://biomejs.dev/linter/rules/no-missing-var-function"
 			}
 		],
-		"flint": {
-			"name": "customPropertyVarFunctionPresence",
-			"plugin": "css",
-			"preset": "logical"
-		},
 		"stylelint": [
 			{
 				"name": "custom-property-no-missing-var-function",
@@ -1559,13 +1559,13 @@
 			"plugin": "css",
 			"status": "skipped"
 		},
-		"notes": "Formatting rule.",
 		"stylelint": [
 			{
 				"name": "declaration-empty-line-before",
 				"url": "https://stylelint.io/user-guide/rules/declaration-empty-line-before"
 			}
-		]
+		],
+		"notes": "Formatting rule."
 	},
 	{
 		"flint": {
@@ -1581,17 +1581,17 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "declarationPropertyDuplicates",
+			"plugin": "css",
+			"preset": "logical"
+		},
 		"biome": [
 			{
 				"name": "noDuplicateProperties",
 				"url": "https://biomejs.dev/linter/rules/no-duplicate-properties"
 			}
 		],
-		"flint": {
-			"name": "declarationPropertyDuplicates",
-			"plugin": "css",
-			"preset": "logical"
-		},
 		"stylelint": [
 			{
 				"name": "declaration-block-no-duplicate-properties",
@@ -1634,13 +1634,13 @@
 			"plugin": "css",
 			"status": "skipped"
 		},
-		"notes": "Overly opinionated.",
 		"stylelint": [
 			{
 				"name": "declaration-property-max-values",
 				"url": "https://stylelint.io/user-guide/rules/declaration-property-max-values"
 			}
-		]
+		],
+		"notes": "Overly opinionated."
 	},
 	{
 		"flint": {
@@ -1659,18 +1659,18 @@
 		]
 	},
 	{
-		"biome": [
-			{
-				"name": "noDescendingSpecificity",
-				"url": "https://biomejs.dev/linter/rules/no-descending-specificity"
-			}
-		],
 		"flint": {
 			"name": "descendingSpecificity",
 			"plugin": "css",
 			"preset": "logical",
 			"strictness": "strict"
 		},
+		"biome": [
+			{
+				"name": "noDescendingSpecificity",
+				"url": "https://biomejs.dev/linter/rules/no-descending-specificity"
+			}
+		],
 		"stylelint": [
 			{
 				"name": "no-descending-specificity",
@@ -1705,6 +1705,11 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "emptyBlocks",
+			"plugin": "css",
+			"preset": "logical"
+		},
 		"biome": [
 			{
 				"name": "noEmptyBlock",
@@ -1717,11 +1722,6 @@
 				"url": "https://github.com/eslint/css/blob/main/docs/rules/no-empty-blocks.md"
 			}
 		],
-		"flint": {
-			"name": "emptyBlocks",
-			"plugin": "css",
-			"preset": "logical"
-		},
 		"stylelint": [
 			{
 				"name": "block-no-empty",
@@ -1743,17 +1743,17 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "emptySources",
+			"plugin": "css",
+			"preset": "logical"
+		},
 		"biome": [
 			{
 				"name": "noEmptySource",
 				"url": "https://biomejs.dev/linter/rules/no-empty-source"
 			}
 		],
-		"flint": {
-			"name": "emptySources",
-			"plugin": "css",
-			"preset": "logical"
-		},
 		"stylelint": [
 			{
 				"name": "no-empty-source",
@@ -1762,20 +1762,25 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "fileLineLimits",
+			"plugin": "css",
+			"status": "skipped"
+		},
 		"biome": [
 			{
 				"name": "noExcessiveLinesPerFile",
 				"url": "https://biomejs.dev/linter/rules/no-excessive-lines-per-file"
 			}
 		],
-		"flint": {
-			"name": "fileLineLimits",
-			"plugin": "css",
-			"status": "skipped"
-		},
 		"notes": "Overly opinionated."
 	},
 	{
+		"flint": {
+			"name": "fontFamilyFallbacks",
+			"plugin": "css",
+			"preset": "logical"
+		},
 		"biome": [
 			{
 				"name": "useGenericFontNames",
@@ -1788,11 +1793,6 @@
 				"url": "https://github.com/eslint/css/blob/main/docs/rules/font-family-fallbacks.md"
 			}
 		],
-		"flint": {
-			"name": "fontFamilyFallbacks",
-			"plugin": "css",
-			"preset": "logical"
-		},
 		"stylelint": [
 			{
 				"name": "font-family-no-missing-generic-family-keyword",
@@ -1801,17 +1801,17 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "fontFamilyNameDuplicates",
+			"plugin": "css",
+			"preset": "logical"
+		},
 		"biome": [
 			{
 				"name": "noDuplicateFontNames",
 				"url": "https://biomejs.dev/linter/rules/no-duplicate-font-names"
 			}
 		],
-		"flint": {
-			"name": "fontFamilyNameDuplicates",
-			"plugin": "css",
-			"preset": "logical"
-		},
 		"stylelint": [
 			{
 				"name": "font-family-no-duplicate-names",
@@ -1833,31 +1833,31 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "fontNameDuplicates",
+			"plugin": "css",
+			"preset": "logical"
+		},
 		"biome": [
 			{
 				"name": "noDuplicateFontNames",
 				"url": "https://biomejs.dev/linter/rules/no-duplicate-font-names"
 			}
-		],
-		"flint": {
-			"name": "fontNameDuplicates",
-			"plugin": "css",
-			"preset": "logical"
-		}
+		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "css/relative-font-units",
-				"url": "https://github.com/eslint/css/blob/main/docs/rules/relative-font-units.md"
-			}
-		],
 		"flint": {
 			"name": "fontUnitRelativity",
 			"plugin": "css",
 			"preset": "logical",
 			"strictness": "strict"
-		}
+		},
+		"eslint": [
+			{
+				"name": "css/relative-font-units",
+				"url": "https://github.com/eslint/css/blob/main/docs/rules/relative-font-units.md"
+			}
+		]
 	},
 	{
 		"flint": {
@@ -1902,17 +1902,17 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "functionValidity",
+			"plugin": "css",
+			"preset": "logical"
+		},
 		"biome": [
 			{
 				"name": "noUnknownFunction",
 				"url": "https://biomejs.dev/linter/rules/no-unknown-function"
 			}
 		],
-		"flint": {
-			"name": "functionValidity",
-			"plugin": "css",
-			"preset": "logical"
-		},
 		"stylelint": [
 			{
 				"name": "function-no-unknown",
@@ -1921,30 +1921,30 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "genericFontNames",
+			"plugin": "css",
+			"preset": "logical"
+		},
 		"biome": [
 			{
 				"name": "useGenericFontNames",
 				"url": "https://biomejs.dev/linter/rules/use-generic-font-names"
 			}
-		],
-		"flint": {
-			"name": "genericFontNames",
-			"plugin": "css",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "gridAreaValidity",
+			"plugin": "css",
+			"preset": "logical"
+		},
 		"biome": [
 			{
 				"name": "noInvalidGridAreas",
 				"url": "https://biomejs.dev/linter/rules/no-invalid-grid-areas"
 			}
-		],
-		"flint": {
-			"name": "gridAreaValidity",
-			"plugin": "css",
-			"preset": "logical"
-		}
+		]
 	},
 	{
 		"flint": {
@@ -1960,18 +1960,18 @@
 		]
 	},
 	{
-		"biome": [
-			{
-				"name": "noHexColors",
-				"url": "https://biomejs.dev/linter/rules/no-hex-colors"
-			}
-		],
 		"flint": {
 			"name": "hexColors",
 			"plugin": "css",
 			"preset": "stylistic",
 			"strictness": "strict"
 		},
+		"biome": [
+			{
+				"name": "noHexColors",
+				"url": "https://biomejs.dev/linter/rules/no-hex-colors"
+			}
+		],
 		"stylelint": [
 			{
 				"name": "color-no-hex",
@@ -1980,17 +1980,17 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "hexColorStyles",
+			"plugin": "css",
+			"preset": "stylistic"
+		},
 		"eslint": [
 			{
 				"name": "css/color-hex-style",
 				"url": "https://ota-meshi.github.io/eslint-plugin-css/rules/color-hex-style.html"
 			}
 		],
-		"flint": {
-			"name": "hexColorStyles",
-			"plugin": "css",
-			"preset": "stylistic"
-		},
 		"stylelint": [
 			{
 				"name": "color-hex-length",
@@ -1999,18 +1999,18 @@
 		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "css/no-invalid-color-hex",
-				"url": "https://ota-meshi.github.io/eslint-plugin-css/rules/no-invalid-color-hex.html"
-			}
-		],
 		"flint": {
 			"name": "hexColorValidity",
 			"plugin": "css",
 			"preset": "logical",
 			"status": "implemented"
 		},
+		"eslint": [
+			{
+				"name": "css/no-invalid-color-hex",
+				"url": "https://ota-meshi.github.io/eslint-plugin-css/rules/no-invalid-color-hex.html"
+			}
+		],
 		"stylelint": [
 			{
 				"name": "color-no-invalid-hex",
@@ -2032,6 +2032,12 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "importantDeclarations",
+			"plugin": "css",
+			"preset": "logical",
+			"strictness": "strict"
+		},
 		"biome": [
 			{
 				"name": "noImportantInKeyframe",
@@ -2048,13 +2054,6 @@
 				"url": "https://github.com/eslint/css/blob/main/docs/rules/no-important.md"
 			}
 		],
-		"flint": {
-			"name": "importantDeclarations",
-			"plugin": "css",
-			"preset": "logical",
-			"strictness": "strict"
-		},
-		"notes": "Stylelint splits !important declarations in keyframes into a separate rule.",
 		"stylelint": [
 			{
 				"name": "declaration-no-important",
@@ -2064,23 +2063,29 @@
 				"name": "keyframe-declaration-no-important",
 				"url": "https://stylelint.io/user-guide/rules/keyframe-declaration-no-important"
 			}
-		]
+		],
+		"notes": "Stylelint splits !important declarations in keyframes into a separate rule."
 	},
 	{
-		"biome": [
-			{
-				"name": "noImportantStyles",
-				"url": "https://biomejs.dev/linter/rules/no-important-styles"
-			}
-		],
 		"flint": {
 			"name": "importantStyles",
 			"plugin": "css",
 			"preset": "stylistic",
 			"strictness": "strict"
-		}
+		},
+		"biome": [
+			{
+				"name": "noImportantStyles",
+				"url": "https://biomejs.dev/linter/rules/no-important-styles"
+			}
+		]
 	},
 	{
+		"flint": {
+			"name": "importDuplicates",
+			"plugin": "css",
+			"preset": "logical"
+		},
 		"biome": [
 			{
 				"name": "noDuplicateAtImportRules",
@@ -2093,11 +2098,6 @@
 				"url": "https://github.com/eslint/css/blob/main/docs/rules/no-duplicate-imports.md"
 			}
 		],
-		"flint": {
-			"name": "importDuplicates",
-			"plugin": "css",
-			"preset": "logical"
-		},
 		"stylelint": [
 			{
 				"name": "no-duplicate-at-import-rules",
@@ -2119,45 +2119,50 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "importRuleDuplicates",
+			"plugin": "css",
+			"preset": "logical"
+		},
 		"biome": [
 			{
 				"name": "noDuplicateAtImportRules",
 				"url": "https://biomejs.dev/linter/rules/no-duplicate-at-import-rules"
 			}
-		],
-		"flint": {
-			"name": "importRuleDuplicates",
-			"plugin": "css",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "importRulePositions",
+			"plugin": "css",
+			"preset": "logical"
+		},
 		"biome": [
 			{
 				"name": "noInvalidPositionAtImportRule",
 				"url": "https://biomejs.dev/linter/rules/no-invalid-position-at-import-rule"
 			}
-		],
-		"flint": {
-			"name": "importRulePositions",
-			"plugin": "css",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "keyframeImportantDeclarations",
+			"plugin": "css",
+			"preset": "logical"
+		},
 		"biome": [
 			{
 				"name": "noImportantInKeyframe",
 				"url": "https://biomejs.dev/linter/rules/no-important-in-keyframe"
 			}
-		],
-		"flint": {
-			"name": "keyframeImportantDeclarations",
-			"plugin": "css",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "keyframeSelectorDuplicates",
+			"plugin": "css",
+			"preset": "logical"
+		},
 		"biome": [
 			{
 				"name": "noDuplicateSelectorsKeyframeBlock",
@@ -2170,11 +2175,6 @@
 				"url": "https://github.com/eslint/css/blob/main/docs/rules/no-duplicate-keyframe-selectors.md"
 			}
 		],
-		"flint": {
-			"name": "keyframeSelectorDuplicates",
-			"plugin": "css",
-			"preset": "logical"
-		},
 		"stylelint": [
 			{
 				"name": "keyframe-block-no-duplicate-selectors",
@@ -2233,30 +2233,30 @@
 		]
 	},
 	{
-		"biome": [
-			{
-				"name": "noInvalidDirectionInLinearGradient",
-				"url": "https://biomejs.dev/linter/rules/no-invalid-direction-in-linear-gradient"
-			}
-		],
 		"flint": {
 			"name": "linearGradientDirections",
 			"plugin": "css",
 			"preset": "logical"
-		}
-	},
-	{
+		},
 		"biome": [
 			{
 				"name": "noInvalidDirectionInLinearGradient",
 				"url": "https://biomejs.dev/linter/rules/no-invalid-direction-in-linear-gradient"
 			}
-		],
+		]
+	},
+	{
 		"flint": {
 			"name": "linearGradientDirectionValidity",
 			"plugin": "css",
 			"preset": "logical"
 		},
+		"biome": [
+			{
+				"name": "noInvalidDirectionInLinearGradient",
+				"url": "https://biomejs.dev/linter/rules/no-invalid-direction-in-linear-gradient"
+			}
+		],
 		"stylelint": [
 			{
 				"name": "function-linear-gradient-no-nonstandard-direction",
@@ -2265,18 +2265,18 @@
 		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "css/prefer-logical-properties",
-				"url": "https://github.com/eslint/css/blob/main/docs/rules/prefer-logical-properties.md"
-			}
-		],
 		"flint": {
 			"name": "logicalProperties",
 			"plugin": "css",
 			"preset": "logical",
 			"strictness": "strict"
-		}
+		},
+		"eslint": [
+			{
+				"name": "css/prefer-logical-properties",
+				"url": "https://github.com/eslint/css/blob/main/docs/rules/prefer-logical-properties.md"
+			}
+		]
 	},
 	{
 		"flint": {
@@ -2308,17 +2308,17 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "mediaFeatureNameValidity",
+			"plugin": "css",
+			"preset": "logical"
+		},
 		"biome": [
 			{
 				"name": "noUnknownMediaFeatureName",
 				"url": "https://biomejs.dev/linter/rules/no-unknown-media-feature-name"
 			}
 		],
-		"flint": {
-			"name": "mediaFeatureNameValidity",
-			"plugin": "css",
-			"preset": "logical"
-		},
 		"stylelint": [
 			{
 				"name": "media-feature-name-no-unknown",
@@ -2404,17 +2404,17 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "mediaTypeDeprecations",
+			"plugin": "css",
+			"preset": "logical"
+		},
 		"biome": [
 			{
 				"name": "noDeprecatedMediaType",
 				"url": "https://biomejs.dev/linter/rules/no-deprecated-media-type"
 			}
 		],
-		"flint": {
-			"name": "mediaTypeDeprecations",
-			"plugin": "css",
-			"preset": "logical"
-		},
 		"stylelint": [
 			{
 				"name": "media-type-no-deprecated",
@@ -2428,26 +2428,26 @@
 			"plugin": "css",
 			"status": "skipped"
 		},
-		"notes": "Overly opinionated.",
 		"stylelint": [
 			{
 				"name": "time-min-milliseconds",
 				"url": "https://stylelint.io/user-guide/rules/time-min-milliseconds"
 			}
-		]
+		],
+		"notes": "Overly opinionated."
 	},
 	{
+		"flint": {
+			"name": "namedColors",
+			"plugin": "css",
+			"preset": "stylistic"
+		},
 		"eslint": [
 			{
 				"name": "css/named-color",
 				"url": "https://ota-meshi.github.io/eslint-plugin-css/rules/named-color.html"
 			}
 		],
-		"flint": {
-			"name": "namedColors",
-			"plugin": "css",
-			"preset": "stylistic"
-		},
 		"stylelint": [
 			{
 				"name": "color-named",
@@ -2456,6 +2456,11 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "namedGridAreaValidity",
+			"plugin": "css",
+			"preset": "logical"
+		},
 		"biome": [
 			{
 				"name": "noInvalidGridAreas",
@@ -2468,11 +2473,6 @@
 				"url": "https://github.com/eslint/css/blob/main/docs/rules/no-invalid-named-grid-areas.md"
 			}
 		],
-		"flint": {
-			"name": "namedGridAreaValidity",
-			"plugin": "css",
-			"preset": "logical"
-		},
 		"stylelint": [
 			{
 				"name": "named-grid-areas-no-invalid",
@@ -2511,13 +2511,13 @@
 			"plugin": "css",
 			"status": "skipped"
 		},
-		"notes": "Overly opinionated.",
 		"stylelint": [
 			{
 				"name": "max-nesting-depth",
 				"url": "https://stylelint.io/user-guide/rules/max-nesting-depth"
 			}
-		]
+		],
+		"notes": "Overly opinionated."
 	},
 	{
 		"flint": {
@@ -2533,17 +2533,17 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "numberLeadingZeros",
+			"plugin": "css",
+			"preset": "stylistic"
+		},
 		"eslint": [
 			{
 				"name": "css/number-leading-zero",
 				"url": "https://ota-meshi.github.io/eslint-plugin-css/rules/number-leading-zero.html"
 			}
-		],
-		"flint": {
-			"name": "numberLeadingZeros",
-			"plugin": "css",
-			"preset": "stylistic"
-		}
+		]
 	},
 	{
 		"flint": {
@@ -2551,26 +2551,26 @@
 			"plugin": "css",
 			"status": "skipped"
 		},
-		"notes": "Overly opinionated.",
 		"stylelint": [
 			{
 				"name": "number-max-precision",
 				"url": "https://stylelint.io/user-guide/rules/number-max-precision"
 			}
-		]
+		],
+		"notes": "Overly opinionated."
 	},
 	{
+		"flint": {
+			"name": "numericTrailingZeros",
+			"plugin": "css",
+			"preset": "stylistic"
+		},
 		"eslint": [
 			{
 				"name": "css/no-number-trailing-zeros",
 				"url": "https://ota-meshi.github.io/eslint-plugin-css/rules/no-number-trailing-zeros.html"
 			}
-		],
-		"flint": {
-			"name": "numericTrailingZeros",
-			"plugin": "css",
-			"preset": "stylistic"
-		}
+		]
 	},
 	{
 		"flint": {
@@ -2589,17 +2589,17 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "propertyCasing",
+			"plugin": "css",
+			"preset": "stylistic"
+		},
 		"eslint": [
 			{
 				"name": "css/property-casing",
 				"url": "https://ota-meshi.github.io/eslint-plugin-css/rules/property-casing.html"
 			}
-		],
-		"flint": {
-			"name": "propertyCasing",
-			"plugin": "css",
-			"preset": "stylistic"
-		}
+		]
 	},
 	{
 		"flint": {
@@ -2615,17 +2615,17 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "propertyDuplicates",
+			"plugin": "css",
+			"preset": "logical"
+		},
 		"biome": [
 			{
 				"name": "noDuplicateProperties",
 				"url": "https://biomejs.dev/linter/rules/no-duplicate-properties"
 			}
-		],
-		"flint": {
-			"name": "propertyDuplicates",
-			"plugin": "css",
-			"preset": "logical"
-		}
+		]
 	},
 	{
 		"flint": {
@@ -2640,6 +2640,11 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "propertyValidity",
+			"plugin": "css",
+			"preset": "logical"
+		},
 		"biome": [
 			{
 				"name": "noUnknownProperty",
@@ -2652,11 +2657,6 @@
 				"url": "https://github.com/eslint/css/blob/main/docs/rules/no-invalid-properties.md"
 			}
 		],
-		"flint": {
-			"name": "propertyValidity",
-			"plugin": "css",
-			"preset": "logical"
-		},
 		"stylelint": [
 			{
 				"name": "declaration-property-value-no-unknown",
@@ -2699,17 +2699,17 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "pseudoClassValidity",
+			"plugin": "css",
+			"preset": "logical"
+		},
 		"biome": [
 			{
 				"name": "noUnknownPseudoClass",
 				"url": "https://biomejs.dev/linter/rules/no-unknown-pseudo-class"
 			}
 		],
-		"flint": {
-			"name": "pseudoClassValidity",
-			"plugin": "css",
-			"preset": "logical"
-		},
 		"stylelint": [
 			{
 				"name": "selector-pseudo-class-no-unknown",
@@ -2734,17 +2734,17 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "pseudoElementValidity",
+			"plugin": "css",
+			"preset": "logical"
+		},
 		"biome": [
 			{
 				"name": "noUnknownPseudoElement",
 				"url": "https://biomejs.dev/linter/rules/no-unknown-pseudo-element"
 			}
 		],
-		"flint": {
-			"name": "pseudoElementValidity",
-			"plugin": "css",
-			"preset": "logical"
-		},
 		"stylelint": [
 			{
 				"name": "selector-pseudo-element-no-unknown",
@@ -2772,13 +2772,13 @@
 			"plugin": "css",
 			"status": "skipped"
 		},
-		"notes": "Formatting rule.",
 		"stylelint": [
 			{
 				"name": "rule-empty-line-before",
 				"url": "https://stylelint.io/user-guide/rules/rule-empty-line-before"
 			}
-		]
+		],
+		"notes": "Formatting rule."
 	},
 	{
 		"flint": {
@@ -2834,31 +2834,31 @@
 		]
 	},
 	{
-		"biome": [
-			{
-				"name": "noExcessiveSelectorClasses",
-				"url": "https://biomejs.dev/linter/rules/no-excessive-selector-classes"
-			}
-		],
 		"flint": {
 			"name": "selectorClassCounts",
 			"plugin": "css",
 			"preset": "stylistic",
 			"strictness": "strict"
-		}
+		},
+		"biome": [
+			{
+				"name": "noExcessiveSelectorClasses",
+				"url": "https://biomejs.dev/linter/rules/no-excessive-selector-classes"
+			}
+		]
 	},
 	{
+		"flint": {
+			"name": "selectorClassLimits",
+			"plugin": "css",
+			"status": "skipped"
+		},
 		"biome": [
 			{
 				"name": "noExcessiveSelectorClasses",
 				"url": "https://biomejs.dev/linter/rules/no-excessive-selector-classes"
 			}
 		],
-		"flint": {
-			"name": "selectorClassLimits",
-			"plugin": "css",
-			"status": "skipped"
-		},
 		"notes": "Overly opinionated."
 	},
 	{
@@ -2890,18 +2890,17 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "selectorComplexity",
+			"plugin": "css",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "css/selector-complexity",
 				"url": "https://github.com/eslint/css/blob/main/docs/rules/selector-complexity.md"
 			}
 		],
-		"flint": {
-			"name": "selectorComplexity",
-			"plugin": "css",
-			"status": "skipped"
-		},
-		"notes": "Overly opinionated.",
 		"stylelint": [
 			{
 				"name": "selector-max-attribute",
@@ -2935,7 +2934,8 @@
 				"name": "selector-max-universal",
 				"url": "https://stylelint.io/user-guide/rules/selector-max-universal"
 			}
-		]
+		],
+		"notes": "Overly opinionated."
 	},
 	{
 		"flint": {
@@ -2951,17 +2951,17 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "selectorDuplicates",
+			"plugin": "css",
+			"preset": "logical"
+		},
 		"biome": [
 			{
 				"name": "noDuplicateSelectors",
 				"url": "https://biomejs.dev/linter/rules/no-duplicate-selectors"
 			}
 		],
-		"flint": {
-			"name": "selectorDuplicates",
-			"plugin": "css",
-			"preset": "logical"
-		},
 		"stylelint": [
 			{
 				"name": "no-duplicate-selectors",
@@ -2982,6 +2982,11 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "selectorMatchability",
+			"plugin": "css",
+			"preset": "logical"
+		},
 		"biome": [
 			{
 				"name": "noUnmatchableAnbSelector",
@@ -2994,11 +2999,6 @@
 				"url": "https://github.com/eslint/css/blob/main/docs/rules/no-unmatchable-selectors.md"
 			}
 		],
-		"flint": {
-			"name": "selectorMatchability",
-			"plugin": "css",
-			"preset": "logical"
-		},
 		"stylelint": [
 			{
 				"name": "selector-anb-no-unmatchable",
@@ -3070,17 +3070,17 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "selectorSpecificities",
+			"plugin": "css",
+			"preset": "logical"
+		},
 		"biome": [
 			{
 				"name": "noDescendingSpecificity",
 				"url": "https://biomejs.dev/linter/rules/no-descending-specificity"
 			}
-		],
-		"flint": {
-			"name": "selectorSpecificities",
-			"plugin": "css",
-			"preset": "logical"
-		}
+		]
 	},
 	{
 		"flint": {
@@ -3088,13 +3088,13 @@
 			"plugin": "css",
 			"status": "skipped"
 		},
-		"notes": "Overly opinionated.",
 		"stylelint": [
 			{
 				"name": "selector-max-specificity",
 				"url": "https://stylelint.io/user-guide/rules/selector-max-specificity"
 			}
-		]
+		],
+		"notes": "Overly opinionated."
 	},
 	{
 		"flint": {
@@ -3110,17 +3110,17 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "selectorTypeValidity",
+			"plugin": "css",
+			"preset": "logical"
+		},
 		"biome": [
 			{
 				"name": "noUnknownTypeSelector",
 				"url": "https://biomejs.dev/linter/rules/no-unknown-type-selector"
 			}
 		],
-		"flint": {
-			"name": "selectorTypeValidity",
-			"plugin": "css",
-			"preset": "logical"
-		},
 		"stylelint": [
 			{
 				"name": "selector-type-no-unknown",
@@ -3156,17 +3156,17 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "shorthandPropertyOverrides",
+			"plugin": "css",
+			"preset": "logical"
+		},
 		"biome": [
 			{
 				"name": "noShorthandPropertyOverrides",
 				"url": "https://biomejs.dev/linter/rules/no-shorthand-property-overrides"
 			}
 		],
-		"flint": {
-			"name": "shorthandPropertyOverrides",
-			"plugin": "css",
-			"preset": "logical"
-		},
 		"stylelint": [
 			{
 				"name": "declaration-block-no-shorthand-property-overrides",
@@ -3175,17 +3175,17 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "shorthandValueRedundancy",
+			"plugin": "css",
+			"preset": "stylistic"
+		},
 		"eslint": [
 			{
 				"name": "css/prefer-reduce-shorthand-property-box-values",
 				"url": "https://ota-meshi.github.io/eslint-plugin-css/rules/prefer-reduce-shorthand-property-box-values.html"
 			}
 		],
-		"flint": {
-			"name": "shorthandValueRedundancy",
-			"plugin": "css",
-			"preset": "stylistic"
-		},
 		"stylelint": [
 			{
 				"name": "shorthand-property-no-redundant-values",
@@ -3199,26 +3199,26 @@
 			"plugin": "css",
 			"status": "skipped"
 		},
-		"notes": "Overly opinionated.",
 		"stylelint": [
 			{
 				"name": "declaration-block-single-line-max-declarations",
 				"url": "https://stylelint.io/user-guide/rules/declaration-block-single-line-max-declarations"
 			}
-		]
+		],
+		"notes": "Overly opinionated."
 	},
 	{
+		"flint": {
+			"name": "stringValidity",
+			"plugin": "css",
+			"preset": "logical"
+		},
 		"biome": [
 			{
 				"name": "noUselessEscapeInString",
 				"url": "https://biomejs.dev/linter/rules/no-useless-escape-in-string"
 			}
 		],
-		"flint": {
-			"name": "stringValidity",
-			"plugin": "css",
-			"preset": "logical"
-		},
 		"stylelint": [
 			{
 				"name": "string-no-newline",
@@ -3240,17 +3240,17 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "typeSelectorValidity",
+			"plugin": "css",
+			"preset": "logical"
+		},
 		"biome": [
 			{
 				"name": "noUnknownTypeSelector",
 				"url": "https://biomejs.dev/linter/rules/no-unknown-type-selector"
 			}
-		],
-		"flint": {
-			"name": "typeSelectorValidity",
-			"plugin": "css",
-			"preset": "logical"
-		}
+		]
 	},
 	{
 		"flint": {
@@ -3281,17 +3281,17 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "unitValidity",
+			"plugin": "css",
+			"preset": "logical"
+		},
 		"biome": [
 			{
 				"name": "noUnknownUnit",
 				"url": "https://biomejs.dev/linter/rules/no-unknown-unit"
 			}
 		],
-		"flint": {
-			"name": "unitValidity",
-			"plugin": "css",
-			"preset": "logical"
-		},
 		"stylelint": [
 			{
 				"name": "unit-no-unknown",
@@ -3343,17 +3343,17 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "valueAtRules",
+			"plugin": "css",
+			"preset": "logical"
+		},
 		"biome": [
 			{
 				"name": "noValueAtRule",
 				"url": "https://biomejs.dev/linter/rules/no-value-at-rule"
 			}
-		],
-		"flint": {
-			"name": "valueAtRules",
-			"plugin": "css",
-			"preset": "logical"
-		}
+		]
 	},
 	{
 		"flint": {
@@ -3395,30 +3395,30 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "variableFunctionPresence",
+			"plugin": "css",
+			"preset": "logical"
+		},
 		"biome": [
 			{
 				"name": "noMissingVarFunction",
 				"url": "https://biomejs.dev/linter/rules/no-missing-var-function"
 			}
-		],
-		"flint": {
-			"name": "variableFunctionPresence",
-			"plugin": "css",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "whitespaceValidity",
+			"plugin": "css",
+			"preset": "logical"
+		},
 		"biome": [
 			{
 				"name": "noIrregularWhitespace",
 				"url": "https://biomejs.dev/linter/rules/no-irregular-whitespace"
 			}
 		],
-		"flint": {
-			"name": "whitespaceValidity",
-			"plugin": "css",
-			"preset": "logical"
-		},
 		"stylelint": [
 			{
 				"name": "no-irregular-whitespace",
@@ -3427,17 +3427,17 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "zeroLengthUnits",
+			"plugin": "css",
+			"preset": "stylistic"
+		},
 		"eslint": [
 			{
 				"name": "css/no-length-zero-unit",
 				"url": "https://ota-meshi.github.io/eslint-plugin-css/rules/no-length-zero-unit.html"
 			}
 		],
-		"flint": {
-			"name": "zeroLengthUnits",
-			"plugin": "css",
-			"preset": "stylistic"
-		},
 		"stylelint": [
 			{
 				"name": "length-zero-no-unit",
@@ -3446,238 +3446,238 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "deleteWhereClauses",
+			"plugin": "drizzle",
+			"status": "skipped"
+		},
 		"biome": [
 			{
 				"name": "noDrizzleDeleteWithoutWhere",
 				"url": "https://biomejs.dev/linter/rules/no-drizzle-delete-without-where"
 			}
-		],
-		"flint": {
-			"name": "deleteWhereClauses",
-			"plugin": "drizzle",
-			"status": "skipped"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "updateWhereClauses",
+			"plugin": "drizzle",
+			"status": "skipped"
+		},
 		"biome": [
 			{
 				"name": "noDrizzleUpdateWithoutWhere",
 				"url": "https://biomejs.dev/linter/rules/no-drizzle-update-without-where"
 			}
-		],
-		"flint": {
-			"name": "updateWhereClauses",
-			"plugin": "drizzle",
-			"status": "skipped"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "aboutSchemaDescriptions",
+			"plugin": "flint",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "eslint-plugin/require-meta-schema-description",
 				"url": "https://github.com/eslint-community/eslint-plugin-eslint-plugin/blob/main/docs/rules/require-meta-schema-description.md"
 			}
-		],
-		"flint": {
-			"name": "aboutSchemaDescriptions",
-			"plugin": "flint",
-			"status": "skipped"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "aboutSchemas",
+			"plugin": "flint",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "eslint-plugin/require-meta-schema",
 				"url": "https://github.com/eslint-community/eslint-plugin-eslint-plugin/blob/main/docs/rules/require-meta-schema.md"
 			}
-		],
-		"flint": {
-			"name": "aboutSchemas",
-			"plugin": "flint",
-			"status": "skipped"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "aboutSuggestions",
+			"plugin": "flint",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "eslint-plugin/require-meta-has-suggestions",
 				"url": "https://github.com/eslint-community/eslint-plugin-eslint-plugin/blob/main/docs/rules/require-meta-has-suggestions.md"
 			}
-		],
-		"flint": {
-			"name": "aboutSuggestions",
-			"plugin": "flint",
-			"status": "skipped"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "aboutTypes",
+			"plugin": "flint",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "eslint-plugin/require-meta-type",
 				"url": "https://github.com/eslint-community/eslint-plugin-eslint-plugin/blob/main/docs/rules/require-meta-type.md"
 			}
-		],
-		"flint": {
-			"name": "aboutTypes",
-			"plugin": "flint",
-			"status": "skipped"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "biomeFirstExceptions",
+			"plugin": "flint",
+			"status": "skipped"
+		},
 		"biome": [
 			{
 				"name": "noBiomeFirstException",
 				"url": "https://biomejs.dev/linter/rules/no-biome-first-exception"
 			}
-		],
-		"flint": {
-			"name": "biomeFirstExceptions",
-			"plugin": "flint",
-			"status": "skipped"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "biomeIgnoreFolders",
+			"plugin": "flint",
+			"status": "skipped"
+		},
 		"biome": [
 			{
 				"name": "useBiomeIgnoreFolder",
 				"url": "https://biomejs.dev/linter/rules/use-biome-ignore-folder"
 			}
-		],
-		"flint": {
-			"name": "biomeIgnoreFolders",
-			"plugin": "flint",
-			"status": "skipped"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "biomeQuickfixSettings",
+			"plugin": "flint",
+			"status": "skipped"
+		},
 		"biome": [
 			{
 				"name": "noQuickfixBiome",
 				"url": "https://biomejs.dev/linter/rules/no-quickfix-biome"
 			}
-		],
-		"flint": {
-			"name": "biomeQuickfixSettings",
-			"plugin": "flint",
-			"status": "skipped"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "deprecatedContextMethods",
+			"plugin": "flint",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "eslint-plugin/no-deprecated-context-methods",
 				"url": "https://github.com/eslint-community/eslint-plugin-eslint-plugin/blob/main/docs/rules/no-deprecated-context-methods.md"
 			}
-		],
-		"flint": {
-			"name": "deprecatedContextMethods",
-			"plugin": "flint",
-			"status": "skipped"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "deprecatedMessagePlaceholders",
+			"plugin": "flint",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "eslint-plugin/prefer-placeholders",
 				"url": "https://github.com/eslint-community/eslint-plugin-eslint-plugin/blob/main/docs/rules/prefer-placeholders.md"
 			}
-		],
-		"flint": {
-			"name": "deprecatedMessagePlaceholders",
-			"plugin": "flint",
-			"status": "skipped"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "deprecatedMessageStrings",
+			"plugin": "flint",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "eslint-plugin/prefer-message-ids",
 				"url": "https://github.com/eslint-community/eslint-plugin-eslint-plugin/blob/main/docs/rules/prefer-message-ids.md"
 			}
-		],
-		"flint": {
-			"name": "deprecatedMessageStrings",
-			"plugin": "flint",
-			"status": "skipped"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "deprecatedReplacedBy",
+			"plugin": "flint",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "eslint-plugin/no-meta-replaced-by",
 				"url": "https://github.com/eslint-community/eslint-plugin-eslint-plugin/blob/main/docs/rules/no-meta-replaced-by.md"
 			}
-		],
-		"flint": {
-			"name": "deprecatedReplacedBy",
-			"plugin": "flint",
-			"status": "skipped"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "deprecatedReportAPIs",
+			"plugin": "flint",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "eslint-plugin/no-deprecated-report-api",
 				"url": "https://github.com/eslint-community/eslint-plugin-eslint-plugin/blob/main/docs/rules/no-deprecated-report-api.md"
 			}
-		],
-		"flint": {
-			"name": "deprecatedReportAPIs",
-			"plugin": "flint",
-			"status": "skipped"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "deprecatedRuleFunctions",
+			"plugin": "flint",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "eslint-plugin/prefer-object-rule",
 				"url": "https://github.com/eslint-community/eslint-plugin-eslint-plugin/blob/main/docs/rules/prefer-object-rule.md"
 			}
-		],
-		"flint": {
-			"name": "deprecatedRuleFunctions",
-			"plugin": "flint",
-			"status": "skipped"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "deprecatedSchemaDefaults",
+			"plugin": "flint",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "eslint-plugin/no-meta-schema-default",
 				"url": "https://github.com/eslint-community/eslint-plugin-eslint-plugin/blob/main/docs/rules/no-meta-schema-default.md"
 			}
-		],
-		"flint": {
-			"name": "deprecatedSchemaDefaults",
-			"plugin": "flint",
-			"status": "skipped"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "deprecatedTextReplacements",
+			"plugin": "flint",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "eslint-plugin/prefer-replace-text",
 				"url": "https://github.com/eslint-community/eslint-plugin-eslint-plugin/blob/main/docs/rules/prefer-replace-text.md"
 			}
-		],
-		"flint": {
-			"name": "deprecatedTextReplacements",
-			"plugin": "flint",
-			"status": "skipped"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "fixerReturns",
+			"plugin": "flint",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "eslint-plugin/fixer-return",
 				"url": "https://github.com/eslint-community/eslint-plugin-eslint-plugin/blob/main/docs/rules/fixer-return.md"
 			}
-		],
-		"flint": {
-			"name": "fixerReturns",
-			"plugin": "flint",
-			"status": "skipped"
-		}
+		]
 	},
 	{
 		"flint": {
@@ -3688,72 +3688,72 @@
 		}
 	},
 	{
+		"flint": {
+			"name": "messageIdMismatches",
+			"plugin": "flint",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "eslint-plugin/no-missing-message-ids",
 				"url": "https://github.com/eslint-community/eslint-plugin-eslint-plugin/blob/main/docs/rules/no-missing-message-ids.md"
 			}
-		],
-		"flint": {
-			"name": "messageIdMismatches",
-			"plugin": "flint",
-			"status": "skipped"
-		}
+		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "eslint-plugin/report-message-format",
-				"url": "https://github.com/eslint-community/eslint-plugin-eslint-plugin/blob/main/docs/rules/report-message-format.md"
-			}
-		],
 		"flint": {
 			"name": "messagePhrases",
 			"plugin": "flint",
 			"preset": "logical",
 			"strictness": "strict"
-		}
-	},
-	{
+		},
 		"eslint": [
 			{
-				"name": "eslint-plugin/no-missing-placeholders",
-				"url": "https://github.com/eslint-community/eslint-plugin-eslint-plugin/blob/main/docs/rules/no-missing-placeholders.md"
+				"name": "eslint-plugin/report-message-format",
+				"url": "https://github.com/eslint-community/eslint-plugin-eslint-plugin/blob/main/docs/rules/report-message-format.md"
 			}
-		],
+		]
+	},
+	{
 		"flint": {
 			"name": "missingPlaceholders",
 			"plugin": "flint",
 			"preset": "logical",
 			"status": "implemented"
-		}
-	},
-	{
+		},
 		"eslint": [
 			{
-				"name": "eslint-plugin/no-property-in-node",
-				"url": "https://github.com/eslint-community/eslint-plugin-eslint-plugin/blob/main/docs/rules/no-property-in-node.md"
+				"name": "eslint-plugin/no-missing-placeholders",
+				"url": "https://github.com/eslint-community/eslint-plugin-eslint-plugin/blob/main/docs/rules/no-missing-placeholders.md"
 			}
-		],
+		]
+	},
+	{
 		"flint": {
 			"name": "nodePropertyInChecks",
 			"plugin": "flint",
 			"preset": "logical",
 			"status": "implemented"
-		}
+		},
+		"eslint": [
+			{
+				"name": "eslint-plugin/no-property-in-node",
+				"url": "https://github.com/eslint-community/eslint-plugin-eslint-plugin/blob/main/docs/rules/no-property-in-node.md"
+			}
+		]
 	},
 	{
+		"flint": {
+			"name": "optionDefaults",
+			"plugin": "flint",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "eslint-plugin/require-meta-default-options",
 				"url": "https://github.com/eslint-community/eslint-plugin-eslint-plugin/blob/main/docs/rules/require-meta-default-options.md"
 			}
-		],
-		"flint": {
-			"name": "optionDefaults",
-			"plugin": "flint",
-			"status": "skipped"
-		}
+		]
 	},
 	{
 		"flint": {
@@ -3765,30 +3765,30 @@
 		}
 	},
 	{
+		"flint": {
+			"name": "propertyOrdering",
+			"plugin": "flint",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "eslint-plugin/meta-property-ordering",
 				"url": "https://github.com/eslint-community/eslint-plugin-eslint-plugin/blob/main/docs/rules/meta-property-ordering.md"
 			}
-		],
-		"flint": {
-			"name": "propertyOrdering",
-			"plugin": "flint",
-			"status": "skipped"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "ruleAboutChangers",
+			"plugin": "flint",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "eslint-plugin/require-meta-fixable",
 				"url": "https://github.com/eslint-community/eslint-plugin-eslint-plugin/blob/main/docs/rules/require-meta-fixable.md"
 			}
-		],
-		"flint": {
-			"name": "ruleAboutChangers",
-			"plugin": "flint",
-			"status": "skipped"
-		}
+		]
 	},
 	{
 		"flint": {
@@ -3799,84 +3799,84 @@
 		}
 	},
 	{
+		"flint": {
+			"name": "ruleDescriptions",
+			"plugin": "flint",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "eslint-plugin/require-meta-docs-description",
 				"url": "https://github.com/eslint-community/eslint-plugin-eslint-plugin/blob/main/docs/rules/require-meta-docs-description.md"
 			}
-		],
-		"flint": {
-			"name": "ruleDescriptions",
-			"plugin": "flint",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "rulePresets",
+			"plugin": "flint",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "eslint-plugin/require-meta-docs-recommended",
 				"url": "https://github.com/eslint-community/eslint-plugin-eslint-plugin/blob/main/docs/rules/require-meta-docs-recommended"
 			}
-		],
-		"flint": {
-			"name": "rulePresets",
-			"plugin": "flint",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "ruleURLs",
+			"plugin": "flint",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "eslint-plugin/require-meta-docs-url",
 				"url": "https://github.com/eslint-community/eslint-plugin-eslint-plugin/blob/main/docs/rules/require-meta-docs-url.md"
 			}
-		],
-		"flint": {
-			"name": "ruleURLs",
-			"plugin": "flint",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "suggestionMessageIdMatches",
+			"plugin": "flint",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "eslint-plugin/no-matching-violation-suggest-message-ids",
 				"url": "https://github.com/eslint-community/eslint-plugin-eslint-plugin/tree/HEAD/docs/rules/no-matching-violation-suggest-message-ids.md"
 			}
-		],
-		"flint": {
-			"name": "suggestionMessageIdMatches",
-			"plugin": "flint",
-			"preset": "logical"
-		}
+		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "eslint-plugin/no-identical-tests",
-				"url": "https://github.com/eslint-community/eslint-plugin-eslint-plugin/blob/main/docs/rules/no-identical-tests.md"
-			}
-		],
 		"flint": {
 			"name": "testCaseDuplicates",
 			"plugin": "flint",
 			"preset": "logical",
 			"status": "implemented"
-		}
-	},
-	{
+		},
 		"eslint": [
 			{
-				"name": "eslint-plugin/unique-test-case-names",
-				"url": "https://github.com/eslint-community/eslint-plugin-eslint-plugin/blob/main/docs/rules/unique-test-case-names.md"
+				"name": "eslint-plugin/no-identical-tests",
+				"url": "https://github.com/eslint-community/eslint-plugin-eslint-plugin/blob/main/docs/rules/no-identical-tests.md"
 			}
-		],
+		]
+	},
+	{
 		"flint": {
 			"name": "testCaseNameDuplicates",
 			"plugin": "flint",
 			"preset": "logical",
 			"status": "implemented"
-		}
+		},
+		"eslint": [
+			{
+				"name": "eslint-plugin/unique-test-case-names",
+				"url": "https://github.com/eslint-community/eslint-plugin-eslint-plugin/blob/main/docs/rules/unique-test-case-names.md"
+			}
+		]
 	},
 	{
 		"flint": {
@@ -3887,332 +3887,332 @@
 		}
 	},
 	{
-		"eslint": [
-			{
-				"name": "eslint-plugin/no-only-tests",
-				"url": "https://github.com/eslint-community/eslint-plugin-eslint-plugin/blob/main/docs/rules/no-only-tests.md"
-			}
-		],
 		"flint": {
 			"name": "testCaseOnlyFlags",
 			"plugin": "flint",
 			"preset": "logical",
 			"status": "implemented"
-		}
+		},
+		"eslint": [
+			{
+				"name": "eslint-plugin/no-only-tests",
+				"url": "https://github.com/eslint-community/eslint-plugin-eslint-plugin/blob/main/docs/rules/no-only-tests.md"
+			}
+		]
 	},
 	{
+		"flint": {
+			"name": "testNames",
+			"plugin": "flint",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "eslint-plugin/require-test-case-name",
 				"url": "https://github.com/eslint-community/eslint-plugin-eslint-plugin/blob/main/docs/rules/require-test-case-name.md"
 			}
-		],
-		"flint": {
-			"name": "testNames",
-			"plugin": "flint",
-			"status": "skipped"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "testOutputNulls",
+			"plugin": "flint",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "eslint-plugin/prefer-output-null",
 				"url": "https://github.com/eslint-community/eslint-plugin-eslint-plugin/blob/main/docs/rules/prefer-output-null.md"
 			}
-		],
-		"flint": {
-			"name": "testOutputNulls",
-			"plugin": "flint",
-			"status": "skipped"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "testOutputs",
+			"plugin": "flint",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "eslint-plugin/consistent-output",
 				"url": "https://github.com/eslint-community/eslint-plugin-eslint-plugin/blob/main/docs/rules/consistent-output.md"
 			}
-		],
-		"flint": {
-			"name": "testOutputs",
-			"plugin": "flint",
-			"status": "skipped"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "testPropertyOrders",
+			"plugin": "flint",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "eslint-plugin/test-case-property-ordering",
 				"url": "https://github.com/eslint-community/eslint-plugin-eslint-plugin/blob/main/docs/rules/test-case-property-ordering.md"
 			}
-		],
-		"flint": {
-			"name": "testPropertyOrders",
-			"plugin": "flint",
-			"status": "skipped"
-		}
+		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "eslint-plugin/test-case-shorthand-strings",
-				"url": "https://github.com/eslint-community/eslint-plugin-eslint-plugin/blob/main/docs/rules/test-case-shorthand-strings.md"
-			}
-		],
 		"flint": {
 			"name": "testShorthands",
 			"plugin": "flint",
 			"preset": "stylistic",
 			"status": "implemented"
-		}
+		},
+		"eslint": [
+			{
+				"name": "eslint-plugin/test-case-shorthand-strings",
+				"url": "https://github.com/eslint-community/eslint-plugin-eslint-plugin/blob/main/docs/rules/test-case-shorthand-strings.md"
+			}
+		]
 	},
 	{
+		"flint": {
+			"name": "unnecessaryTokenRanges",
+			"plugin": "flint",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "eslint-plugin/no-useless-token-range",
 				"url": "https://github.com/eslint-community/eslint-plugin-eslint-plugin/blob/main/docs/rules/no-useless-token-range.md"
 			}
-		],
-		"flint": {
-			"name": "unnecessaryTokenRanges",
-			"plugin": "flint",
-			"status": "skipped"
-		}
+		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "eslint-plugin/no-unused-message-ids",
-				"url": "https://github.com/eslint-community/eslint-plugin-eslint-plugin/blob/main/docs/rules/no-unused-message-ids.md"
-			}
-		],
 		"flint": {
 			"name": "unusedMessageIds",
 			"plugin": "flint",
 			"preset": "logical",
 			"status": "implemented"
-		}
+		},
+		"eslint": [
+			{
+				"name": "eslint-plugin/no-unused-message-ids",
+				"url": "https://github.com/eslint-community/eslint-plugin-eslint-plugin/blob/main/docs/rules/no-unused-message-ids.md"
+			}
+		]
 	},
 	{
+		"flint": {
+			"name": "unusedPlaceholders",
+			"plugin": "flint",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "eslint-plugin/no-unused-placeholders",
 				"url": "https://github.com/eslint-community/eslint-plugin-eslint-plugin/blob/main/docs/rules/no-unused-placeholders.md"
 			}
-		],
-		"flint": {
-			"name": "unusedPlaceholders",
-			"plugin": "flint",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "anonymousOperations",
+			"plugin": "graphql",
+			"status": "skipped"
+		},
 		"biome": [
 			{
 				"name": "useLoneAnonymousOperation",
 				"url": "https://biomejs.dev/linter/rules/use-lone-anonymous-operation"
 			}
-		],
-		"flint": {
-			"name": "anonymousOperations",
-			"plugin": "graphql",
-			"status": "skipped"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "argumentNameDuplicates",
+			"plugin": "graphql",
+			"status": "skipped"
+		},
 		"biome": [
 			{
 				"name": "noDuplicateArgumentNames",
 				"url": "https://biomejs.dev/linter/rules/no-duplicate-argument-names"
 			}
-		],
-		"flint": {
-			"name": "argumentNameDuplicates",
-			"plugin": "graphql",
-			"status": "skipped"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "deprecatedDates",
+			"plugin": "graphql",
+			"status": "skipped"
+		},
 		"biome": [
 			{
 				"name": "useDeprecatedDate",
 				"url": "https://biomejs.dev/linter/rules/use-deprecated-date"
 			}
-		],
-		"flint": {
-			"name": "deprecatedDates",
-			"plugin": "graphql",
-			"status": "skipped"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "deprecatedReasons",
+			"plugin": "graphql",
+			"status": "skipped"
+		},
 		"biome": [
 			{
 				"name": "useDeprecatedReason",
 				"url": "https://biomejs.dev/linter/rules/use-deprecated-reason"
 			}
-		],
-		"flint": {
-			"name": "deprecatedReasons",
-			"plugin": "graphql",
-			"status": "skipped"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "descriptionStyles",
+			"plugin": "graphql",
+			"status": "skipped"
+		},
 		"biome": [
 			{
 				"name": "useConsistentGraphqlDescriptions",
 				"url": "https://biomejs.dev/linter/rules/use-consistent-graphql-descriptions"
 			}
-		],
-		"flint": {
-			"name": "descriptionStyles",
-			"plugin": "graphql",
-			"status": "skipped"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "enumValueNameDuplicates",
+			"plugin": "graphql",
+			"status": "skipped"
+		},
 		"biome": [
 			{
 				"name": "noDuplicateEnumValueNames",
 				"url": "https://biomejs.dev/linter/rules/no-duplicate-enum-value-names"
 			}
-		],
-		"flint": {
-			"name": "enumValueNameDuplicates",
-			"plugin": "graphql",
-			"status": "skipped"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "executableDefinitionLocations",
+			"plugin": "graphql",
+			"status": "skipped"
+		},
 		"biome": [
 			{
 				"name": "useLoneExecutableDefinition",
 				"url": "https://biomejs.dev/linter/rules/use-lone-executable-definition"
 			}
-		],
-		"flint": {
-			"name": "executableDefinitionLocations",
-			"plugin": "graphql",
-			"status": "skipped"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "fieldDefinitionNameDuplicates",
+			"plugin": "graphql",
+			"status": "skipped"
+		},
 		"biome": [
 			{
 				"name": "noDuplicateFieldDefinitionNames",
 				"url": "https://biomejs.dev/linter/rules/no-duplicate-field-definition-names"
 			}
-		],
-		"flint": {
-			"name": "fieldDefinitionNameDuplicates",
-			"plugin": "graphql",
-			"status": "skipped"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "fieldDuplicates",
+			"plugin": "graphql",
+			"status": "skipped"
+		},
 		"biome": [
 			{
 				"name": "noDuplicateFields",
 				"url": "https://biomejs.dev/linter/rules/no-duplicate-fields"
 			}
-		],
-		"flint": {
-			"name": "fieldDuplicates",
-			"plugin": "graphql",
-			"status": "skipped"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "inputFieldNameDuplicates",
+			"plugin": "graphql",
+			"status": "skipped"
+		},
 		"biome": [
 			{
 				"name": "noDuplicateInputFieldNames",
 				"url": "https://biomejs.dev/linter/rules/no-duplicate-input-field-names"
 			}
-		],
-		"flint": {
-			"name": "inputFieldNameDuplicates",
-			"plugin": "graphql",
-			"status": "skipped"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "inputNames",
+			"plugin": "graphql",
+			"status": "skipped"
+		},
 		"biome": [
 			{
 				"name": "useInputName",
 				"url": "https://biomejs.dev/linter/rules/use-input-name"
 			}
-		],
-		"flint": {
-			"name": "inputNames",
-			"plugin": "graphql",
-			"status": "skipped"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "namedOperations",
+			"plugin": "graphql",
+			"status": "skipped"
+		},
 		"biome": [
 			{
 				"name": "useGraphqlNamedOperations",
 				"url": "https://biomejs.dev/linter/rules/use-graphql-named-operations"
 			}
-		],
-		"flint": {
-			"name": "namedOperations",
-			"plugin": "graphql",
-			"status": "skipped"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "namingConventions",
+			"plugin": "graphql",
+			"status": "skipped"
+		},
 		"biome": [
 			{
 				"name": "useGraphqlNamingConvention",
 				"url": "https://biomejs.dev/linter/rules/use-graphql-naming-convention"
 			}
-		],
-		"flint": {
-			"name": "namingConventions",
-			"plugin": "graphql",
-			"status": "skipped"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "operationNameDuplicates",
+			"plugin": "graphql",
+			"status": "skipped"
+		},
 		"biome": [
 			{
 				"name": "noDuplicateGraphqlOperationName",
 				"url": "https://biomejs.dev/linter/rules/no-duplicate-graphql-operation-name"
 			}
-		],
-		"flint": {
-			"name": "operationNameDuplicates",
-			"plugin": "graphql",
-			"status": "skipped"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "rootTypes",
+			"plugin": "graphql",
+			"status": "skipped"
+		},
 		"biome": [
 			{
 				"name": "noRootType",
 				"url": "https://biomejs.dev/linter/rules/no-root-type"
 			}
-		],
-		"flint": {
-			"name": "rootTypes",
-			"plugin": "graphql",
-			"status": "skipped"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "variableNameDuplicates",
+			"plugin": "graphql",
+			"status": "skipped"
+		},
 		"biome": [
 			{
 				"name": "noDuplicateVariableNames",
 				"url": "https://biomejs.dev/linter/rules/no-duplicate-variable-names"
 			}
-		],
-		"flint": {
-			"name": "variableNameDuplicates",
-			"plugin": "graphql",
-			"status": "skipped"
-		}
+		]
 	},
 	{
 		"flint": {
@@ -4995,255 +4995,260 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "arrayBracketNewlines",
+			"plugin": "json",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "jsonc/array-bracket-newline",
 				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/array-bracket-newline.html"
 			}
 		],
-		"flint": {
-			"name": "arrayBracketNewlines",
-			"plugin": "json",
-			"status": "skipped"
-		},
 		"notes": "Formatting rule."
 	},
 	{
+		"flint": {
+			"name": "arrayBracketSpaces",
+			"plugin": "json",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "jsonc/array-bracket-spacing",
 				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/array-bracket-spacing.html"
 			}
 		],
-		"flint": {
-			"name": "arrayBracketSpaces",
-			"plugin": "json",
-			"status": "skipped"
-		},
 		"notes": "Formatting rule."
 	},
 	{
+		"flint": {
+			"name": "arrayElementNewlines",
+			"plugin": "json",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "jsonc/array-element-newline",
 				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/array-element-newline.html"
 			}
 		],
-		"flint": {
-			"name": "arrayElementNewlines",
-			"plugin": "json",
-			"status": "skipped"
-		},
 		"notes": "Formatting rule."
 	},
 	{
+		"flint": {
+			"name": "arrayElementsSorting",
+			"plugin": "json",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "jsonc/sort-array-values",
 				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/sort-array-values.html"
 			}
-		],
-		"flint": {
-			"name": "arrayElementsSorting",
-			"plugin": "json",
-			"status": "skipped"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "automaticJsoncRules",
+			"plugin": "json",
+			"preset": "config"
+		},
 		"eslint": [
 			{
 				"name": "jsonc/auto",
 				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/auto.html"
 			}
-		],
-		"flint": {
-			"name": "automaticJsoncRules",
-			"plugin": "json",
-			"preset": "config"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "bigintLiterals",
+			"plugin": "json",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "jsonc/no-bigint-literals",
 				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/no-bigint-literals.html"
 			}
 		],
-		"flint": {
-			"name": "bigintLiterals",
-			"plugin": "json",
-			"status": "skipped"
-		},
 		"notes": "Generally handled by parsers."
 	},
 	{
+		"flint": {
+			"name": "binaryExpressions",
+			"plugin": "json",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "jsonc/no-binary-expression",
 				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/no-binary-expression.html"
 			}
 		],
-		"flint": {
-			"name": "binaryExpressions",
-			"plugin": "json",
-			"status": "skipped"
-		},
 		"notes": "Generally handled by parsers."
 	},
 	{
+		"flint": {
+			"name": "binaryNumericLiterals",
+			"plugin": "json",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "jsonc/no-binary-numeric-literals",
 				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/no-binary-numeric-literals.html"
 			}
 		],
-		"flint": {
-			"name": "binaryNumericLiterals",
-			"plugin": "json",
-			"status": "skipped"
-		},
 		"notes": "Generally handled by parsers."
 	},
 	{
+		"flint": {
+			"name": "commaStyles",
+			"plugin": "json",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "jsonc/comma-style",
 				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/comma-style.html"
 			}
 		],
-		"flint": {
-			"name": "commaStyles",
-			"plugin": "json",
-			"status": "skipped"
-		},
 		"notes": "Formatting rule."
 	},
 	{
+		"flint": {
+			"name": "comments",
+			"plugin": "json",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "jsonc/no-comments",
 				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/no-comments.html"
 			}
 		],
-		"flint": {
-			"name": "comments",
-			"plugin": "json",
-			"status": "skipped"
-		},
 		"notes": "Generally handled by parsers."
 	},
 	{
+		"flint": {
+			"name": "duplicateKeys",
+			"plugin": "json",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "json/no-duplicate-keys",
 				"url": "https://github.com/eslint/json/tree/main/docs/rules/no-duplicate-keys.md"
 			}
-		],
-		"flint": {
-			"name": "duplicateKeys",
-			"plugin": "json",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "floatingDecimals",
+			"plugin": "json",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "jsonc/no-floating-decimal",
 				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/no-floating-decimal.html"
 			}
 		],
-		"flint": {
-			"name": "floatingDecimals",
-			"plugin": "json",
-			"status": "skipped"
-		},
 		"notes": "Generally handled by parsers."
 	},
 	{
+		"flint": {
+			"name": "hexadecimalNumericLiterals",
+			"plugin": "json",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "jsonc/no-hexadecimal-numeric-literals",
 				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/no-hexadecimal-numeric-literals.html"
 			}
 		],
-		"flint": {
-			"name": "hexadecimalNumericLiterals",
-			"plugin": "json",
-			"status": "skipped"
-		},
 		"notes": "Generally handled by parsers."
 	},
 	{
+		"flint": {
+			"name": "identifierEscapeSequences",
+			"plugin": "json",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "jsonc/no-escape-sequence-in-identifier",
 				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/no-escape-sequence-in-identifier.html"
 			}
 		],
-		"flint": {
-			"name": "identifierEscapeSequences",
-			"plugin": "json",
-			"status": "skipped"
-		},
 		"notes": "Generally handled by parsers."
 	},
 	{
+		"flint": {
+			"name": "identifierNumbers",
+			"plugin": "json",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "jsonc/no-number-props",
 				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/no-number-props.html"
 			}
 		],
-		"flint": {
-			"name": "identifierNumbers",
-			"plugin": "json",
-			"status": "skipped"
-		},
 		"notes": "Generally handled by parsers."
 	},
 	{
+		"flint": {
+			"name": "indentation",
+			"plugin": "json",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "jsonc/indent",
 				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/indent.html"
 			}
 		],
-		"flint": {
-			"name": "indentation",
-			"plugin": "json",
-			"status": "skipped"
-		},
 		"notes": "Formatting rule."
 	},
 	{
+		"flint": {
+			"name": "infinity",
+			"plugin": "json",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "jsonc/no-infinity",
 				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/no-infinity.html"
 			}
 		],
-		"flint": {
-			"name": "infinity",
-			"plugin": "json",
-			"status": "skipped"
-		},
 		"notes": "Generally handled by parsers."
 	},
 	{
+		"flint": {
+			"name": "irregularWhitespace",
+			"plugin": "json",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "jsonc/no-irregular-whitespace",
 				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/no-irregular-whitespace.html"
 			}
 		],
-		"flint": {
-			"name": "irregularWhitespace",
-			"plugin": "json",
-			"status": "skipped"
-		},
 		"notes": "Formatting rule."
 	},
 	{
+		"flint": {
+			"name": "jsonKeysOrder",
+			"plugin": "json",
+			"preset": "sorting"
+		},
 		"eslint": [
 			{
 				"name": "json/sort-keys",
@@ -5253,27 +5258,27 @@
 				"name": "jsonc/sort-keys",
 				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/sort-keys.html"
 			}
-		],
-		"flint": {
-			"name": "jsonKeysOrder",
-			"plugin": "json",
-			"preset": "sorting"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "keyCasing",
+			"plugin": "json",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "jsonc/key-name-casing",
 				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/key-name-casing.html"
 			}
-		],
-		"flint": {
-			"name": "keyCasing",
-			"plugin": "json",
-			"status": "skipped"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "keyContents",
+			"plugin": "json",
+			"status": "skipped"
+		},
 		"biome": [
 			{
 				"name": "noEmptyObjectKeys",
@@ -5285,14 +5290,15 @@
 				"name": "json/no-empty-keys",
 				"url": "https://github.com/eslint/json/blob/HEAD/docs/rules/no-empty-keys.md"
 			}
-		],
-		"flint": {
-			"name": "keyContents",
-			"plugin": "json",
-			"status": "skipped"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "keyDuplicates",
+			"plugin": "json",
+			"preset": "logical",
+			"status": "implemented"
+		},
 		"deno": [
 			{
 				"name": "no-dupe-keys",
@@ -5304,291 +5310,290 @@
 				"name": "jsonc/no-dupe-keys",
 				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/no-dupe-keys.html"
 			}
-		],
-		"flint": {
-			"name": "keyDuplicates",
-			"plugin": "json",
-			"preset": "logical",
-			"status": "implemented"
-		}
+		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "json/no-unnormalized-keys",
-				"url": "https://github.com/eslint/json/blob/HEAD/docs/rules/no-unnormalized-keys.md"
-			}
-		],
 		"flint": {
 			"name": "keyNormalization",
 			"plugin": "json",
 			"preset": "logical",
 			"status": "implemented"
-		}
+		},
+		"eslint": [
+			{
+				"name": "json/no-unnormalized-keys",
+				"url": "https://github.com/eslint/json/blob/HEAD/docs/rules/no-unnormalized-keys.md"
+			}
+		]
 	},
 	{
+		"flint": {
+			"name": "keySpaces",
+			"plugin": "json",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "jsonc/key-spacing",
 				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/key-spacing.html"
 			}
 		],
-		"flint": {
-			"name": "keySpaces",
-			"plugin": "json",
-			"status": "skipped"
-		},
 		"notes": "Formatting rule."
 	},
 	{
+		"flint": {
+			"name": "legacyOctalLiterals",
+			"plugin": "json",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "jsonc/no-octal",
 				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/no-octal.html"
 			}
-		],
-		"flint": {
-			"name": "legacyOctalLiterals",
-			"plugin": "json",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "multilineStrings",
+			"plugin": "json",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "jsonc/no-multi-str",
 				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/no-multi-str.html"
 			}
-		],
-		"flint": {
-			"name": "multilineStrings",
-			"plugin": "json",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "nan",
+			"plugin": "json",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "jsonc/no-nan",
 				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/no-nan.html"
 			}
 		],
-		"flint": {
-			"name": "nan",
-			"plugin": "json",
-			"status": "skipped"
-		},
 		"notes": "Generally handled by parsers."
 	},
 	{
+		"flint": {
+			"name": "numbers",
+			"plugin": "json",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "jsonc/valid-json-number",
 				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/valid-json-number.html"
 			}
 		],
-		"flint": {
-			"name": "numbers",
-			"plugin": "json",
-			"status": "skipped"
-		},
 		"notes": "Generally handled by parsers."
 	},
 	{
+		"flint": {
+			"name": "numericSeparators",
+			"plugin": "json",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "jsonc/no-numeric-separators",
 				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/no-numeric-separators.html"
 			}
 		],
-		"flint": {
-			"name": "numericSeparators",
-			"plugin": "json",
-			"status": "skipped"
-		},
 		"notes": "Generally handled by parsers."
 	},
 	{
+		"flint": {
+			"name": "objectCurlyNewlines",
+			"plugin": "json",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "jsonc/object-curly-newline",
 				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/object-curly-newline.html"
 			}
 		],
-		"flint": {
-			"name": "objectCurlyNewlines",
-			"plugin": "json",
-			"status": "skipped"
-		},
 		"notes": "Formatting rule."
 	},
 	{
+		"flint": {
+			"name": "objectCurlySpaces",
+			"plugin": "json",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "jsonc/object-curly-spacing",
 				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/object-curly-spacing.html"
 			}
 		],
-		"flint": {
-			"name": "objectCurlySpaces",
-			"plugin": "json",
-			"status": "skipped"
-		},
 		"notes": "Formatting rule."
 	},
 	{
+		"flint": {
+			"name": "objectPropertyNewlines",
+			"plugin": "json",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "jsonc/object-property-newline",
 				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/object-property-newline.html"
 			}
 		],
-		"flint": {
-			"name": "objectPropertyNewlines",
-			"plugin": "json",
-			"status": "skipped"
-		},
 		"notes": "Formatting rule."
 	},
 	{
-		"eslint": [
-			{
-				"name": "jsonc/no-octal-escape",
-				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/no-octal-escape.html"
-			}
-		],
 		"flint": {
 			"name": "octalEscapeSequences",
 			"plugin": "json",
 			"status": "skipped"
 		},
-		"notes": "Generally handled by parsers."
-	},
-	{
 		"eslint": [
 			{
 				"name": "jsonc/no-octal-escape",
 				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/no-octal-escape.html"
 			}
 		],
+		"notes": "Generally handled by parsers."
+	},
+	{
 		"flint": {
 			"name": "octalLiterals",
 			"plugin": "json",
 			"status": "skipped"
 		},
+		"eslint": [
+			{
+				"name": "jsonc/no-octal-escape",
+				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/no-octal-escape.html"
+			}
+		],
 		"notes": "Generally handled by parsers."
 	},
 	{
+		"flint": {
+			"name": "octalNumericLiterals",
+			"plugin": "json",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "jsonc/no-octal-numeric-literals",
 				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/no-octal-numeric-literals.html"
 			}
 		],
-		"flint": {
-			"name": "octalNumericLiterals",
-			"plugin": "json",
-			"status": "skipped"
-		},
 		"notes": "Generally handled by parsers."
 	},
 	{
+		"flint": {
+			"name": "parentheses",
+			"plugin": "json",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "jsonc/no-parenthesized",
 				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/no-parenthesized.html"
 			}
 		],
-		"flint": {
-			"name": "parentheses",
-			"plugin": "json",
-			"status": "skipped"
-		},
 		"notes": "Generally handled by parsers."
 	},
 	{
+		"flint": {
+			"name": "plusOperators",
+			"plugin": "json",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "jsonc/no-plus-sign",
 				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/no-plus-sign.html"
 			}
 		],
-		"flint": {
-			"name": "plusOperators",
-			"plugin": "json",
-			"status": "skipped"
-		},
 		"notes": "Generally handled by parsers."
 	},
 	{
+		"flint": {
+			"name": "propertyQuotes",
+			"plugin": "json",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "jsonc/quote-props",
 				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/quote-props.html"
 			}
 		],
-		"flint": {
-			"name": "propertyQuotes",
-			"plugin": "json",
-			"status": "skipped"
-		},
 		"notes": "Formatting rule."
 	},
 	{
+		"flint": {
+			"name": "regexLiterals",
+			"plugin": "json",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "jsonc/no-regexp-literals",
 				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/no-regexp-literals.html"
 			}
-		],
-		"flint": {
-			"name": "regexLiterals",
-			"plugin": "json",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "sparseArrays",
+			"plugin": "json",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "jsonc/no-sparse-arrays",
 				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/no-sparse-arrays.html"
 			}
-		],
-		"flint": {
-			"name": "sparseArrays",
-			"plugin": "json",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "stringQuotes",
+			"plugin": "json",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "jsonc/quotes",
 				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/quotes.html"
 			}
 		],
-		"flint": {
-			"name": "stringQuotes",
-			"plugin": "json",
-			"status": "skipped"
-		},
 		"notes": "Formatting rule."
 	},
 	{
+		"flint": {
+			"name": "templateLiterals",
+			"plugin": "json",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "jsonc/no-template-literals",
 				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/no-template-literals.html"
 			}
 		],
-		"flint": {
-			"name": "templateLiterals",
-			"plugin": "json",
-			"status": "skipped"
-		},
 		"notes": "Generally handled by parsers."
 	},
 	{
+		"flint": {
+			"name": "topLevelInteroperability",
+			"plugin": "json",
+			"status": "skipped"
+		},
 		"biome": [
 			{
 				"name": "noTopLevelLiterals",
@@ -5600,124 +5605,125 @@
 				"name": "json/top-level-interop",
 				"url": "https://github.com/eslint/json/blob/HEAD/docs/rules/top-level-interop.md"
 			}
-		],
-		"flint": {
-			"name": "topLevelInteroperability",
-			"plugin": "json",
-			"status": "skipped"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "trailingCommas",
+			"plugin": "json",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "jsonc/comma-dangle",
 				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/comma-dangle.html"
 			}
 		],
-		"flint": {
-			"name": "trailingCommas",
-			"plugin": "json",
-			"status": "skipped"
-		},
 		"notes": "Formatting rule."
 	},
 	{
+		"flint": {
+			"name": "unaryOperatorSpaces",
+			"plugin": "json",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "jsonc/space-unary-ops",
 				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/space-unary-ops.html"
 			}
 		],
-		"flint": {
-			"name": "unaryOperatorSpaces",
-			"plugin": "json",
-			"status": "skipped"
-		},
 		"notes": "Formatting rule."
 	},
 	{
+		"flint": {
+			"name": "undefined",
+			"plugin": "json",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "jsonc/no-undefined-value",
 				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/no-undefined-value.html"
 			}
 		],
-		"flint": {
-			"name": "undefined",
-			"plugin": "json",
-			"status": "skipped"
-		},
 		"notes": "Generally handled by parsers."
 	},
 	{
+		"flint": {
+			"name": "unicodeCodepointEscapes",
+			"plugin": "json",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "jsonc/no-unicode-codepoint-escapes",
 				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/no-unicode-codepoint-escapes.html"
 			}
 		],
-		"flint": {
-			"name": "unicodeCodepointEscapes",
-			"plugin": "json",
-			"status": "skipped"
-		},
 		"notes": "Generally handled by parsers."
 	},
 	{
+		"flint": {
+			"name": "unnecessaryEscapes",
+			"plugin": "json",
+			"preset": "stylistic"
+		},
 		"eslint": [
 			{
 				"name": "jsonc/no-useless-escape",
 				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/no-useless-escape.html"
 			}
-		],
-		"flint": {
-			"name": "unnecessaryEscapes",
-			"plugin": "json",
-			"preset": "stylistic"
-		}
+		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "json/no-unsafe-values",
-				"url": "https://github.com/eslint/json/blob/HEAD/docs/rules/no-unsafe-values.md"
-			}
-		],
 		"flint": {
 			"name": "valueSafety",
 			"plugin": "json",
 			"preset": "logical",
 			"status": "implemented"
-		}
+		},
+		"eslint": [
+			{
+				"name": "json/no-unsafe-values",
+				"url": "https://github.com/eslint/json/blob/HEAD/docs/rules/no-unsafe-values.md"
+			}
+		]
 	},
 	{
+		"flint": {
+			"name": "vueCustomBlockParsingErrors",
+			"plugin": "json",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "jsonc/vue-custom-block/no-parsing-error",
 				"url": "https://ota-meshi.github.io/eslint-plugin-jsonc/rules/vue-custom-block/no-parsing-error.html"
 			}
-		],
-		"flint": {
-			"name": "vueCustomBlockParsingErrors",
-			"plugin": "json",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "accessibleEmojis",
+			"plugin": "jsx",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "jsx-a11y/accessible-emoji",
 				"url": "https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/tree/HEAD/docs/rules/accessible-emoji.md"
 			}
 		],
-		"flint": {
-			"name": "accessibleEmojis",
-			"plugin": "jsx",
-			"status": "skipped"
-		},
 		"notes": "Deprecated."
 	},
 	{
+		"flint": {
+			"name": "accessKeys",
+			"plugin": "jsx",
+			"preset": "logical",
+			"status": "implemented"
+		},
 		"biome": [
 			{
 				"name": "noAccessKey",
@@ -5730,12 +5736,6 @@
 				"url": "https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/no-access-key.md"
 			}
 		],
-		"flint": {
-			"name": "accessKeys",
-			"plugin": "jsx",
-			"preset": "logical",
-			"status": "implemented"
-		},
 		"oxlint": [
 			{
 				"name": "jsx-a11y/no-access-key",
@@ -5744,20 +5744,26 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "adjacentInlineElements",
+			"plugin": "jsx",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "react/no-adjacent-inline-elements",
 				"url": "https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-adjacent-inline-elements.md"
 			}
 		],
-		"flint": {
-			"name": "adjacentInlineElements",
-			"plugin": "jsx",
-			"status": "skipped"
-		},
 		"notes": "Overly opinionated."
 	},
 	{
+		"flint": {
+			"name": "altTexts",
+			"plugin": "jsx",
+			"preset": "logical",
+			"status": "implemented"
+		},
 		"biome": [
 			{
 				"name": "useAltText",
@@ -5770,12 +5776,6 @@
 				"url": "https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/alt-text.md"
 			}
 		],
-		"flint": {
-			"name": "altTexts",
-			"plugin": "jsx",
-			"preset": "logical",
-			"status": "implemented"
-		},
 		"oxlint": [
 			{
 				"name": "jsx-a11y/alt-text",
@@ -5784,6 +5784,13 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "anchorAmbiguousText",
+			"plugin": "jsx",
+			"preset": "logical",
+			"status": "implemented",
+			"strictness": "strict"
+		},
 		"biome": [
 			{
 				"name": "noAmbiguousAnchorText",
@@ -5796,13 +5803,6 @@
 				"url": "https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/anchor-ambiguous-text.md"
 			}
 		],
-		"flint": {
-			"name": "anchorAmbiguousText",
-			"plugin": "jsx",
-			"preset": "logical",
-			"status": "implemented",
-			"strictness": "strict"
-		},
 		"oxlint": [
 			{
 				"name": "jsx-a11y/anchor-ambiguous-text",
@@ -5811,6 +5811,12 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "anchorContent",
+			"plugin": "jsx",
+			"preset": "logical",
+			"status": "implemented"
+		},
 		"biome": [
 			{
 				"name": "useAnchorContent",
@@ -5823,12 +5829,6 @@
 				"url": "https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/tree/HEAD/docs/rules/anchor-has-content.md"
 			}
 		],
-		"flint": {
-			"name": "anchorContent",
-			"plugin": "jsx",
-			"preset": "logical",
-			"status": "implemented"
-		},
 		"oxlint": [
 			{
 				"name": "jsx-a11y/anchor-has-content",
@@ -5837,6 +5837,12 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "anchorValidity",
+			"plugin": "jsx",
+			"preset": "logical",
+			"status": "implemented"
+		},
 		"biome": [
 			{
 				"name": "useValidAnchor",
@@ -5849,12 +5855,6 @@
 				"url": "https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/anchor-is-valid.md"
 			}
 		],
-		"flint": {
-			"name": "anchorValidity",
-			"plugin": "jsx",
-			"preset": "logical",
-			"status": "implemented"
-		},
 		"oxlint": [
 			{
 				"name": "jsx-a11y/anchor-is-valid",
@@ -5863,6 +5863,12 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "ariaActiveDescendantTabIndex",
+			"plugin": "jsx",
+			"preset": "logical",
+			"status": "implemented"
+		},
 		"biome": [
 			{
 				"name": "useAriaActivedescendantWithTabindex",
@@ -5875,12 +5881,6 @@
 				"url": "https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/aria-activedescendant-has-tabindex.md"
 			}
 		],
-		"flint": {
-			"name": "ariaActiveDescendantTabIndex",
-			"plugin": "jsx",
-			"preset": "logical",
-			"status": "implemented"
-		},
 		"oxlint": [
 			{
 				"name": "jsx-a11y/aria-activedescendant-has-tabindex",
@@ -5889,6 +5889,13 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "ariaHiddenFocusables",
+			"plugin": "jsx",
+			"preset": "logical",
+			"status": "implemented",
+			"strictness": "strict"
+		},
 		"biome": [
 			{
 				"name": "noAriaHiddenOnFocusable",
@@ -5901,13 +5908,6 @@
 				"url": "https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/no-aria-hidden-on-focusable.md"
 			}
 		],
-		"flint": {
-			"name": "ariaHiddenFocusables",
-			"plugin": "jsx",
-			"preset": "logical",
-			"status": "implemented",
-			"strictness": "strict"
-		},
 		"oxlint": [
 			{
 				"name": "jsx-a11y/no-aria-hidden-on-focusable",
@@ -5916,6 +5916,12 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "ariaProps",
+			"plugin": "jsx",
+			"preset": "logical",
+			"status": "implemented"
+		},
 		"biome": [
 			{
 				"name": "useValidAriaProps",
@@ -5928,12 +5934,6 @@
 				"url": "https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/aria-props.md"
 			}
 		],
-		"flint": {
-			"name": "ariaProps",
-			"plugin": "jsx",
-			"preset": "logical",
-			"status": "implemented"
-		},
 		"oxlint": [
 			{
 				"name": "jsx-a11y/aria-props",
@@ -5942,6 +5942,12 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "ariaPropTypes",
+			"plugin": "jsx",
+			"preset": "logical",
+			"status": "implemented"
+		},
 		"biome": [
 			{
 				"name": "useValidAriaValues",
@@ -5954,12 +5960,6 @@
 				"url": "https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/aria-proptypes.md"
 			}
 		],
-		"flint": {
-			"name": "ariaPropTypes",
-			"plugin": "jsx",
-			"preset": "logical",
-			"status": "implemented"
-		},
 		"oxlint": [
 			{
 				"name": "jsx-a11y/aria-proptypes",
@@ -5968,6 +5968,12 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "ariaRoleValidity",
+			"plugin": "jsx",
+			"preset": "logical",
+			"status": "implemented"
+		},
 		"biome": [
 			{
 				"name": "useValidAriaRole",
@@ -5980,12 +5986,6 @@
 				"url": "https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/aria-role.md"
 			}
 		],
-		"flint": {
-			"name": "ariaRoleValidity",
-			"plugin": "jsx",
-			"preset": "logical",
-			"status": "implemented"
-		},
 		"oxlint": [
 			{
 				"name": "jsx-a11y/aria-role",
@@ -5994,6 +5994,12 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "ariaUnsupportedElements",
+			"plugin": "jsx",
+			"preset": "logical",
+			"status": "implemented"
+		},
 		"biome": [
 			{
 				"name": "noAriaUnsupportedElements",
@@ -6006,12 +6012,6 @@
 				"url": "https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/aria-unsupported-elements.md"
 			}
 		],
-		"flint": {
-			"name": "ariaUnsupportedElements",
-			"plugin": "jsx",
-			"preset": "logical",
-			"status": "implemented"
-		},
 		"oxlint": [
 			{
 				"name": "jsx-a11y/aria-unsupported-elements",
@@ -6020,19 +6020,25 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "attributeValidity",
+			"plugin": "jsx",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "react/no-invalid-html-attribute",
 				"url": "https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-invalid-html-attribute.md"
 			}
-		],
-		"flint": {
-			"name": "attributeValidity",
-			"plugin": "jsx",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "autocomplete",
+			"plugin": "jsx",
+			"preset": "logical",
+			"status": "implemented"
+		},
 		"biome": [
 			{
 				"name": "useValidAutocomplete",
@@ -6045,12 +6051,6 @@
 				"url": "https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/autocomplete-valid.md"
 			}
 		],
-		"flint": {
-			"name": "autocomplete",
-			"plugin": "jsx",
-			"preset": "logical",
-			"status": "implemented"
-		},
 		"oxlint": [
 			{
 				"name": "jsx-a11y/autocomplete-valid",
@@ -6059,6 +6059,12 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "autoFocusProps",
+			"plugin": "jsx",
+			"preset": "logical",
+			"status": "implemented"
+		},
 		"biome": [
 			{
 				"name": "noAutofocus",
@@ -6071,12 +6077,6 @@
 				"url": "https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/no-autofocus.md"
 			}
 		],
-		"flint": {
-			"name": "autoFocusProps",
-			"plugin": "jsx",
-			"preset": "logical",
-			"status": "implemented"
-		},
 		"oxlint": [
 			{
 				"name": "jsx-a11y/no-autofocus",
@@ -6085,20 +6085,26 @@
 		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "react/boolean-prop-naming",
-				"url": "https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/boolean-prop-naming.md"
-			}
-		],
 		"flint": {
 			"name": "booleanPropNames",
 			"plugin": "jsx",
 			"preset": "stylistic",
 			"strictness": "strict"
-		}
+		},
+		"eslint": [
+			{
+				"name": "react/boolean-prop-naming",
+				"url": "https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/boolean-prop-naming.md"
+			}
+		]
 	},
 	{
+		"flint": {
+			"name": "booleanValues",
+			"plugin": "jsx",
+			"preset": "stylistic",
+			"status": "implemented"
+		},
 		"biome": [
 			{
 				"name": "noImplicitBoolean",
@@ -6117,12 +6123,6 @@
 				"url": "https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-boolean-value.md"
 			}
 		],
-		"flint": {
-			"name": "booleanValues",
-			"plugin": "jsx",
-			"preset": "stylistic",
-			"status": "implemented"
-		},
 		"oxlint": [
 			{
 				"name": "react/jsx-boolean-value",
@@ -6131,32 +6131,38 @@
 		]
 	},
 	{
-		"deno": [
-			{
-				"name": "jsx-curly-braces",
-				"url": "https://docs.deno.com/lint/rules/jsx-curly-braces"
-			}
-		],
 		"flint": {
 			"name": "bracedStatements",
 			"plugin": "jsx",
 			"preset": "stylistic",
 			"status": "implemented"
-		}
+		},
+		"deno": [
+			{
+				"name": "jsx-curly-braces",
+				"url": "https://docs.deno.com/lint/rules/jsx-curly-braces"
+			}
+		]
 	},
 	{
+		"flint": {
+			"name": "buttonTypePresence",
+			"plugin": "jsx"
+		},
 		"eslint": [
 			{
 				"name": "@eslint-react/dom-no-missing-button-type",
 				"url": "https://eslint-react.xyz/docs/rules/dom-no-missing-button-type"
 			}
-		],
-		"flint": {
-			"name": "buttonTypePresence",
-			"plugin": "jsx"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "buttonTypes",
+			"plugin": "jsx",
+			"preset": "logical",
+			"status": "implemented"
+		},
 		"biome": [
 			{
 				"name": "useButtonType",
@@ -6179,12 +6185,6 @@
 				"url": "https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/button-has-type.md"
 			}
 		],
-		"flint": {
-			"name": "buttonTypes",
-			"plugin": "jsx",
-			"preset": "logical",
-			"status": "implemented"
-		},
 		"oxlint": [
 			{
 				"name": "react/button-has-type",
@@ -6193,20 +6193,25 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "changeEventHandlers",
+			"plugin": "jsx",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "jsx-a11y/no-onchange",
 				"url": "https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/tree/HEAD/docs/rules/no-onchange.md"
 			}
 		],
-		"flint": {
-			"name": "changeEventHandlers",
-			"plugin": "jsx",
-			"status": "skipped"
-		},
 		"notes": "No longer necessary in modern browsers."
 	},
 	{
+		"flint": {
+			"name": "childrenCurlyBraces",
+			"plugin": "jsx",
+			"status": "skipped"
+		},
 		"biome": [
 			{
 				"name": "useConsistentCurlyBraces",
@@ -6219,20 +6224,21 @@
 				"url": "https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-curly-brace-presence.md"
 			}
 		],
-		"flint": {
-			"name": "childrenCurlyBraces",
-			"plugin": "jsx",
-			"status": "skipped"
-		},
-		"notes": "Formatting rule.",
 		"oxlint": [
 			{
 				"name": "react/jsx-curly-brace-presence",
 				"url": "https://oxc.rs/docs/guide/usage/linter/rules/react/jsx-curly-brace-presence.html"
 			}
-		]
+		],
+		"notes": "Formatting rule."
 	},
 	{
+		"flint": {
+			"name": "childrenProps",
+			"plugin": "jsx",
+			"preset": "stylistic",
+			"status": "implemented"
+		},
 		"biome": [
 			{
 				"name": "noChildrenProp",
@@ -6255,12 +6261,6 @@
 				"url": "https://eslint-react.xyz/docs/rules/jsx-no-children-prop"
 			}
 		],
-		"flint": {
-			"name": "childrenProps",
-			"plugin": "jsx",
-			"preset": "stylistic",
-			"status": "implemented"
-		},
 		"oxlint": [
 			{
 				"name": "react/no-children-prop",
@@ -6269,33 +6269,39 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "childrenPropsWithChildren",
+			"plugin": "jsx",
+			"preset": "stylistic"
+		},
 		"eslint": [
 			{
 				"name": "@eslint-react/jsx-no-children-prop-with-children",
 				"url": "https://eslint-react.xyz/docs/rules/jsx-no-children-prop-with-children"
 			}
-		],
-		"flint": {
-			"name": "childrenPropsWithChildren",
-			"plugin": "jsx",
-			"preset": "stylistic"
-		}
+		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "react/jsx-child-element-spacing",
-				"url": "https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-child-element-spacing.md"
-			}
-		],
 		"flint": {
 			"name": "childrenWhitespace",
 			"plugin": "jsx",
 			"preset": "logical",
 			"strictness": "strict"
-		}
+		},
+		"eslint": [
+			{
+				"name": "react/jsx-child-element-spacing",
+				"url": "https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-child-element-spacing.md"
+			}
+		]
 	},
 	{
+		"flint": {
+			"name": "clickEventKeyEvents",
+			"plugin": "jsx",
+			"preset": "logical",
+			"status": "implemented"
+		},
 		"biome": [
 			{
 				"name": "useKeyWithClickEvents",
@@ -6308,12 +6314,6 @@
 				"url": "https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/click-events-have-key-events.md"
 			}
 		],
-		"flint": {
-			"name": "clickEventKeyEvents",
-			"plugin": "jsx",
-			"preset": "logical",
-			"status": "implemented"
-		},
 		"oxlint": [
 			{
 				"name": "jsx-a11y/click-events-have-key-events",
@@ -6322,48 +6322,54 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "closingBracketSpacing",
+			"plugin": "jsx",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "react/jsx-closing-bracket-location",
 				"url": "https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-closing-bracket-location.md"
 			}
 		],
-		"flint": {
-			"name": "closingBracketSpacing",
-			"plugin": "jsx",
-			"status": "skipped"
-		},
 		"notes": "Formatting rule."
 	},
 	{
+		"flint": {
+			"name": "closingTagSpaces",
+			"plugin": "jsx",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "react/jsx-space-before-closing",
 				"url": "https://github.com/jsx-eslint/eslint-plugin-react/tree/master/docs/rules/jsx-space-before-closing.md"
 			}
 		],
-		"flint": {
-			"name": "closingTagSpaces",
-			"plugin": "jsx",
-			"status": "skipped"
-		},
 		"notes": "Formatting rule."
 	},
 	{
+		"flint": {
+			"name": "closingTagSpacing",
+			"plugin": "jsx",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "react/jsx-closing-tag-location",
 				"url": "https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-closing-tag-location.md"
 			}
 		],
-		"flint": {
-			"name": "closingTagSpacing",
-			"plugin": "jsx",
-			"status": "skipped"
-		},
 		"notes": "Formatting rule."
 	},
 	{
+		"flint": {
+			"name": "commentTextNodes",
+			"plugin": "jsx",
+			"preset": "logical",
+			"status": "implemented"
+		},
 		"biome": [
 			{
 				"name": "noCommentText",
@@ -6386,12 +6392,6 @@
 				"url": "https://eslint-react.xyz/docs/rules/jsx-no-comment-textnodes"
 			}
 		],
-		"flint": {
-			"name": "commentTextNodes",
-			"plugin": "jsx",
-			"preset": "logical",
-			"status": "implemented"
-		},
 		"oxlint": [
 			{
 				"name": "react/jsx-no-comment-textnodes",
@@ -6400,37 +6400,37 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "componentNameCases",
+			"plugin": "jsx",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "react/jsx-pascal-case",
 				"url": "https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-pascal-case.md"
 			}
 		],
-		"flint": {
-			"name": "componentNameCases",
-			"plugin": "jsx",
-			"status": "skipped"
-		},
-		"notes": "Overly opinionated and brittle.",
 		"oxlint": [
 			{
 				"name": "react/jsx-pascal-case",
 				"url": "https://oxc.rs/docs/guide/usage/linter/rules/react/jsx-pascal-case.html"
 			}
-		]
+		],
+		"notes": "Overly opinionated and brittle."
 	},
 	{
+		"flint": {
+			"name": "controlAssociatedLabels",
+			"plugin": "jsx",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "jsx-a11y/control-has-associated-label",
 				"url": "https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/control-has-associated-label.md"
 			}
 		],
-		"flint": {
-			"name": "controlAssociatedLabels",
-			"plugin": "jsx",
-			"preset": "logical"
-		},
 		"oxlint": [
 			{
 				"name": "jsx-a11y/control-has-associated-label",
@@ -6439,67 +6439,73 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "curlyNewlines",
+			"plugin": "jsx",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "react/jsx-curly-newline",
 				"url": "https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-curly-newline.md"
 			}
 		],
-		"flint": {
-			"name": "curlyNewlines",
-			"plugin": "jsx",
-			"status": "skipped"
-		},
 		"notes": "Formatting rule."
 	},
 	{
+		"flint": {
+			"name": "curlySpacing",
+			"plugin": "jsx",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "react/jsx-curly-spacing",
 				"url": "https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-curly-spacing.md"
 			}
 		],
-		"flint": {
-			"name": "curlySpacing",
-			"plugin": "jsx",
-			"status": "skipped"
-		},
 		"notes": "Formatting rule."
 	},
 	{
+		"flint": {
+			"name": "defaultPropObjectValues",
+			"plugin": "jsx",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "react/no-object-type-as-default-prop",
 				"url": "https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-object-type-as-default-prop.md"
 			}
 		],
-		"flint": {
-			"name": "defaultPropObjectValues",
-			"plugin": "jsx",
-			"status": "skipped"
-		},
-		"notes": "Overly opinionated.",
 		"oxlint": [
 			{
 				"name": "react/no-object-type-as-default-prop",
 				"url": "https://oxc.rs/docs/guide/usage/linter/rules/react/no-object-type-as-default-prop.html"
 			}
-		]
+		],
+		"notes": "Overly opinionated."
 	},
 	{
+		"flint": {
+			"name": "defaultPropsOrder",
+			"plugin": "jsx",
+			"preset": "sorting"
+		},
 		"eslint": [
 			{
 				"name": "react/jsx-sort-default-props",
 				"url": "https://github.com/jsx-eslint/eslint-plugin-react/tree/master/docs/rules/jsx-sort-default-props.md"
 			}
-		],
-		"flint": {
-			"name": "defaultPropsOrder",
-			"plugin": "jsx",
-			"preset": "sorting"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "distractingElements",
+			"plugin": "jsx",
+			"preset": "logical",
+			"status": "implemented"
+		},
 		"biome": [
 			{
 				"name": "noDistractingElements",
@@ -6512,12 +6518,6 @@
 				"url": "https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/no-distracting-elements.md"
 			}
 		],
-		"flint": {
-			"name": "distractingElements",
-			"plugin": "jsx",
-			"preset": "logical",
-			"status": "implemented"
-		},
 		"oxlint": [
 			{
 				"name": "jsx-a11y/no-distracting-elements",
@@ -6526,31 +6526,36 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "dollarLeakage",
+			"plugin": "jsx"
+		},
 		"eslint": [
 			{
 				"name": "@eslint-react/jsx-no-leaked-dollar",
 				"url": "https://eslint-react.xyz/docs/rules/jsx-no-leaked-dollar"
 			}
-		],
-		"flint": {
-			"name": "dollarLeakage",
-			"plugin": "jsx"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "dollarLeaks",
+			"plugin": "jsx",
+			"preset": "logical"
+		},
 		"biome": [
 			{
 				"name": "noJsxLeakedDollar",
 				"url": "https://biomejs.dev/linter/rules/no-jsx-leaked-dollar"
 			}
-		],
-		"flint": {
-			"name": "dollarLeaks",
-			"plugin": "jsx",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "duplicateSpreads",
+			"plugin": "jsx",
+			"status": "skipped"
+		},
 		"biome": [
 			{
 				"name": "noDuplicatedSpreadProps",
@@ -6569,11 +6574,6 @@
 				"url": "https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-props-no-spread-multi.md"
 			}
 		],
-		"flint": {
-			"name": "duplicateSpreads",
-			"plugin": "jsx",
-			"status": "skipped"
-		},
 		"oxlint": [
 			{
 				"name": "react/jsx-props-no-spread-multi",
@@ -6582,6 +6582,13 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "elementChildrenValidity",
+			"plugin": "jsx",
+			"preset": "logical",
+			"status": "implemented",
+			"strictness": "strict"
+		},
 		"biome": [
 			{
 				"name": "noVoidElementsWithChildren",
@@ -6600,13 +6607,6 @@
 				"url": "https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/void-dom-elements-no-children.md"
 			}
 		],
-		"flint": {
-			"name": "elementChildrenValidity",
-			"plugin": "jsx",
-			"preset": "logical",
-			"status": "implemented",
-			"strictness": "strict"
-		},
 		"oxlint": [
 			{
 				"name": "react/void-dom-elements-no-children",
@@ -6615,68 +6615,73 @@
 		]
 	},
 	{
-		"biome": [
-			{
-				"name": "useUniqueElementIds",
-				"url": "https://biomejs.dev/linter/rules/use-unique-element-ids"
-			}
-		],
 		"flint": {
 			"name": "elementIdUniqueness",
 			"plugin": "jsx",
 			"preset": "logical",
 			"strictness": "strict"
-		}
+		},
+		"biome": [
+			{
+				"name": "useUniqueElementIds",
+				"url": "https://biomejs.dev/linter/rules/use-unique-element-ids"
+			}
+		]
 	},
 	{
+		"flint": {
+			"name": "equalsSpacing",
+			"plugin": "jsx",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "react/jsx-equals-spacing",
 				"url": "https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-equals-spacing.md"
 			}
 		],
-		"flint": {
-			"name": "equalsSpacing",
-			"plugin": "jsx",
-			"status": "skipped"
-		},
 		"notes": "Formatting rule."
 	},
 	{
+		"flint": {
+			"name": "expressionsPerLine",
+			"plugin": "jsx",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "react/jsx-one-expression-per-line",
 				"url": "https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-one-expression-per-line.md"
 			}
 		],
-		"flint": {
-			"name": "expressionsPerLine",
-			"plugin": "jsx",
-			"status": "skipped"
-		},
 		"notes": "Formatting rule."
 	},
 	{
+		"flint": {
+			"name": "filenameExtensions",
+			"plugin": "jsx",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "react/jsx-filename-extension",
 				"url": "https://github.com/jsx-eslint/eslint-plugin-react/tree/master/docs/rules/jsx-filename-extension.md"
 			}
 		],
-		"flint": {
-			"name": "filenameExtensions",
-			"plugin": "jsx",
-			"status": "skipped"
-		},
-		"notes": "Generally handled by parsers.",
 		"oxlint": [
 			{
 				"name": "react/jsx-filename-extension",
 				"url": "https://oxc.rs/docs/guide/usage/linter/rules/react/jsx-filename-extension.html"
 			}
-		]
+		],
+		"notes": "Generally handled by parsers."
 	},
 	{
+		"flint": {
+			"name": "fragmentElements",
+			"plugin": "jsx",
+			"preset": "stylistic"
+		},
 		"biome": [
 			{
 				"name": "useFragmentSyntax",
@@ -6689,11 +6694,6 @@
 				"url": "https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-fragments.md"
 			}
 		],
-		"flint": {
-			"name": "fragmentElements",
-			"plugin": "jsx",
-			"preset": "stylistic"
-		},
 		"oxlint": [
 			{
 				"name": "react/jsx-fragments",
@@ -6702,6 +6702,11 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "functionBinds",
+			"plugin": "jsx",
+			"status": "skipped"
+		},
 		"biome": [
 			{
 				"name": "noJsxPropsBind",
@@ -6714,34 +6719,35 @@
 				"url": "https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-no-bind.md"
 			}
 		],
-		"flint": {
-			"name": "functionBinds",
-			"plugin": "jsx",
-			"status": "skipped"
-		},
 		"notes": "Overly opinionated."
 	},
 	{
+		"flint": {
+			"name": "handlerNames",
+			"plugin": "jsx",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "react/jsx-handler-names",
 				"url": "https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-handler-names.md"
 			}
 		],
-		"flint": {
-			"name": "handlerNames",
-			"plugin": "jsx",
-			"status": "skipped"
-		},
-		"notes": "Overly opinionated.",
 		"oxlint": [
 			{
 				"name": "react/jsx-handler-names",
 				"url": "https://oxc.rs/docs/guide/usage/linter/rules/react/jsx-handler-names.html"
 			}
-		]
+		],
+		"notes": "Overly opinionated."
 	},
 	{
+		"flint": {
+			"name": "headingContents",
+			"plugin": "jsx",
+			"preset": "logical",
+			"status": "implemented"
+		},
 		"biome": [
 			{
 				"name": "useHeadingContent",
@@ -6754,12 +6760,6 @@
 				"url": "https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/heading-has-content.md"
 			}
 		],
-		"flint": {
-			"name": "headingContents",
-			"plugin": "jsx",
-			"preset": "logical",
-			"status": "implemented"
-		},
 		"oxlint": [
 			{
 				"name": "jsx-a11y/heading-has-content",
@@ -6768,6 +6768,12 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "htmlLangs",
+			"plugin": "jsx",
+			"preset": "logical",
+			"status": "implemented"
+		},
 		"biome": [
 			{
 				"name": "useHtmlLang",
@@ -6780,12 +6786,6 @@
 				"url": "https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/html-has-lang.md"
 			}
 		],
-		"flint": {
-			"name": "htmlLangs",
-			"plugin": "jsx",
-			"preset": "logical",
-			"status": "implemented"
-		},
 		"oxlint": [
 			{
 				"name": "jsx-a11y/html-has-lang",
@@ -6794,6 +6794,12 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "iframeSandboxes",
+			"plugin": "jsx",
+			"preset": "logical",
+			"strictness": "strict"
+		},
 		"biome": [
 			{
 				"name": "useIframeSandbox",
@@ -6806,12 +6812,6 @@
 				"url": "https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/iframe-missing-sandbox.md"
 			}
 		],
-		"flint": {
-			"name": "iframeSandboxes",
-			"plugin": "jsx",
-			"preset": "logical",
-			"strictness": "strict"
-		},
 		"oxlint": [
 			{
 				"name": "react/iframe-missing-sandbox",
@@ -6820,32 +6820,38 @@
 		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "@eslint-react/dom-no-missing-iframe-sandbox",
-				"url": "https://eslint-react.xyz/docs/rules/dom-no-missing-iframe-sandbox"
-			}
-		],
 		"flint": {
 			"name": "iframeSandboxPresence",
 			"plugin": "jsx",
 			"preset": "logical",
 			"strictness": "strict"
-		}
+		},
+		"eslint": [
+			{
+				"name": "@eslint-react/dom-no-missing-iframe-sandbox",
+				"url": "https://eslint-react.xyz/docs/rules/dom-no-missing-iframe-sandbox"
+			}
+		]
 	},
 	{
+		"flint": {
+			"name": "iframeSandboxSafety",
+			"plugin": "jsx"
+		},
 		"eslint": [
 			{
 				"name": "@eslint-react/dom-no-unsafe-iframe-sandbox",
 				"url": "https://eslint-react.xyz/docs/rules/dom-no-unsafe-iframe-sandbox"
 			}
-		],
-		"flint": {
-			"name": "iframeSandboxSafety",
-			"plugin": "jsx"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "iframeTitles",
+			"plugin": "jsx",
+			"preset": "logical",
+			"status": "implemented"
+		},
 		"biome": [
 			{
 				"name": "useIframeTitle",
@@ -6858,12 +6864,6 @@
 				"url": "https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/iframe-has-title.md"
 			}
 		],
-		"flint": {
-			"name": "iframeTitles",
-			"plugin": "jsx",
-			"preset": "logical",
-			"status": "implemented"
-		},
 		"oxlint": [
 			{
 				"name": "jsx-a11y/iframe-has-title",
@@ -6872,6 +6872,11 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "imageAltRedundancy",
+			"plugin": "jsx",
+			"status": "skipped"
+		},
 		"biome": [
 			{
 				"name": "noRedundantAlt",
@@ -6884,11 +6889,6 @@
 				"url": "https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/img-redundant-alt.md"
 			}
 		],
-		"flint": {
-			"name": "imageAltRedundancy",
-			"plugin": "jsx",
-			"status": "skipped"
-		},
 		"oxlint": [
 			{
 				"name": "jsx-a11y/img-redundant-alt",
@@ -6897,44 +6897,44 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "imageSizes",
+			"plugin": "jsx",
+			"preset": "logical"
+		},
 		"biome": [
 			{
 				"name": "useImageSize",
 				"url": "https://biomejs.dev/linter/rules/use-image-size"
 			}
-		],
-		"flint": {
-			"name": "imageSizes",
-			"plugin": "jsx",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "indents",
+			"plugin": "jsx",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "react/jsx-indent",
 				"url": "https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-indent.md"
 			}
 		],
-		"flint": {
-			"name": "indents",
-			"plugin": "jsx",
-			"status": "skipped"
-		},
 		"notes": "Formatting rule."
 	},
 	{
+		"flint": {
+			"name": "inputCheckedMutability",
+			"plugin": "jsx",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "react/checked-requires-onchange-or-readonly",
 				"url": "https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/checked-requires-onchange-or-readonly.md"
 			}
 		],
-		"flint": {
-			"name": "inputCheckedMutability",
-			"plugin": "jsx",
-			"preset": "logical"
-		},
 		"oxlint": [
 			{
 				"name": "react/checked-requires-onchange-or-readonly",
@@ -6943,6 +6943,12 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "interactiveElementRoles",
+			"plugin": "jsx",
+			"preset": "logical",
+			"status": "implemented"
+		},
 		"biome": [
 			{
 				"name": "noInteractiveElementToNoninteractiveRole",
@@ -6955,12 +6961,6 @@
 				"url": "https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/no-interactive-element-to-noninteractive-role.md"
 			}
 		],
-		"flint": {
-			"name": "interactiveElementRoles",
-			"plugin": "jsx",
-			"preset": "logical",
-			"status": "implemented"
-		},
 		"oxlint": [
 			{
 				"name": "jsx-a11y/no-interactive-element-to-noninteractive-role",
@@ -6969,6 +6969,12 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "interactiveElementsFocusable",
+			"plugin": "jsx",
+			"preset": "logical",
+			"status": "implemented"
+		},
 		"biome": [
 			{
 				"name": "useFocusableInteractive",
@@ -6981,12 +6987,6 @@
 				"url": "https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/tree/HEAD/docs/rules/interactive-supports-focus.md"
 			}
 		],
-		"flint": {
-			"name": "interactiveElementsFocusable",
-			"plugin": "jsx",
-			"preset": "logical",
-			"status": "implemented"
-		},
 		"oxlint": [
 			{
 				"name": "jsx-a11y/interactive-supports-focus",
@@ -6995,32 +6995,38 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "iterableKeys",
+			"plugin": "jsx",
+			"status": "skipped"
+		},
 		"deno": [
 			{
 				"name": "jsx-key",
 				"url": "https://docs.deno.com/lint/rules/jsx-key"
 			}
-		],
-		"flint": {
-			"name": "iterableKeys",
-			"plugin": "jsx",
-			"status": "skipped"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "keyAndSpreadOrderings",
+			"plugin": "jsx",
+			"preset": "stylistic"
+		},
 		"eslint": [
 			{
 				"name": "@eslint-react/jsx-no-key-after-spread",
 				"url": "https://eslint-react.xyz/docs/rules/jsx-no-key-after-spread"
 			}
-		],
-		"flint": {
-			"name": "keyAndSpreadOrderings",
-			"plugin": "jsx",
-			"preset": "stylistic"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "labelAssociatedControls",
+			"plugin": "jsx",
+			"preset": "logical",
+			"status": "implemented"
+		},
 		"biome": [
 			{
 				"name": "noLabelWithoutControl",
@@ -7033,12 +7039,6 @@
 				"url": "https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/label-has-associated-control.md"
 			}
 		],
-		"flint": {
-			"name": "labelAssociatedControls",
-			"plugin": "jsx",
-			"preset": "logical",
-			"status": "implemented"
-		},
 		"oxlint": [
 			{
 				"name": "jsx-a11y/label-has-associated-control",
@@ -7047,20 +7047,27 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "labelForAssociations",
+			"plugin": "jsx",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "jsx-a11y/label-has-for",
 				"url": "https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/tree/HEAD/docs/rules/label-has-for.md"
 			}
 		],
-		"flint": {
-			"name": "labelForAssociations",
-			"plugin": "jsx",
-			"status": "skipped"
-		},
 		"notes": "Superseded by labelAssociatedControls."
 	},
 	{
+		"flint": {
+			"name": "langValidity",
+			"plugin": "jsx",
+			"preset": "logical",
+			"status": "implemented",
+			"strictness": "strict"
+		},
 		"biome": [
 			{
 				"name": "useValidLang",
@@ -7073,13 +7080,6 @@
 				"url": "https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/lang.md"
 			}
 		],
-		"flint": {
-			"name": "langValidity",
-			"plugin": "jsx",
-			"preset": "logical",
-			"status": "implemented",
-			"strictness": "strict"
-		},
 		"oxlint": [
 			{
 				"name": "jsx-a11y/lang",
@@ -7088,20 +7088,25 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "lifecycleMethodArrowFunctions",
+			"plugin": "jsx",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "react/no-arrow-function-lifecycle",
 				"url": "https://github.com/jsx-eslint/eslint-plugin-react/tree/master/docs/rules/no-arrow-function-lifecycle.md"
 			}
 		],
-		"flint": {
-			"name": "lifecycleMethodArrowFunctions",
-			"plugin": "jsx",
-			"status": "skipped"
-		},
 		"notes": "Overly opinionated."
 	},
 	{
+		"flint": {
+			"name": "literals",
+			"plugin": "jsx",
+			"status": "skipped"
+		},
 		"biome": [
 			{
 				"name": "noJsxLiterals",
@@ -7114,48 +7119,49 @@
 				"url": "https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-no-literals.md"
 			}
 		],
-		"flint": {
-			"name": "literals",
-			"plugin": "jsx",
-			"status": "skipped"
-		},
 		"notes": "Overly opinionated."
 	},
 	{
+		"flint": {
+			"name": "maximumChildrenDepth",
+			"plugin": "jsx",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "react/jsx-max-depth",
 				"url": "https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-max-depth.md"
 			}
 		],
-		"flint": {
-			"name": "maximumChildrenDepth",
-			"plugin": "jsx",
-			"status": "skipped"
-		},
-		"notes": "Overly opinionated.",
 		"oxlint": [
 			{
 				"name": "react/jsx-max-depth",
 				"url": "https://oxc.rs/docs/guide/usage/linter/rules/react/jsx-max-depth.html"
 			}
-		]
+		],
+		"notes": "Overly opinionated."
 	},
 	{
+		"flint": {
+			"name": "maximumPropsPerLine",
+			"plugin": "jsx",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "react/jsx-max-props-per-line",
 				"url": "https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-max-props-per-line.md"
 			}
 		],
-		"flint": {
-			"name": "maximumPropsPerLine",
-			"plugin": "jsx",
-			"status": "skipped"
-		},
 		"notes": "Formatting rule."
 	},
 	{
+		"flint": {
+			"name": "mediaCaptions",
+			"plugin": "jsx",
+			"preset": "logical",
+			"status": "implemented"
+		},
 		"biome": [
 			{
 				"name": "useMediaCaption",
@@ -7168,12 +7174,6 @@
 				"url": "https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/media-has-caption.md"
 			}
 		],
-		"flint": {
-			"name": "mediaCaptions",
-			"plugin": "jsx",
-			"preset": "logical",
-			"status": "implemented"
-		},
 		"oxlint": [
 			{
 				"name": "jsx-a11y/media-has-caption",
@@ -7182,19 +7182,25 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "misleadingSemicolons",
+			"plugin": "jsx",
+			"status": "skipped"
+		},
 		"biome": [
 			{
 				"name": "noSuspiciousSemicolonInJsx",
 				"url": "https://biomejs.dev/linter/rules/no-suspicious-semicolon-in-jsx"
 			}
-		],
-		"flint": {
-			"name": "misleadingSemicolons",
-			"plugin": "jsx",
-			"status": "skipped"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "mouseEventKeyEvents",
+			"plugin": "jsx",
+			"preset": "logical",
+			"status": "implemented"
+		},
 		"biome": [
 			{
 				"name": "useKeyWithMouseEvents",
@@ -7207,12 +7213,6 @@
 				"url": "https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/mouse-events-have-key-events.md"
 			}
 		],
-		"flint": {
-			"name": "mouseEventKeyEvents",
-			"plugin": "jsx",
-			"preset": "logical",
-			"status": "implemented"
-		},
 		"oxlint": [
 			{
 				"name": "jsx-a11y/mouse-events-have-key-events",
@@ -7221,6 +7221,11 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "namespaces",
+			"plugin": "jsx",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "react/no-namespace",
@@ -7231,47 +7236,48 @@
 				"url": "https://eslint-react.xyz/docs/rules/jsx-no-namespace"
 			}
 		],
-		"flint": {
-			"name": "namespaces",
-			"plugin": "jsx",
-			"status": "skipped"
-		},
-		"notes": "Generally handled by parsers.",
 		"oxlint": [
 			{
 				"name": "react/no-namespace",
 				"url": "https://oxc.rs/docs/guide/usage/linter/rules/react/no-namespace.html"
 			}
-		]
+		],
+		"notes": "Generally handled by parsers."
 	},
 	{
+		"flint": {
+			"name": "namespaceSyntax",
+			"plugin": "jsx",
+			"preset": "logical"
+		},
 		"biome": [
 			{
 				"name": "noJsxNamespace",
 				"url": "https://biomejs.dev/linter/rules/no-jsx-namespace"
 			}
-		],
-		"flint": {
-			"name": "namespaceSyntax",
-			"plugin": "jsx",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "newlines",
+			"plugin": "jsx",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "react/jsx-newline",
 				"url": "https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-newline.md"
 			}
 		],
-		"flint": {
-			"name": "newlines",
-			"plugin": "jsx",
-			"status": "skipped"
-		},
 		"notes": "Formatting rule."
 	},
 	{
+		"flint": {
+			"name": "nonInteractiveElementInteractions",
+			"plugin": "jsx",
+			"preset": "logical",
+			"status": "implemented"
+		},
 		"biome": [
 			{
 				"name": "noNoninteractiveElementInteractions",
@@ -7284,12 +7290,6 @@
 				"url": "https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/no-noninteractive-element-interactions.md"
 			}
 		],
-		"flint": {
-			"name": "nonInteractiveElementInteractions",
-			"plugin": "jsx",
-			"preset": "logical",
-			"status": "implemented"
-		},
 		"oxlint": [
 			{
 				"name": "jsx-a11y/no-noninteractive-element-interactions",
@@ -7298,6 +7298,12 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "nonInteractiveElementRoles",
+			"plugin": "jsx",
+			"preset": "logical",
+			"status": "implemented"
+		},
 		"biome": [
 			{
 				"name": "noNoninteractiveElementToInteractiveRole",
@@ -7310,12 +7316,6 @@
 				"url": "https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/no-noninteractive-element-to-interactive-role.md"
 			}
 		],
-		"flint": {
-			"name": "nonInteractiveElementRoles",
-			"plugin": "jsx",
-			"preset": "logical",
-			"status": "implemented"
-		},
 		"oxlint": [
 			{
 				"name": "jsx-a11y/no-noninteractive-element-to-interactive-role",
@@ -7324,6 +7324,12 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "nonInteractiveElementTabIndexes",
+			"plugin": "jsx",
+			"preset": "logical",
+			"status": "implemented"
+		},
 		"biome": [
 			{
 				"name": "noNoninteractiveTabindex",
@@ -7336,12 +7342,6 @@
 				"url": "https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/no-noninteractive-tabindex.md"
 			}
 		],
-		"flint": {
-			"name": "nonInteractiveElementTabIndexes",
-			"plugin": "jsx",
-			"preset": "logical",
-			"status": "implemented"
-		},
 		"oxlint": [
 			{
 				"name": "jsx-a11y/no-noninteractive-tabindex",
@@ -7350,6 +7350,12 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "propDuplicates",
+			"plugin": "jsx",
+			"preset": "logical",
+			"status": "implemented"
+		},
 		"biome": [
 			{
 				"name": "noDuplicateJsxProps",
@@ -7368,12 +7374,6 @@
 				"url": "https://github.com/jsx-eslint/eslint-plugin-react/tree/master/docs/rules/jsx-no-duplicate-props.md"
 			}
 		],
-		"flint": {
-			"name": "propDuplicates",
-			"plugin": "jsx",
-			"preset": "logical",
-			"status": "implemented"
-		},
 		"oxlint": [
 			{
 				"name": "react/jsx-no-duplicate-props",
@@ -7382,107 +7382,107 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "propIndents",
+			"plugin": "jsx",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "react/jsx-indent-props",
 				"url": "https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-indent-props.md"
 			}
 		],
-		"flint": {
-			"name": "propIndents",
-			"plugin": "jsx",
-			"status": "skipped"
-		},
 		"notes": "Formatting rule."
 	},
 	{
+		"flint": {
+			"name": "propNewlines",
+			"plugin": "jsx",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "react/jsx-first-prop-new-line",
 				"url": "https://github.com/jsx-eslint/eslint-plugin-react/tree/master/docs/rules/jsx-first-prop-new-line.md"
 			}
 		],
-		"flint": {
-			"name": "propNewlines",
-			"plugin": "jsx",
-			"status": "skipped"
-		},
 		"notes": "Formatting rule."
 	},
 	{
+		"flint": {
+			"name": "propsOrder",
+			"plugin": "jsx",
+			"preset": "sorting"
+		},
 		"eslint": [
 			{
 				"name": "perfectionist/sort-jsx-props",
 				"url": "https://perfectionist.dev/rules/sort-jsx-props"
 			}
-		],
-		"flint": {
-			"name": "propsOrder",
-			"plugin": "jsx",
-			"preset": "sorting"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "propsSorting",
+			"plugin": "jsx",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "react/jsx-sort-props",
 				"url": "https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-sort-props.md"
 			}
 		],
-		"flint": {
-			"name": "propsSorting",
-			"plugin": "jsx",
-			"status": "skipped"
-		},
 		"notes": "Superseded by jsx sorting preset"
 	},
 	{
+		"flint": {
+			"name": "propsSpaces",
+			"plugin": "jsx",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "react/jsx-props-no-multi-spaces",
 				"url": "https://github.com/jsx-eslint/eslint-plugin-react/tree/master/docs/rules/jsx-props-no-multi-spaces.md"
 			}
 		],
-		"flint": {
-			"name": "propsSpaces",
-			"plugin": "jsx",
-			"status": "skipped"
-		},
 		"notes": "Formatting rule."
 	},
 	{
+		"flint": {
+			"name": "propsSpreads",
+			"plugin": "jsx",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "react/jsx-props-no-spreading",
 				"url": "https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-props-no-spreading.md"
 			}
 		],
-		"flint": {
-			"name": "propsSpreads",
-			"plugin": "jsx",
-			"status": "skipped"
-		},
-		"notes": "Overly opinionated.",
 		"oxlint": [
 			{
 				"name": "react/jsx-props-no-spreading",
 				"url": "https://oxc.rs/docs/guide/usage/linter/rules/react/jsx-props-no-spreading.html"
 			}
-		]
+		],
+		"notes": "Overly opinionated."
 	},
 	{
-		"eslint": [
-			{
-				"name": "react/no-redundant-should-component-update",
-				"url": "https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-redundant-should-component-update.md"
-			}
-		],
 		"flint": {
 			"name": "pureComponentShouldUpdateDefinitions",
 			"plugin": "jsx",
 			"preset": "logical",
 			"strictness": "strict"
 		},
+		"eslint": [
+			{
+				"name": "react/no-redundant-should-component-update",
+				"url": "https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-redundant-should-component-update.md"
+			}
+		],
 		"oxlint": [
 			{
 				"name": "react/no-redundant-should-component-update",
@@ -7491,6 +7491,12 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "renderedLiteralLeaks",
+			"plugin": "jsx",
+			"preset": "logical",
+			"strictness": "strict"
+		},
 		"biome": [
 			{
 				"name": "noLeakedRender",
@@ -7502,26 +7508,20 @@
 				"name": "react/jsx-no-leaked-render",
 				"url": "https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-no-leaked-render.md"
 			}
-		],
-		"flint": {
-			"name": "renderedLiteralLeaks",
-			"plugin": "jsx",
-			"preset": "logical",
-			"strictness": "strict"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "renderReturns",
+			"plugin": "jsx",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "react/require-render-return",
 				"url": "https://github.com/jsx-eslint/eslint-plugin-react/tree/master/docs/rules/require-render-return.md"
 			}
 		],
-		"flint": {
-			"name": "renderReturns",
-			"plugin": "jsx",
-			"preset": "logical"
-		},
 		"oxlint": [
 			{
 				"name": "react/require-render-return",
@@ -7530,6 +7530,12 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "roleRedundancies",
+			"plugin": "jsx",
+			"preset": "logical",
+			"status": "implemented"
+		},
 		"biome": [
 			{
 				"name": "noRedundantRoles",
@@ -7542,12 +7548,6 @@
 				"url": "https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/no-redundant-roles.md"
 			}
 		],
-		"flint": {
-			"name": "roleRedundancies",
-			"plugin": "jsx",
-			"preset": "logical",
-			"status": "implemented"
-		},
 		"oxlint": [
 			{
 				"name": "jsx-a11y/no-redundant-roles",
@@ -7556,6 +7556,12 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "roleRequiredAriaProps",
+			"plugin": "jsx",
+			"preset": "logical",
+			"status": "implemented"
+		},
 		"biome": [
 			{
 				"name": "useAriaPropsForRole",
@@ -7568,12 +7574,6 @@
 				"url": "https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/role-has-required-aria-props.md"
 			}
 		],
-		"flint": {
-			"name": "roleRequiredAriaProps",
-			"plugin": "jsx",
-			"preset": "logical",
-			"status": "implemented"
-		},
 		"oxlint": [
 			{
 				"name": "jsx-a11y/role-has-required-aria-props",
@@ -7582,6 +7582,12 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "roleSupportedAriaProps",
+			"plugin": "jsx",
+			"preset": "logical",
+			"status": "implemented"
+		},
 		"biome": [
 			{
 				"name": "useAriaPropsSupportedByRole",
@@ -7594,12 +7600,6 @@
 				"url": "https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/role-supports-aria-props.md"
 			}
 		],
-		"flint": {
-			"name": "roleSupportedAriaProps",
-			"plugin": "jsx",
-			"preset": "logical",
-			"status": "implemented"
-		},
 		"oxlint": [
 			{
 				"name": "jsx-a11y/role-supports-aria-props",
@@ -7608,6 +7608,13 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "roleTags",
+			"plugin": "jsx",
+			"preset": "logical",
+			"status": "implemented",
+			"strictness": "strict"
+		},
 		"biome": [
 			{
 				"name": "useSemanticElements",
@@ -7620,13 +7627,6 @@
 				"url": "https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/prefer-tag-over-role.md"
 			}
 		],
-		"flint": {
-			"name": "roleTags",
-			"plugin": "jsx",
-			"preset": "logical",
-			"status": "implemented",
-			"strictness": "strict"
-		},
 		"oxlint": [
 			{
 				"name": "jsx-a11y/prefer-tag-over-role",
@@ -7635,6 +7635,12 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "scopeProps",
+			"plugin": "jsx",
+			"preset": "logical",
+			"status": "implemented"
+		},
 		"biome": [
 			{
 				"name": "noHeaderScope",
@@ -7647,12 +7653,6 @@
 				"url": "https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/scope.md"
 			}
 		],
-		"flint": {
-			"name": "scopeProps",
-			"plugin": "jsx",
-			"preset": "logical",
-			"status": "implemented"
-		},
 		"oxlint": [
 			{
 				"name": "jsx-a11y/scope",
@@ -7661,6 +7661,11 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "scriptUrls",
+			"plugin": "jsx",
+			"preset": "logical"
+		},
 		"biome": [
 			{
 				"name": "noScriptUrl",
@@ -7677,11 +7682,6 @@
 				"url": "https://eslint-react.xyz/docs/rules/dom-no-script-url"
 			}
 		],
-		"flint": {
-			"name": "scriptUrls",
-			"plugin": "jsx",
-			"preset": "logical"
-		},
 		"oxlint": [
 			{
 				"name": "react/jsx-no-script-url",
@@ -7690,6 +7690,11 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "selfClosingTags",
+			"plugin": "jsx",
+			"preset": "stylistic"
+		},
 		"biome": [
 			{
 				"name": "useSelfClosingElements",
@@ -7702,11 +7707,6 @@
 				"url": "https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/self-closing-comp.md"
 			}
 		],
-		"flint": {
-			"name": "selfClosingTags",
-			"plugin": "jsx",
-			"preset": "stylistic"
-		},
 		"oxlint": [
 			{
 				"name": "react/self-closing-comp",
@@ -7715,18 +7715,22 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "semicolonLeakage",
+			"plugin": "jsx"
+		},
 		"eslint": [
 			{
 				"name": "@eslint-react/jsx-no-leaked-semicolon",
 				"url": "https://eslint-react.xyz/docs/rules/jsx-no-leaked-semicolon"
 			}
-		],
-		"flint": {
-			"name": "semicolonLeakage",
-			"plugin": "jsx"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "stateAccessesInSetStates",
+			"plugin": "jsx"
+		},
 		"eslint": [
 			{
 				"name": "react/no-access-state-in-setstate",
@@ -7736,26 +7740,28 @@
 				"name": "@eslint-react/no-access-state-in-setstate",
 				"url": "https://eslint-react.xyz/docs/rules/no-access-state-in-setstate"
 			}
-		],
-		"flint": {
-			"name": "stateAccessesInSetStates",
-			"plugin": "jsx"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "statelessComponents",
+			"plugin": "jsx",
+			"preset": "stylistic"
+		},
 		"eslint": [
 			{
 				"name": "react/prefer-stateless-function",
 				"url": "https://github.com/jsx-eslint/eslint-plugin-react/tree/master/docs/rules/prefer-stateless-function.md"
 			}
-		],
-		"flint": {
-			"name": "statelessComponents",
-			"plugin": "jsx",
-			"preset": "stylistic"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "staticElementInteractions",
+			"plugin": "jsx",
+			"preset": "logical",
+			"status": "implemented"
+		},
 		"biome": [
 			{
 				"name": "noStaticElementInteractions",
@@ -7768,12 +7774,6 @@
 				"url": "https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/no-static-element-interactions.md"
 			}
 		],
-		"flint": {
-			"name": "staticElementInteractions",
-			"plugin": "jsx",
-			"preset": "logical",
-			"status": "implemented"
-		},
 		"oxlint": [
 			{
 				"name": "jsx-a11y/no-static-element-interactions",
@@ -7782,20 +7782,26 @@
 		]
 	},
 	{
-		"biome": [
-			{
-				"name": "noSvgWithoutTitle",
-				"url": "https://biomejs.dev/linter/rules/no-svg-without-title"
-			}
-		],
 		"flint": {
 			"name": "svgTitles",
 			"plugin": "jsx",
 			"preset": "logical",
 			"status": "implemented"
-		}
+		},
+		"biome": [
+			{
+				"name": "noSvgWithoutTitle",
+				"url": "https://biomejs.dev/linter/rules/no-svg-without-title"
+			}
+		]
 	},
 	{
+		"flint": {
+			"name": "tabIndexPositiveValues",
+			"plugin": "jsx",
+			"preset": "logical",
+			"status": "implemented"
+		},
 		"biome": [
 			{
 				"name": "noPositiveTabindex",
@@ -7808,12 +7814,6 @@
 				"url": "https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/tabindex-no-positive.md"
 			}
 		],
-		"flint": {
-			"name": "tabIndexPositiveValues",
-			"plugin": "jsx",
-			"preset": "logical",
-			"status": "implemented"
-		},
 		"oxlint": [
 			{
 				"name": "jsx-a11y/tabindex-no-positive",
@@ -7822,20 +7822,25 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "tagSpaces",
+			"plugin": "jsx",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "react/jsx-tag-spacing",
 				"url": "https://github.com/jsx-eslint/eslint-plugin-react/tree/master/docs/rules/jsx-tag-spacing.md"
 			}
 		],
-		"flint": {
-			"name": "tagSpaces",
-			"plugin": "jsx",
-			"status": "skipped"
-		},
 		"notes": "Formatting rule."
 	},
 	{
+		"flint": {
+			"name": "targetBlanks",
+			"plugin": "jsx",
+			"status": "skipped"
+		},
 		"biome": [
 			{
 				"name": "noBlankTarget",
@@ -7848,43 +7853,38 @@
 				"url": "https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-no-target-blank.md"
 			}
 		],
-		"flint": {
-			"name": "targetBlanks",
-			"plugin": "jsx",
-			"status": "skipped"
-		},
-		"notes": "No longer necessary in modern browsers.",
 		"oxlint": [
 			{
 				"name": "react/jsx-no-target-blank",
 				"url": "https://oxc.rs/docs/guide/usage/linter/rules/react/jsx-no-target-blank.html"
 			}
-		]
+		],
+		"notes": "No longer necessary in modern browsers."
 	},
 	{
+		"flint": {
+			"name": "targetBlankSafety",
+			"plugin": "jsx"
+		},
 		"eslint": [
 			{
 				"name": "@eslint-react/dom-no-unsafe-target-blank",
 				"url": "https://eslint-react.xyz/docs/rules/dom-no-unsafe-target-blank"
 			}
-		],
-		"flint": {
-			"name": "targetBlankSafety",
-			"plugin": "jsx"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "undefinedElements",
+			"plugin": "jsx",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "react/jsx-no-undef",
 				"url": "https://github.com/jsx-eslint/eslint-plugin-react/tree/master/docs/rules/jsx-no-undef.md"
 			}
 		],
-		"flint": {
-			"name": "undefinedElements",
-			"plugin": "jsx",
-			"preset": "logical"
-		},
 		"oxlint": [
 			{
 				"name": "react/jsx-no-undef",
@@ -7893,6 +7893,12 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "unescapedEntities",
+			"plugin": "jsx",
+			"preset": "stylistic",
+			"status": "implemented"
+		},
 		"deno": [
 			{
 				"name": "jsx-no-unescaped-entities",
@@ -7905,12 +7911,6 @@
 				"url": "https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-unescaped-entities.md"
 			}
 		],
-		"flint": {
-			"name": "unescapedEntities",
-			"plugin": "jsx",
-			"preset": "stylistic",
-			"status": "implemented"
-		},
 		"oxlint": [
 			{
 				"name": "react/no-unescaped-entities",
@@ -7919,6 +7919,12 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "unnecessaryFragments",
+			"plugin": "jsx",
+			"preset": "stylistic",
+			"status": "implemented"
+		},
 		"biome": [
 			{
 				"name": "noUselessFragments",
@@ -7941,12 +7947,6 @@
 				"url": "https://eslint-react.xyz/docs/rules/jsx-no-useless-fragment"
 			}
 		],
-		"flint": {
-			"name": "unnecessaryFragments",
-			"plugin": "jsx",
-			"preset": "stylistic",
-			"status": "implemented"
-		},
 		"oxlint": [
 			{
 				"name": "react/jsx-no-useless-fragment",
@@ -7955,17 +7955,17 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "unsafeLifecycleMethods",
+			"plugin": "jsx",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "react/no-unsafe",
 				"url": "https://github.com/jsx-eslint/eslint-plugin-react/tree/master/docs/rules/no-unsafe.md"
 			}
 		],
-		"flint": {
-			"name": "unsafeLifecycleMethods",
-			"plugin": "jsx",
-			"preset": "logical"
-		},
 		"oxlint": [
 			{
 				"name": "react/no-unsafe",
@@ -7974,39 +7974,33 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "variableUses",
+			"plugin": "jsx",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "react/jsx-uses-vars",
 				"url": "https://github.com/jsx-eslint/eslint-plugin-react/tree/master/docs/rules/jsx-uses-vars.md"
 			}
-		],
-		"flint": {
-			"name": "variableUses",
-			"plugin": "jsx",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "wrappedMultilines",
+			"plugin": "jsx",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "react/jsx-wrap-multilines",
 				"url": "https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-wrap-multilines.md"
 			}
 		],
-		"flint": {
-			"name": "wrappedMultilines",
-			"plugin": "jsx",
-			"status": "skipped"
-		},
 		"notes": "Formatting rule."
 	},
 	{
-		"eslint": [
-			{
-				"name": "markdown/no-bare-urls",
-				"url": "https://github.com/eslint/markdown/blob/HEAD/docs/rules/no-bare-urls.md"
-			}
-		],
 		"flint": {
 			"name": "bareUrls",
 			"plugin": "md",
@@ -8014,6 +8008,12 @@
 			"status": "implemented",
 			"strictness": "strict"
 		},
+		"eslint": [
+			{
+				"name": "markdown/no-bare-urls",
+				"url": "https://github.com/eslint/markdown/blob/HEAD/docs/rules/no-bare-urls.md"
+			}
+		],
 		"markdownlint": [
 			{
 				"name": "no-bare-urls",
@@ -8134,46 +8134,46 @@
 		"notes": "Overly opinionated."
 	},
 	{
-		"eslint": [
-			{
-				"name": "markdown/no-empty-definitions",
-				"url": "https://github.com/eslint/markdown/blob/HEAD/docs/rules/no-empty-definitions.md"
-			}
-		],
 		"flint": {
 			"name": "definitionContents",
 			"plugin": "md",
 			"preset": "logical",
 			"status": "implemented"
-		}
-	},
-	{
+		},
 		"eslint": [
 			{
-				"name": "markdown/no-duplicate-definitions",
-				"url": "https://github.com/eslint/markdown/blob/HEAD/docs/rules/no-duplicate-definitions.md"
+				"name": "markdown/no-empty-definitions",
+				"url": "https://github.com/eslint/markdown/blob/HEAD/docs/rules/no-empty-definitions.md"
 			}
-		],
+		]
+	},
+	{
 		"flint": {
 			"name": "definitionDuplicates",
 			"plugin": "md",
 			"preset": "logical",
 			"status": "implemented"
-		}
-	},
-	{
+		},
 		"eslint": [
 			{
-				"name": "markdown/no-unused-definitions",
-				"url": "https://github.com/eslint/markdown/blob/HEAD/docs/rules/no-unused-definitions.md"
+				"name": "markdown/no-duplicate-definitions",
+				"url": "https://github.com/eslint/markdown/blob/HEAD/docs/rules/no-duplicate-definitions.md"
 			}
-		],
+		]
+	},
+	{
 		"flint": {
 			"name": "definitionUses",
 			"plugin": "md",
 			"preset": "logical",
 			"status": "implemented"
 		},
+		"eslint": [
+			{
+				"name": "markdown/no-unused-definitions",
+				"url": "https://github.com/eslint/markdown/blob/HEAD/docs/rules/no-unused-definitions.md"
+			}
+		],
 		"markdownlint": [
 			{
 				"name": "link-image-reference-definitions",
@@ -8182,17 +8182,17 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "emphasisMarkerSpacing",
+			"plugin": "md",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "markdown/no-space-in-emphasis",
 				"url": "https://github.com/eslint/markdown/blob/HEAD/docs/rules/no-space-in-emphasis.md"
 			}
 		],
-		"flint": {
-			"name": "emphasisMarkerSpacing",
-			"plugin": "md",
-			"status": "skipped"
-		},
 		"notes": "Formatting rule."
 	},
 	{
@@ -8224,12 +8224,6 @@
 		"notes": "Formatting rule."
 	},
 	{
-		"eslint": [
-			{
-				"name": "markdown/fenced-code-language",
-				"url": "https://github.com/eslint/markdown/blob/HEAD/docs/rules/fenced-code-language.md"
-			}
-		],
 		"flint": {
 			"name": "fencedCodeLanguages",
 			"plugin": "md",
@@ -8237,6 +8231,12 @@
 			"status": "implemented",
 			"strictness": "strict"
 		},
+		"eslint": [
+			{
+				"name": "markdown/fenced-code-language",
+				"url": "https://github.com/eslint/markdown/blob/HEAD/docs/rules/fenced-code-language.md"
+			}
+		],
 		"markdownlint": [
 			{
 				"name": "fenced-code-language",
@@ -8245,17 +8245,17 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "fencedCodeMeta",
+			"plugin": "md",
+			"preset": "stylistic"
+		},
 		"eslint": [
 			{
 				"name": "markdown/fenced-code-meta",
 				"url": "https://github.com/eslint/markdown/blob/main/docs/rules/fenced-code-meta.md"
 			}
-		],
-		"flint": {
-			"name": "fencedCodeMeta",
-			"plugin": "md",
-			"preset": "stylistic"
-		}
+		]
 	},
 	{
 		"flint": {
@@ -8342,18 +8342,18 @@
 		"notes": "Formatting rule."
 	},
 	{
-		"eslint": [
-			{
-				"name": "markdown/no-duplicate-headings",
-				"url": "https://github.com/eslint/markdown/blob/HEAD/docs/rules/no-duplicate-headings.md"
-			}
-		],
 		"flint": {
 			"name": "headingDuplicates",
 			"plugin": "md",
 			"preset": "stylistic",
 			"strictness": "strict"
 		},
+		"eslint": [
+			{
+				"name": "markdown/no-duplicate-headings",
+				"url": "https://github.com/eslint/markdown/blob/HEAD/docs/rules/no-duplicate-headings.md"
+			}
+		],
 		"markdownlint": [
 			{
 				"name": "no-duplicate-heading",
@@ -8378,18 +8378,18 @@
 		"notes": "Overly opinionated."
 	},
 	{
-		"eslint": [
-			{
-				"name": "markdown/heading-increment",
-				"url": "https://github.com/eslint/markdown/blob/HEAD/docs/rules/heading-increment.md"
-			}
-		],
 		"flint": {
 			"name": "headingIncrements",
 			"plugin": "md",
 			"preset": "logical",
 			"status": "implemented"
 		},
+		"eslint": [
+			{
+				"name": "markdown/heading-increment",
+				"url": "https://github.com/eslint/markdown/blob/HEAD/docs/rules/heading-increment.md"
+			}
+		],
 		"markdownlint": [
 			{
 				"name": "heading-increment",
@@ -8440,12 +8440,6 @@
 		"notes": "Overly opinionated."
 	},
 	{
-		"eslint": [
-			{
-				"name": "markdown/no-multiple-h1",
-				"url": "https://github.com/eslint/markdown/blob/HEAD/docs/rules/no-multiple-h1.md"
-			}
-		],
 		"flint": {
 			"name": "headingRootDuplicates",
 			"plugin": "md",
@@ -8453,6 +8447,12 @@
 			"status": "implemented",
 			"strictness": "strict"
 		},
+		"eslint": [
+			{
+				"name": "markdown/no-multiple-h1",
+				"url": "https://github.com/eslint/markdown/blob/HEAD/docs/rules/no-multiple-h1.md"
+			}
+		],
 		"markdownlint": [
 			{
 				"name": "single-h1",
@@ -8475,17 +8475,17 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "headingSpaces",
+			"plugin": "md",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "markdown/no-missing-atx-heading-space",
 				"url": "https://github.com/eslint/markdown/blob/HEAD/docs/rules/no-missing-atx-heading-space.md"
 			}
 		],
-		"flint": {
-			"name": "headingSpaces",
-			"plugin": "md",
-			"status": "skipped"
-		},
 		"notes": "Formatting rule."
 	},
 	{
@@ -8532,17 +8532,17 @@
 		"notes": "Formatting rule."
 	},
 	{
+		"flint": {
+			"name": "html",
+			"plugin": "md",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "markdown/no-html",
 				"url": "https://github.com/eslint/markdown/blob/HEAD/docs/rules/no-html.md"
 			}
 		],
-		"flint": {
-			"name": "html",
-			"plugin": "md",
-			"status": "skipped"
-		},
 		"markdownlint": [
 			{
 				"name": "no-inline-html",
@@ -8551,18 +8551,18 @@
 		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "markdown/require-alt-text",
-				"url": "https://github.com/eslint/markdown/blob/HEAD/docs/rules/require-alt-text.md"
-			}
-		],
 		"flint": {
 			"name": "imageAltTexts",
 			"plugin": "md",
 			"preset": "logical",
 			"status": "implemented"
 		},
+		"eslint": [
+			{
+				"name": "markdown/require-alt-text",
+				"url": "https://github.com/eslint/markdown/blob/HEAD/docs/rules/require-alt-text.md"
+			}
+		],
 		"markdownlint": [
 			{
 				"name": "no-alt-text",
@@ -8571,32 +8571,32 @@
 		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "markdown/no-empty-images",
-				"url": "https://github.com/eslint/markdown/blob/HEAD/docs/rules/no-empty-images.md"
-			}
-		],
 		"flint": {
 			"name": "imageContents",
 			"plugin": "md",
 			"preset": "logical",
 			"status": "implemented"
-		}
-	},
-	{
+		},
 		"eslint": [
 			{
-				"name": "markdown/no-missing-label-refs",
-				"url": "https://github.com/eslint/markdown/blob/HEAD/docs/rules/no-missing-label-refs.md"
+				"name": "markdown/no-empty-images",
+				"url": "https://github.com/eslint/markdown/blob/HEAD/docs/rules/no-empty-images.md"
 			}
-		],
+		]
+	},
+	{
 		"flint": {
 			"name": "labelReferences",
 			"plugin": "md",
 			"preset": "logical",
 			"status": "implemented"
 		},
+		"eslint": [
+			{
+				"name": "markdown/no-missing-label-refs",
+				"url": "https://github.com/eslint/markdown/blob/HEAD/docs/rules/no-missing-label-refs.md"
+			}
+		],
 		"markdownlint": [
 			{
 				"name": "reference-links-images",
@@ -8605,18 +8605,18 @@
 		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "markdown/no-invalid-label-refs",
-				"url": "https://github.com/eslint/markdown/blob/HEAD/docs/rules/no-invalid-label-refs.md"
-			}
-		],
 		"flint": {
 			"name": "labelReferenceValidity",
 			"plugin": "md",
 			"preset": "logical",
 			"status": "implemented"
-		}
+		},
+		"eslint": [
+			{
+				"name": "markdown/no-invalid-label-refs",
+				"url": "https://github.com/eslint/markdown/blob/HEAD/docs/rules/no-invalid-label-refs.md"
+			}
+		]
 	},
 	{
 		"flint": {
@@ -8661,18 +8661,18 @@
 		"notes": "Formatting rule."
 	},
 	{
-		"eslint": [
-			{
-				"name": "markdown/no-empty-links",
-				"url": "https://github.com/eslint/markdown/blob/HEAD/docs/rules/no-empty-links.md"
-			}
-		],
 		"flint": {
 			"name": "linkContents",
 			"plugin": "md",
 			"preset": "logical",
 			"status": "implemented"
 		},
+		"eslint": [
+			{
+				"name": "markdown/no-empty-links",
+				"url": "https://github.com/eslint/markdown/blob/HEAD/docs/rules/no-empty-links.md"
+			}
+		],
 		"markdownlint": [
 			{
 				"name": "no-empty-links",
@@ -8695,18 +8695,18 @@
 		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "markdown/no-missing-link-fragments",
-				"url": "https://github.com/eslint/markdown/blob/HEAD/docs/rules/no-missing-link-fragments.md"
-			}
-		],
 		"flint": {
 			"name": "linkFragments",
 			"plugin": "md",
 			"preset": "logical",
 			"status": "implemented"
 		},
+		"eslint": [
+			{
+				"name": "markdown/no-missing-link-fragments",
+				"url": "https://github.com/eslint/markdown/blob/HEAD/docs/rules/no-missing-link-fragments.md"
+			}
+		],
 		"markdownlint": [
 			{
 				"name": "link-fragments",
@@ -8770,18 +8770,18 @@
 		"notes": "Formatting rule."
 	},
 	{
-		"eslint": [
-			{
-				"name": "markdown/no-reversed-media-syntax",
-				"url": "https://github.com/eslint/markdown/blob/HEAD/docs/rules/no-reversed-media-syntax.md"
-			}
-		],
 		"flint": {
 			"name": "mediaSyntaxReversals",
 			"plugin": "md",
 			"preset": "stylistic",
 			"status": "implemented"
 		},
+		"eslint": [
+			{
+				"name": "markdown/no-reversed-media-syntax",
+				"url": "https://github.com/eslint/markdown/blob/HEAD/docs/rules/no-reversed-media-syntax.md"
+			}
+		],
 		"markdownlint": [
 			{
 				"name": "no-reversed-links",
@@ -8819,18 +8819,18 @@
 		"notes": "Superseded by cspell."
 	},
 	{
-		"eslint": [
-			{
-				"name": "markdown/no-reference-like-urls",
-				"url": "https://github.com/eslint/markdown/blob/main/docs/rules/no-reference-like-urls.md"
-			}
-		],
 		"flint": {
 			"name": "referenceLikeUrls",
 			"plugin": "md",
 			"preset": "logical",
 			"status": "implemented"
-		}
+		},
+		"eslint": [
+			{
+				"name": "markdown/no-reference-like-urls",
+				"url": "https://github.com/eslint/markdown/blob/main/docs/rules/no-reference-like-urls.md"
+			}
+		]
 	},
 	{
 		"flint": {
@@ -8861,18 +8861,18 @@
 		"notes": "Formatting rule."
 	},
 	{
-		"eslint": [
-			{
-				"name": "markdown/table-column-count",
-				"url": "https://github.com/eslint/markdown/blob/HEAD/docs/rules/table-column-count.md"
-			}
-		],
 		"flint": {
 			"name": "tableColumnCounts",
 			"plugin": "md",
 			"preset": "logical",
 			"status": "implemented"
 		},
+		"eslint": [
+			{
+				"name": "markdown/table-column-count",
+				"url": "https://github.com/eslint/markdown/blob/HEAD/docs/rules/table-column-count.md"
+			}
+		],
 		"markdownlint": [
 			{
 				"name": "table-column-count",
@@ -8937,17 +8937,17 @@
 		"notes": "Formatting rule."
 	},
 	{
+		"flint": {
+			"name": "anchorNatives",
+			"plugin": "next",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "@next/next/no-html-link-for-pages",
 				"url": "https://nextjs.org/docs/messages/no-html-link-for-pages"
 			}
 		],
-		"flint": {
-			"name": "anchorNatives",
-			"plugin": "next",
-			"preset": "logical"
-		},
 		"oxlint": [
 			{
 				"name": "nextjs/no-html-link-for-pages",
@@ -8956,6 +8956,11 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "clientComponentAsyncDefinitions",
+			"plugin": "next",
+			"preset": "logical"
+		},
 		"biome": [
 			{
 				"name": "noNextAsyncClientComponent",
@@ -8968,11 +8973,6 @@
 				"url": "https://nextjs.org/docs/messages/no-async-client-component"
 			}
 		],
-		"flint": {
-			"name": "clientComponentAsyncDefinitions",
-			"plugin": "next",
-			"preset": "logical"
-		},
 		"oxlint": [
 			{
 				"name": "nextjs/no-async-client-component",
@@ -8981,17 +8981,17 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "cssManualStylesheets",
+			"plugin": "next",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "@next/next/no-css-tags",
 				"url": "https://nextjs.org/docs/messages/no-css-tags"
 			}
 		],
-		"flint": {
-			"name": "cssManualStylesheets",
-			"plugin": "next",
-			"preset": "logical"
-		},
 		"oxlint": [
 			{
 				"name": "nextjs/no-css-tags",
@@ -9000,17 +9000,17 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "customFontsInPages",
+			"plugin": "next",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "@next/next/no-page-custom-font",
 				"url": "https://nextjs.org/docs/messages/no-page-custom-font"
 			}
 		],
-		"flint": {
-			"name": "customFontsInPages",
-			"plugin": "next",
-			"preset": "logical"
-		},
 		"oxlint": [
 			{
 				"name": "nextjs/no-page-custom-font",
@@ -9019,17 +9019,17 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "googleAnalyticsInlineScript",
+			"plugin": "next",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "@next/next/next-script-for-ga",
 				"url": "https://nextjs.org/docs/messages/next-script-for-ga"
 			}
 		],
-		"flint": {
-			"name": "googleAnalyticsInlineScript",
-			"plugin": "next",
-			"preset": "logical"
-		},
 		"oxlint": [
 			{
 				"name": "nextjs/next-script-for-ga",
@@ -9038,6 +9038,11 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "googleFontDisplay",
+			"plugin": "next",
+			"preset": "logical"
+		},
 		"biome": [
 			{
 				"name": "useGoogleFontDisplay",
@@ -9050,11 +9055,6 @@
 				"url": "https://nextjs.org/docs/messages/google-font-display"
 			}
 		],
-		"flint": {
-			"name": "googleFontDisplay",
-			"plugin": "next",
-			"preset": "logical"
-		},
 		"oxlint": [
 			{
 				"name": "nextjs/google-font-display",
@@ -9063,6 +9063,11 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "googleFontPreconnect",
+			"plugin": "next",
+			"preset": "logical"
+		},
 		"biome": [
 			{
 				"name": "useGoogleFontPreconnect",
@@ -9075,11 +9080,6 @@
 				"url": "https://nextjs.org/docs/messages/google-font-preconnect"
 			}
 		],
-		"flint": {
-			"name": "googleFontPreconnect",
-			"plugin": "next",
-			"preset": "logical"
-		},
 		"oxlint": [
 			{
 				"name": "nextjs/google-font-preconnect",
@@ -9088,17 +9088,17 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "headDuplicates",
+			"plugin": "next",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "@next/next/no-duplicate-head",
 				"url": "https://nextjs.org/docs/messages/no-duplicate-head"
 			}
 		],
-		"flint": {
-			"name": "headDuplicates",
-			"plugin": "next",
-			"preset": "logical"
-		},
 		"oxlint": [
 			{
 				"name": "nextjs/no-duplicate-head",
@@ -9107,6 +9107,11 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "headImportsInDocuments",
+			"plugin": "next",
+			"preset": "logical"
+		},
 		"biome": [
 			{
 				"name": "noHeadImportInDocument",
@@ -9119,11 +9124,6 @@
 				"url": "https://nextjs.org/docs/messages/no-head-import-in-document"
 			}
 		],
-		"flint": {
-			"name": "headImportsInDocuments",
-			"plugin": "next",
-			"preset": "logical"
-		},
 		"oxlint": [
 			{
 				"name": "nextjs/no-head-import-in-document",
@@ -9132,6 +9132,11 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "headNatives",
+			"plugin": "next",
+			"preset": "logical"
+		},
 		"biome": [
 			{
 				"name": "noHeadElement",
@@ -9144,11 +9149,6 @@
 				"url": "https://nextjs.org/docs/messages/no-head-element"
 			}
 		],
-		"flint": {
-			"name": "headNatives",
-			"plugin": "next",
-			"preset": "logical"
-		},
 		"oxlint": [
 			{
 				"name": "nextjs/no-head-element",
@@ -9157,6 +9157,11 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "imgNatives",
+			"plugin": "next",
+			"preset": "logical"
+		},
 		"biome": [
 			{
 				"name": "noImgElement",
@@ -9169,11 +9174,6 @@
 				"url": "https://nextjs.org/docs/messages/no-img-element"
 			}
 		],
-		"flint": {
-			"name": "imgNatives",
-			"plugin": "next",
-			"preset": "logical"
-		},
 		"oxlint": [
 			{
 				"name": "nextjs/no-img-element",
@@ -9182,6 +9182,11 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "inlineScriptId",
+			"plugin": "next",
+			"preset": "logical"
+		},
 		"biome": [
 			{
 				"name": "useInlineScriptId",
@@ -9194,11 +9199,6 @@
 				"url": "https://nextjs.org/docs/messages/inline-script-id"
 			}
 		],
-		"flint": {
-			"name": "inlineScriptId",
-			"plugin": "next",
-			"preset": "logical"
-		},
 		"oxlint": [
 			{
 				"name": "nextjs/inline-script-id",
@@ -9207,17 +9207,17 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "moduleAssignments",
+			"plugin": "next",
+			"preset": "javascript"
+		},
 		"eslint": [
 			{
 				"name": "@next/next/no-assign-module-variable",
 				"url": "https://nextjs.org/docs/messages/no-assign-module-variable"
 			}
 		],
-		"flint": {
-			"name": "moduleAssignments",
-			"plugin": "next",
-			"preset": "javascript"
-		},
 		"oxlint": [
 			{
 				"name": "nextjs/no-assign-module-variable",
@@ -9226,6 +9226,11 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "nextDocumentOutsidePage",
+			"plugin": "next",
+			"preset": "logical"
+		},
 		"biome": [
 			{
 				"name": "noDocumentImportInPage",
@@ -9238,11 +9243,6 @@
 				"url": "https://nextjs.org/docs/messages/no-document-import-in-page"
 			}
 		],
-		"flint": {
-			"name": "nextDocumentOutsidePage",
-			"plugin": "next",
-			"preset": "logical"
-		},
 		"oxlint": [
 			{
 				"name": "nextjs/no-document-import-in-page",
@@ -9251,17 +9251,17 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "nextScriptInHeads",
+			"plugin": "next",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "@next/next/no-script-component-in-head",
 				"url": "https://nextjs.org/docs/messages/no-script-component-in-head"
 			}
 		],
-		"flint": {
-			"name": "nextScriptInHeads",
-			"plugin": "next",
-			"preset": "logical"
-		},
 		"oxlint": [
 			{
 				"name": "nextjs/no-script-component-in-head",
@@ -9270,6 +9270,11 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "nextScriptInteractiveOutsideDocument",
+			"plugin": "next",
+			"preset": "logical"
+		},
 		"biome": [
 			{
 				"name": "noBeforeInteractiveScriptOutsideDocument",
@@ -9282,11 +9287,6 @@
 				"url": "https://nextjs.org/docs/messages/no-before-interactive-script-outside-document"
 			}
 		],
-		"flint": {
-			"name": "nextScriptInteractiveOutsideDocument",
-			"plugin": "next",
-			"preset": "logical"
-		},
 		"oxlint": [
 			{
 				"name": "nextjs/no-before-interactive-script-outside-document",
@@ -9295,6 +9295,11 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "polyfillDuplicates",
+			"plugin": "next",
+			"preset": "logical"
+		},
 		"biome": [
 			{
 				"name": "noUnwantedPolyfillio",
@@ -9307,11 +9312,6 @@
 				"url": "https://nextjs.org/docs/messages/no-unwanted-polyfillio"
 			}
 		],
-		"flint": {
-			"name": "polyfillDuplicates",
-			"plugin": "next",
-			"preset": "logical"
-		},
 		"oxlint": [
 			{
 				"name": "nextjs/no-unwanted-polyfillio",
@@ -9320,6 +9320,11 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "scriptSyncs",
+			"plugin": "next",
+			"preset": "logical"
+		},
 		"biome": [
 			{
 				"name": "noSyncScripts",
@@ -9332,11 +9337,6 @@
 				"url": "https://nextjs.org/docs/messages/no-sync-scripts"
 			}
 		],
-		"flint": {
-			"name": "scriptSyncs",
-			"plugin": "next",
-			"preset": "logical"
-		},
 		"oxlint": [
 			{
 				"name": "nextjs/no-sync-scripts",
@@ -9345,17 +9345,17 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "styledJsxInDocuments",
+			"plugin": "next",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "@next/next/no-styled-jsx-in-document",
 				"url": "https://nextjs.org/docs/messages/no-styled-jsx-in-document"
 			}
 		],
-		"flint": {
-			"name": "styledJsxInDocuments",
-			"plugin": "next",
-			"preset": "logical"
-		},
 		"oxlint": [
 			{
 				"name": "nextjs/no-styled-jsx-in-document",
@@ -9364,17 +9364,17 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "titleInDocumentHeads",
+			"plugin": "next",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "@next/next/no-title-in-document-head",
 				"url": "https://nextjs.org/docs/messages/no-title-in-document-head"
 			}
 		],
-		"flint": {
-			"name": "titleInDocumentHeads",
-			"plugin": "next",
-			"preset": "logical"
-		},
 		"oxlint": [
 			{
 				"name": "nextjs/no-title-in-document-head",
@@ -9383,17 +9383,17 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "typos",
+			"plugin": "next",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "@next/next/no-typos",
 				"url": "https://nextjs.org/docs/messages/no-typos"
 			}
 		],
-		"flint": {
-			"name": "typos",
-			"plugin": "next",
-			"preset": "logical"
-		},
 		"oxlint": [
 			{
 				"name": "nextjs/no-typos",
@@ -9402,45 +9402,45 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "asciiCharacters",
+			"plugin": "node",
+			"status": "skipped"
+		},
 		"deno": [
 			{
 				"name": "prefer-ascii",
 				"url": "https://docs.deno.com/lint/rules/prefer-ascii"
 			}
-		],
-		"flint": {
-			"name": "asciiCharacters",
-			"plugin": "node",
-			"status": "skipped"
-		}
+		]
 	},
 	{
-		"biome": [
-			{
-				"name": "useNodeAssertStrict",
-				"url": "https://biomejs.dev/linter/rules/use-node-assert-strict"
-			}
-		],
 		"flint": {
 			"name": "assertStrict",
 			"plugin": "node",
 			"preset": "logical",
 			"status": "implemented"
-		}
+		},
+		"biome": [
+			{
+				"name": "useNodeAssertStrict",
+				"url": "https://biomejs.dev/linter/rules/use-node-assert-strict"
+			}
+		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "unicorn/consistent-assert",
-				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/consistent-assert.md"
-			}
-		],
 		"flint": {
 			"name": "assertStyles",
 			"plugin": "node",
 			"preset": "stylistic",
 			"status": "implemented"
 		},
+		"eslint": [
+			{
+				"name": "unicorn/consistent-assert",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/consistent-assert.md"
+			}
+		],
 		"oxlint": [
 			{
 				"name": "unicorn/consistent-assert",
@@ -9449,18 +9449,18 @@
 		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "unicorn/prefer-blob-reading-methods",
-				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prefer-blob-reading-methods.md"
-			}
-		],
 		"flint": {
 			"name": "blobReadingMethods",
 			"plugin": "node",
 			"preset": "stylistic",
 			"status": "implemented"
 		},
+		"eslint": [
+			{
+				"name": "unicorn/prefer-blob-reading-methods",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prefer-blob-reading-methods.md"
+			}
+		],
 		"oxlint": [
 			{
 				"name": "unicorn/prefer-blob-reading-methods",
@@ -9469,18 +9469,18 @@
 		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "unicorn/no-new-buffer",
-				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-new-buffer.md"
-			}
-		],
 		"flint": {
 			"name": "bufferAllocators",
 			"plugin": "node",
 			"preset": "logical",
 			"status": "implemented"
 		},
+		"eslint": [
+			{
+				"name": "unicorn/no-new-buffer",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-new-buffer.md"
+			}
+		],
 		"oxlint": [
 			{
 				"name": "unicorn/no-new-buffer",
@@ -9489,17 +9489,17 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "callbackErrorHandling",
+			"plugin": "node",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "n/handle-callback-err",
 				"url": "https://github.com/eslint-community/eslint-plugin-n/blob/HEAD/docs/rules/handle-callback-err.md"
 			}
 		],
-		"flint": {
-			"name": "callbackErrorHandling",
-			"plugin": "node",
-			"status": "skipped"
-		},
 		"oxlint": [
 			{
 				"name": "node/handle-callback-err",
@@ -9508,30 +9508,30 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "callbackErrorLiterals",
+			"plugin": "node",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "n/no-callback-literal",
 				"url": "https://github.com/eslint-community/eslint-plugin-n/blob/HEAD/docs/rules/no-callback-literal.md"
 			}
-		],
-		"flint": {
-			"name": "callbackErrorLiterals",
-			"plugin": "node",
-			"status": "skipped"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "callbackReturns",
+			"plugin": "node",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "n/callback-return",
 				"url": "https://github.com/eslint-community/eslint-plugin-n/blob/HEAD/docs/rules/callback-return.md"
 			}
 		],
-		"flint": {
-			"name": "callbackReturns",
-			"plugin": "node",
-			"status": "skipped"
-		},
 		"oxlint": [
 			{
 				"name": "node/callback-return",
@@ -9540,12 +9540,6 @@
 		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "unicorn/no-console-spaces",
-				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-console-spaces.md"
-			}
-		],
 		"flint": {
 			"name": "consoleSpaces",
 			"plugin": "node",
@@ -9553,6 +9547,12 @@
 			"status": "implemented",
 			"strictness": "strict"
 		},
+		"eslint": [
+			{
+				"name": "unicorn/no-console-spaces",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-console-spaces.md"
+			}
+		],
 		"oxlint": [
 			{
 				"name": "unicorn/no-console-spaces",
@@ -9561,19 +9561,24 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "coreModuleHiding",
+			"plugin": "node"
+		},
 		"eslint": [
 			{
 				"name": "n/no-hide-core-modules",
 				"url": "https://github.com/eslint-community/eslint-plugin-n/blob/HEAD/docs/rules/no-hide-core-modules.md"
 			}
 		],
-		"flint": {
-			"name": "coreModuleHiding",
-			"plugin": "node"
-		},
 		"notes": "Deprecated because the rule was based on an invalid assumption."
 	},
 	{
+		"flint": {
+			"name": "deprecatedAPIs",
+			"plugin": "node",
+			"status": "skipped"
+		},
 		"deno": [
 			{
 				"name": "no-deprecated-deno-api",
@@ -9586,33 +9591,22 @@
 				"url": "https://github.com/eslint-community/eslint-plugin-n/blob/HEAD/docs/rules/no-deprecated-api.md"
 			}
 		],
-		"flint": {
-			"name": "deprecatedAPIs",
-			"plugin": "node",
-			"status": "skipped"
-		},
 		"notes": "Superseded by deprecated."
 	},
 	{
+		"flint": {
+			"name": "environmentVariableDeclarations",
+			"plugin": "node",
+			"preset": "logical"
+		},
 		"biome": [
 			{
 				"name": "noUndeclaredEnvVars",
 				"url": "https://biomejs.dev/linter/rules/no-undeclared-env-vars"
 			}
-		],
-		"flint": {
-			"name": "environmentVariableDeclarations",
-			"plugin": "node",
-			"preset": "logical"
-		}
+		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "unicorn/prefer-event-target",
-				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prefer-event-target.md"
-			}
-		],
 		"flint": {
 			"name": "eventClasses",
 			"plugin": "node",
@@ -9620,6 +9614,12 @@
 			"status": "implemented",
 			"strictness": "strict"
 		},
+		"eslint": [
+			{
+				"name": "unicorn/prefer-event-target",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prefer-event-target.md"
+			}
+		],
 		"oxlint": [
 			{
 				"name": "unicorn/prefer-event-target",
@@ -9628,18 +9628,18 @@
 		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "n/no-exports-assign",
-				"url": "https://github.com/eslint-community/eslint-plugin-n/blob/HEAD/docs/rules/no-exports-assign.md"
-			}
-		],
 		"flint": {
 			"name": "exportsAssignments",
 			"plugin": "node",
 			"preset": "logical",
 			"status": "implemented"
 		},
+		"eslint": [
+			{
+				"name": "n/no-exports-assign",
+				"url": "https://github.com/eslint-community/eslint-plugin-n/blob/HEAD/docs/rules/no-exports-assign.md"
+			}
+		],
 		"oxlint": [
 			{
 				"name": "node/no-exports-assign",
@@ -9648,40 +9648,34 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "exportsStyle",
+			"plugin": "node",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "n/exports-style",
 				"url": "https://github.com/eslint-community/eslint-plugin-n/blob/HEAD/docs/rules/exports-style.md"
 			}
 		],
-		"flint": {
-			"name": "exportsStyle",
-			"plugin": "node",
-			"status": "skipped"
-		},
 		"notes": "CJS-specific."
 	},
 	{
+		"flint": {
+			"name": "extraneousRequires",
+			"plugin": "node",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "n/no-extraneous-require",
 				"url": "https://github.com/eslint-community/eslint-plugin-n/blob/HEAD/docs/rules/no-extraneous-require.md"
 			}
 		],
-		"flint": {
-			"name": "extraneousRequires",
-			"plugin": "node",
-			"status": "skipped"
-		},
 		"notes": "Superseded by Knip."
 	},
 	{
-		"eslint": [
-			{
-				"name": "unicorn/prefer-import-meta-properties",
-				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prefer-import-meta-properties.md"
-			}
-		],
 		"flint": {
 			"name": "filePathsFromImportMeta",
 			"plugin": "node",
@@ -9689,6 +9683,12 @@
 			"status": "implemented",
 			"strictness": "strict"
 		},
+		"eslint": [
+			{
+				"name": "unicorn/prefer-import-meta-properties",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prefer-import-meta-properties.md"
+			}
+		],
 		"oxlint": [
 			{
 				"name": "unicorn/prefer-import-meta-properties",
@@ -9697,59 +9697,64 @@
 		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "unicorn/prefer-json-parse-buffer",
-				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prefer-json-parse-buffer.md"
-			}
-		],
 		"flint": {
 			"name": "fileReadJSONBuffers",
 			"plugin": "node",
 			"preset": "stylistic",
 			"status": "implemented",
 			"strictness": "strict"
-		}
+		},
+		"eslint": [
+			{
+				"name": "unicorn/prefer-json-parse-buffer",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prefer-json-parse-buffer.md"
+			}
+		]
 	},
 	{
+		"flint": {
+			"name": "globalBuffer",
+			"plugin": "node",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "n/prefer-global/buffer",
 				"url": "https://github.com/eslint-community/eslint-plugin-n/blob/HEAD/docs/rules/prefer-global.md"
 			}
-		],
-		"flint": {
-			"name": "globalBuffer",
-			"plugin": "node",
-			"status": "skipped"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "globalConsole",
+			"plugin": "node",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "n/prefer-global/console",
 				"url": "https://github.com/eslint-community/eslint-plugin-n/blob/HEAD/docs/rules/prefer-global.md"
 			}
-		],
-		"flint": {
-			"name": "globalConsole",
-			"plugin": "node",
-			"status": "skipped"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "globalCrypto",
+			"plugin": "node"
+		},
 		"eslint": [
 			{
 				"name": "n/prefer-global/crypto",
 				"url": "https://github.com/eslint-community/eslint-plugin-n/blob/HEAD/docs/rules/prefer-global/crypto.md"
 			}
-		],
-		"flint": {
-			"name": "globalCrypto",
-			"plugin": "node"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "globalProcess",
+			"plugin": "node",
+			"status": "skipped"
+		},
 		"biome": [
 			{
 				"name": "noProcessGlobal",
@@ -9767,91 +9772,90 @@
 				"name": "n/prefer-global/process",
 				"url": "https://github.com/eslint-community/eslint-plugin-n/blob/HEAD/docs/rules/prefer-global.md"
 			}
-		],
-		"flint": {
-			"name": "globalProcess",
-			"plugin": "node",
-			"status": "skipped"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "globalTextDecoder",
+			"plugin": "node",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "n/prefer-global/text-decoder",
 				"url": "https://github.com/eslint-community/eslint-plugin-n/blob/HEAD/docs/rules/prefer-global.md"
 			}
-		],
-		"flint": {
-			"name": "globalTextDecoder",
-			"plugin": "node",
-			"status": "skipped"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "globalTextEncoder",
+			"plugin": "node",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "n/prefer-global/text-encoder",
 				"url": "https://github.com/eslint-community/eslint-plugin-n/blob/HEAD/docs/rules/prefer-global.md"
 			}
-		],
-		"flint": {
-			"name": "globalTextEncoder",
-			"plugin": "node",
-			"status": "skipped"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "globalTimers",
+			"plugin": "node"
+		},
 		"eslint": [
 			{
 				"name": "n/prefer-global/timers",
 				"url": "https://github.com/eslint-community/eslint-plugin-n/blob/HEAD/docs/rules/prefer-global/timers.md"
 			}
-		],
-		"flint": {
-			"name": "globalTimers",
-			"plugin": "node"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "globalURL",
+			"plugin": "node",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "n/prefer-global/url",
 				"url": "https://github.com/eslint-community/eslint-plugin-n/blob/HEAD/docs/rules/prefer-global/url.md"
 			}
-		],
-		"flint": {
-			"name": "globalURL",
-			"plugin": "node",
-			"status": "skipped"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "globalURLSearchParams",
+			"plugin": "node",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "n/prefer-global/url-search-params",
 				"url": "https://github.com/eslint-community/eslint-plugin-n/blob/HEAD/docs/rules/prefer-global/url-search-params.md"
 			}
-		],
-		"flint": {
-			"name": "globalURLSearchParams",
-			"plugin": "node",
-			"status": "skipped"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "hashbangs",
+			"plugin": "node",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "n/hashbang",
 				"url": "https://github.com/eslint-community/eslint-plugin-n/blob/HEAD/docs/rules/hashbang.md"
 			}
-		],
-		"flint": {
-			"name": "hashbangs",
-			"plugin": "node",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "importFileExtensions",
+			"plugin": "node"
+		},
 		"biome": [
 			{
 				"name": "useImportExtensions",
@@ -9870,10 +9874,6 @@
 				"url": "https://github.com/eslint-community/eslint-plugin-n/blob/HEAD/docs/rules/file-extension-in-import.md"
 			}
 		],
-		"flint": {
-			"name": "importFileExtensions",
-			"plugin": "node"
-		},
 		"oxlint": [
 			{
 				"name": "import/extensions",
@@ -9882,57 +9882,57 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "missingImports",
+			"plugin": "node",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "n/no-missing-import",
 				"url": "https://github.com/eslint-community/eslint-plugin-n/blob/HEAD/docs/rules/no-missing-import.md"
 			}
-		],
-		"flint": {
-			"name": "missingImports",
-			"plugin": "node",
-			"status": "skipped"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "missingRequires",
+			"plugin": "node",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "n/no-missing-require",
 				"url": "https://github.com/eslint-community/eslint-plugin-n/blob/HEAD/docs/rules/no-missing-require.md"
 			}
-		],
-		"flint": {
-			"name": "missingRequires",
-			"plugin": "node",
-			"status": "skipped"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "mixedRequires",
+			"plugin": "node",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "n/no-mixed-requires",
 				"url": "https://github.com/eslint-community/eslint-plugin-n/blob/HEAD/docs/rules/no-mixed-requires.md"
 			}
 		],
-		"flint": {
-			"name": "mixedRequires",
-			"plugin": "node",
-			"status": "skipped"
-		},
 		"notes": "Superseded by ESM and ordering rules."
 	},
 	{
+		"flint": {
+			"name": "newRequires",
+			"plugin": "node",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "n/no-new-require",
 				"url": "https://github.com/eslint-community/eslint-plugin-n/blob/HEAD/docs/rules/no-new-require.md"
 			}
 		],
-		"flint": {
-			"name": "newRequires",
-			"plugin": "node",
-			"status": "skipped"
-		},
 		"oxlint": [
 			{
 				"name": "node/no-new-require",
@@ -9941,19 +9941,25 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "nodeGlobals",
+			"plugin": "node",
+			"status": "skipped"
+		},
 		"deno": [
 			{
 				"name": "no-node-globals",
 				"url": "https://docs.deno.com/lint/rules/no-node-globals"
 			}
-		],
-		"flint": {
-			"name": "nodeGlobals",
-			"plugin": "node",
-			"status": "skipped"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "nodeProtocols",
+			"plugin": "node",
+			"preset": "logical",
+			"status": "implemented"
+		},
 		"biome": [
 			{
 				"name": "useNodejsImportProtocol",
@@ -9974,12 +9980,6 @@
 				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prefer-node-protocol.md"
 			}
 		],
-		"flint": {
-			"name": "nodeProtocols",
-			"plugin": "node",
-			"preset": "logical",
-			"status": "implemented"
-		},
 		"oxlint": [
 			{
 				"name": "unicorn/prefer-node-protocol",
@@ -9988,17 +9988,17 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "pathConcatenations",
+			"plugin": "node",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "n/no-path-concat",
 				"url": "https://github.com/eslint-community/eslint-plugin-n/blob/HEAD/docs/rules/no-path-concat.md"
 			}
 		],
-		"flint": {
-			"name": "pathConcatenations",
-			"plugin": "node",
-			"status": "skipped"
-		},
 		"oxlint": [
 			{
 				"name": "node/no-path-concat",
@@ -10007,6 +10007,11 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "processEnvs",
+			"plugin": "node",
+			"status": "skipped"
+		},
 		"biome": [
 			{
 				"name": "noProcessEnv",
@@ -10019,11 +10024,6 @@
 				"url": "https://github.com/eslint-community/eslint-plugin-n/blob/HEAD/docs/rules/no-process-env.md"
 			}
 		],
-		"flint": {
-			"name": "processEnvs",
-			"plugin": "node",
-			"status": "skipped"
-		},
 		"oxlint": [
 			{
 				"name": "node/no-process-env",
@@ -10032,6 +10032,12 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "processExits",
+			"plugin": "node",
+			"preset": "logical",
+			"status": "implemented"
+		},
 		"eslint": [
 			{
 				"name": "n/no-process-exit",
@@ -10042,12 +10048,6 @@
 				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-process-exit.md"
 			}
 		],
-		"flint": {
-			"name": "processExits",
-			"plugin": "node",
-			"preset": "logical",
-			"status": "implemented"
-		},
 		"oxlint": [
 			{
 				"name": "unicorn/no-process-exit",
@@ -10056,30 +10056,30 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "processExitThrows",
+			"plugin": "node",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "n/process-exit-as-throw",
 				"url": "https://github.com/eslint-community/eslint-plugin-n/blob/HEAD/docs/rules/process-exit-as-throw.md"
 			}
-		],
-		"flint": {
-			"name": "processExitThrows",
-			"plugin": "node",
-			"status": "skipped"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "promiseCallbackFunctions",
+			"plugin": "node",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "promise/no-callback-in-promise",
 				"url": "https://github.com/eslint-community/eslint-plugin-promise/blob/HEAD/docs/rules/no-callback-in-promise.md"
 			}
 		],
-		"flint": {
-			"name": "promiseCallbackFunctions",
-			"plugin": "node",
-			"status": "skipped"
-		},
 		"oxlint": [
 			{
 				"name": "promise/no-callback-in-promise",
@@ -10088,540 +10088,546 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "promisesDNS",
+			"plugin": "node",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "n/prefer-promises/dns",
 				"url": "https://github.com/eslint-community/eslint-plugin-n/blob/HEAD/docs/rules/prefer-promises.md"
 			}
-		],
-		"flint": {
-			"name": "promisesDNS",
-			"plugin": "node",
-			"status": "skipped"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "promisesFS",
+			"plugin": "node",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "n/prefer-promises/fs",
 				"url": "https://github.com/eslint-community/eslint-plugin-n/blob/HEAD/docs/rules/prefer-promises.md"
 			}
-		],
-		"flint": {
-			"name": "promisesFS",
-			"plugin": "node",
-			"status": "skipped"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "restrictedImports",
+			"plugin": "node"
+		},
 		"eslint": [
 			{
 				"name": "n/no-restricted-import",
 				"url": "https://github.com/eslint-community/eslint-plugin-n/blob/HEAD/docs/rules/no-restricted-import.md"
 			}
-		],
-		"flint": {
-			"name": "restrictedImports",
-			"plugin": "node"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "restrictedRequires",
+			"plugin": "node",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "n/no-restricted-require",
 				"url": "https://github.com/eslint-community/eslint-plugin-n/blob/HEAD/docs/rules/no-restricted-require.md"
 			}
-		],
-		"flint": {
-			"name": "restrictedRequires",
-			"plugin": "node",
-			"status": "skipped"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "shebangs",
+			"plugin": "node"
+		},
 		"eslint": [
 			{
 				"name": "n/shebang",
 				"url": "https://github.com/eslint-community/eslint-plugin-n/blob/HEAD/docs/rules/hashbang.md"
 			}
 		],
-		"flint": {
-			"name": "shebangs",
-			"plugin": "node"
-		},
 		"notes": "Superseded by hashbangs."
 	},
 	{
+		"flint": {
+			"name": "syncFunctionInAsyncFunctions",
+			"plugin": "node",
+			"status": "skipped"
+		},
 		"deno": [
 			{
 				"name": "no-sync-fn-in-async-fn",
 				"url": "https://docs.deno.com/lint/rules/no-sync-fn-in-async-fn"
 			}
-		],
-		"flint": {
-			"name": "syncFunctionInAsyncFunctions",
-			"plugin": "node",
-			"status": "skipped"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "synchronousMethods",
+			"plugin": "node",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "n/no-sync",
 				"url": "https://github.com/eslint-community/eslint-plugin-n/blob/HEAD/docs/rules/no-sync.md"
 			}
-		],
-		"flint": {
-			"name": "synchronousMethods",
-			"plugin": "node",
-			"status": "skipped"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "topLevelAwaits",
+			"plugin": "node"
+		},
 		"eslint": [
 			{
 				"name": "n/no-top-level-await",
 				"url": "https://github.com/eslint-community/eslint-plugin-n/blob/HEAD/docs/rules/no-top-level-await.md"
 			}
-		],
-		"flint": {
-			"name": "topLevelAwaits",
-			"plugin": "node"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "topLevelRequires",
+			"plugin": "node",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "n/global-require",
 				"url": "https://github.com/eslint-community/eslint-plugin-n/blob/HEAD/docs/rules/global-require.md"
 			}
 		],
-		"flint": {
-			"name": "topLevelRequires",
-			"plugin": "node",
-			"status": "skipped"
-		},
-		"notes": "CJS-specific.",
 		"oxlint": [
 			{
 				"name": "node/global-require",
 				"url": "https://oxc.rs/docs/guide/usage/linter/rules/node/global-require.html"
 			}
-		]
+		],
+		"notes": "CJS-specific."
 	},
 	{
+		"flint": {
+			"name": "unpublishedBins",
+			"plugin": "node",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "n/no-unpublished-bin",
 				"url": "https://github.com/eslint-community/eslint-plugin-n/blob/HEAD/docs/rules/no-unpublished-bin.md"
 			}
-		],
-		"flint": {
-			"name": "unpublishedBins",
-			"plugin": "node",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "unpublishedImports",
+			"plugin": "node",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "n/no-unpublished-import",
 				"url": "https://github.com/eslint-community/eslint-plugin-n/blob/HEAD/docs/rules/no-unpublished-import.md"
 			}
-		],
-		"flint": {
-			"name": "unpublishedImports",
-			"plugin": "node",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "unpublishedRequires",
+			"plugin": "node",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "n/no-unpublished-require",
 				"url": "https://github.com/eslint-community/eslint-plugin-n/blob/HEAD/docs/rules/no-unpublished-require.md"
 			}
-		],
-		"flint": {
-			"name": "unpublishedRequires",
-			"plugin": "node",
-			"status": "skipped"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "unsupportedGlobals",
+			"plugin": "node",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "n/no-unsupported-features/es-builtins",
 				"url": "https://github.com/eslint-community/eslint-plugin-n/blob/HEAD/docs/rules/no-unsupported-features.md"
 			}
-		],
-		"flint": {
-			"name": "unsupportedGlobals",
-			"plugin": "node",
-			"status": "skipped"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "unsupportedNodeAPIs",
+			"plugin": "node",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "n/no-unsupported-features/node-builtins",
 				"url": "https://github.com/eslint-community/eslint-plugin-n/blob/HEAD/docs/rules/no-unsupported-features.md"
 			}
-		],
-		"flint": {
-			"name": "unsupportedNodeAPIs",
-			"plugin": "node",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "unsupportedSyntax",
+			"plugin": "node",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "n/no-unsupported-features/es-syntax",
 				"url": "https://github.com/eslint-community/eslint-plugin-n/blob/HEAD/docs/rules/no-unsupported-features.md"
 			}
-		],
-		"flint": {
-			"name": "unsupportedSyntax",
-			"plugin": "node",
-			"status": "skipped"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "importMetaProperties",
+			"plugin": "nuxt",
+			"preset": "stylistic"
+		},
 		"eslint": [
 			{
 				"name": "nuxt/prefer-import-meta",
 				"url": "https://eslint.nuxt.com/packages/plugin#nuxtprefer-import-meta"
 			}
-		],
-		"flint": {
-			"name": "importMetaProperties",
-			"plugin": "nuxt",
-			"preset": "stylistic"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "nuxtConfigKeysOrder",
+			"plugin": "nuxt",
+			"preset": "sorting"
+		},
 		"eslint": [
 			{
 				"name": "nuxt/nuxt-config-keys-order",
 				"url": "https://eslint.nuxt.com/packages/plugin#nuxtnuxt-config-keys-order"
 			}
-		],
-		"flint": {
-			"name": "nuxtConfigKeysOrder",
-			"plugin": "nuxt",
-			"preset": "sorting"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "nuxtConfigTestKeys",
+			"plugin": "nuxt",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "nuxt/no-nuxt-config-test-key",
 				"url": "https://eslint.nuxt.com/packages/plugin#nuxtno-nuxt-config-test-key"
 			}
-		],
-		"flint": {
-			"name": "nuxtConfigTestKeys",
-			"plugin": "nuxt",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "pageMetaRuntimeValues",
+			"plugin": "nuxt",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "nuxt/no-page-meta-runtime-values",
 				"url": "https://eslint.nuxt.com/packages/plugin#nuxtno-page-meta-runtime-values"
 			}
-		],
-		"flint": {
-			"name": "pageMetaRuntimeValues",
-			"plugin": "nuxt",
-			"preset": "logical"
-		}
+		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "package-json/require-attribution",
-				"url": "https://eslint-plugin-package-json.dev/rules/require-attribution"
-			}
-		],
 		"flint": {
 			"name": "attribution",
 			"plugin": "package-json",
 			"preset": "logical",
 			"status": "implemented"
-		}
+		},
+		"eslint": [
+			{
+				"name": "package-json/require-attribution",
+				"url": "https://eslint-plugin-package-json.dev/rules/require-attribution"
+			}
+		]
 	},
 	{
+		"flint": {
+			"name": "authorPresence",
+			"plugin": "package-json",
+			"status": "implemented"
+		},
 		"eslint": [
 			{
 				"name": "package-json/require-author",
 				"url": "https://eslint-plugin-package-json.dev/rules/require-properties/require-author"
 			}
-		],
-		"flint": {
-			"name": "authorPresence",
-			"plugin": "package-json",
-			"status": "implemented"
-		}
+		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "package-json/valid-author",
-				"url": "https://eslint-plugin-package-json.dev/rules/valid-properties/valid-author"
-			}
-		],
 		"flint": {
 			"name": "authorValidity",
 			"plugin": "package-json",
 			"preset": "logical",
 			"status": "implemented"
-		}
-	},
-	{
+		},
 		"eslint": [
 			{
-				"name": "package-json/bin-name-casing",
-				"url": "https://eslint-plugin-package-json.dev/rules/bin-name-casing"
+				"name": "package-json/valid-author",
+				"url": "https://eslint-plugin-package-json.dev/rules/valid-properties/valid-author"
 			}
-		],
+		]
+	},
+	{
 		"flint": {
 			"name": "binNameCasing",
 			"plugin": "package-json",
 			"preset": "stylistic",
 			"status": "implemented"
-		}
+		},
+		"eslint": [
+			{
+				"name": "package-json/bin-name-casing",
+				"url": "https://eslint-plugin-package-json.dev/rules/bin-name-casing"
+			}
+		]
 	},
 	{
+		"flint": {
+			"name": "binPresence",
+			"plugin": "package-json",
+			"status": "implemented"
+		},
 		"eslint": [
 			{
 				"name": "package-json/require-bin",
 				"url": "https://eslint-plugin-package-json.dev/rules/require-properties/require-bin"
 			}
-		],
-		"flint": {
-			"name": "binPresence",
-			"plugin": "package-json",
-			"status": "implemented"
-		}
+		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "package-json/valid-bin",
-				"url": "https://eslint-plugin-package-json.dev/rules/valid-properties/valid-bin"
-			}
-		],
 		"flint": {
 			"name": "binValidity",
 			"plugin": "package-json",
 			"preset": "logical",
 			"status": "implemented"
-		}
+		},
+		"eslint": [
+			{
+				"name": "package-json/valid-bin",
+				"url": "https://eslint-plugin-package-json.dev/rules/valid-properties/valid-bin"
+			}
+		]
 	},
 	{
+		"flint": {
+			"name": "browserPresence",
+			"plugin": "package-json",
+			"status": "implemented"
+		},
 		"eslint": [
 			{
 				"name": "package-json/require-browser",
 				"url": "https://eslint-plugin-package-json.dev/rules/require-properties/require-browser"
 			}
-		],
-		"flint": {
-			"name": "browserPresence",
-			"plugin": "package-json",
-			"status": "implemented"
-		}
+		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "package-json/valid-browser",
-				"url": "https://eslint-plugin-package-json.dev/rules/valid-properties/valid-browser"
-			}
-		],
 		"flint": {
 			"name": "browserValidity",
 			"plugin": "package-json",
 			"preset": "logical",
 			"status": "implemented"
-		}
+		},
+		"eslint": [
+			{
+				"name": "package-json/valid-browser",
+				"url": "https://eslint-plugin-package-json.dev/rules/valid-properties/valid-browser"
+			}
+		]
 	},
 	{
+		"flint": {
+			"name": "bugsPresence",
+			"plugin": "package-json",
+			"status": "implemented"
+		},
 		"eslint": [
 			{
 				"name": "package-json/require-bugs",
 				"url": "https://eslint-plugin-package-json.dev/rules/require-properties/require-bugs"
 			}
-		],
-		"flint": {
-			"name": "bugsPresence",
-			"plugin": "package-json",
-			"status": "implemented"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "bugsValidity",
+			"plugin": "package-json",
+			"status": "implemented"
+		},
 		"eslint": [
 			{
 				"name": "package-json/valid-bugs",
 				"url": "https://eslint-plugin-package-json.dev/rules/valid-properties/valid-bugs"
 			}
-		],
-		"flint": {
-			"name": "bugsValidity",
-			"plugin": "package-json",
-			"status": "implemented"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "bundleDependenciesPresence",
+			"plugin": "package-json",
+			"status": "implemented"
+		},
 		"eslint": [
 			{
 				"name": "package-json/require-bundleDependencies",
 				"url": "https://eslint-plugin-package-json.dev/rules/require-properties/require-bundleDependencies"
 			}
-		],
-		"flint": {
-			"name": "bundleDependenciesPresence",
-			"plugin": "package-json",
-			"status": "implemented"
-		}
+		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "package-json/valid-bundleDependencies",
-				"url": "https://eslint-plugin-package-json.dev/rules/valid-properties/valid-bundleDependencies"
-			}
-		],
 		"flint": {
 			"name": "bundleDependenciesValidity",
 			"plugin": "package-json",
 			"preset": "logical",
 			"status": "implemented"
-		}
+		},
+		"eslint": [
+			{
+				"name": "package-json/valid-bundleDependencies",
+				"url": "https://eslint-plugin-package-json.dev/rules/valid-properties/valid-bundleDependencies"
+			}
+		]
 	},
 	{
+		"flint": {
+			"name": "configPresence",
+			"plugin": "package-json",
+			"status": "implemented"
+		},
 		"eslint": [
 			{
 				"name": "package-json/require-config",
 				"url": "https://eslint-plugin-package-json.dev/rules/require-properties/require-config"
 			}
-		],
-		"flint": {
-			"name": "configPresence",
-			"plugin": "package-json",
-			"status": "implemented"
-		}
+		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "package-json/valid-config",
-				"url": "https://eslint-plugin-package-json.dev/rules/valid-properties/valid-config"
-			}
-		],
 		"flint": {
 			"name": "configValidity",
 			"plugin": "package-json",
 			"preset": "logical",
 			"status": "implemented"
-		}
+		},
+		"eslint": [
+			{
+				"name": "package-json/valid-config",
+				"url": "https://eslint-plugin-package-json.dev/rules/valid-properties/valid-config"
+			}
+		]
 	},
 	{
+		"flint": {
+			"name": "contributorsPresence",
+			"plugin": "package-json",
+			"status": "implemented"
+		},
 		"eslint": [
 			{
 				"name": "package-json/require-contributors",
 				"url": "https://eslint-plugin-package-json.dev/rules/require-properties/require-contributors"
 			}
-		],
-		"flint": {
-			"name": "contributorsPresence",
-			"plugin": "package-json",
-			"status": "implemented"
-		}
+		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "package-json/valid-contributors",
-				"url": "https://eslint-plugin-package-json.dev/rules/valid-properties/valid-contributors"
-			}
-		],
 		"flint": {
 			"name": "contributorsValidity",
 			"plugin": "package-json",
 			"preset": "logical",
 			"status": "implemented"
-		}
+		},
+		"eslint": [
+			{
+				"name": "package-json/valid-contributors",
+				"url": "https://eslint-plugin-package-json.dev/rules/valid-properties/valid-contributors"
+			}
+		]
 	},
 	{
+		"flint": {
+			"name": "cpuPresence",
+			"plugin": "package-json",
+			"status": "implemented"
+		},
 		"eslint": [
 			{
 				"name": "package-json/require-cpu",
 				"url": "https://eslint-plugin-package-json.dev/rules/require-properties/require-cpu"
 			}
-		],
-		"flint": {
-			"name": "cpuPresence",
-			"plugin": "package-json",
-			"status": "implemented"
-		}
+		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "package-json/valid-cpu",
-				"url": "https://eslint-plugin-package-json.dev/rules/valid-properties/valid-cpu"
-			}
-		],
 		"flint": {
 			"name": "cpuValidity",
 			"plugin": "package-json",
 			"preset": "logical",
 			"status": "implemented"
-		}
+		},
+		"eslint": [
+			{
+				"name": "package-json/valid-cpu",
+				"url": "https://eslint-plugin-package-json.dev/rules/valid-properties/valid-cpu"
+			}
+		]
 	},
 	{
+		"flint": {
+			"name": "dependenciesPresence",
+			"plugin": "package-json",
+			"status": "implemented"
+		},
 		"eslint": [
 			{
 				"name": "package-json/require-dependencies",
 				"url": "https://eslint-plugin-package-json.dev/rules/require-properties/require-dependencies"
 			}
-		],
-		"flint": {
-			"name": "dependenciesPresence",
-			"plugin": "package-json",
-			"status": "implemented"
-		}
+		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "package-json/valid-dependencies",
-				"url": "https://eslint-plugin-package-json.dev/rules/valid-properties/valid-dependencies"
-			}
-		],
 		"flint": {
 			"name": "dependenciesValidity",
 			"plugin": "package-json",
 			"preset": "logical",
 			"status": "implemented"
-		}
+		},
+		"eslint": [
+			{
+				"name": "package-json/valid-dependencies",
+				"url": "https://eslint-plugin-package-json.dev/rules/valid-properties/valid-dependencies"
+			}
+		]
 	},
 	{
+		"flint": {
+			"name": "dependencyRanges",
+			"plugin": "package-json"
+		},
 		"eslint": [
 			{
 				"name": "package-json/restrict-dependency-ranges",
 				"url": "https://eslint-plugin-package-json.dev/rules/restrict-dependency-ranges"
 			}
-		],
-		"flint": {
-			"name": "dependencyRanges",
-			"plugin": "package-json"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "dependencyUniqueness",
+			"plugin": "package-json",
+			"preset": "logical",
+			"status": "implemented"
+		},
 		"biome": [
 			{
 				"name": "noDuplicateDependencies",
@@ -10633,888 +10639,887 @@
 				"name": "package-json/unique-dependencies",
 				"url": "https://eslint-plugin-package-json.dev/rules/unique-dependencies"
 			}
-		],
-		"flint": {
-			"name": "dependencyUniqueness",
-			"plugin": "package-json",
-			"preset": "logical",
-			"status": "implemented"
-		}
+		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "package-json/require-description",
-				"url": "https://eslint-plugin-package-json.dev/rules/require-properties/require-description"
-			}
-		],
 		"flint": {
 			"name": "descriptionPresence",
 			"plugin": "package-json",
 			"preset": "logical",
 			"status": "implemented"
-		}
-	},
-	{
+		},
 		"eslint": [
 			{
-				"name": "package-json/valid-description",
-				"url": "https://eslint-plugin-package-json.dev/rules/valid-properties/valid-description"
+				"name": "package-json/require-description",
+				"url": "https://eslint-plugin-package-json.dev/rules/require-properties/require-description"
 			}
-		],
+		]
+	},
+	{
 		"flint": {
 			"name": "descriptionValidity",
 			"plugin": "package-json",
 			"preset": "logical",
 			"status": "implemented"
-		}
+		},
+		"eslint": [
+			{
+				"name": "package-json/valid-description",
+				"url": "https://eslint-plugin-package-json.dev/rules/valid-properties/valid-description"
+			}
+		]
 	},
 	{
+		"flint": {
+			"name": "devDependenciesPresence",
+			"plugin": "package-json",
+			"status": "implemented"
+		},
 		"eslint": [
 			{
 				"name": "package-json/require-devDependencies",
 				"url": "https://eslint-plugin-package-json.dev/rules/require-properties/require-devDependencies"
 			}
-		],
-		"flint": {
-			"name": "devDependenciesPresence",
-			"plugin": "package-json",
-			"status": "implemented"
-		}
+		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "package-json/valid-devDependencies",
-				"url": "https://eslint-plugin-package-json.dev/rules/valid-properties/valid-devDependencies"
-			}
-		],
 		"flint": {
 			"name": "devDependenciesValidity",
 			"plugin": "package-json",
 			"preset": "logical",
 			"status": "implemented"
-		}
+		},
+		"eslint": [
+			{
+				"name": "package-json/valid-devDependencies",
+				"url": "https://eslint-plugin-package-json.dev/rules/valid-properties/valid-devDependencies"
+			}
+		]
 	},
 	{
+		"flint": {
+			"name": "devEnginesPresence",
+			"plugin": "package-json",
+			"status": "implemented"
+		},
 		"eslint": [
 			{
 				"name": "package-json/require-devEngines",
 				"url": "https://eslint-plugin-package-json.dev/rules/require-properties/require-devEngines"
 			}
-		],
-		"flint": {
-			"name": "devEnginesPresence",
-			"plugin": "package-json",
-			"status": "implemented"
-		}
+		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "package-json/valid-devEngines",
-				"url": "https://eslint-plugin-package-json.dev/rules/valid-properties/valid-devEngines"
-			}
-		],
 		"flint": {
 			"name": "devEnginesValidity",
 			"plugin": "package-json",
 			"preset": "logical",
 			"status": "implemented"
-		}
+		},
+		"eslint": [
+			{
+				"name": "package-json/valid-devEngines",
+				"url": "https://eslint-plugin-package-json.dev/rules/valid-properties/valid-devEngines"
+			}
+		]
 	},
 	{
+		"flint": {
+			"name": "directoriesPresence",
+			"plugin": "package-json",
+			"status": "implemented"
+		},
 		"eslint": [
 			{
 				"name": "package-json/require-directories",
 				"url": "https://eslint-plugin-package-json.dev/rules/require-properties/require-directories"
 			}
-		],
-		"flint": {
-			"name": "directoriesPresence",
-			"plugin": "package-json",
-			"status": "implemented"
-		}
+		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "package-json/valid-directories",
-				"url": "https://eslint-plugin-package-json.dev/rules/valid-properties/valid-directories"
-			}
-		],
 		"flint": {
 			"name": "directoriesValidity",
 			"plugin": "package-json",
 			"preset": "logical",
 			"status": "implemented"
-		}
-	},
-	{
+		},
 		"eslint": [
 			{
-				"name": "package-json/no-empty-fields",
-				"url": "https://eslint-plugin-package-json.dev/rules/no-empty-fields"
+				"name": "package-json/valid-directories",
+				"url": "https://eslint-plugin-package-json.dev/rules/valid-properties/valid-directories"
 			}
-		],
+		]
+	},
+	{
 		"flint": {
 			"name": "emptyFields",
 			"plugin": "package-json",
 			"preset": "logical",
 			"status": "implemented"
-		}
+		},
+		"eslint": [
+			{
+				"name": "package-json/no-empty-fields",
+				"url": "https://eslint-plugin-package-json.dev/rules/no-empty-fields"
+			}
+		]
 	},
 	{
+		"flint": {
+			"name": "enginesPresence",
+			"plugin": "package-json",
+			"status": "implemented"
+		},
 		"eslint": [
 			{
 				"name": "package-json/require-engines",
 				"url": "https://eslint-plugin-package-json.dev/rules/require-properties/require-engines"
 			}
-		],
-		"flint": {
-			"name": "enginesPresence",
-			"plugin": "package-json",
-			"status": "implemented"
-		}
+		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "package-json/valid-engines",
-				"url": "https://eslint-plugin-package-json.dev/rules/valid-properties/valid-engines"
-			}
-		],
 		"flint": {
 			"name": "enginesValidity",
 			"plugin": "package-json",
 			"preset": "logical",
 			"status": "implemented"
-		}
-	},
-	{
+		},
 		"eslint": [
 			{
-				"name": "package-json/require-exports",
-				"url": "https://eslint-plugin-package-json.dev/rules/require-properties/require-exports"
+				"name": "package-json/valid-engines",
+				"url": "https://eslint-plugin-package-json.dev/rules/valid-properties/valid-engines"
 			}
-		],
+		]
+	},
+	{
 		"flint": {
 			"name": "exportsPresence",
 			"plugin": "package-json",
 			"preset": "logical",
 			"status": "implemented"
-		}
-	},
-	{
+		},
 		"eslint": [
 			{
-				"name": "package-json/exports-subpaths-style",
-				"url": "https://eslint-plugin-package-json.dev/rules/exports-subpaths-style"
+				"name": "package-json/require-exports",
+				"url": "https://eslint-plugin-package-json.dev/rules/require-properties/require-exports"
 			}
-		],
+		]
+	},
+	{
 		"flint": {
 			"name": "exportsSubpathsStyle",
 			"plugin": "package-json",
 			"preset": "stylistic",
 			"status": "implemented"
-		}
-	},
-	{
+		},
 		"eslint": [
 			{
-				"name": "package-json/valid-exports",
-				"url": "https://eslint-plugin-package-json.dev/rules/valid-properties/valid-exports"
+				"name": "package-json/exports-subpaths-style",
+				"url": "https://eslint-plugin-package-json.dev/rules/exports-subpaths-style"
 			}
-		],
+		]
+	},
+	{
 		"flint": {
 			"name": "exportsValidity",
 			"plugin": "package-json",
 			"preset": "logical",
 			"status": "implemented"
-		}
+		},
+		"eslint": [
+			{
+				"name": "package-json/valid-exports",
+				"url": "https://eslint-plugin-package-json.dev/rules/valid-properties/valid-exports"
+			}
+		]
 	},
 	{
+		"flint": {
+			"name": "filesPresence",
+			"plugin": "package-json",
+			"status": "implemented"
+		},
 		"eslint": [
 			{
 				"name": "package-json/require-files",
 				"url": "https://eslint-plugin-package-json.dev/rules/require-properties/require-files"
 			}
-		],
-		"flint": {
-			"name": "filesPresence",
-			"plugin": "package-json",
-			"status": "implemented"
-		}
+		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "package-json/no-redundant-files",
-				"url": "https://eslint-plugin-package-json.dev/rules/no-redundant-files"
-			}
-		],
 		"flint": {
 			"name": "filesRedundancy",
 			"plugin": "package-json",
 			"preset": "logical",
 			"status": "implemented"
-		}
-	},
-	{
+		},
 		"eslint": [
 			{
-				"name": "package-json/valid-files",
-				"url": "https://eslint-plugin-package-json.dev/rules/valid-properties/valid-files"
+				"name": "package-json/no-redundant-files",
+				"url": "https://eslint-plugin-package-json.dev/rules/no-redundant-files"
 			}
-		],
+		]
+	},
+	{
 		"flint": {
 			"name": "filesValidity",
 			"plugin": "package-json",
 			"preset": "logical",
 			"status": "implemented"
-		}
+		},
+		"eslint": [
+			{
+				"name": "package-json/valid-files",
+				"url": "https://eslint-plugin-package-json.dev/rules/valid-properties/valid-files"
+			}
+		]
 	},
 	{
+		"flint": {
+			"name": "fundingPresence",
+			"plugin": "package-json",
+			"status": "implemented"
+		},
 		"eslint": [
 			{
 				"name": "package-json/require-funding",
 				"url": "https://eslint-plugin-package-json.dev/rules/require-properties/require-funding"
 			}
-		],
-		"flint": {
-			"name": "fundingPresence",
-			"plugin": "package-json",
-			"status": "implemented"
-		}
+		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "package-json/valid-funding",
-				"url": "https://eslint-plugin-package-json.dev/rules/valid-properties/valid-funding"
-			}
-		],
 		"flint": {
 			"name": "fundingValidity",
 			"plugin": "package-json",
 			"preset": "logical",
 			"status": "implemented"
-		}
+		},
+		"eslint": [
+			{
+				"name": "package-json/valid-funding",
+				"url": "https://eslint-plugin-package-json.dev/rules/valid-properties/valid-funding"
+			}
+		]
 	},
 	{
+		"flint": {
+			"name": "gypfilePresence",
+			"plugin": "package-json",
+			"status": "implemented"
+		},
 		"eslint": [
 			{
 				"name": "package-json/require-gypfile",
 				"url": "https://eslint-plugin-package-json.dev/rules/require-properties/require-gypfile"
 			}
-		],
-		"flint": {
-			"name": "gypfilePresence",
-			"plugin": "package-json",
-			"status": "implemented"
-		}
+		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "package-json/valid-gypfile",
-				"url": "https://eslint-plugin-package-json.dev/rules/valid-properties/valid-gypfile"
-			}
-		],
 		"flint": {
 			"name": "gypfileValidity",
 			"plugin": "package-json",
 			"preset": "logical",
 			"status": "implemented"
-		}
-	},
-	{
+		},
 		"eslint": [
 			{
-				"name": "package-json/require-homepage",
-				"url": "https://eslint-plugin-package-json.dev/rules/require-properties/require-homepage"
+				"name": "package-json/valid-gypfile",
+				"url": "https://eslint-plugin-package-json.dev/rules/valid-properties/valid-gypfile"
 			}
-		],
+		]
+	},
+	{
 		"flint": {
 			"name": "homepagePresence",
 			"plugin": "package-json",
 			"preset": "logical",
 			"status": "implemented"
-		}
-	},
-	{
+		},
 		"eslint": [
 			{
-				"name": "package-json/valid-homepage",
-				"url": "https://eslint-plugin-package-json.dev/rules/valid-properties/valid-homepage"
+				"name": "package-json/require-homepage",
+				"url": "https://eslint-plugin-package-json.dev/rules/require-properties/require-homepage"
 			}
-		],
+		]
+	},
+	{
 		"flint": {
 			"name": "homepageValidity",
 			"plugin": "package-json",
 			"preset": "logical",
 			"status": "implemented"
-		}
+		},
+		"eslint": [
+			{
+				"name": "package-json/valid-homepage",
+				"url": "https://eslint-plugin-package-json.dev/rules/valid-properties/valid-homepage"
+			}
+		]
 	},
 	{
+		"flint": {
+			"name": "keywordsPresence",
+			"plugin": "package-json",
+			"status": "implemented"
+		},
 		"eslint": [
 			{
 				"name": "package-json/require-keywords",
 				"url": "https://eslint-plugin-package-json.dev/rules/require-properties/require-keywords"
 			}
-		],
-		"flint": {
-			"name": "keywordsPresence",
-			"plugin": "package-json",
-			"status": "implemented"
-		}
+		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "package-json/valid-keywords",
-				"url": "https://eslint-plugin-package-json.dev/rules/valid-properties/valid-keywords"
-			}
-		],
 		"flint": {
 			"name": "keywordsValidity",
 			"plugin": "package-json",
 			"preset": "logical",
 			"status": "implemented"
-		}
+		},
+		"eslint": [
+			{
+				"name": "package-json/valid-keywords",
+				"url": "https://eslint-plugin-package-json.dev/rules/valid-properties/valid-keywords"
+			}
+		]
 	},
 	{
+		"flint": {
+			"name": "libcPresence",
+			"plugin": "package-json",
+			"status": "implemented"
+		},
 		"eslint": [
 			{
 				"name": "package-json/require-libc",
 				"url": "https://eslint-plugin-package-json.dev/rules/require-properties/require-libc"
 			}
-		],
-		"flint": {
-			"name": "libcPresence",
-			"plugin": "package-json",
-			"status": "implemented"
-		}
+		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "package-json/valid-libc",
-				"url": "https://eslint-plugin-package-json.dev/rules/valid-properties/valid-libc"
-			}
-		],
 		"flint": {
 			"name": "libcValidity",
 			"plugin": "package-json",
 			"preset": "logical",
 			"status": "implemented"
-		}
-	},
-	{
+		},
 		"eslint": [
 			{
-				"name": "package-json/require-license",
-				"url": "https://eslint-plugin-package-json.dev/rules/require-properties/require-license"
+				"name": "package-json/valid-libc",
+				"url": "https://eslint-plugin-package-json.dev/rules/valid-properties/valid-libc"
 			}
-		],
+		]
+	},
+	{
 		"flint": {
 			"name": "licensePresence",
 			"plugin": "package-json",
 			"preset": "logical",
 			"status": "implemented"
-		}
+		},
+		"eslint": [
+			{
+				"name": "package-json/require-license",
+				"url": "https://eslint-plugin-package-json.dev/rules/require-properties/require-license"
+			}
+		]
 	},
 	{
-		"biome": [
-			{
-				"name": "noUntrustedLicenses",
-				"url": "https://biomejs.dev/linter/rules/no-untrusted-licenses"
-			}
-		],
 		"flint": {
 			"name": "licenseTrust",
 			"plugin": "package-json",
 			"preset": "logical",
 			"strictness": "strict"
-		}
+		},
+		"biome": [
+			{
+				"name": "noUntrustedLicenses",
+				"url": "https://biomejs.dev/linter/rules/no-untrusted-licenses"
+			}
+		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "package-json/valid-license",
-				"url": "https://eslint-plugin-package-json.dev/rules/valid-properties/valid-license"
-			}
-		],
 		"flint": {
 			"name": "licenseValidity",
 			"plugin": "package-json",
 			"preset": "logical",
 			"status": "implemented"
-		}
+		},
+		"eslint": [
+			{
+				"name": "package-json/valid-license",
+				"url": "https://eslint-plugin-package-json.dev/rules/valid-properties/valid-license"
+			}
+		]
 	},
 	{
+		"flint": {
+			"name": "localDependencies",
+			"plugin": "package-json",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "package-json/no-local-dependencies",
 				"url": "https://eslint-plugin-package-json.dev/rules/no-local-dependencies/"
 			}
-		],
-		"flint": {
-			"name": "localDependencies",
-			"plugin": "package-json",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "mainPresence",
+			"plugin": "package-json",
+			"status": "implemented"
+		},
 		"eslint": [
 			{
 				"name": "package-json/require-main",
 				"url": "https://eslint-plugin-package-json.dev/rules/require-properties/require-main"
 			}
-		],
-		"flint": {
-			"name": "mainPresence",
-			"plugin": "package-json",
-			"status": "implemented"
-		}
+		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "package-json/valid-main",
-				"url": "https://eslint-plugin-package-json.dev/rules/valid-properties/valid-main"
-			}
-		],
 		"flint": {
 			"name": "mainValidity",
 			"plugin": "package-json",
 			"preset": "logical",
 			"status": "implemented"
-		}
+		},
+		"eslint": [
+			{
+				"name": "package-json/valid-main",
+				"url": "https://eslint-plugin-package-json.dev/rules/valid-properties/valid-main"
+			}
+		]
 	},
 	{
+		"flint": {
+			"name": "manPresence",
+			"plugin": "package-json",
+			"status": "implemented"
+		},
 		"eslint": [
 			{
 				"name": "package-json/require-man",
 				"url": "https://eslint-plugin-package-json.dev/rules/require-properties/require-man"
 			}
-		],
-		"flint": {
-			"name": "manPresence",
-			"plugin": "package-json",
-			"status": "implemented"
-		}
+		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "package-json/valid-man",
-				"url": "https://eslint-plugin-package-json.dev/rules/valid-properties/valid-man"
-			}
-		],
 		"flint": {
 			"name": "manValidity",
 			"plugin": "package-json",
 			"preset": "logical",
 			"status": "implemented"
-		}
+		},
+		"eslint": [
+			{
+				"name": "package-json/valid-man",
+				"url": "https://eslint-plugin-package-json.dev/rules/valid-properties/valid-man"
+			}
+		]
 	},
 	{
+		"flint": {
+			"name": "modulePresence",
+			"plugin": "package-json",
+			"status": "implemented"
+		},
 		"eslint": [
 			{
 				"name": "package-json/require-module",
 				"url": "https://eslint-plugin-package-json.dev/rules/require-properties/require-module"
 			}
-		],
-		"flint": {
-			"name": "modulePresence",
-			"plugin": "package-json",
-			"status": "implemented"
-		}
+		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "package-json/valid-module",
-				"url": "https://eslint-plugin-package-json.dev/rules/valid-properties/valid-module"
-			}
-		],
 		"flint": {
 			"name": "moduleValidity",
 			"plugin": "package-json",
 			"preset": "logical",
 			"status": "implemented"
-		}
-	},
-	{
+		},
 		"eslint": [
 			{
-				"name": "package-json/require-name",
-				"url": "https://eslint-plugin-package-json.dev/rules/require-properties/require-name"
+				"name": "package-json/valid-module",
+				"url": "https://eslint-plugin-package-json.dev/rules/valid-properties/valid-module"
 			}
-		],
+		]
+	},
+	{
 		"flint": {
 			"name": "namePresence",
 			"plugin": "package-json",
 			"preset": "logical",
 			"status": "implemented"
-		}
-	},
-	{
+		},
 		"eslint": [
 			{
-				"name": "package-json/valid-name",
-				"url": "https://eslint-plugin-package-json.dev/rules/valid-properties/valid-name"
+				"name": "package-json/require-name",
+				"url": "https://eslint-plugin-package-json.dev/rules/require-properties/require-name"
 			}
-		],
+		]
+	},
+	{
 		"flint": {
 			"name": "nameValidity",
 			"plugin": "package-json",
 			"preset": "logical",
 			"status": "implemented"
-		}
+		},
+		"eslint": [
+			{
+				"name": "package-json/valid-name",
+				"url": "https://eslint-plugin-package-json.dev/rules/valid-properties/valid-name"
+			}
+		]
 	},
 	{
+		"flint": {
+			"name": "optionalDependenciesPresence",
+			"plugin": "package-json",
+			"status": "implemented"
+		},
 		"eslint": [
 			{
 				"name": "package-json/require-optionalDependencies",
 				"url": "https://eslint-plugin-package-json.dev/rules/require-properties/require-optionalDependencies"
 			}
-		],
-		"flint": {
-			"name": "optionalDependenciesPresence",
-			"plugin": "package-json",
-			"status": "implemented"
-		}
+		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "package-json/valid-optionalDependencies",
-				"url": "https://eslint-plugin-package-json.dev/rules/valid-properties/valid-optionalDependencies"
-			}
-		],
 		"flint": {
 			"name": "optionalDependenciesValidity",
 			"plugin": "package-json",
 			"preset": "logical",
 			"status": "implemented"
-		}
+		},
+		"eslint": [
+			{
+				"name": "package-json/valid-optionalDependencies",
+				"url": "https://eslint-plugin-package-json.dev/rules/valid-properties/valid-optionalDependencies"
+			}
+		]
 	},
 	{
+		"flint": {
+			"name": "osPresence",
+			"plugin": "package-json",
+			"status": "implemented"
+		},
 		"eslint": [
 			{
 				"name": "package-json/require-os",
 				"url": "https://eslint-plugin-package-json.dev/rules/require-properties/require-os"
 			}
-		],
-		"flint": {
-			"name": "osPresence",
-			"plugin": "package-json",
-			"status": "implemented"
-		}
+		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "package-json/valid-os",
-				"url": "https://eslint-plugin-package-json.dev/rules/valid-properties/valid-os"
-			}
-		],
 		"flint": {
 			"name": "osValidity",
 			"plugin": "package-json",
 			"preset": "logical",
 			"status": "implemented"
-		}
+		},
+		"eslint": [
+			{
+				"name": "package-json/valid-os",
+				"url": "https://eslint-plugin-package-json.dev/rules/valid-properties/valid-os"
+			}
+		]
 	},
 	{
+		"flint": {
+			"name": "packageCollectionsOrder",
+			"plugin": "package-json",
+			"preset": "sorting"
+		},
 		"eslint": [
 			{
 				"name": "package-json/sort-collections",
 				"url": "https://eslint-plugin-package-json.dev/rules/sort-collections"
 			}
-		],
-		"flint": {
-			"name": "packageCollectionsOrder",
-			"plugin": "package-json",
-			"preset": "sorting"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "packageManagerPresence",
+			"plugin": "package-json",
+			"status": "implemented"
+		},
 		"eslint": [
 			{
 				"name": "package-json/require-packageManager",
 				"url": "https://eslint-plugin-package-json.dev/rules/require-properties/require-packagemanager"
 			}
-		],
-		"flint": {
-			"name": "packageManagerPresence",
-			"plugin": "package-json",
-			"status": "implemented"
-		}
+		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "package-json/valid-packageManager",
-				"url": "https://eslint-plugin-package-json.dev/rules/valid-properties/valid-packageManager"
-			}
-		],
 		"flint": {
 			"name": "packageManagerValidity",
 			"plugin": "package-json",
 			"preset": "logical",
 			"status": "implemented"
-		}
-	},
-	{
+		},
 		"eslint": [
 			{
-				"name": "package-json/specify-peers-locally",
-				"url": "https://eslint-plugin-package-json.dev/rules/specify-peers-locally"
+				"name": "package-json/valid-packageManager",
+				"url": "https://eslint-plugin-package-json.dev/rules/valid-properties/valid-packageManager"
 			}
-		],
+		]
+	},
+	{
 		"flint": {
 			"name": "peerDependenciesInstallation",
 			"plugin": "package-json",
 			"preset": "logical",
 			"status": "implemented"
-		}
+		},
+		"eslint": [
+			{
+				"name": "package-json/specify-peers-locally",
+				"url": "https://eslint-plugin-package-json.dev/rules/specify-peers-locally"
+			}
+		]
 	},
 	{
+		"flint": {
+			"name": "peerDependenciesMetaPresence",
+			"plugin": "package-json",
+			"status": "implemented"
+		},
 		"eslint": [
 			{
 				"name": "package-json/require-peerDependenciesMeta",
 				"url": "https://eslint-plugin-package-json.dev/rules/require-properties/require-peerDependenciesMeta"
 			}
-		],
-		"flint": {
-			"name": "peerDependenciesMetaPresence",
-			"plugin": "package-json",
-			"status": "implemented"
-		}
+		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "package-json/valid-peerDependenciesMeta-relationship",
-				"url": "https://eslint-plugin-package-json.dev/rules/valid-peerdependenciesmeta-relationship"
-			}
-		],
 		"flint": {
 			"name": "peerDependenciesMetaRelationship",
 			"plugin": "package-json",
 			"preset": "logical",
 			"status": "implemented"
-		}
-	},
-	{
+		},
 		"eslint": [
 			{
-				"name": "package-json/valid-peerDependenciesMeta",
-				"url": "https://eslint-plugin-package-json.dev/rules/valid-properties/valid-peerDependenciesMeta"
+				"name": "package-json/valid-peerDependenciesMeta-relationship",
+				"url": "https://eslint-plugin-package-json.dev/rules/valid-peerdependenciesmeta-relationship"
 			}
-		],
+		]
+	},
+	{
 		"flint": {
 			"name": "peerDependenciesMetaValidity",
 			"plugin": "package-json",
 			"preset": "logical",
 			"status": "implemented"
-		}
+		},
+		"eslint": [
+			{
+				"name": "package-json/valid-peerDependenciesMeta",
+				"url": "https://eslint-plugin-package-json.dev/rules/valid-properties/valid-peerDependenciesMeta"
+			}
+		]
 	},
 	{
+		"flint": {
+			"name": "peerDependenciesPresence",
+			"plugin": "package-json",
+			"status": "implemented"
+		},
 		"eslint": [
 			{
 				"name": "package-json/require-peerDependencies",
 				"url": "https://eslint-plugin-package-json.dev/rules/require-properties/require-peerDependencies"
 			}
-		],
-		"flint": {
-			"name": "peerDependenciesPresence",
-			"plugin": "package-json",
-			"status": "implemented"
-		}
+		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "package-json/valid-peerDependencies",
-				"url": "https://eslint-plugin-package-json.dev/rules/valid-properties/valid-peerDependencies"
-			}
-		],
 		"flint": {
 			"name": "peerDependenciesValidity",
 			"plugin": "package-json",
 			"preset": "logical",
 			"status": "implemented"
-		}
+		},
+		"eslint": [
+			{
+				"name": "package-json/valid-peerDependencies",
+				"url": "https://eslint-plugin-package-json.dev/rules/valid-properties/valid-peerDependencies"
+			}
+		]
 	},
 	{
+		"flint": {
+			"name": "privatePackageProperties",
+			"plugin": "package-json",
+			"status": "implemented"
+		},
 		"eslint": [
 			{
 				"name": "package-json/restrict-private-properties",
 				"url": "https://eslint-plugin-package-json.dev/rules/restrict-private-properties"
 			}
-		],
-		"flint": {
-			"name": "privatePackageProperties",
-			"plugin": "package-json",
-			"status": "implemented"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "privatePresence",
+			"plugin": "package-json",
+			"status": "implemented"
+		},
 		"eslint": [
 			{
 				"name": "package-json/require-private",
 				"url": "https://eslint-plugin-package-json.dev/rules/require-properties/require-private"
 			}
-		],
-		"flint": {
-			"name": "privatePresence",
-			"plugin": "package-json",
-			"status": "implemented"
-		}
+		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "package-json/valid-private",
-				"url": "https://eslint-plugin-package-json.dev/rules/valid-properties/valid-private"
-			}
-		],
 		"flint": {
 			"name": "privateValidity",
 			"plugin": "package-json",
 			"preset": "logical",
 			"status": "implemented"
-		}
-	},
-	{
+		},
 		"eslint": [
 			{
-				"name": "package-json/order-properties",
-				"url": "https://eslint-plugin-package-json.dev/rules/order-properties"
+				"name": "package-json/valid-private",
+				"url": "https://eslint-plugin-package-json.dev/rules/valid-properties/valid-private"
 			}
-		],
+		]
+	},
+	{
 		"flint": {
 			"name": "propertyOrder",
 			"plugin": "package-json",
 			"preset": "sorting",
 			"status": "implemented"
-		}
+		},
+		"eslint": [
+			{
+				"name": "package-json/order-properties",
+				"url": "https://eslint-plugin-package-json.dev/rules/order-properties"
+			}
+		]
 	},
 	{
+		"flint": {
+			"name": "publishConfigPresence",
+			"plugin": "package-json",
+			"status": "implemented"
+		},
 		"eslint": [
 			{
 				"name": "package-json/require-publishConfig",
 				"url": "https://eslint-plugin-package-json.dev/rules/require-properties/require-publishconfig"
 			}
-		],
-		"flint": {
-			"name": "publishConfigPresence",
-			"plugin": "package-json",
-			"status": "implemented"
-		}
+		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "package-json/no-redundant-publishConfig",
-				"url": "https://eslint-plugin-package-json.dev/rules/no-redundant-publishconfig"
-			}
-		],
 		"flint": {
 			"name": "publishConfigRedundancy",
 			"plugin": "package-json",
 			"preset": "logical",
 			"status": "implemented"
-		}
-	},
-	{
+		},
 		"eslint": [
 			{
-				"name": "package-json/valid-publishConfig",
-				"url": "https://eslint-plugin-package-json.dev/rules/valid-properties/valid-publishConfig"
+				"name": "package-json/no-redundant-publishConfig",
+				"url": "https://eslint-plugin-package-json.dev/rules/no-redundant-publishconfig"
 			}
-		],
+		]
+	},
+	{
 		"flint": {
 			"name": "publishConfigValidity",
 			"plugin": "package-json",
 			"preset": "logical",
 			"status": "implemented"
-		}
+		},
+		"eslint": [
+			{
+				"name": "package-json/valid-publishConfig",
+				"url": "https://eslint-plugin-package-json.dev/rules/valid-properties/valid-publishConfig"
+			}
+		]
 	},
 	{
+		"flint": {
+			"name": "repositoryDirectoryValidity",
+			"plugin": "package-json",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "package-json/valid-repository-directory",
 				"url": "https://eslint-plugin-package-json.dev/rules/valid-repository-directory"
 			}
-		],
-		"flint": {
-			"name": "repositoryDirectoryValidity",
-			"plugin": "package-json",
-			"preset": "logical"
-		}
+		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "package-json/require-repository",
-				"url": "https://eslint-plugin-package-json.dev/rules/require-properties/require-repository"
-			}
-		],
 		"flint": {
 			"name": "repositoryPresence",
 			"plugin": "package-json",
 			"preset": "logical",
 			"status": "implemented"
-		}
-	},
-	{
+		},
 		"eslint": [
 			{
-				"name": "package-json/repository-shorthand",
-				"url": "https://eslint-plugin-package-json.dev/rules/repository-shorthand"
+				"name": "package-json/require-repository",
+				"url": "https://eslint-plugin-package-json.dev/rules/require-properties/require-repository"
 			}
-		],
+		]
+	},
+	{
 		"flint": {
 			"name": "repositoryShorthand",
 			"plugin": "package-json",
 			"preset": "logical",
 			"status": "implemented"
-		}
-	},
-	{
+		},
 		"eslint": [
 			{
-				"name": "package-json/valid-repository",
-				"url": "https://eslint-plugin-package-json.dev/rules/valid-properties/valid-repository"
+				"name": "package-json/repository-shorthand",
+				"url": "https://eslint-plugin-package-json.dev/rules/repository-shorthand"
 			}
-		],
+		]
+	},
+	{
 		"flint": {
 			"name": "repositoryValidity",
 			"plugin": "package-json",
 			"preset": "logical",
 			"status": "implemented"
-		}
-	},
-	{
+		},
 		"eslint": [
 			{
-				"name": "package-json/scripts-name-casing",
-				"url": "https://eslint-plugin-package-json.dev/rules/scripts-name-casing"
+				"name": "package-json/valid-repository",
+				"url": "https://eslint-plugin-package-json.dev/rules/valid-properties/valid-repository"
 			}
-		],
+		]
+	},
+	{
 		"flint": {
 			"name": "scriptsNameCasing",
 			"plugin": "package-json",
 			"preset": "stylistic",
 			"status": "implemented"
-		}
+		},
+		"eslint": [
+			{
+				"name": "package-json/scripts-name-casing",
+				"url": "https://eslint-plugin-package-json.dev/rules/scripts-name-casing"
+			}
+		]
 	},
 	{
+		"flint": {
+			"name": "scriptsPresence",
+			"plugin": "package-json",
+			"status": "implemented"
+		},
 		"biome": [
 			{
 				"name": "useRequiredScripts",
@@ -11526,135 +11531,130 @@
 				"name": "package-json/require-scripts",
 				"url": "https://eslint-plugin-package-json.dev/rules/require-properties/require-scripts"
 			}
-		],
-		"flint": {
-			"name": "scriptsPresence",
-			"plugin": "package-json",
-			"status": "implemented"
-		}
+		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "package-json/valid-scripts",
-				"url": "https://eslint-plugin-package-json.dev/rules/valid-properties/valid-scripts"
-			}
-		],
 		"flint": {
 			"name": "scriptsValidity",
 			"plugin": "package-json",
 			"preset": "logical",
 			"status": "implemented"
-		}
-	},
-	{
+		},
 		"eslint": [
 			{
-				"name": "package-json/require-sideEffects",
-				"url": "https://eslint-plugin-package-json.dev/rules/require-properties/require-sideEffects"
+				"name": "package-json/valid-scripts",
+				"url": "https://eslint-plugin-package-json.dev/rules/valid-properties/valid-scripts"
 			}
-		],
+		]
+	},
+	{
 		"flint": {
 			"name": "sideEffectsPresence",
 			"plugin": "package-json",
 			"preset": "logical",
 			"status": "implemented"
-		}
-	},
-	{
+		},
 		"eslint": [
 			{
-				"name": "package-json/valid-sideEffects",
-				"url": "https://eslint-plugin-package-json.dev/rules/valid-properties/valid-sideEffects"
+				"name": "package-json/require-sideEffects",
+				"url": "https://eslint-plugin-package-json.dev/rules/require-properties/require-sideEffects"
 			}
-		],
+		]
+	},
+	{
 		"flint": {
 			"name": "sideEffectsValidity",
 			"plugin": "package-json",
 			"preset": "logical",
 			"status": "implemented"
-		}
+		},
+		"eslint": [
+			{
+				"name": "package-json/valid-sideEffects",
+				"url": "https://eslint-plugin-package-json.dev/rules/valid-properties/valid-sideEffects"
+			}
+		]
 	},
 	{
+		"flint": {
+			"name": "topLevelPackageProperties",
+			"plugin": "package-json"
+		},
 		"eslint": [
 			{
 				"name": "package-json/restrict-top-level-properties",
 				"url": "https://eslint-plugin-package-json.dev/rules/restrict-top-level-properties"
 			}
-		],
-		"flint": {
-			"name": "topLevelPackageProperties",
-			"plugin": "package-json"
-		}
+		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "package-json/require-type",
-				"url": "https://eslint-plugin-package-json.dev/rules/require-properties/require-type"
-			}
-		],
 		"flint": {
 			"name": "typePresence",
 			"plugin": "package-json",
 			"preset": "logical",
 			"status": "implemented"
-		}
+		},
+		"eslint": [
+			{
+				"name": "package-json/require-type",
+				"url": "https://eslint-plugin-package-json.dev/rules/require-properties/require-type"
+			}
+		]
 	},
 	{
+		"flint": {
+			"name": "typesPresence",
+			"plugin": "package-json",
+			"status": "implemented"
+		},
 		"eslint": [
 			{
 				"name": "package-json/require-types",
 				"url": "https://eslint-plugin-package-json.dev/rules/require-properties/require-types"
 			}
-		],
-		"flint": {
-			"name": "typesPresence",
-			"plugin": "package-json",
-			"status": "implemented"
-		}
+		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "package-json/valid-type",
-				"url": "https://eslint-plugin-package-json.dev/rules/valid-properties/valid-type"
-			}
-		],
 		"flint": {
 			"name": "typeValidity",
 			"plugin": "package-json",
 			"preset": "logical",
 			"status": "implemented"
-		}
-	},
-	{
+		},
 		"eslint": [
 			{
-				"name": "package-json/require-version",
-				"url": "https://eslint-plugin-package-json.dev/rules/require-properties/require-version"
+				"name": "package-json/valid-type",
+				"url": "https://eslint-plugin-package-json.dev/rules/valid-properties/valid-type"
 			}
-		],
+		]
+	},
+	{
 		"flint": {
 			"name": "versionPresence",
 			"plugin": "package-json",
 			"preset": "logical",
 			"status": "implemented"
-		}
-	},
-	{
+		},
 		"eslint": [
 			{
-				"name": "package-json/valid-version",
-				"url": "https://eslint-plugin-package-json.dev/rules/valid-properties/valid-version"
+				"name": "package-json/require-version",
+				"url": "https://eslint-plugin-package-json.dev/rules/require-properties/require-version"
 			}
-		],
+		]
+	},
+	{
 		"flint": {
 			"name": "versionValidity",
 			"plugin": "package-json",
 			"preset": "logical",
 			"status": "implemented"
-		}
+		},
+		"eslint": [
+			{
+				"name": "package-json/valid-version",
+				"url": "https://eslint-plugin-package-json.dev/rules/valid-properties/valid-version"
+			}
+		]
 	},
 	{
 		"flint": {
@@ -11664,46 +11664,46 @@
 		}
 	},
 	{
-		"eslint": [
-			{
-				"name": "package-json/valid-workspaces",
-				"url": "https://eslint-plugin-package-json.dev/rules/valid-properties/valid-workspaces"
-			}
-		],
 		"flint": {
 			"name": "workspacesValidity",
 			"plugin": "package-json",
 			"preset": "logical",
 			"status": "implemented"
-		}
+		},
+		"eslint": [
+			{
+				"name": "package-json/valid-workspaces",
+				"url": "https://eslint-plugin-package-json.dev/rules/valid-properties/valid-workspaces"
+			}
+		]
 	},
 	{
-		"biome": [
-			{
-				"name": "noDelete",
-				"url": "https://biomejs.dev/linter/rules/no-delete"
-			}
-		],
 		"flint": {
 			"name": "deletes",
 			"plugin": "performance",
 			"preset": "logical",
 			"status": "implemented"
-		}
-	},
-	{
+		},
 		"biome": [
 			{
-				"name": "noDynamicNamespaceImportAccess",
-				"url": "https://biomejs.dev/linter/rules/no-dynamic-namespace-import-access"
+				"name": "noDelete",
+				"url": "https://biomejs.dev/linter/rules/no-delete"
 			}
-		],
+		]
+	},
+	{
 		"flint": {
 			"name": "importedNamespaceDynamicAccesses",
 			"plugin": "performance",
 			"preset": "logical",
 			"status": "implemented"
-		}
+		},
+		"biome": [
+			{
+				"name": "noDynamicNamespaceImportAccess",
+				"url": "https://biomejs.dev/linter/rules/no-dynamic-namespace-import-access"
+			}
+		]
 	},
 	{
 		"flint": {
@@ -11758,6 +11758,12 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "loopAwaits",
+			"plugin": "performance",
+			"preset": "logical",
+			"status": "implemented"
+		},
 		"biome": [
 			{
 				"name": "noAwaitInLoops",
@@ -11776,12 +11782,6 @@
 				"url": "https://eslint.org/docs/latest/rules/no-await-in-loop"
 			}
 		],
-		"flint": {
-			"name": "loopAwaits",
-			"plugin": "performance",
-			"preset": "logical",
-			"status": "implemented"
-		},
 		"oxlint": [
 			{
 				"name": "eslint/no-await-in-loop",
@@ -11790,6 +11790,12 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "loopFunctions",
+			"plugin": "performance",
+			"preset": "logical",
+			"status": "implemented"
+		},
 		"biome": [
 			{
 				"name": "noLoopFunc",
@@ -11806,12 +11812,6 @@
 				"url": "https://typescript-eslint.io/rules/no-loop-func"
 			}
 		],
-		"flint": {
-			"name": "loopFunctions",
-			"plugin": "performance",
-			"preset": "logical",
-			"status": "implemented"
-		},
 		"oxlint": [
 			{
 				"name": "eslint/no-loop-func",
@@ -11833,18 +11833,18 @@
 		]
 	},
 	{
-		"biome": [
-			{
-				"name": "noAccumulatingSpread",
-				"url": "https://biomejs.dev/linter/rules/no-accumulating-spread"
-			}
-		],
 		"flint": {
 			"name": "spreadAccumulators",
 			"plugin": "performance",
 			"preset": "logical",
 			"status": "implemented"
 		},
+		"biome": [
+			{
+				"name": "noAccumulatingSpread",
+				"url": "https://biomejs.dev/linter/rules/no-accumulating-spread"
+			}
+		],
 		"oxlint": [
 			{
 				"name": "oxc/no-accumulating-spread",
@@ -11853,214 +11853,219 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "describeCallbacks",
+			"plugin": "playwright",
+			"status": "skipped"
+		},
 		"biome": [
 			{
 				"name": "usePlaywrightValidDescribeCallback",
 				"url": "https://biomejs.dev/linter/rules/use-playwright-valid-describe-callback"
 			}
-		],
-		"flint": {
-			"name": "describeCallbacks",
-			"plugin": "playwright",
-			"status": "skipped"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "elementHandles",
+			"plugin": "playwright",
+			"status": "skipped"
+		},
 		"biome": [
 			{
 				"name": "noPlaywrightElementHandle",
 				"url": "https://biomejs.dev/linter/rules/no-playwright-element-handle"
 			}
-		],
-		"flint": {
-			"name": "elementHandles",
-			"plugin": "playwright",
-			"status": "skipped"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "evals",
+			"plugin": "playwright",
+			"status": "skipped"
+		},
 		"biome": [
 			{
 				"name": "noPlaywrightEval",
 				"url": "https://biomejs.dev/linter/rules/no-playwright-eval"
 			}
-		],
-		"flint": {
-			"name": "evals",
-			"plugin": "playwright",
-			"status": "skipped"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "forceOptions",
+			"plugin": "playwright",
+			"status": "skipped"
+		},
 		"biome": [
 			{
 				"name": "noPlaywrightForceOption",
 				"url": "https://biomejs.dev/linter/rules/no-playwright-force-option"
 			}
-		],
-		"flint": {
-			"name": "forceOptions",
-			"plugin": "playwright",
-			"status": "skipped"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "missingAwaits",
+			"plugin": "playwright",
+			"status": "skipped"
+		},
 		"biome": [
 			{
 				"name": "noPlaywrightMissingAwait",
 				"url": "https://biomejs.dev/linter/rules/no-playwright-missing-await"
 			}
-		],
-		"flint": {
-			"name": "missingAwaits",
-			"plugin": "playwright",
-			"status": "skipped"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "networkidles",
+			"plugin": "playwright",
+			"status": "skipped"
+		},
 		"biome": [
 			{
 				"name": "noPlaywrightNetworkidle",
 				"url": "https://biomejs.dev/linter/rules/no-playwright-networkidle"
 			}
-		],
-		"flint": {
-			"name": "networkidles",
-			"plugin": "playwright",
-			"status": "skipped"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "pagePauses",
+			"plugin": "playwright",
+			"status": "skipped"
+		},
 		"biome": [
 			{
 				"name": "noPlaywrightPagePause",
 				"url": "https://biomejs.dev/linter/rules/no-playwright-page-pause"
 			}
-		],
-		"flint": {
-			"name": "pagePauses",
-			"plugin": "playwright",
-			"status": "skipped"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "uselessAwaits",
+			"plugin": "playwright",
+			"status": "skipped"
+		},
 		"biome": [
 			{
 				"name": "noPlaywrightUselessAwait",
 				"url": "https://biomejs.dev/linter/rules/no-playwright-useless-await"
 			}
-		],
-		"flint": {
-			"name": "uselessAwaits",
-			"plugin": "playwright",
-			"status": "skipped"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "waitForNavigations",
+			"plugin": "playwright",
+			"status": "skipped"
+		},
 		"biome": [
 			{
 				"name": "noPlaywrightWaitForNavigation",
 				"url": "https://biomejs.dev/linter/rules/no-playwright-wait-for-navigation"
 			}
-		],
-		"flint": {
-			"name": "waitForNavigations",
-			"plugin": "playwright",
-			"status": "skipped"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "waitForSelectors",
+			"plugin": "playwright",
+			"status": "skipped"
+		},
 		"biome": [
 			{
 				"name": "noPlaywrightWaitForSelector",
 				"url": "https://biomejs.dev/linter/rules/no-playwright-wait-for-selector"
 			}
-		],
-		"flint": {
-			"name": "waitForSelectors",
-			"plugin": "playwright",
-			"status": "skipped"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "waitForTimeouts",
+			"plugin": "playwright",
+			"status": "skipped"
+		},
 		"biome": [
 			{
 				"name": "noPlaywrightWaitForTimeout",
 				"url": "https://biomejs.dev/linter/rules/no-playwright-wait-for-timeout"
 			}
-		],
-		"flint": {
-			"name": "waitForTimeouts",
-			"plugin": "playwright",
-			"status": "skipped"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "classlists",
+			"plugin": "qwik",
+			"status": "skipped"
+		},
 		"biome": [
 			{
 				"name": "useQwikClasslist",
 				"url": "https://biomejs.dev/linter/rules/use-qwik-classlist"
 			}
-		],
-		"flint": {
-			"name": "classlists",
-			"plugin": "qwik",
-			"status": "skipped"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "lexicalScopes",
+			"plugin": "qwik",
+			"status": "skipped"
+		},
 		"biome": [
 			{
 				"name": "useQwikValidLexicalScope",
 				"url": "https://biomejs.dev/linter/rules/use-qwik-valid-lexical-scope"
 			}
-		],
-		"flint": {
-			"name": "lexicalScopes",
-			"plugin": "qwik",
-			"status": "skipped"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "loaderLocations",
+			"plugin": "qwik",
+			"status": "skipped"
+		},
 		"biome": [
 			{
 				"name": "useQwikLoaderLocation",
 				"url": "https://biomejs.dev/linter/rules/use-qwik-loader-location"
 			}
-		],
-		"flint": {
-			"name": "loaderLocations",
-			"plugin": "qwik",
-			"status": "skipped"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "methodUsages",
+			"plugin": "qwik",
+			"status": "skipped"
+		},
 		"biome": [
 			{
 				"name": "useQwikMethodUsage",
 				"url": "https://biomejs.dev/linter/rules/use-qwik-method-usage"
 			}
-		],
-		"flint": {
-			"name": "methodUsages",
-			"plugin": "qwik",
-			"status": "skipped"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "visibleTasks",
+			"plugin": "qwik",
+			"status": "skipped"
+		},
 		"biome": [
 			{
 				"name": "noQwikUseVisibleTask",
 				"url": "https://biomejs.dev/linter/rules/no-qwik-use-visible-task"
 			}
-		],
-		"flint": {
-			"name": "visibleTasks",
-			"plugin": "qwik",
-			"status": "skipped"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "arrayIndexKeys",
+			"plugin": "react",
+			"preset": "logical"
+		},
 		"biome": [
 			{
 				"name": "noArrayIndexKey",
@@ -12077,11 +12082,6 @@
 				"url": "https://eslint-react.xyz/docs/rules/no-array-index-key"
 			}
 		],
-		"flint": {
-			"name": "arrayIndexKeys",
-			"plugin": "react",
-			"preset": "logical"
-		},
 		"oxlint": [
 			{
 				"name": "react/no-array-index-key",
@@ -12090,67 +12090,67 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "asyncServerFunctions",
+			"plugin": "react",
+			"preset": "logical"
+		},
 		"biome": [
 			{
 				"name": "useReactAsyncServerFunction",
 				"url": "https://biomejs.dev/linter/rules/use-react-async-server-function"
 			}
-		],
-		"flint": {
-			"name": "asyncServerFunctions",
-			"plugin": "react",
-			"preset": "logical"
-		}
+		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "@eslint-react/no-misused-capture-owner-stack",
-				"url": "https://eslint-react.xyz/docs/rules/no-misused-capture-owner-stack"
-			}
-		],
 		"flint": {
 			"name": "captureOwnerStackUsage",
 			"plugin": "react",
 			"preset": "logical",
 			"strictness": "strict"
-		}
+		},
+		"eslint": [
+			{
+				"name": "@eslint-react/no-misused-capture-owner-stack",
+				"url": "https://eslint-react.xyz/docs/rules/no-misused-capture-owner-stack"
+			}
+		]
 	},
 	{
+		"flint": {
+			"name": "childrenCounts",
+			"plugin": "react"
+		},
 		"eslint": [
 			{
 				"name": "@eslint-react/no-children-count",
 				"url": "https://eslint-react.xyz/docs/rules/no-children-count"
 			}
-		],
-		"flint": {
-			"name": "childrenCounts",
-			"plugin": "react"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "childrenForEaches",
+			"plugin": "react"
+		},
 		"eslint": [
 			{
 				"name": "@eslint-react/no-children-for-each",
 				"url": "https://eslint-react.xyz/docs/rules/no-children-for-each"
 			}
-		],
-		"flint": {
-			"name": "childrenForEaches",
-			"plugin": "react"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "childrenMaps",
+			"plugin": "react"
+		},
 		"eslint": [
 			{
 				"name": "@eslint-react/no-children-map",
 				"url": "https://eslint-react.xyz/docs/rules/no-children-map"
 			}
-		],
-		"flint": {
-			"name": "childrenMaps",
-			"plugin": "react"
-		}
+		]
 	},
 	{
 		"flint": {
@@ -12158,71 +12158,71 @@
 			"plugin": "react",
 			"status": "skipped"
 		},
-		"notes": "Split into more granular rules.",
 		"oxlint": [
 			{
 				"name": "react/no-react-children",
 				"url": "https://oxc.rs/docs/guide/usage/linter/rules/react/no-react-children.html"
 			}
-		]
+		],
+		"notes": "Split into more granular rules."
 	},
 	{
+		"flint": {
+			"name": "childrenOnlys",
+			"plugin": "react"
+		},
 		"eslint": [
 			{
 				"name": "@eslint-react/no-children-only",
 				"url": "https://eslint-react.xyz/docs/rules/no-children-only"
 			}
-		],
-		"flint": {
-			"name": "childrenOnlys",
-			"plugin": "react"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "childrenToArrays",
+			"plugin": "react"
+		},
 		"eslint": [
 			{
 				"name": "@eslint-react/no-children-to-array",
 				"url": "https://eslint-react.xyz/docs/rules/no-children-to-array"
 			}
-		],
-		"flint": {
-			"name": "childrenToArrays",
-			"plugin": "react"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "classComponentDefinitions",
+			"plugin": "react",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "react/prefer-es6-class",
 				"url": "https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/prefer-es6-class.md"
 			}
 		],
-		"flint": {
-			"name": "classComponentDefinitions",
-			"plugin": "react",
-			"status": "skipped"
-		},
-		"notes": "create-react-class is long-outdated.",
 		"oxlint": [
 			{
 				"name": "react/prefer-es6-class",
 				"url": "https://oxc.rs/docs/guide/usage/linter/rules/react/prefer-es6-class.html"
 			}
-		]
+		],
+		"notes": "create-react-class is long-outdated."
 	},
 	{
-		"eslint": [
-			{
-				"name": "@eslint-react/no-class-component",
-				"url": "https://eslint-react.xyz/docs/rules/no-class-component"
-			}
-		],
 		"flint": {
 			"name": "classComponents",
 			"plugin": "react",
 			"preset": "logical",
 			"strictness": "strict"
 		},
+		"eslint": [
+			{
+				"name": "@eslint-react/no-class-component",
+				"url": "https://eslint-react.xyz/docs/rules/no-class-component"
+			}
+		],
 		"oxlint": [
 			{
 				"name": "react/prefer-function-component",
@@ -12231,32 +12231,32 @@
 		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "react/static-property-placement",
-				"url": "https://github.com/jsx-eslint/eslint-plugin-react/tree/master/docs/rules/static-property-placement.md"
-			}
-		],
 		"flint": {
 			"name": "classComponentStateDefinitions",
 			"plugin": "react",
 			"preset": "stylistic",
 			"strictness": "strict"
-		}
-	},
-	{
+		},
 		"eslint": [
 			{
-				"name": "react/state-in-constructor",
-				"url": "https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/state-in-constructor.md"
+				"name": "react/static-property-placement",
+				"url": "https://github.com/jsx-eslint/eslint-plugin-react/tree/master/docs/rules/static-property-placement.md"
 			}
-		],
+		]
+	},
+	{
 		"flint": {
 			"name": "classComponentStateInitialization",
 			"plugin": "react",
 			"preset": "stylistic",
 			"strictness": "strict"
 		},
+		"eslint": [
+			{
+				"name": "react/state-in-constructor",
+				"url": "https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/state-in-constructor.md"
+			}
+		],
 		"oxlint": [
 			{
 				"name": "react/state-in-constructor",
@@ -12265,16 +12265,16 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "cloneElementCalls",
+			"plugin": "react"
+		},
 		"eslint": [
 			{
 				"name": "@eslint-react/no-clone-element",
 				"url": "https://eslint-react.xyz/docs/rules/no-clone-element"
 			}
 		],
-		"flint": {
-			"name": "cloneElementCalls",
-			"plugin": "react"
-		},
 		"oxlint": [
 			{
 				"name": "react/no-clone-element",
@@ -12283,44 +12283,44 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "compilerOptions",
+			"plugin": "react",
+			"preset": "config"
+		},
 		"eslint": [
 			{
 				"name": "react-hooks/config",
 				"url": "https://react.dev/reference/eslint-plugin-react-hooks/lints/config"
 			}
-		],
-		"flint": {
-			"name": "compilerOptions",
-			"plugin": "react",
-			"preset": "config"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "componentDefinitions",
+			"plugin": "react",
+			"preset": "stylistic"
+		},
 		"eslint": [
 			{
 				"name": "react/prefer-read-only-props",
 				"url": "https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/prefer-read-only-props.md"
 			}
-		],
-		"flint": {
-			"name": "componentDefinitions",
-			"plugin": "react",
-			"preset": "stylistic"
-		}
+		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "react/no-did-mount-set-state",
-				"url": "https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-did-mount-set-state.md"
-			}
-		],
 		"flint": {
 			"name": "componentDidMountSetStates",
 			"plugin": "react",
 			"preset": "logical",
 			"strictness": "strict"
 		},
+		"eslint": [
+			{
+				"name": "react/no-did-mount-set-state",
+				"url": "https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-did-mount-set-state.md"
+			}
+		],
 		"oxlint": [
 			{
 				"name": "react/no-did-mount-set-state",
@@ -12329,18 +12329,18 @@
 		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "react/no-did-update-set-state",
-				"url": "https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-did-update-set-state.md"
-			}
-		],
 		"flint": {
 			"name": "componentDidUpdateSetStates",
 			"plugin": "react",
 			"preset": "logical",
 			"strictness": "strict"
 		},
+		"eslint": [
+			{
+				"name": "react/no-did-update-set-state",
+				"url": "https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-did-update-set-state.md"
+			}
+		],
 		"oxlint": [
 			{
 				"name": "react/no-did-update-set-state",
@@ -12349,6 +12349,12 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "componentDisplayNames",
+			"plugin": "react",
+			"preset": "logical",
+			"strictness": "strict"
+		},
 		"eslint": [
 			{
 				"name": "react/display-name",
@@ -12359,12 +12365,6 @@
 				"url": "https://eslint-react.xyz/docs/rules/no-missing-component-display-name"
 			}
 		],
-		"flint": {
-			"name": "componentDisplayNames",
-			"plugin": "react",
-			"preset": "logical",
-			"strictness": "strict"
-		},
 		"oxlint": [
 			{
 				"name": "react/display-name",
@@ -12373,18 +12373,18 @@
 		]
 	},
 	{
-		"biome": [
-			{
-				"name": "useComponentExportOnlyModules",
-				"url": "https://biomejs.dev/linter/rules/use-component-export-only-modules"
-			}
-		],
 		"flint": {
 			"name": "componentExportModules",
 			"plugin": "react",
 			"preset": "logical",
 			"strictness": "strict"
 		},
+		"biome": [
+			{
+				"name": "useComponentExportOnlyModules",
+				"url": "https://biomejs.dev/linter/rules/use-component-export-only-modules"
+			}
+		],
 		"oxlint": [
 			{
 				"name": "react/only-export-components",
@@ -12393,6 +12393,11 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "componentHookFactories",
+			"plugin": "react",
+			"preset": "logical"
+		},
 		"biome": [
 			{
 				"name": "noComponentHookFactories",
@@ -12404,25 +12409,20 @@
 				"name": "react-hooks/component-hook-factories",
 				"url": "https://react.dev/reference/eslint-plugin-react-hooks/lints/component-hook-factories"
 			}
-		],
-		"flint": {
-			"name": "componentHookFactories",
-			"plugin": "react",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "componentNesting",
+			"plugin": "react",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "react/no-unstable-nested-components",
 				"url": "https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-unstable-nested-components.md"
 			}
 		],
-		"flint": {
-			"name": "componentNesting",
-			"plugin": "react",
-			"preset": "logical"
-		},
 		"oxlint": [
 			{
 				"name": "react/no-unstable-nested-components",
@@ -12431,108 +12431,108 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "componentOptimizations",
+			"plugin": "react",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "react/require-optimization",
 				"url": "https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/require-optimization.md"
 			}
 		],
-		"flint": {
-			"name": "componentOptimizations",
-			"plugin": "react",
-			"status": "skipped"
-		},
 		"notes": "Overly opinionated."
 	},
 	{
+		"flint": {
+			"name": "componentPropertySorting",
+			"plugin": "react",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "react/sort-comp",
 				"url": "https://github.com/jsx-eslint/eslint-plugin-react/tree/master/docs/rules/sort-comp.md"
 			}
 		],
-		"flint": {
-			"name": "componentPropertySorting",
-			"plugin": "react",
-			"status": "skipped"
-		},
 		"notes": "Handled by ts sorting preset."
 	},
 	{
+		"flint": {
+			"name": "componentsPerFile",
+			"plugin": "react",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "react/no-multi-comp",
 				"url": "https://github.com/jsx-eslint/eslint-plugin-react/tree/master/docs/rules/no-multi-comp.md"
 			}
 		],
-		"flint": {
-			"name": "componentsPerFile",
-			"plugin": "react",
-			"status": "skipped"
-		},
-		"notes": "Overly opinionated.",
 		"oxlint": [
 			{
 				"name": "react/no-multi-comp",
 				"url": "https://oxc.rs/docs/guide/usage/linter/rules/react/no-multi-comp.html"
 			}
-		]
+		],
+		"notes": "Overly opinionated."
 	},
 	{
+		"flint": {
+			"name": "componentWillMountCalls",
+			"plugin": "react",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "@eslint-react/no-component-will-mount",
 				"url": "https://eslint-react.xyz/docs/rules/no-component-will-mount"
 			}
 		],
-		"flint": {
-			"name": "componentWillMountCalls",
-			"plugin": "react",
-			"preset": "logical"
-		},
 		"notes": "React Versions >= 16.3.0"
 	},
 	{
+		"flint": {
+			"name": "componentWillReceivePropsCalls",
+			"plugin": "react",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "@eslint-react/no-component-will-receive-props",
 				"url": "https://eslint-react.xyz/docs/rules/no-component-will-receive-props"
 			}
 		],
-		"flint": {
-			"name": "componentWillReceivePropsCalls",
-			"plugin": "react",
-			"preset": "logical"
-		},
 		"notes": "React Versions >= 16.3.0"
 	},
 	{
+		"flint": {
+			"name": "componentWillUpdateCalls",
+			"plugin": "react",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "@eslint-react/no-component-will-update",
 				"url": "https://eslint-react.xyz/docs/rules/no-component-will-update"
 			}
 		],
-		"flint": {
-			"name": "componentWillUpdateCalls",
-			"plugin": "react",
-			"preset": "logical"
-		},
 		"notes": "React Versions >= 16.3.0"
 	},
 	{
-		"eslint": [
-			{
-				"name": "react/no-will-update-set-state",
-				"url": "https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-will-update-set-state.md"
-			}
-		],
 		"flint": {
 			"name": "componentWillUpdateSetStates",
 			"plugin": "react",
 			"preset": "logical",
 			"strictness": "strict"
 		},
+		"eslint": [
+			{
+				"name": "react/no-will-update-set-state",
+				"url": "https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-will-update-set-state.md"
+			}
+		],
 		"oxlint": [
 			{
 				"name": "react/no-will-update-set-state",
@@ -12541,58 +12541,58 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "contextDisplayNames",
+			"plugin": "react"
+		},
 		"eslint": [
 			{
 				"name": "@eslint-react/no-missing-context-display-name",
 				"url": "https://eslint-react.xyz/docs/rules/no-missing-context-display-name"
 			}
-		],
-		"flint": {
-			"name": "contextDisplayNames",
-			"plugin": "react"
-		}
+		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "@eslint-react/naming-convention-context-name",
-				"url": "https://eslint-react.xyz/docs/rules/naming-convention-context-name"
-			}
-		],
 		"flint": {
 			"name": "contextNames",
 			"plugin": "react",
 			"preset": "stylistic",
 			"strictness": "strict"
-		}
+		},
+		"eslint": [
+			{
+				"name": "@eslint-react/naming-convention-context-name",
+				"url": "https://eslint-react.xyz/docs/rules/naming-convention-context-name"
+			}
+		]
 	},
 	{
+		"flint": {
+			"name": "contextProviders",
+			"plugin": "react",
+			"preset": "stylistic"
+		},
 		"eslint": [
 			{
 				"name": "@eslint-react/no-context-provider",
 				"url": "https://eslint-react.xyz/docs/rules/no-context-provider"
 			}
 		],
-		"flint": {
-			"name": "contextProviders",
-			"plugin": "react",
-			"preset": "stylistic"
-		},
 		"notes": "React Versions >= 19.0.0"
 	},
 	{
-		"eslint": [
-			{
-				"name": "react/jsx-no-constructed-context-values",
-				"url": "https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-no-constructed-context-values.md"
-			}
-		],
 		"flint": {
 			"name": "contextValueReferences",
 			"plugin": "react",
 			"preset": "logical",
 			"strictness": "strict"
 		},
+		"eslint": [
+			{
+				"name": "react/jsx-no-constructed-context-values",
+				"url": "https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-no-constructed-context-values.md"
+			}
+		],
 		"oxlint": [
 			{
 				"name": "react/jsx-no-constructed-context-values",
@@ -12601,72 +12601,77 @@
 		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "@eslint-react/no-unstable-context-value",
-				"url": "https://eslint-react.xyz/docs/rules/no-unstable-context-value"
-			}
-		],
 		"flint": {
 			"name": "contextValueStability",
 			"plugin": "react",
 			"preset": "logical",
 			"strictness": "strict"
-		}
+		},
+		"eslint": [
+			{
+				"name": "@eslint-react/no-unstable-context-value",
+				"url": "https://eslint-react.xyz/docs/rules/no-unstable-context-value"
+			}
+		]
 	},
 	{
+		"flint": {
+			"name": "createRefCalls",
+			"plugin": "react",
+			"preset": "stylistic"
+		},
 		"eslint": [
 			{
 				"name": "@eslint-react/no-create-ref",
 				"url": "https://eslint-react.xyz/docs/rules/no-create-ref"
 			}
-		],
-		"flint": {
-			"name": "createRefCalls",
-			"plugin": "react",
-			"preset": "stylistic"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "crossComponentPropTypes",
+			"plugin": "react",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "react/forbid-foreign-prop-types",
 				"url": "https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/forbid-foreign-prop-types.md"
 			}
 		],
-		"flint": {
-			"name": "crossComponentPropTypes",
-			"plugin": "react",
-			"status": "skipped"
-		},
 		"notes": "Overly opinionated and for the no-longer-recommended propTypes pattern"
 	},
 	{
+		"flint": {
+			"name": "dangerouslySetInnerHtmls",
+			"plugin": "react"
+		},
 		"eslint": [
 			{
 				"name": "@eslint-react/dom-no-dangerously-set-innerhtml",
 				"url": "https://eslint-react.xyz/docs/rules/dom-no-dangerously-set-innerhtml"
 			}
-		],
-		"flint": {
-			"name": "dangerouslySetInnerHtmls",
-			"plugin": "react"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "dangerouslySetInnerHtmlsWithChildren",
+			"plugin": "react",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "@eslint-react/dom-no-dangerously-set-innerhtml-with-children",
 				"url": "https://eslint-react.xyz/docs/rules/dom-no-dangerously-set-innerhtml-with-children"
 			}
-		],
-		"flint": {
-			"name": "dangerouslySetInnerHtmlsWithChildren",
-			"plugin": "react",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "dangerouslySetInnerHTMLWithChildren",
+			"plugin": "react",
+			"preset": "logical"
+		},
 		"biome": [
 			{
 				"name": "noDangerouslySetInnerHtmlWithChildren",
@@ -12679,11 +12684,6 @@
 				"url": "https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-danger-with-children.md"
 			}
 		],
-		"flint": {
-			"name": "dangerouslySetInnerHTMLWithChildren",
-			"plugin": "react",
-			"preset": "logical"
-		},
 		"oxlint": [
 			{
 				"name": "react/no-danger-with-children",
@@ -12692,6 +12692,12 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "dangerousProps",
+			"plugin": "react",
+			"preset": "logical",
+			"strictness": "strict"
+		},
 		"biome": [
 			{
 				"name": "noDangerouslySetInnerHtml",
@@ -12704,12 +12710,6 @@
 				"url": "https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-danger.md"
 			}
 		],
-		"flint": {
-			"name": "dangerousProps",
-			"plugin": "react",
-			"preset": "logical",
-			"strictness": "strict"
-		},
 		"oxlint": [
 			{
 				"name": "react/no-danger",
@@ -12718,74 +12718,79 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "defaultPropsMatchingPropTypes",
+			"plugin": "react",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "react/default-props-match-prop-types",
 				"url": "https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/default-props-match-prop-types.md"
 			}
-		],
-		"flint": {
-			"name": "defaultPropsMatchingPropTypes",
-			"plugin": "react",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "defaultPropsSoring",
+			"plugin": "react",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "react/sort-default-props",
 				"url": "https://github.com/jsx-eslint/eslint-plugin-react/tree/master/docs/rules/sort-default-props.md"
 			}
 		],
-		"flint": {
-			"name": "defaultPropsSoring",
-			"plugin": "react",
-			"status": "skipped"
-		},
 		"notes": "Handled by ts sorting preset."
 	},
 	{
-		"eslint": [
-			{
-				"name": "@eslint-react/no-unstable-default-props",
-				"url": "https://eslint-react.xyz/docs/rules/no-unstable-default-props"
-			}
-		],
 		"flint": {
 			"name": "defaultPropsStability",
 			"plugin": "react",
 			"preset": "logical",
 			"strictness": "strict"
-		}
+		},
+		"eslint": [
+			{
+				"name": "@eslint-react/no-unstable-default-props",
+				"url": "https://eslint-react.xyz/docs/rules/no-unstable-default-props"
+			}
+		]
 	},
 	{
+		"flint": {
+			"name": "deprecated",
+			"plugin": "react",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "react/no-deprecated",
 				"url": "https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-deprecated.md"
 			}
 		],
-		"flint": {
-			"name": "deprecated",
-			"plugin": "react",
-			"status": "skipped"
-		},
 		"notes": "Superseded by deprecated."
 	},
 	{
+		"flint": {
+			"name": "destructuring",
+			"plugin": "react",
+			"preset": "stylistic"
+		},
 		"eslint": [
 			{
 				"name": "react/destructuring-assignment",
 				"url": "https://github.com/jsx-eslint/eslint-plugin-react/tree/master/docs/rules/destructuring-assignment.md"
 			}
-		],
-		"flint": {
-			"name": "destructuring",
-			"plugin": "react",
-			"preset": "stylistic"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "effectSetStates",
+			"plugin": "react",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "react-hooks/set-state-in-effect",
@@ -12795,14 +12800,14 @@
 				"name": "@eslint-react/set-state-in-effect",
 				"url": "https://eslint-react.xyz/docs/rules/set-state-in-effect"
 			}
-		],
-		"flint": {
-			"name": "effectSetStates",
-			"plugin": "react",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "errorBoundaries",
+			"plugin": "react",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "react-hooks/error-boundaries",
@@ -12812,28 +12817,28 @@
 				"name": "@eslint-react/error-boundaries",
 				"url": "https://eslint-react.xyz/docs/rules/error-boundaries"
 			}
-		],
-		"flint": {
-			"name": "errorBoundaries",
-			"plugin": "react",
-			"preset": "logical"
-		}
+		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "@eslint-react/web-api-no-leaked-event-listener",
-				"url": "https://eslint-react.xyz/docs/rules/web-api-no-leaked-event-listener"
-			}
-		],
 		"flint": {
 			"name": "eventListenerCleanup",
 			"plugin": "react",
 			"preset": "logical",
 			"strictness": "strict"
-		}
+		},
+		"eslint": [
+			{
+				"name": "@eslint-react/web-api-no-leaked-event-listener",
+				"url": "https://eslint-react.xyz/docs/rules/web-api-no-leaked-event-listener"
+			}
+		]
 	},
 	{
+		"flint": {
+			"name": "exhaustiveDeps",
+			"plugin": "react",
+			"preset": "logical"
+		},
 		"biome": [
 			{
 				"name": "useExhaustiveDependencies",
@@ -12850,11 +12855,6 @@
 				"url": "https://eslint-react.xyz/docs/rules/exhaustive-deps"
 			}
 		],
-		"flint": {
-			"name": "exhaustiveDeps",
-			"plugin": "react",
-			"preset": "logical"
-		},
 		"oxlint": [
 			{
 				"name": "react/exhaustive-deps",
@@ -12863,20 +12863,25 @@
 		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "@eslint-react/web-api-no-leaked-fetch",
-				"url": "https://eslint-react.xyz/docs/rules/web-api-no-leaked-fetch"
-			}
-		],
 		"flint": {
 			"name": "fetchCleanup",
 			"plugin": "react",
 			"preset": "logical",
 			"strictness": "strict"
-		}
+		},
+		"eslint": [
+			{
+				"name": "@eslint-react/web-api-no-leaked-fetch",
+				"url": "https://eslint-react.xyz/docs/rules/web-api-no-leaked-fetch"
+			}
+		]
 	},
 	{
+		"flint": {
+			"name": "findDOMNodeCalls",
+			"plugin": "react",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "react/no-find-dom-node",
@@ -12887,67 +12892,67 @@
 				"url": "https://eslint-react.xyz/docs/rules/dom-no-find-dom-node"
 			}
 		],
-		"flint": {
-			"name": "findDOMNodeCalls",
-			"plugin": "react",
-			"status": "skipped"
-		},
-		"notes": "Superseded by deprecated.",
 		"oxlint": [
 			{
 				"name": "react/no-find-dom-node",
 				"url": "https://oxc.rs/docs/guide/usage/linter/rules/react/no-find-dom-node.html"
 			}
-		]
+		],
+		"notes": "Superseded by deprecated."
 	},
 	{
+		"flint": {
+			"name": "forwardRefArguments",
+			"plugin": "react",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "react/forward-ref-uses-ref",
 				"url": "https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/forward-ref-uses-ref.md"
 			}
 		],
-		"flint": {
-			"name": "forwardRefArguments",
-			"plugin": "react",
-			"status": "skipped"
-		},
-		"notes": "`React.forwardRef` is no longer necessary as of React 19.",
 		"oxlint": [
 			{
 				"name": "react/forward-ref-uses-ref",
 				"url": "https://oxc.rs/docs/guide/usage/linter/rules/react/forward-ref-uses-ref.html"
 			}
-		]
+		],
+		"notes": "`React.forwardRef` is no longer necessary as of React 19."
 	},
 	{
+		"flint": {
+			"name": "forwardRefCalls",
+			"plugin": "react"
+		},
 		"eslint": [
 			{
 				"name": "@eslint-react/no-forward-ref",
 				"url": "https://eslint-react.xyz/docs/rules/no-forward-ref"
 			}
 		],
-		"flint": {
-			"name": "forwardRefCalls",
-			"plugin": "react"
-		},
 		"notes": "React Versions >= 19.0.0"
 	},
 	{
-		"biome": [
-			{
-				"name": "noReactForwardRef",
-				"url": "https://biomejs.dev/linter/rules/no-react-forward-ref"
-			}
-		],
 		"flint": {
 			"name": "forwardRefs",
 			"plugin": "react",
 			"preset": "stylistic",
 			"strictness": "strict"
-		}
+		},
+		"biome": [
+			{
+				"name": "noReactForwardRef",
+				"url": "https://biomejs.dev/linter/rules/no-react-forward-ref"
+			}
+		]
 	},
 	{
+		"flint": {
+			"name": "functionComponentDefinitions",
+			"plugin": "react",
+			"preset": "stylistic"
+		},
 		"biome": [
 			{
 				"name": "useReactFunctionComponents",
@@ -12959,25 +12964,20 @@
 				"name": "react/function-component-definition",
 				"url": "https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/function-component-definition.md"
 			}
-		],
-		"flint": {
-			"name": "functionComponentDefinitions",
-			"plugin": "react",
-			"preset": "stylistic"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "functionComponentThisReferences",
+			"plugin": "react",
+			"preset": "javascript"
+		},
 		"eslint": [
 			{
 				"name": "react/no-this-in-sfc",
 				"url": "https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-this-in-sfc.md"
 			}
 		],
-		"flint": {
-			"name": "functionComponentThisReferences",
-			"plugin": "react",
-			"preset": "javascript"
-		},
 		"oxlint": [
 			{
 				"name": "react/no-this-in-sfc",
@@ -12986,19 +12986,24 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "gating",
+			"plugin": "react",
+			"preset": "config"
+		},
 		"eslint": [
 			{
 				"name": "react-hooks/gating",
 				"url": "https://react.dev/reference/eslint-plugin-react-hooks/lints/gating"
 			}
-		],
-		"flint": {
-			"name": "gating",
-			"plugin": "react",
-			"preset": "config"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "globalMutations",
+			"plugin": "react",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "react-hooks/globals",
@@ -13008,28 +13013,28 @@
 				"name": "@eslint-react/globals",
 				"url": "https://eslint-react.xyz/docs/rules/globals"
 			}
-		],
-		"flint": {
-			"name": "globalMutations",
-			"plugin": "react",
-			"preset": "logical"
-		}
+		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "@eslint-react/naming-convention-id-name",
-				"url": "https://eslint-react.xyz/docs/rules/naming-convention-id-name"
-			}
-		],
 		"flint": {
 			"name": "idNames",
 			"plugin": "react",
 			"preset": "stylistic",
 			"strictness": "strict"
-		}
+		},
+		"eslint": [
+			{
+				"name": "@eslint-react/naming-convention-id-name",
+				"url": "https://eslint-react.xyz/docs/rules/naming-convention-id-name"
+			}
+		]
 	},
 	{
+		"flint": {
+			"name": "immutability",
+			"plugin": "react",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "react-hooks/immutability",
@@ -13039,97 +13044,98 @@
 				"name": "@eslint-react/immutability",
 				"url": "https://eslint-react.xyz/docs/rules/immutability"
 			}
-		],
-		"flint": {
-			"name": "immutability",
-			"plugin": "react",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "implicitChildren",
+			"plugin": "react"
+		},
 		"eslint": [
 			{
 				"name": "@eslint-react/no-implicit-children",
 				"url": "https://eslint-react.xyz/docs/rules/no-implicit-children"
 			}
-		],
-		"flint": {
-			"name": "implicitChildren",
-			"plugin": "react"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "implicitKeys",
+			"plugin": "react"
+		},
 		"eslint": [
 			{
 				"name": "@eslint-react/no-implicit-key",
 				"url": "https://eslint-react.xyz/docs/rules/no-implicit-key"
 			}
-		],
-		"flint": {
-			"name": "implicitKeys",
-			"plugin": "react"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "implicitRefs",
+			"plugin": "react"
+		},
 		"eslint": [
 			{
 				"name": "@eslint-react/no-implicit-ref",
 				"url": "https://eslint-react.xyz/docs/rules/no-implicit-ref"
 			}
-		],
-		"flint": {
-			"name": "implicitRefs",
-			"plugin": "react"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "incompatibleLibraries",
+			"plugin": "react",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "react-hooks/incompatible-library",
 				"url": "https://react.dev/reference/eslint-plugin-react-hooks/lints/incompatible-library"
 			}
-		],
-		"flint": {
-			"name": "incompatibleLibraries",
-			"plugin": "react",
-			"preset": "logical"
-		}
+		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "@eslint-react/web-api-no-leaked-interval",
-				"url": "https://eslint-react.xyz/docs/rules/web-api-no-leaked-interval"
-			}
-		],
 		"flint": {
 			"name": "intervalCleanup",
 			"plugin": "react",
 			"preset": "logical",
 			"strictness": "strict"
-		}
+		},
+		"eslint": [
+			{
+				"name": "@eslint-react/web-api-no-leaked-interval",
+				"url": "https://eslint-react.xyz/docs/rules/web-api-no-leaked-interval"
+			}
+		]
 	},
 	{
+		"flint": {
+			"name": "isMounted",
+			"plugin": "react",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "react/no-is-mounted",
 				"url": "https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-is-mounted.md"
 			}
 		],
-		"flint": {
-			"name": "isMounted",
-			"plugin": "react",
-			"status": "skipped"
-		},
-		"notes": "`isMounted` is no longer present in modern React.",
 		"oxlint": [
 			{
 				"name": "react/no-is-mounted",
 				"url": "https://oxc.rs/docs/guide/usage/linter/rules/react/no-is-mounted.html"
 			}
-		]
+		],
+		"notes": "`isMounted` is no longer present in modern React."
 	},
 	{
+		"flint": {
+			"name": "iterableKeys",
+			"plugin": "react",
+			"preset": "logical",
+			"strictness": "strict"
+		},
 		"biome": [
 			{
 				"name": "useJsxKeyInIterable",
@@ -13142,12 +13148,6 @@
 				"url": "https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-key.md"
 			}
 		],
-		"flint": {
-			"name": "iterableKeys",
-			"plugin": "react",
-			"preset": "logical",
-			"strictness": "strict"
-		},
 		"oxlint": [
 			{
 				"name": "react/jsx-key",
@@ -13156,55 +13156,60 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "keyDuplications",
+			"plugin": "react"
+		},
 		"eslint": [
 			{
 				"name": "@eslint-react/no-duplicate-key",
 				"url": "https://eslint-react.xyz/docs/rules/no-direct-mutation-state"
 			}
-		],
-		"flint": {
-			"name": "keyDuplications",
-			"plugin": "react"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "leakedConditionalRenderings",
+			"plugin": "react"
+		},
 		"eslint": [
 			{
 				"name": "@eslint-react/no-leaked-conditional-rendering",
 				"url": "https://eslint-react.xyz/docs/rules/no-leaked-conditional-rendering"
 			}
-		],
-		"flint": {
-			"name": "leakedConditionalRenderings",
-			"plugin": "react"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "manualMemoizationPreservations",
+			"plugin": "react",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "react-hooks/preserve-manual-memoization",
 				"url": "https://react.dev/reference/eslint-plugin-react-hooks/lints/preserve-manual-memoization"
 			}
-		],
-		"flint": {
-			"name": "manualMemoizationPreservations",
-			"plugin": "react",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "missingKeys",
+			"plugin": "react"
+		},
 		"eslint": [
 			{
 				"name": "@eslint-react/no-missing-key",
 				"url": "https://eslint-react.xyz/docs/rules/no-missing-key"
 			}
-		],
-		"flint": {
-			"name": "missingKeys",
-			"plugin": "react"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "nestedComponentDefinitions",
+			"plugin": "react",
+			"preset": "logical"
+		},
 		"biome": [
 			{
 				"name": "noNestedComponentDefinitions",
@@ -13216,54 +13221,54 @@
 				"name": "@eslint-react/no-nested-component-definitions",
 				"url": "https://eslint-react.xyz/docs/rules/no-nested-component-definitions"
 			}
-		],
-		"flint": {
-			"name": "nestedComponentDefinitions",
-			"plugin": "react",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "nestedLazyComponentDeclarations",
+			"plugin": "react",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "@eslint-react/no-nested-lazy-component-declarations",
 				"url": "https://eslint-react.xyz/docs/rules/no-nested-lazy-component-declarations"
 			}
-		],
-		"flint": {
-			"name": "nestedLazyComponentDeclarations",
-			"plugin": "react",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "propAssignments",
+			"plugin": "react",
+			"preset": "logical"
+		},
 		"biome": [
 			{
 				"name": "noReactPropAssignments",
 				"url": "https://biomejs.dev/linter/rules/no-react-prop-assignments"
 			}
-		],
-		"flint": {
-			"name": "propAssignments",
-			"plugin": "react",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "propDefaults",
+			"plugin": "react",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "react/require-default-props",
 				"url": "https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/require-default-props.md"
 			}
 		],
-		"flint": {
-			"name": "propDefaults",
-			"plugin": "react",
-			"status": "skipped"
-		},
 		"notes": "Overly opinionated."
 	},
 	{
+		"flint": {
+			"name": "propertyValidity",
+			"plugin": "react",
+			"preset": "javascript"
+		},
 		"biome": [
 			{
 				"name": "noUnknownAttribute",
@@ -13280,11 +13285,6 @@
 				"url": "https://eslint-react.xyz/docs/rules/dom-no-unknown-property"
 			}
 		],
-		"flint": {
-			"name": "propertyValidity",
-			"plugin": "react",
-			"preset": "javascript"
-		},
 		"oxlint": [
 			{
 				"name": "react/no-unknown-property",
@@ -13293,61 +13293,66 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "propTypes",
+			"plugin": "react",
+			"preset": "javascript"
+		},
 		"eslint": [
 			{
 				"name": "react/prop-types",
 				"url": "https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/prop-types.md"
 			}
-		],
-		"flint": {
-			"name": "propTypes",
-			"plugin": "react",
-			"preset": "javascript"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "propTypesExactness",
+			"plugin": "react",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "react/prefer-exact-props",
 				"url": "https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/prefer-exact-props.md"
 			}
 		],
-		"flint": {
-			"name": "propTypesExactness",
-			"plugin": "react",
-			"status": "skipped"
-		},
 		"notes": "Handles an edge case in the no-longer-recommended propTypes package."
 	},
 	{
+		"flint": {
+			"name": "propTypesMutability",
+			"plugin": "react",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "react/prefer-read-only-props",
 				"url": "https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/prefer-read-only-props.md"
 			}
 		],
-		"flint": {
-			"name": "propTypesMutability",
-			"plugin": "react",
-			"status": "skipped"
-		},
 		"notes": "Overly opinionated."
 	},
 	{
+		"flint": {
+			"name": "propTypesSorting",
+			"plugin": "react",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "react/sort-prop-types",
 				"url": "https://github.com/jsx-eslint/eslint-plugin-react/tree/master/docs/rules/sort-prop-types.md"
 			}
 		],
-		"flint": {
-			"name": "propTypesSorting",
-			"plugin": "react",
-			"status": "skipped"
-		},
 		"notes": "Handled by ts sorting preset."
 	},
 	{
+		"flint": {
+			"name": "purity",
+			"plugin": "react",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "react-hooks/purity",
@@ -13357,90 +13362,90 @@
 				"name": "@eslint-react/purity",
 				"url": "https://eslint-react.xyz/docs/rules/purity"
 			}
-		],
-		"flint": {
-			"name": "purity",
-			"plugin": "react",
-			"preset": "logical"
-		}
+		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "@eslint-react/dom-no-flush-sync",
-				"url": "https://eslint-react.xyz/docs/rules/dom-no-flush-sync"
-			}
-		],
 		"flint": {
 			"name": "reactDomFlushSyncCalls",
 			"plugin": "react",
 			"preset": "logical",
 			"strictness": "strict"
-		}
+		},
+		"eslint": [
+			{
+				"name": "@eslint-react/dom-no-flush-sync",
+				"url": "https://eslint-react.xyz/docs/rules/dom-no-flush-sync"
+			}
+		]
 	},
 	{
+		"flint": {
+			"name": "reactDomHydrateCalls",
+			"plugin": "react",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "@eslint-react/dom-no-hydrate",
 				"url": "https://eslint-react.xyz/docs/rules/dom-no-hydrate"
 			}
 		],
-		"flint": {
-			"name": "reactDomHydrateCalls",
-			"plugin": "react",
-			"preset": "logical"
-		},
 		"notes": "React Versions >= 18.0.0"
 	},
 	{
+		"flint": {
+			"name": "reactDomRenderCalls",
+			"plugin": "react",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "@eslint-react/dom-no-render",
 				"url": "https://eslint-react.xyz/docs/rules/dom-no-render"
 			}
 		],
-		"flint": {
-			"name": "reactDomRenderCalls",
-			"plugin": "react",
-			"preset": "logical"
-		},
 		"notes": "React Versions >= 18.0.0"
 	},
 	{
+		"flint": {
+			"name": "reactJsxScopes",
+			"plugin": "react",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "react/react-in-jsx-scope",
 				"url": "https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/react-in-jsx-scope.md"
 			}
 		],
-		"flint": {
-			"name": "reactJsxScopes",
-			"plugin": "react",
-			"status": "skipped"
-		},
-		"notes": "Generally handled by parsers.",
 		"oxlint": [
 			{
 				"name": "react/react-in-jsx-scope",
 				"url": "https://oxc.rs/docs/guide/usage/linter/rules/react/react-in-jsx-scope.html"
 			}
-		]
+		],
+		"notes": "Generally handled by parsers."
 	},
 	{
-		"eslint": [
-			{
-				"name": "@eslint-react/naming-convention-ref-name",
-				"url": "https://eslint-react.xyz/docs/rules/naming-convention-ref-name"
-			}
-		],
 		"flint": {
 			"name": "refNames",
 			"plugin": "react",
 			"preset": "stylistic",
 			"strictness": "strict"
-		}
+		},
+		"eslint": [
+			{
+				"name": "@eslint-react/naming-convention-ref-name",
+				"url": "https://eslint-react.xyz/docs/rules/naming-convention-ref-name"
+			}
+		]
 	},
 	{
+		"flint": {
+			"name": "refs",
+			"plugin": "react",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "react-hooks/refs",
@@ -13450,14 +13455,14 @@
 				"name": "@eslint-react/refs",
 				"url": "https://eslint-react.xyz/docs/rules/refs"
 			}
-		],
-		"flint": {
-			"name": "refs",
-			"plugin": "react",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "refStrings",
+			"plugin": "react",
+			"preset": "logical"
+		},
 		"biome": [
 			{
 				"name": "noReactStringRefs",
@@ -13470,11 +13475,6 @@
 				"url": "https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-string-refs.md"
 			}
 		],
-		"flint": {
-			"name": "refStrings",
-			"plugin": "react",
-			"preset": "logical"
-		},
 		"oxlint": [
 			{
 				"name": "react/no-string-refs",
@@ -13483,6 +13483,11 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "renderReturns",
+			"plugin": "react",
+			"status": "skipped"
+		},
 		"biome": [
 			{
 				"name": "noRenderReturnValue",
@@ -13499,20 +13504,20 @@
 				"url": "https://eslint-react.xyz/docs/rules/dom-no-render-return-value"
 			}
 		],
-		"flint": {
-			"name": "renderReturns",
-			"plugin": "react",
-			"status": "skipped"
-		},
-		"notes": "`render` is no longer recommended in modern React.",
 		"oxlint": [
 			{
 				"name": "react/no-render-return-value",
 				"url": "https://oxc.rs/docs/guide/usage/linter/rules/react/no-render-return-value.html"
 			}
-		]
+		],
+		"notes": "`render` is no longer recommended in modern React."
 	},
 	{
+		"flint": {
+			"name": "renderSetStates",
+			"plugin": "react",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "react-hooks/set-state-in-render",
@@ -13522,38 +13527,33 @@
 				"name": "@eslint-react/set-state-in-render",
 				"url": "https://eslint-react.xyz/docs/rules/set-state-in-render"
 			}
-		],
-		"flint": {
-			"name": "renderSetStates",
-			"plugin": "react",
-			"preset": "logical"
-		}
+		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "@eslint-react/web-api-no-leaked-resize-observer",
-				"url": "https://eslint-react.xyz/docs/rules/web-api-no-leaked-resize-observer"
-			}
-		],
 		"flint": {
 			"name": "resizeObserverCleanup",
 			"plugin": "react",
 			"preset": "logical",
 			"strictness": "strict"
-		}
+		},
+		"eslint": [
+			{
+				"name": "@eslint-react/web-api-no-leaked-resize-observer",
+				"url": "https://eslint-react.xyz/docs/rules/web-api-no-leaked-resize-observer"
+			}
+		]
 	},
 	{
+		"flint": {
+			"name": "restrictedComponentProps",
+			"plugin": "react"
+		},
 		"eslint": [
 			{
 				"name": "react/forbid-component-props",
 				"url": "https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/forbid-component-props.md"
 			}
 		],
-		"flint": {
-			"name": "restrictedComponentProps",
-			"plugin": "react"
-		},
 		"oxlint": [
 			{
 				"name": "react/forbid-component-props",
@@ -13562,16 +13562,16 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "restrictedDomProps",
+			"plugin": "react"
+		},
 		"eslint": [
 			{
 				"name": "react/forbid-dom-props",
 				"url": "https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/forbid-dom-props.md"
 			}
 		],
-		"flint": {
-			"name": "restrictedDomProps",
-			"plugin": "react"
-		},
 		"oxlint": [
 			{
 				"name": "react/forbid-dom-props",
@@ -13580,6 +13580,10 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "restrictedElements",
+			"plugin": "react"
+		},
 		"biome": [
 			{
 				"name": "noRestrictedElements",
@@ -13592,10 +13596,6 @@
 				"url": "https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/forbid-elements.md"
 			}
 		],
-		"flint": {
-			"name": "restrictedElements",
-			"plugin": "react"
-		},
 		"oxlint": [
 			{
 				"name": "react/forbid-elements",
@@ -13604,30 +13604,35 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "restrictedPropTypes",
+			"plugin": "react"
+		},
 		"eslint": [
 			{
 				"name": "react/forbid-prop-types",
 				"url": "https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/forbid-prop-types.md"
 			}
-		],
-		"flint": {
-			"name": "restrictedPropTypes",
-			"plugin": "react"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "rscFunctionDefinitions",
+			"plugin": "react"
+		},
 		"eslint": [
 			{
 				"name": "@eslint-react/rsc-function-definion",
 				"url": "https://eslint-react.xyz/docs/rules/rsc-function-definition"
 			}
-		],
-		"flint": {
-			"name": "rscFunctionDefinitions",
-			"plugin": "react"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "rulesOfHooks",
+			"plugin": "react",
+			"preset": "logical"
+		},
 		"biome": [
 			{
 				"name": "useHookAtTopLevel",
@@ -13644,11 +13649,6 @@
 				"url": "https://eslint-react.xyz/docs/rules/rules-of-hooks"
 			}
 		],
-		"flint": {
-			"name": "rulesOfHooks",
-			"plugin": "react",
-			"preset": "logical"
-		},
 		"oxlint": [
 			{
 				"name": "react/rules-of-hooks",
@@ -13657,82 +13657,87 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "setStates",
+			"plugin": "react",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "react/no-set-state",
 				"url": "https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-set-state.md"
 			}
 		],
-		"flint": {
-			"name": "setStates",
-			"plugin": "react",
-			"status": "skipped"
-		},
-		"notes": "Overly opinionated.",
 		"oxlint": [
 			{
 				"name": "react/no-set-state",
 				"url": "https://oxc.rs/docs/guide/usage/linter/rules/react/no-set-state.html"
 			}
-		]
+		],
+		"notes": "Overly opinionated."
 	},
 	{
+		"flint": {
+			"name": "setStatesInComponentDidMounts",
+			"plugin": "react",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "@eslint-react/no-set-state-in-component-did-mount",
 				"url": "https://eslint-react.xyz/docs/rules/no-set-state-in-component-did-mount"
 			}
 		],
-		"flint": {
-			"name": "setStatesInComponentDidMounts",
-			"plugin": "react",
-			"status": "skipped"
-		},
 		"notes": "Only relevant to Class Components, which are no longer recommended."
 	},
 	{
+		"flint": {
+			"name": "setStatesInComponentDidUpdates",
+			"plugin": "react",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "@eslint-react/no-set-state-in-component-did-update",
 				"url": "https://eslint-react.xyz/docs/rules/no-set-state-in-component-did-update"
 			}
 		],
-		"flint": {
-			"name": "setStatesInComponentDidUpdates",
-			"plugin": "react",
-			"status": "skipped"
-		},
 		"notes": "Only relevant to Class Components, which are no longer recommended."
 	},
 	{
+		"flint": {
+			"name": "setStatesInComponentWillUpdates",
+			"plugin": "react",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "@eslint-react/no-set-state-in-component-will-update",
 				"url": "https://eslint-react.xyz/docs/rules/no-set-state-in-component-will-update"
 			}
 		],
-		"flint": {
-			"name": "setStatesInComponentWillUpdates",
-			"plugin": "react",
-			"status": "skipped"
-		},
 		"notes": "Only relevant to Class Components, which are no longer recommended."
 	},
 	{
+		"flint": {
+			"name": "stateAccessesInSetStates",
+			"plugin": "react",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "https://eslint-react.xyz/docs/rules/no-access-state-in-setstate",
 				"url": "https://eslint-react.xyz/docs/rules/no-access-state-in-setstate"
 			}
 		],
-		"flint": {
-			"name": "stateAccessesInSetStates",
-			"plugin": "react",
-			"status": "skipped"
-		},
 		"notes": "Only relevant to Class Components, which are no longer recommended."
 	},
 	{
+		"flint": {
+			"name": "stateMutations",
+			"plugin": "react",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "react/no-direct-mutation-state",
@@ -13743,11 +13748,6 @@
 				"url": "https://eslint-react.xyz/docs/rules/no-direct-mutation-state"
 			}
 		],
-		"flint": {
-			"name": "stateMutations",
-			"plugin": "react",
-			"preset": "logical"
-		},
 		"oxlint": [
 			{
 				"name": "react/no-direct-mutation-state",
@@ -13756,6 +13756,11 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "staticComponents",
+			"plugin": "react",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "react-hooks/static-components",
@@ -13765,26 +13770,21 @@
 				"name": "@eslint-react/static-components",
 				"url": "https://eslint-react.xyz/docs/rules/static-components"
 			}
-		],
-		"flint": {
-			"name": "staticComponents",
-			"plugin": "react",
-			"preset": "logical"
-		}
+		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "react/style-prop-object",
-				"url": "https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/style-prop-object.md"
-			}
-		],
 		"flint": {
 			"name": "stylePropObjects",
 			"plugin": "react",
 			"preset": "logical",
 			"strictness": "strict"
 		},
+		"eslint": [
+			{
+				"name": "react/style-prop-object",
+				"url": "https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/style-prop-object.md"
+			}
+		],
 		"oxlint": [
 			{
 				"name": "react/style-prop-object",
@@ -13793,88 +13793,93 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "stylePropsType",
+			"plugin": "react",
+			"preset": "stylistic"
+		},
 		"eslint": [
 			{
 				"name": "@eslint-react/dom-no-string-style-prop",
 				"url": "https://eslint-react.xyz/docs/rules/dom-no-string-style-prop"
 			}
-		],
-		"flint": {
-			"name": "stylePropsType",
-			"plugin": "react",
-			"preset": "stylistic"
-		}
+		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "@eslint-react/web-api-no-leaked-timeout",
-				"url": "https://eslint-react.xyz/docs/rules/web-api-no-leaked-timeout"
-			}
-		],
 		"flint": {
 			"name": "timeoutCleanup",
 			"plugin": "react",
 			"preset": "logical",
 			"strictness": "strict"
-		}
+		},
+		"eslint": [
+			{
+				"name": "@eslint-react/web-api-no-leaked-timeout",
+				"url": "https://eslint-react.xyz/docs/rules/web-api-no-leaked-timeout"
+			}
+		]
 	},
 	{
+		"flint": {
+			"name": "typos",
+			"plugin": "react",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "react/no-typos",
 				"url": "https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-typos.md"
 			}
-		],
-		"flint": {
-			"name": "typos",
-			"plugin": "react",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "unsafeComponentWillMountCalls",
+			"plugin": "react",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "@eslint-react/no-unsafe-component-will-mount",
 				"url": "https://eslint-react.xyz/docs/rules/no-unsafe-component-will-mount"
 			}
 		],
-		"flint": {
-			"name": "unsafeComponentWillMountCalls",
-			"plugin": "react",
-			"status": "skipped"
-		},
 		"notes": "Only relevant to Class Components, which are no longer recommended."
 	},
 	{
+		"flint": {
+			"name": "unsafeComponentWillReceivePropsCalls",
+			"plugin": "react",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "@eslint-react/no-unsafe-component-will-receive-props",
 				"url": "https://eslint-react.xyz/docs/rules/no-unsafe-component-will-receive-props"
 			}
 		],
-		"flint": {
-			"name": "unsafeComponentWillReceivePropsCalls",
-			"plugin": "react",
-			"status": "skipped"
-		},
 		"notes": "Only relevant to Class Components, which are no longer recommended."
 	},
 	{
+		"flint": {
+			"name": "unsafeComponentWillUpdateCalls",
+			"plugin": "react",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "@eslint-react/no-unsafe-component-will-update",
 				"url": "https://eslint-react.xyz/docs/rules/no-unsafe-component-will-update"
 			}
 		],
-		"flint": {
-			"name": "unsafeComponentWillUpdateCalls",
-			"plugin": "react",
-			"status": "skipped"
-		},
 		"notes": "Only relevant to Class Components, which are no longer recommended."
 	},
 	{
+		"flint": {
+			"name": "unsupportedSyntax",
+			"plugin": "react",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "react-hooks/unsupported-syntax",
@@ -13884,66 +13889,66 @@
 				"name": "@eslint-react/unsupported-syntax",
 				"url": "https://eslint-react.xyz/docs/rules/unsupported-syntax"
 			}
-		],
-		"flint": {
-			"name": "unsupportedSyntax",
-			"plugin": "react",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "unusedClassComponentMembers",
+			"plugin": "react",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "@eslint-react/no-unused-class-component-members",
 				"url": "https://eslint-react.xyz/docs/rules/no-unused-class-component-members"
 			}
 		],
-		"flint": {
-			"name": "unusedClassComponentMembers",
-			"plugin": "react",
-			"status": "skipped"
-		},
 		"notes": "Only relevant to Class Components, which are no longer recommended."
 	},
 	{
+		"flint": {
+			"name": "unusedClassComponentMethods",
+			"plugin": "react",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "react/no-unused-class-component-methods",
 				"url": "https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-unused-class-component-methods.md"
 			}
-		],
-		"flint": {
-			"name": "unusedClassComponentMethods",
-			"plugin": "react",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "unusedProps",
+			"plugin": "react"
+		},
 		"eslint": [
 			{
 				"name": "@eslint-react/no-unused-props",
 				"url": "https://eslint-react.xyz/docs/rules/no-unused-props"
 			}
-		],
-		"flint": {
-			"name": "unusedProps",
-			"plugin": "react"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "unusedPropTypes",
+			"plugin": "react",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "react/no-unused-prop-types",
 				"url": "https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-unused-prop-types.md"
 			}
-		],
-		"flint": {
-			"name": "unusedPropTypes",
-			"plugin": "react",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "unusedState",
+			"plugin": "react",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "react/no-unused-state",
@@ -13953,40 +13958,40 @@
 				"name": "@eslint-react/no-unused-state",
 				"url": "https://eslint-react.xyz/docs/rules/no-unused-state"
 			}
-		],
-		"flint": {
-			"name": "unusedState",
-			"plugin": "react",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "useContextUsage",
+			"plugin": "react"
+		},
 		"eslint": [
 			{
 				"name": "@eslint-react/no-use-context",
 				"url": "https://eslint-react.xyz/docs/rules/no-use-context"
 			}
 		],
-		"flint": {
-			"name": "useContextUsage",
-			"plugin": "react"
-		},
 		"notes": "React Versions >= 19.0.0"
 	},
 	{
+		"flint": {
+			"name": "useFormStateCalls",
+			"plugin": "react"
+		},
 		"eslint": [
 			{
 				"name": "@eslint-react/dom-no-use-form-state",
 				"url": "https://eslint-react.xyz/docs/rules/dom-no-use-form-state"
 			}
 		],
-		"flint": {
-			"name": "useFormStateCalls",
-			"plugin": "react"
-		},
 		"notes": "React Versions >= 19.0.0"
 	},
 	{
+		"flint": {
+			"name": "useMemoReturns",
+			"plugin": "react",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "react-hooks/use-memo",
@@ -13996,41 +14001,41 @@
 				"name": "@eslint-react/use-memo",
 				"url": "https://eslint-react.xyz/docs/rules/use-memo"
 			}
-		],
-		"flint": {
-			"name": "useMemoReturns",
-			"plugin": "react",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "usePrefixes",
+			"plugin": "react",
+			"preset": "stylistic"
+		},
 		"eslint": [
 			{
 				"name": "@eslint-react/no-unnecessary-use-prefix",
 				"url": "https://eslint-react.xyz/docs/rules/no-unnecessary-use-prefix"
 			}
-		],
-		"flint": {
-			"name": "usePrefixes",
-			"plugin": "react",
-			"preset": "stylistic"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "usesReactPragmas",
+			"plugin": "react",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "react/jsx-uses-react",
 				"url": "https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-uses-react.md"
 			}
 		],
-		"flint": {
-			"name": "usesReactPragmas",
-			"plugin": "react",
-			"status": "skipped"
-		},
 		"notes": "Generally handled by parsers."
 	},
 	{
+		"flint": {
+			"name": "useStateUsage",
+			"plugin": "react",
+			"preset": "stylistic"
+		},
 		"eslint": [
 			{
 				"name": "react/hook-use-state",
@@ -14041,11 +14046,6 @@
 				"url": "https://eslint-react.xyz/docs/rules/use-state"
 			}
 		],
-		"flint": {
-			"name": "useStateUsage",
-			"plugin": "react",
-			"preset": "stylistic"
-		},
 		"oxlint": [
 			{
 				"name": "react/hook-use-state",
@@ -14054,149 +14054,154 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "voidElementsWithChildren",
+			"plugin": "react",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "@eslint-react/dom-no-void-elements-with-children",
 				"url": "https://eslint-react.xyz/docs/rules/dom-no-void-elements-with-children"
 			}
-		],
-		"flint": {
-			"name": "voidElementsWithChildren",
-			"plugin": "react",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "deepImports",
+			"plugin": "react-native",
+			"status": "skipped"
+		},
 		"biome": [
 			{
 				"name": "noReactNativeDeepImports",
 				"url": "https://biomejs.dev/linter/rules/no-react-native-deep-imports"
 			}
-		],
-		"flint": {
-			"name": "deepImports",
-			"plugin": "react-native",
-			"status": "skipped"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "literalColors",
+			"plugin": "react-native",
+			"status": "skipped"
+		},
 		"biome": [
 			{
 				"name": "noReactNativeLiteralColors",
 				"url": "https://biomejs.dev/linter/rules/no-react-native-literal-colors"
 			}
-		],
-		"flint": {
-			"name": "literalColors",
-			"plugin": "react-native",
-			"status": "skipped"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "platformComponents",
+			"plugin": "react-native",
+			"status": "skipped"
+		},
 		"biome": [
 			{
 				"name": "useReactNativePlatformComponents",
 				"url": "https://biomejs.dev/linter/rules/use-react-native-platform-components"
 			}
-		],
-		"flint": {
-			"name": "platformComponents",
-			"plugin": "react-native",
-			"status": "skipped"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "rawTexts",
+			"plugin": "react-native",
+			"status": "skipped"
+		},
 		"biome": [
 			{
 				"name": "noReactNativeRawText",
 				"url": "https://biomejs.dev/linter/rules/no-react-native-raw-text"
 			}
-		],
-		"flint": {
-			"name": "rawTexts",
-			"plugin": "react-native",
-			"status": "skipped"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "secrets",
+			"plugin": "security",
+			"status": "skipped"
+		},
 		"biome": [
 			{
 				"name": "noSecrets",
 				"url": "https://biomejs.dev/linter/rules/no-secrets"
 			}
-		],
-		"flint": {
-			"name": "secrets",
-			"plugin": "security",
-			"status": "skipped"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "arrayHandlers",
+			"plugin": "solid"
+		},
 		"eslint": [
 			{
 				"name": "solid/no-array-handlers",
 				"url": "https://github.com/solidjs-community/eslint-plugin-solid/blob/main/packages/eslint-plugin-solid/docs/no-array-handlers.md"
 			}
-		],
-		"flint": {
-			"name": "arrayHandlers",
-			"plugin": "solid"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "classListProps",
+			"plugin": "solid"
+		},
 		"eslint": [
 			{
 				"name": "solid/prefer-classlist",
 				"url": "https://github.com/solidjs-community/eslint-plugin-solid/blob/main/packages/eslint-plugin-solid/docs/prefer-classlist.md"
 			}
 		],
-		"flint": {
-			"name": "classListProps",
-			"plugin": "solid"
-		},
 		"notes": "Deprecated."
 	},
 	{
+		"flint": {
+			"name": "componentConditionalReturns",
+			"plugin": "solid",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "solid/components-return-once",
 				"url": "https://github.com/solidjs-community/eslint-plugin-solid/blob/main/packages/eslint-plugin-solid/docs/components-return-once.md"
 			}
-		],
-		"flint": {
-			"name": "componentConditionalReturns",
-			"plugin": "solid",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "duplicateProps",
+			"plugin": "solid",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "solid/jsx-no-duplicate-props",
 				"url": "https://github.com/solidjs-community/eslint-plugin-solid/blob/main/packages/eslint-plugin-solid/docs/jsx-no-duplicate-props.md"
 			}
 		],
-		"flint": {
-			"name": "duplicateProps",
-			"plugin": "solid",
-			"status": "skipped"
-		},
 		"notes": "Superseded by jsx plugin's duplicateProps rule."
 	},
 	{
+		"flint": {
+			"name": "eventHandlerCasing",
+			"plugin": "solid",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "solid/event-handlers",
 				"url": "https://github.com/solidjs-community/eslint-plugin-solid/blob/main/packages/eslint-plugin-solid/docs/event-handlers.md"
 			}
-		],
-		"flint": {
-			"name": "eventHandlerCasing",
-			"plugin": "solid",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "forMaps",
+			"plugin": "solid",
+			"preset": "logical"
+		},
 		"biome": [
 			{
 				"name": "useSolidForComponent",
@@ -14208,41 +14213,41 @@
 				"name": "solid/prefer-for",
 				"url": "https://github.com/solidjs-community/eslint-plugin-solid/blob/main/packages/eslint-plugin-solid/docs/prefer-for.md"
 			}
-		],
-		"flint": {
-			"name": "forMaps",
-			"plugin": "solid",
-			"preset": "logical"
-		}
+		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "solid/no-innerhtml",
-				"url": "https://github.com/solidjs-community/eslint-plugin-solid/blob/main/packages/eslint-plugin-solid/docs/no-innerhtml.md"
-			}
-		],
 		"flint": {
 			"name": "innerHTMLProps",
 			"plugin": "solid",
 			"preset": "logical",
 			"strictness": "strict"
-		}
+		},
+		"eslint": [
+			{
+				"name": "solid/no-innerhtml",
+				"url": "https://github.com/solidjs-community/eslint-plugin-solid/blob/main/packages/eslint-plugin-solid/docs/no-innerhtml.md"
+			}
+		]
 	},
 	{
+		"flint": {
+			"name": "namespaceValidity",
+			"plugin": "solid",
+			"preset": "javascript"
+		},
 		"eslint": [
 			{
 				"name": "solid/no-unknown-namespaces",
 				"url": "https://github.com/solidjs-community/eslint-plugin-solid/blob/main/packages/eslint-plugin-solid/docs/no-unknown-namespaces.md"
 			}
-		],
-		"flint": {
-			"name": "namespaceValidity",
-			"plugin": "solid",
-			"preset": "javascript"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "noScriptUrl",
+			"plugin": "solid",
+			"status": "skipped"
+		},
 		"biome": [
 			{
 				"name": "noScriptUrl",
@@ -14255,14 +14260,14 @@
 				"url": "https://github.com/solidjs-community/eslint-plugin-solid/blob/main/packages/eslint-plugin-solid/docs/jsx-no-script-url.md"
 			}
 		],
-		"flint": {
-			"name": "noScriptUrl",
-			"plugin": "solid",
-			"status": "skipped"
-		},
 		"notes": "Superseded by jsx plugin's scriptUrls rule."
 	},
 	{
+		"flint": {
+			"name": "propDestructures",
+			"plugin": "solid",
+			"preset": "logical"
+		},
 		"biome": [
 			{
 				"name": "noSolidDestructuredProps",
@@ -14274,54 +14279,54 @@
 				"name": "solid/no-destructure",
 				"url": "https://github.com/solidjs-community/eslint-plugin-solid/blob/main/packages/eslint-plugin-solid/docs/no-destructure.md"
 			}
-		],
-		"flint": {
-			"name": "propDestructures",
-			"plugin": "solid",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "proxyApis",
+			"plugin": "solid",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "solid/no-proxy-apis",
 				"url": "https://github.com/solidjs-community/eslint-plugin-solid/blob/main/packages/eslint-plugin-solid/docs/no-proxy-apis.md"
 			}
 		],
-		"flint": {
-			"name": "proxyApis",
-			"plugin": "solid",
-			"status": "skipped"
-		},
 		"notes": "Modern environments generally support Proxy."
 	},
 	{
+		"flint": {
+			"name": "reactivity",
+			"plugin": "solid",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "solid/reactivity",
 				"url": "https://github.com/solidjs-community/eslint-plugin-solid/blob/main/packages/eslint-plugin-solid/docs/reactivity.md"
 			}
-		],
-		"flint": {
-			"name": "reactivity",
-			"plugin": "solid",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "reactLikeDeps",
+			"plugin": "solid",
+			"preset": "javascript"
+		},
 		"eslint": [
 			{
 				"name": "solid/no-react-deps",
 				"url": "https://github.com/solidjs-community/eslint-plugin-solid/blob/main/packages/eslint-plugin-solid/docs/no-react-deps.md"
 			}
-		],
-		"flint": {
-			"name": "reactLikeDeps",
-			"plugin": "solid",
-			"preset": "javascript"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "reactLikeProps",
+			"plugin": "solid",
+			"preset": "javascript"
+		},
 		"biome": [
 			{
 				"name": "noReactSpecificProps",
@@ -14333,562 +14338,563 @@
 				"name": "solid/no-react-specific-props",
 				"url": "https://github.com/solidjs-community/eslint-plugin-solid/blob/main/packages/eslint-plugin-solid/docs/no-react-specific-props.md"
 			}
-		],
-		"flint": {
-			"name": "reactLikeProps",
-			"plugin": "solid",
-			"preset": "javascript"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "selfClosingTags",
+			"plugin": "solid",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "solid/self-closing-comp",
 				"url": "https://github.com/solidjs-community/eslint-plugin-solid/blob/main/packages/eslint-plugin-solid/docs/self-closing-comp.md"
 			}
 		],
-		"flint": {
-			"name": "selfClosingTags",
-			"plugin": "solid",
-			"status": "skipped"
-		},
 		"notes": "Superseded by jsx plugin's selfClosingTags rule."
 	},
 	{
+		"flint": {
+			"name": "showWhens",
+			"plugin": "solid",
+			"preset": "stylistic"
+		},
 		"eslint": [
 			{
 				"name": "solid/prefer-show",
 				"url": "https://github.com/solidjs-community/eslint-plugin-solid/blob/main/packages/eslint-plugin-solid/docs/prefer-show.md"
 			}
-		],
-		"flint": {
-			"name": "showWhens",
-			"plugin": "solid",
-			"preset": "stylistic"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "solidImports",
+			"plugin": "solid",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "solid/imports",
 				"url": "https://github.com/solidjs-community/eslint-plugin-solid/blob/main/packages/eslint-plugin-solid/docs/imports.md"
 			}
-		],
-		"flint": {
-			"name": "solidImports",
-			"plugin": "solid",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "stylePropValidity",
+			"plugin": "solid",
+			"preset": "javascript"
+		},
 		"eslint": [
 			{
 				"name": "solid/style-prop",
 				"url": "https://github.com/solidjs-community/eslint-plugin-solid/blob/main/packages/eslint-plugin-solid/docs/style-prop.md"
 			}
-		],
-		"flint": {
-			"name": "stylePropValidity",
-			"plugin": "solid",
-			"preset": "javascript"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "undefinedComponents",
+			"plugin": "solid",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "solid/jsx-no-undef",
 				"url": "https://github.com/solidjs-community/eslint-plugin-solid/blob/main/packages/eslint-plugin-solid/docs/jsx-no-undef.md"
 			}
 		],
-		"flint": {
-			"name": "undefinedComponents",
-			"plugin": "solid",
-			"status": "skipped"
-		},
 		"notes": "Handled by ts plugin's undefinedVariables rule."
 	},
 	{
+		"flint": {
+			"name": "variableUses",
+			"plugin": "solid"
+		},
 		"eslint": [
 			{
 				"name": "solid/jsx-uses-vars",
 				"url": "https://github.com/solidjs-community/eslint-plugin-solid/blob/main/packages/eslint-plugin-solid/docs/jsx-uses-vars.md"
 			}
-		],
-		"flint": {
-			"name": "variableUses",
-			"plugin": "solid"
-		}
+		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "spelling/cspell",
-				"url": "https://github.com/streetsidesoftware/cspell/tree/main/packages/cspell-eslint-plugin"
-			}
-		],
 		"flint": {
 			"name": "cspell",
 			"plugin": "spelling",
 			"preset": "logical",
 			"status": "implemented"
-		}
+		},
+		"eslint": [
+			{
+				"name": "spelling/cspell",
+				"url": "https://github.com/streetsidesoftware/cspell/tree/main/packages/cspell-eslint-plugin"
+			}
+		]
 	},
 	{
+		"flint": {
+			"name": "asyncStores",
+			"plugin": "svelte",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "svelte/no-store-async",
 				"url": "https://sveltejs.github.io/eslint-plugin-svelte/rules/no-store-async"
 			}
 		],
-		"flint": {
-			"name": "asyncStores",
-			"plugin": "svelte",
-			"status": "skipped"
-		},
 		"notes": "Svelte 4-exclusive rule."
 	},
 	{
+		"flint": {
+			"name": "atDebugTags",
+			"plugin": "svelte",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "svelte/no-at-debug-tags",
 				"url": "https://sveltejs.github.io/eslint-plugin-svelte/rules/no-at-debug-tags"
 			}
-		],
-		"flint": {
-			"name": "atDebugTags",
-			"plugin": "svelte",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "atHtmlTags",
+			"plugin": "svelte",
+			"preset": "security"
+		},
 		"eslint": [
 			{
 				"name": "svelte/no-at-html-tags",
 				"url": "https://sveltejs.github.io/eslint-plugin-svelte/rules/no-at-html-tags"
 			}
-		],
-		"flint": {
-			"name": "atHtmlTags",
-			"plugin": "svelte",
-			"preset": "security"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "attributeEqualSignSpaces",
+			"plugin": "svelte",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "svelte/no-spaces-around-equal-signs-in-attribute",
 				"url": "https://sveltejs.github.io/eslint-plugin-svelte/rules/no-spaces-around-equal-signs-in-attribute"
 			}
 		],
-		"flint": {
-			"name": "attributeEqualSignSpaces",
-			"plugin": "svelte",
-			"status": "skipped"
-		},
 		"notes": "Formatting rule."
 	},
 	{
+		"flint": {
+			"name": "attributeOrdering",
+			"plugin": "svelte",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "svelte/sort-attributes",
 				"url": "https://sveltejs.github.io/eslint-plugin-svelte/rules/sort-attributes"
 			}
 		],
-		"flint": {
-			"name": "attributeOrdering",
-			"plugin": "svelte",
-			"status": "skipped"
-		},
 		"notes": "Superseded by the sorting plugin's jsxProps rules."
 	},
 	{
+		"flint": {
+			"name": "attributesLineLimits",
+			"plugin": "svelte",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "svelte/max-attributes-per-line",
 				"url": "https://sveltejs.github.io/eslint-plugin-svelte/rules/max-attributes-per-line"
 			}
 		],
-		"flint": {
-			"name": "attributesLineLimits",
-			"plugin": "svelte",
-			"status": "skipped"
-		},
 		"notes": "Formatting rule."
 	},
 	{
-		"eslint": [
-			{
-				"name": "svelte/block-lang",
-				"url": "https://sveltejs.github.io/eslint-plugin-svelte/rules/block-lang"
-			}
-		],
 		"flint": {
 			"name": "blockLang",
 			"plugin": "svelte",
 			"preset": "logical",
 			"strictness": "strict"
-		}
-	},
-	{
+		},
 		"eslint": [
 			{
-				"name": "svelte/button-has-type",
-				"url": "https://sveltejs.github.io/eslint-plugin-svelte/rules/button-has-type"
+				"name": "svelte/block-lang",
+				"url": "https://sveltejs.github.io/eslint-plugin-svelte/rules/block-lang"
 			}
-		],
+		]
+	},
+	{
 		"flint": {
 			"name": "buttonTypes",
 			"plugin": "svelte",
 			"preset": "logical",
 			"strictness": "strict"
-		}
-	},
-	{
+		},
 		"eslint": [
 			{
-				"name": "svelte/prefer-class-directive",
-				"url": "https://sveltejs.github.io/eslint-plugin-svelte/rules/prefer-class-directive"
+				"name": "svelte/button-has-type",
+				"url": "https://sveltejs.github.io/eslint-plugin-svelte/rules/button-has-type"
 			}
-		],
+		]
+	},
+	{
 		"flint": {
 			"name": "classDirectives",
 			"plugin": "svelte",
 			"preset": "stylistic",
 			"strictness": "strict"
-		}
+		},
+		"eslint": [
+			{
+				"name": "svelte/prefer-class-directive",
+				"url": "https://sveltejs.github.io/eslint-plugin-svelte/rules/prefer-class-directive"
+			}
+		]
 	},
 	{
+		"flint": {
+			"name": "commentDirectives",
+			"plugin": "svelte",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "svelte/comment-directive",
 				"url": "https://sveltejs.github.io/eslint-plugin-svelte/rules/comment-directive"
 			}
 		],
-		"flint": {
-			"name": "commentDirectives",
-			"plugin": "svelte",
-			"status": "skipped"
-		},
 		"notes": "Generally handled by parsers."
 	},
 	{
+		"flint": {
+			"name": "constVariables",
+			"plugin": "svelte",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "svelte/prefer-const",
 				"url": "https://sveltejs.github.io/eslint-plugin-svelte/rules/prefer-const"
 			}
 		],
-		"flint": {
-			"name": "constVariables",
-			"plugin": "svelte",
-			"status": "skipped"
-		},
 		"notes": "Superseded by js plugin's constVariables rule."
 	},
 	{
+		"flint": {
+			"name": "derivedCallbackNamingConsistency",
+			"plugin": "svelte",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "svelte/derived-has-same-inputs-outputs",
 				"url": "https://sveltejs.github.io/eslint-plugin-svelte/rules/derived-has-same-inputs-outputs"
 			}
 		],
-		"flint": {
-			"name": "derivedCallbackNamingConsistency",
-			"plugin": "svelte",
-			"status": "skipped"
-		},
 		"notes": "Svelte 4-exclusive rule."
 	},
 	{
+		"flint": {
+			"name": "destructuredStoreProps",
+			"plugin": "svelte",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "svelte/prefer-destructured-store-props",
 				"url": "https://sveltejs.github.io/eslint-plugin-svelte/rules/prefer-destructured-store-props"
 			}
 		],
-		"flint": {
-			"name": "destructuredStoreProps",
-			"plugin": "svelte",
-			"status": "skipped"
-		},
 		"notes": "Svelte 4-exclusive rule."
 	},
 	{
+		"flint": {
+			"name": "duplicateElseIfBlocks",
+			"plugin": "svelte",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "svelte/no-dupe-else-if-blocks",
 				"url": "https://sveltejs.github.io/eslint-plugin-svelte/rules/no-dupe-else-if-blocks"
 			}
-		],
-		"flint": {
-			"name": "duplicateElseIfBlocks",
-			"plugin": "svelte",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "duplicateOnDirectives",
+			"plugin": "svelte",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "svelte/no-dupe-on-directives",
 				"url": "https://sveltejs.github.io/eslint-plugin-svelte/rules/no-dupe-on-directives"
 			}
 		],
-		"flint": {
-			"name": "duplicateOnDirectives",
-			"plugin": "svelte",
-			"status": "skipped"
-		},
 		"notes": "Svelte 4-exclusive rule."
 	},
 	{
+		"flint": {
+			"name": "duplicateStyleProperties",
+			"plugin": "svelte",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "svelte/no-dupe-style-properties",
 				"url": "https://sveltejs.github.io/eslint-plugin-svelte/rules/no-dupe-style-properties"
 			}
-		],
-		"flint": {
-			"name": "duplicateStyleProperties",
-			"plugin": "svelte",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "duplicateUseDirectives",
+			"plugin": "svelte",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "svelte/no-dupe-use-directives",
 				"url": "https://sveltejs.github.io/eslint-plugin-svelte/rules/no-dupe-use-directives"
 			}
-		],
-		"flint": {
-			"name": "duplicateUseDirectives",
-			"plugin": "svelte",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "dynamicSlotNames",
+			"plugin": "svelte",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "svelte/no-dynamic-slot-name",
 				"url": "https://sveltejs.github.io/eslint-plugin-svelte/rules/no-dynamic-slot-name"
 			}
 		],
-		"flint": {
-			"name": "dynamicSlotNames",
-			"plugin": "svelte",
-			"status": "skipped"
-		},
 		"notes": "Deprecated. Now handled by the Svelte compiler."
 	},
 	{
+		"flint": {
+			"name": "eachBlockKeys",
+			"plugin": "svelte",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "svelte/require-each-key",
 				"url": "https://sveltejs.github.io/eslint-plugin-svelte/rules/require-each-key"
 			}
-		],
-		"flint": {
-			"name": "eachBlockKeys",
-			"plugin": "svelte",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "eventDispatcherTypes",
+			"plugin": "svelte",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "svelte/require-event-dispatcher-types",
 				"url": "https://sveltejs.github.io/eslint-plugin-svelte/rules/require-event-dispatcher-types"
 			}
 		],
-		"flint": {
-			"name": "eventDispatcherTypes",
-			"plugin": "svelte",
-			"status": "skipped"
-		},
 		"notes": "Svelte 4-exclusive rule."
 	},
 	{
-		"eslint": [
-			{
-				"name": "svelte/require-event-prefix",
-				"url": "https://sveltejs.github.io/eslint-plugin-svelte/rules/require-event-prefix"
-			}
-		],
 		"flint": {
 			"name": "eventPrefixes",
 			"plugin": "svelte",
 			"preset": "stylistic",
 			"strictness": "strict"
-		}
+		},
+		"eslint": [
+			{
+				"name": "svelte/require-event-prefix",
+				"url": "https://sveltejs.github.io/eslint-plugin-svelte/rules/require-event-prefix"
+			}
+		]
 	},
 	{
+		"flint": {
+			"name": "extraReactiveCurlies",
+			"plugin": "svelte",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "svelte/no-extra-reactive-curlies",
 				"url": "https://sveltejs.github.io/eslint-plugin-svelte/rules/no-extra-reactive-curlies"
 			}
 		],
-		"flint": {
-			"name": "extraReactiveCurlies",
-			"plugin": "svelte",
-			"status": "skipped"
-		},
 		"notes": "Svelte 4-exclusive rule."
 	},
 	{
+		"flint": {
+			"name": "firstAttributeLinebreaks",
+			"plugin": "svelte",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "svelte/first-attribute-linebreak",
 				"url": "https://sveltejs.github.io/eslint-plugin-svelte/rules/first-attribute-linebreak"
 			}
 		],
-		"flint": {
-			"name": "firstAttributeLinebreaks",
-			"plugin": "svelte",
-			"status": "skipped"
-		},
 		"notes": "Formatting rule."
 	},
 	{
+		"flint": {
+			"name": "functionReactivity",
+			"plugin": "svelte",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "svelte/no-reactive-functions",
 				"url": "https://sveltejs.github.io/eslint-plugin-svelte/rules/no-reactive-functions"
 			}
 		],
-		"flint": {
-			"name": "functionReactivity",
-			"plugin": "svelte",
-			"status": "skipped"
-		},
 		"notes": "Svelte 4-exclusive rule."
 	},
 	{
+		"flint": {
+			"name": "gotosLackingBase",
+			"plugin": "svelte",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "svelte/no-goto-without-base",
 				"url": "https://sveltejs.github.io/eslint-plugin-svelte/rules/no-goto-without-base"
 			}
 		],
-		"flint": {
-			"name": "gotosLackingBase",
-			"plugin": "svelte",
-			"status": "skipped"
-		},
 		"notes": "Deprecated. Superseded by unresolvedNavigations."
 	},
 	{
+		"flint": {
+			"name": "htmlClosingBracketNewLine",
+			"plugin": "svelte",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "svelte/html-closing-bracket-new-line",
 				"url": "https://sveltejs.github.io/eslint-plugin-svelte/rules/html-closing-bracket-new-line"
 			}
 		],
-		"flint": {
-			"name": "htmlClosingBracketNewLine",
-			"plugin": "svelte",
-			"status": "skipped"
-		},
 		"notes": "Formatting rule."
 	},
 	{
+		"flint": {
+			"name": "htmlClosingBracketSpacings",
+			"plugin": "svelte",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "svelte/html-closing-bracket-spacing",
 				"url": "https://sveltejs.github.io/eslint-plugin-svelte/rules/html-closing-bracket-spacing"
 			}
 		],
-		"flint": {
-			"name": "htmlClosingBracketSpacings",
-			"plugin": "svelte",
-			"status": "skipped"
-		},
 		"notes": "Formatting rule."
 	},
 	{
-		"eslint": [
-			{
-				"name": "svelte/spaced-html-comment",
-				"url": "https://sveltejs.github.io/eslint-plugin-svelte/rules/spaced-html-comment"
-			}
-		],
 		"flint": {
 			"name": "htmlCommentSpacing",
 			"plugin": "svelte",
 			"preset": "stylistic",
 			"strictness": "strict"
-		}
+		},
+		"eslint": [
+			{
+				"name": "svelte/spaced-html-comment",
+				"url": "https://sveltejs.github.io/eslint-plugin-svelte/rules/spaced-html-comment"
+			}
+		]
 	},
 	{
+		"flint": {
+			"name": "htmlQuotes",
+			"plugin": "svelte",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "svelte/html-quotes",
 				"url": "https://sveltejs.github.io/eslint-plugin-svelte/rules/html-quotes"
 			}
 		],
-		"flint": {
-			"name": "htmlQuotes",
-			"plugin": "svelte",
-			"status": "skipped"
-		},
 		"notes": "Formatting rule."
 	},
 	{
+		"flint": {
+			"name": "ignoredUnsubscribes",
+			"plugin": "svelte",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "svelte/no-ignored-unsubscribe",
 				"url": "https://sveltejs.github.io/eslint-plugin-svelte/rules/no-ignored-unsubscribe"
 			}
 		],
-		"flint": {
-			"name": "ignoredUnsubscribes",
-			"plugin": "svelte",
-			"status": "skipped"
-		},
 		"notes": "Svelte 4-exclusive rule."
 	},
 	{
+		"flint": {
+			"name": "immutableReactiveStatements",
+			"plugin": "svelte",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "svelte/no-immutable-reactive-statements",
 				"url": "https://sveltejs.github.io/eslint-plugin-svelte/rules/no-immutable-reactive-statements"
 			}
 		],
-		"flint": {
-			"name": "immutableReactiveStatements",
-			"plugin": "svelte",
-			"status": "skipped"
-		},
 		"notes": "Svelte 4-exclusive rule."
 	},
 	{
+		"flint": {
+			"name": "indentation",
+			"plugin": "svelte",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "svelte/indent",
 				"url": "https://sveltejs.github.io/eslint-plugin-svelte/rules/indent"
 			}
 		],
-		"flint": {
-			"name": "indentation",
-			"plugin": "svelte",
-			"status": "skipped"
-		},
 		"notes": "Formatting rule."
 	},
 	{
+		"flint": {
+			"name": "infiniteReactivityLoops",
+			"plugin": "svelte",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "svelte/infinite-reactive-loop",
 				"url": "https://sveltejs.github.io/eslint-plugin-svelte/rules/infinite-reactive-loop"
 			}
-		],
-		"flint": {
-			"name": "infiniteReactivityLoops",
-			"plugin": "svelte",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "inlineStyles",
+			"plugin": "svelte",
+			"preset": "logical",
+			"strictness": "strict"
+		},
 		"biome": [
 			{
 				"name": "noInlineStyles",
@@ -14900,653 +14906,653 @@
 				"name": "svelte/no-inline-styles",
 				"url": "https://sveltejs.github.io/eslint-plugin-svelte/rules/no-inline-styles"
 			}
-		],
-		"flint": {
-			"name": "inlineStyles",
-			"plugin": "svelte",
-			"preset": "logical",
-			"strictness": "strict"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "innerDeclarations",
+			"plugin": "svelte",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "svelte/no-inner-declarations",
 				"url": "https://sveltejs.github.io/eslint-plugin-svelte/rules/no-inner-declarations"
 			}
 		],
-		"flint": {
-			"name": "innerDeclarations",
-			"plugin": "svelte",
-			"status": "skipped"
-		},
 		"notes": "Superseded by ts plugin's innerDeclarations rule."
 	},
 	{
+		"flint": {
+			"name": "inspectRunes",
+			"plugin": "svelte",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "svelte/no-inspect",
 				"url": "https://sveltejs.github.io/eslint-plugin-svelte/rules/no-inspect"
 			}
-		],
-		"flint": {
-			"name": "inspectRunes",
-			"plugin": "svelte",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "kitPagePropNames",
+			"plugin": "svelte",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "svelte/valid-prop-names-in-kit-pages",
 				"url": "https://sveltejs.github.io/eslint-plugin-svelte/rules/valid-prop-names-in-kit-pages"
 			}
-		],
-		"flint": {
-			"name": "kitPagePropNames",
-			"plugin": "svelte",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "linesPerBlockLimits",
+			"plugin": "svelte",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "svelte/max-lines-per-block",
 				"url": "https://sveltejs.github.io/eslint-plugin-svelte/rules/max-lines-per-block"
 			}
 		],
-		"flint": {
-			"name": "linesPerBlockLimits",
-			"plugin": "svelte",
-			"status": "skipped"
-		},
 		"notes": "Overly opinionated."
 	},
 	{
+		"flint": {
+			"name": "literalReactivity",
+			"plugin": "svelte",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "svelte/no-reactive-literals",
 				"url": "https://sveltejs.github.io/eslint-plugin-svelte/rules/no-reactive-literals"
 			}
 		],
-		"flint": {
-			"name": "literalReactivity",
-			"plugin": "svelte",
-			"status": "skipped"
-		},
 		"notes": "Svelte 4-exclusive rule."
 	},
 	{
+		"flint": {
+			"name": "manualDomManipulations",
+			"plugin": "svelte",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "svelte/no-dom-manipulating",
 				"url": "https://sveltejs.github.io/eslint-plugin-svelte/rules/no-dom-manipulating"
 			}
-		],
-		"flint": {
-			"name": "manualDomManipulations",
-			"plugin": "svelte",
-			"preset": "logical"
-		}
+		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "svelte/no-add-event-listener",
-				"url": "https://sveltejs.github.io/eslint-plugin-svelte/rules/no-add-event-listener"
-			}
-		],
 		"flint": {
 			"name": "manualEventListeners",
 			"plugin": "svelte",
 			"preset": "logical",
 			"strictness": "strict"
-		}
+		},
+		"eslint": [
+			{
+				"name": "svelte/no-add-event-listener",
+				"url": "https://sveltejs.github.io/eslint-plugin-svelte/rules/no-add-event-listener"
+			}
+		]
 	},
 	{
+		"flint": {
+			"name": "mustacheObjects",
+			"plugin": "svelte",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "svelte/no-object-in-text-mustaches",
 				"url": "https://sveltejs.github.io/eslint-plugin-svelte/rules/no-object-in-text-mustaches"
 			}
-		],
-		"flint": {
-			"name": "mustacheObjects",
-			"plugin": "svelte",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "mustacheSpacings",
+			"plugin": "svelte",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "svelte/mustache-spacing",
 				"url": "https://sveltejs.github.io/eslint-plugin-svelte/rules/mustache-spacing"
 			}
 		],
-		"flint": {
-			"name": "mustacheSpacings",
-			"plugin": "svelte",
-			"status": "skipped"
-		},
 		"notes": "Formatting rule."
 	},
 	{
+		"flint": {
+			"name": "navigationLackingBase",
+			"plugin": "svelte",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "svelte/no-navigation-without-base",
 				"url": "https://sveltejs.github.io/eslint-plugin-svelte/rules/no-navigation-without-base"
 			}
 		],
-		"flint": {
-			"name": "navigationLackingBase",
-			"plugin": "svelte",
-			"status": "skipped"
-		},
 		"notes": "Deprecated. Superseded by unresolvedNavigations."
 	},
 	{
+		"flint": {
+			"name": "nonFunctionHandlers",
+			"plugin": "svelte",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "svelte/no-not-function-handler",
 				"url": "https://sveltejs.github.io/eslint-plugin-svelte/rules/no-not-function-handler"
 			}
 		],
-		"flint": {
-			"name": "nonFunctionHandlers",
-			"plugin": "svelte",
-			"status": "skipped"
-		},
 		"notes": "Svelte 4-exclusive rule."
 	},
 	{
-		"eslint": [
-			{
-				"name": "svelte/require-optimized-style-attribute",
-				"url": "https://sveltejs.github.io/eslint-plugin-svelte/rules/require-optimized-style-attribute"
-			}
-		],
 		"flint": {
 			"name": "optimizedStyleAttributes",
 			"plugin": "svelte",
 			"preset": "logical",
 			"strictness": "strict"
-		}
+		},
+		"eslint": [
+			{
+				"name": "svelte/require-optimized-style-attribute",
+				"url": "https://sveltejs.github.io/eslint-plugin-svelte/rules/require-optimized-style-attribute"
+			}
+		]
 	},
 	{
+		"flint": {
+			"name": "pageLoaders",
+			"plugin": "svelte",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "svelte/no-export-load-in-svelte-module-in-kit-pages",
 				"url": "https://sveltejs.github.io/eslint-plugin-svelte/rules/no-export-load-in-svelte-module-in-kit-pages"
 			}
-		],
-		"flint": {
-			"name": "pageLoaders",
-			"plugin": "svelte",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "reactiveReassignments",
+			"plugin": "svelte",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "svelte/no-reactive-reassign",
 				"url": "https://sveltejs.github.io/eslint-plugin-svelte/rules/no-reactive-reassign"
 			}
-		],
-		"flint": {
-			"name": "reactiveReassignments",
-			"plugin": "svelte",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "restrictedHtmlElements",
+			"plugin": "svelte",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "svelte/no-restricted-html-elements",
 				"url": "https://sveltejs.github.io/eslint-plugin-svelte/rules/no-restricted-html-elements"
 			}
 		],
-		"flint": {
-			"name": "restrictedHtmlElements",
-			"plugin": "svelte",
-			"status": "skipped"
-		},
 		"notes": "Superseded by js plugin's restrictedSyntax rule."
 	},
 	{
-		"eslint": [
-			{
-				"name": "svelte/consistent-selector-style",
-				"url": "https://sveltejs.github.io/eslint-plugin-svelte/rules/consistent-selector-style"
-			}
-		],
 		"flint": {
 			"name": "selectorConsistency",
 			"plugin": "svelte",
 			"preset": "stylistic",
 			"strictness": "strict"
-		}
-	},
-	{
+		},
 		"eslint": [
 			{
-				"name": "svelte/html-self-closing",
-				"url": "https://sveltejs.github.io/eslint-plugin-svelte/rules/html-self-closing"
+				"name": "svelte/consistent-selector-style",
+				"url": "https://sveltejs.github.io/eslint-plugin-svelte/rules/consistent-selector-style"
 			}
-		],
+		]
+	},
+	{
 		"flint": {
 			"name": "selfClosingHtmlElements",
 			"plugin": "svelte",
 			"preset": "stylistic",
 			"strictness": "strict"
-		}
-	},
-	{
+		},
 		"eslint": [
 			{
-				"name": "svelte/shorthand-attribute",
-				"url": "https://sveltejs.github.io/eslint-plugin-svelte/rules/shorthand-attribute"
+				"name": "svelte/html-self-closing",
+				"url": "https://sveltejs.github.io/eslint-plugin-svelte/rules/html-self-closing"
 			}
-		],
+		]
+	},
+	{
 		"flint": {
 			"name": "shorthandAttributes",
 			"plugin": "svelte",
 			"preset": "stylistic",
 			"strictness": "strict"
-		}
-	},
-	{
+		},
 		"eslint": [
 			{
-				"name": "svelte/shorthand-directive",
-				"url": "https://sveltejs.github.io/eslint-plugin-svelte/rules/shorthand-directive"
+				"name": "svelte/shorthand-attribute",
+				"url": "https://sveltejs.github.io/eslint-plugin-svelte/rules/shorthand-attribute"
 			}
-		],
+		]
+	},
+	{
 		"flint": {
 			"name": "shorthandDirectives",
 			"plugin": "svelte",
 			"preset": "stylistic",
 			"strictness": "strict"
-		}
+		},
+		"eslint": [
+			{
+				"name": "svelte/shorthand-directive",
+				"url": "https://sveltejs.github.io/eslint-plugin-svelte/rules/shorthand-directive"
+			}
+		]
 	},
 	{
+		"flint": {
+			"name": "shorthandStylePropertyOverrides",
+			"plugin": "svelte",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "svelte/no-shorthand-style-property-overrides",
 				"url": "https://sveltejs.github.io/eslint-plugin-svelte/rules/no-shorthand-style-property-overrides"
 			}
-		],
-		"flint": {
-			"name": "shorthandStylePropertyOverrides",
-			"plugin": "svelte",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "slotTypes",
+			"plugin": "svelte",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "svelte/experimental-require-slot-types",
 				"url": "https://sveltejs.github.io/eslint-plugin-svelte/rules/experimental-require-slot-types"
 			}
 		],
-		"flint": {
-			"name": "slotTypes",
-			"plugin": "svelte",
-			"status": "skipped"
-		},
 		"notes": "Svelte 4-exclusive rule."
 	},
 	{
+		"flint": {
+			"name": "specialElementPrefixes",
+			"plugin": "svelte",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "svelte/no-raw-special-elements",
 				"url": "https://sveltejs.github.io/eslint-plugin-svelte/rules/no-raw-special-elements"
 			}
-		],
-		"flint": {
-			"name": "specialElementPrefixes",
-			"plugin": "svelte",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "storeCallbackSetParameters",
+			"plugin": "svelte",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "svelte/require-store-callbacks-use-set-param",
 				"url": "https://sveltejs.github.io/eslint-plugin-svelte/rules/require-store-callbacks-use-set-param"
 			}
 		],
-		"flint": {
-			"name": "storeCallbackSetParameters",
-			"plugin": "svelte",
-			"status": "skipped"
-		},
 		"notes": "Svelte 4-exclusive rule."
 	},
 	{
+		"flint": {
+			"name": "storeInitializations",
+			"plugin": "svelte",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "svelte/require-stores-init",
 				"url": "https://sveltejs.github.io/eslint-plugin-svelte/rules/require-stores-init"
 			}
 		],
-		"flint": {
-			"name": "storeInitializations",
-			"plugin": "svelte",
-			"status": "skipped"
-		},
 		"notes": "Svelte 4-exclusive rule."
 	},
 	{
+		"flint": {
+			"name": "storeReactiveAccess",
+			"plugin": "svelte",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "svelte/require-store-reactive-access",
 				"url": "https://sveltejs.github.io/eslint-plugin-svelte/rules/require-store-reactive-access"
 			}
 		],
-		"flint": {
-			"name": "storeReactiveAccess",
-			"plugin": "svelte",
-			"status": "skipped"
-		},
 		"notes": "Svelte 4-exclusive rule."
 	},
 	{
+		"flint": {
+			"name": "strictEvents",
+			"plugin": "svelte",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "svelte/experimental-require-strict-events",
 				"url": "https://sveltejs.github.io/eslint-plugin-svelte/rules/experimental-require-strict-events"
 			}
 		],
-		"flint": {
-			"name": "strictEvents",
-			"plugin": "svelte",
-			"status": "skipped"
-		},
 		"notes": "Svelte 4-exclusive rule."
 	},
 	{
-		"eslint": [
-			{
-				"name": "svelte/prefer-style-directive",
-				"url": "https://sveltejs.github.io/eslint-plugin-svelte/rules/prefer-style-directive"
-			}
-		],
 		"flint": {
 			"name": "styleDirectives",
 			"plugin": "svelte",
 			"preset": "stylistic",
 			"strictness": "strict"
-		}
+		},
+		"eslint": [
+			{
+				"name": "svelte/prefer-style-directive",
+				"url": "https://sveltejs.github.io/eslint-plugin-svelte/rules/prefer-style-directive"
+			}
+		]
 	},
 	{
+		"flint": {
+			"name": "svelteInternalImports",
+			"plugin": "svelte",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "svelte/no-svelte-internal",
 				"url": "https://sveltejs.github.io/eslint-plugin-svelte/rules/no-svelte-internal"
 			}
-		],
-		"flint": {
-			"name": "svelteInternalImports",
-			"plugin": "svelte",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "svelteReactivityClasses",
+			"plugin": "svelte",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "svelte/prefer-svelte-reactivity",
 				"url": "https://sveltejs.github.io/eslint-plugin-svelte/rules/prefer-svelte-reactivity"
 			}
-		],
-		"flint": {
-			"name": "svelteReactivityClasses",
-			"plugin": "svelte",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "svelteSystem",
+			"plugin": "svelte",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "svelte/system",
 				"url": "https://sveltejs.github.io/eslint-plugin-svelte/rules/system"
 			}
 		],
-		"flint": {
-			"name": "svelteSystem",
-			"plugin": "svelte",
-			"status": "skipped"
-		},
 		"notes": "Generally handled by parsers."
 	},
 	{
-		"eslint": [
-			{
-				"name": "svelte/no-target-blank",
-				"url": "https://sveltejs.github.io/eslint-plugin-svelte/rules/no-target-blank"
-			}
-		],
 		"flint": {
 			"name": "targetBlankLinks",
 			"plugin": "svelte",
 			"preset": "security",
 			"strictness": "strict"
-		}
-	},
-	{
+		},
 		"eslint": [
 			{
-				"name": "svelte/no-top-level-browser-globals",
-				"url": "https://sveltejs.github.io/eslint-plugin-svelte/rules/no-top-level-browser-globals"
+				"name": "svelte/no-target-blank",
+				"url": "https://sveltejs.github.io/eslint-plugin-svelte/rules/no-target-blank"
 			}
-		],
+		]
+	},
+	{
 		"flint": {
 			"name": "topLevelBrowserGlobals",
 			"plugin": "svelte",
 			"preset": "logical",
 			"strictness": "strict"
-		}
+		},
+		"eslint": [
+			{
+				"name": "svelte/no-top-level-browser-globals",
+				"url": "https://sveltejs.github.io/eslint-plugin-svelte/rules/no-top-level-browser-globals"
+			}
+		]
 	},
 	{
+		"flint": {
+			"name": "trailingSpaces",
+			"plugin": "svelte",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "svelte/no-trailing-spaces",
 				"url": "https://sveltejs.github.io/eslint-plugin-svelte/rules/no-trailing-spaces"
 			}
 		],
-		"flint": {
-			"name": "trailingSpaces",
-			"plugin": "svelte",
-			"status": "skipped"
-		},
 		"notes": "Formatting rule."
 	},
 	{
+		"flint": {
+			"name": "unknownStyleDirectiveProperties",
+			"plugin": "svelte",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "svelte/no-unknown-style-directive-property",
 				"url": "https://sveltejs.github.io/eslint-plugin-svelte/rules/no-unknown-style-directive-property"
 			}
-		],
-		"flint": {
-			"name": "unknownStyleDirectiveProperties",
-			"plugin": "svelte",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "unnecessaryConditions",
+			"plugin": "svelte",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "svelte/@typescript-eslint/no-unnecessary-condition",
 				"url": "https://sveltejs.github.io/eslint-plugin-svelte/rules/@typescript-eslint/no-unnecessary-condition"
 			}
 		],
-		"flint": {
-			"name": "unnecessaryConditions",
-			"plugin": "svelte",
-			"status": "skipped"
-		},
 		"notes": "Deprecated. No longer needed when using svelte-eslint-parser>=v0.19.0."
 	},
 	{
+		"flint": {
+			"name": "unnecessaryStateWraps",
+			"plugin": "svelte",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "svelte/no-unnecessary-state-wrap",
 				"url": "https://sveltejs.github.io/eslint-plugin-svelte/rules/no-unnecessary-state-wrap"
 			}
-		],
-		"flint": {
-			"name": "unnecessaryStateWraps",
-			"plugin": "svelte",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "unresolvedNavigations",
+			"plugin": "svelte",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "svelte/no-navigation-without-resolve",
 				"url": "https://sveltejs.github.io/eslint-plugin-svelte/rules/no-navigation-without-resolve"
 			}
-		],
-		"flint": {
-			"name": "unresolvedNavigations",
-			"plugin": "svelte",
-			"preset": "logical"
-		}
+		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "svelte/no-unused-class-name",
-				"url": "https://sveltejs.github.io/eslint-plugin-svelte/rules/no-unused-class-name"
-			}
-		],
 		"flint": {
 			"name": "unusedClassNames",
 			"plugin": "svelte",
 			"preset": "logical",
 			"strictness": "strict"
-		}
+		},
+		"eslint": [
+			{
+				"name": "svelte/no-unused-class-name",
+				"url": "https://sveltejs.github.io/eslint-plugin-svelte/rules/no-unused-class-name"
+			}
+		]
 	},
 	{
+		"flint": {
+			"name": "unusedProps",
+			"plugin": "svelte",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "svelte/no-unused-props",
 				"url": "https://sveltejs.github.io/eslint-plugin-svelte/rules/no-unused-props"
 			}
-		],
-		"flint": {
-			"name": "unusedProps",
-			"plugin": "svelte",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "unusedSvelteIgnores",
+			"plugin": "svelte",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "svelte/no-unused-svelte-ignore",
 				"url": "https://sveltejs.github.io/eslint-plugin-svelte/rules/no-unused-svelte-ignore"
 			}
-		],
-		"flint": {
-			"name": "unusedSvelteIgnores",
-			"plugin": "svelte",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "uselessChildrenSnippets",
+			"plugin": "svelte",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "svelte/no-useless-children-snippet",
 				"url": "https://sveltejs.github.io/eslint-plugin-svelte/rules/no-useless-children-snippet"
 			}
-		],
-		"flint": {
-			"name": "uselessChildrenSnippets",
-			"plugin": "svelte",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "uselessMustaches",
+			"plugin": "svelte",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "svelte/no-useless-mustaches",
 				"url": "https://sveltejs.github.io/eslint-plugin-svelte/rules/no-useless-mustaches"
 			}
-		],
-		"flint": {
-			"name": "uselessMustaches",
-			"plugin": "svelte",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "validCompilations",
+			"plugin": "svelte",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "svelte/valid-compile",
 				"url": "https://sveltejs.github.io/eslint-plugin-svelte/rules/valid-compile"
 			}
 		],
-		"flint": {
-			"name": "validCompilations",
-			"plugin": "svelte",
-			"status": "skipped"
-		},
 		"notes": "Provided by language reports."
 	},
 	{
+		"flint": {
+			"name": "validEachKeys",
+			"plugin": "svelte",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "svelte/valid-each-key",
 				"url": "https://sveltejs.github.io/eslint-plugin-svelte/rules/valid-each-key"
 			}
-		],
-		"flint": {
-			"name": "validEachKeys",
-			"plugin": "svelte",
-			"preset": "logical"
-		}
+		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "svelte/valid-style-parse",
-				"url": "https://sveltejs.github.io/eslint-plugin-svelte/rules/valid-style-parse"
-			}
-		],
 		"flint": {
 			"name": "validStyleParsing",
 			"plugin": "svelte",
 			"preset": "logical",
 			"strictness": "strict"
-		}
+		},
+		"eslint": [
+			{
+				"name": "svelte/valid-style-parse",
+				"url": "https://sveltejs.github.io/eslint-plugin-svelte/rules/valid-style-parse"
+			}
+		]
 	},
 	{
+		"flint": {
+			"name": "writableDerivedStores",
+			"plugin": "svelte",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "svelte/prefer-writable-derived",
 				"url": "https://sveltejs.github.io/eslint-plugin-svelte/rules/prefer-writable-derived"
 			}
-		],
-		"flint": {
-			"name": "writableDerivedStores",
-			"plugin": "svelte",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "abbreviations",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "unicorn/prevent-abbreviations",
 				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prevent-abbreviations.md"
 			}
-		],
-		"flint": {
-			"name": "abbreviations",
-			"plugin": "ts",
-			"status": "skipped"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "accessorPairGroups",
+			"plugin": "ts",
+			"preset": "stylistic",
+			"status": "implemented"
+		},
 		"biome": [
 			{
 				"name": "useGroupedAccessorPairs",
@@ -15559,12 +15565,6 @@
 				"url": "https://eslint.org/docs/latest/rules/grouped-accessor-pairs"
 			}
 		],
-		"flint": {
-			"name": "accessorPairGroups",
-			"plugin": "ts",
-			"preset": "stylistic",
-			"status": "implemented"
-		},
 		"oxlint": [
 			{
 				"name": "eslint/grouped-accessor-pairs",
@@ -15573,17 +15573,17 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "accessorPairs",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "accessor-pairs",
 				"url": "https://eslint.org/docs/latest/rules/accessor-pairs"
 			}
 		],
-		"flint": {
-			"name": "accessorPairs",
-			"plugin": "ts",
-			"status": "skipped"
-		},
 		"oxlint": [
 			{
 				"name": "eslint/accessor-pairs",
@@ -15592,18 +15592,18 @@
 		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "@typescript-eslint/related-getter-setter-pairs",
-				"url": "https://typescript-eslint.io/rules/related-getter-setter-pairs"
-			}
-		],
 		"flint": {
 			"name": "accessorPairTypes",
 			"plugin": "ts",
 			"preset": "logical",
 			"status": "implemented"
 		},
+		"eslint": [
+			{
+				"name": "@typescript-eslint/related-getter-setter-pairs",
+				"url": "https://typescript-eslint.io/rules/related-getter-setter-pairs"
+			}
+		],
 		"oxlint": [
 			{
 				"name": "typescript/related-getter-setter-pairs",
@@ -15612,12 +15612,6 @@
 		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "unicorn/no-accessor-recursion",
-				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-accessor-recursion.md"
-			}
-		],
 		"flint": {
 			"name": "accessorThisRecursion",
 			"plugin": "ts",
@@ -15625,6 +15619,12 @@
 			"status": "implemented",
 			"strictness": "strict"
 		},
+		"eslint": [
+			{
+				"name": "unicorn/no-accessor-recursion",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-accessor-recursion.md"
+			}
+		],
 		"oxlint": [
 			{
 				"name": "unicorn/no-accessor-recursion",
@@ -15633,16 +15633,16 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "amdImports",
+			"plugin": "ts"
+		},
 		"eslint": [
 			{
 				"name": "import/no-amd",
 				"url": "https://github.com/import-js/eslint-plugin-import/blob/v2.32.0/docs/rules/no-amd.md"
 			}
 		],
-		"flint": {
-			"name": "amdImports",
-			"plugin": "ts"
-		},
 		"oxlint": [
 			{
 				"name": "import/no-amd",
@@ -15651,30 +15651,30 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "anonymousDefaultExports",
+			"plugin": "ts"
+		},
 		"eslint": [
 			{
 				"name": "import/no-anonymous-default-export",
 				"url": "https://github.com/import-js/eslint-plugin-import/blob/v2.32.0/docs/rules/no-anonymous-default-export.md"
 			}
-		],
-		"flint": {
-			"name": "anonymousDefaultExports",
-			"plugin": "ts"
-		}
+		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "@typescript-eslint/no-unsafe-argument",
-				"url": "https://typescript-eslint.io/rules/no-unsafe-argument"
-			}
-		],
 		"flint": {
 			"name": "anyArguments",
 			"plugin": "ts",
 			"preset": "logical",
 			"status": "implemented"
 		},
+		"eslint": [
+			{
+				"name": "@typescript-eslint/no-unsafe-argument",
+				"url": "https://typescript-eslint.io/rules/no-unsafe-argument"
+			}
+		],
 		"oxlint": [
 			{
 				"name": "typescript/no-unsafe-argument",
@@ -15683,18 +15683,18 @@
 		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "@typescript-eslint/no-unsafe-assignment",
-				"url": "https://typescript-eslint.io/rules/no-unsafe-assignment"
-			}
-		],
 		"flint": {
 			"name": "anyAssignments",
 			"plugin": "ts",
 			"preset": "logical",
 			"status": "implemented"
 		},
+		"eslint": [
+			{
+				"name": "@typescript-eslint/no-unsafe-assignment",
+				"url": "https://typescript-eslint.io/rules/no-unsafe-assignment"
+			}
+		],
 		"oxlint": [
 			{
 				"name": "typescript/no-unsafe-assignment",
@@ -15703,18 +15703,18 @@
 		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "@typescript-eslint/no-unsafe-call",
-				"url": "https://typescript-eslint.io/rules/no-unsafe-call"
-			}
-		],
 		"flint": {
 			"name": "anyCalls",
 			"plugin": "ts",
 			"preset": "logical",
 			"status": "implemented"
 		},
+		"eslint": [
+			{
+				"name": "@typescript-eslint/no-unsafe-call",
+				"url": "https://typescript-eslint.io/rules/no-unsafe-call"
+			}
+		],
 		"oxlint": [
 			{
 				"name": "typescript/no-unsafe-call",
@@ -15723,18 +15723,18 @@
 		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "@typescript-eslint/no-unsafe-member-access",
-				"url": "https://typescript-eslint.io/rules/no-unsafe-member-access"
-			}
-		],
 		"flint": {
 			"name": "anyMemberAccess",
 			"plugin": "ts",
 			"preset": "logical",
 			"status": "implemented"
 		},
+		"eslint": [
+			{
+				"name": "@typescript-eslint/no-unsafe-member-access",
+				"url": "https://typescript-eslint.io/rules/no-unsafe-member-access"
+			}
+		],
 		"oxlint": [
 			{
 				"name": "typescript/no-unsafe-member-access",
@@ -15743,18 +15743,18 @@
 		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "@typescript-eslint/no-unsafe-return",
-				"url": "https://typescript-eslint.io/rules/no-unsafe-return"
-			}
-		],
 		"flint": {
 			"name": "anyReturns",
 			"plugin": "ts",
 			"preset": "logical",
 			"status": "implemented"
 		},
+		"eslint": [
+			{
+				"name": "@typescript-eslint/no-unsafe-return",
+				"url": "https://typescript-eslint.io/rules/no-unsafe-return"
+			}
+		],
 		"oxlint": [
 			{
 				"name": "typescript/no-unsafe-return",
@@ -15763,6 +15763,12 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "arguments",
+			"plugin": "ts",
+			"preset": "logical",
+			"status": "implemented"
+		},
 		"biome": [
 			{
 				"name": "noArguments",
@@ -15775,12 +15781,6 @@
 				"url": "https://eslint.org/docs/latest/rules/prefer-rest-params"
 			}
 		],
-		"flint": {
-			"name": "arguments",
-			"plugin": "ts",
-			"preset": "logical",
-			"status": "implemented"
-		},
 		"oxlint": [
 			{
 				"name": "eslint/prefer-rest-params",
@@ -15802,17 +15802,17 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "argumentsProperties",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "no-caller",
 				"url": "https://eslint.org/docs/latest/rules/no-caller"
 			}
 		],
-		"flint": {
-			"name": "argumentsProperties",
-			"plugin": "ts",
-			"status": "skipped"
-		},
 		"oxlint": [
 			{
 				"name": "eslint/no-caller",
@@ -15821,6 +15821,12 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "arrayCallbackReturns",
+			"plugin": "ts",
+			"preset": "javascript",
+			"status": "implemented"
+		},
 		"biome": [
 			{
 				"name": "useIterableCallbackReturn",
@@ -15833,12 +15839,6 @@
 				"url": "https://eslint.org/docs/latest/rules/array-callback-return"
 			}
 		],
-		"flint": {
-			"name": "arrayCallbackReturns",
-			"plugin": "ts",
-			"preset": "javascript",
-			"status": "implemented"
-		},
 		"oxlint": [
 			{
 				"name": "eslint/array-callback-return",
@@ -15847,6 +15847,12 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "arrayConstructors",
+			"plugin": "ts",
+			"preset": "logical",
+			"status": "implemented"
+		},
 		"biome": [
 			{
 				"name": "useArrayLiterals",
@@ -15873,12 +15879,6 @@
 				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-new-array.md"
 			}
 		],
-		"flint": {
-			"name": "arrayConstructors",
-			"plugin": "ts",
-			"preset": "logical",
-			"status": "implemented"
-		},
 		"oxlint": [
 			{
 				"name": "eslint/no-array-constructor",
@@ -15891,18 +15891,18 @@
 		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "unicorn/no-unnecessary-array-splice-count",
-				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-unnecessary-array-splice-count.md"
-			}
-		],
 		"flint": {
 			"name": "arrayDeleteUnnecessaryCounts",
 			"plugin": "ts",
 			"preset": "stylistic",
 			"status": "implemented"
 		},
+		"eslint": [
+			{
+				"name": "unicorn/no-unnecessary-array-splice-count",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-unnecessary-array-splice-count.md"
+			}
+		],
 		"oxlint": [
 			{
 				"name": "unicorn/no-unnecessary-array-splice-count",
@@ -15911,17 +15911,17 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "arrayDestructuringSparsity",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "unicorn/no-unreadable-array-destructuring",
 				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-unreadable-array-destructuring.md"
 			}
 		],
-		"flint": {
-			"name": "arrayDestructuringSparsity",
-			"plugin": "ts",
-			"status": "skipped"
-		},
 		"oxlint": [
 			{
 				"name": "unicorn/no-unreadable-array-destructuring",
@@ -15930,18 +15930,18 @@
 		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "@typescript-eslint/no-array-delete",
-				"url": "https://typescript-eslint.io/rules/no-array-delete"
-			}
-		],
 		"flint": {
 			"name": "arrayElementDeletions",
 			"plugin": "ts",
 			"preset": "logical",
 			"status": "implemented"
 		},
+		"eslint": [
+			{
+				"name": "@typescript-eslint/no-array-delete",
+				"url": "https://typescript-eslint.io/rules/no-array-delete"
+			}
+		],
 		"oxlint": [
 			{
 				"name": "typescript/no-array-delete",
@@ -15964,18 +15964,18 @@
 		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "unicorn/consistent-existence-index-check",
-				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/consistent-existence-index-check.md"
-			}
-		],
 		"flint": {
 			"name": "arrayExistenceChecksConsistency",
 			"plugin": "ts",
 			"preset": "stylistic",
 			"status": "implemented"
 		},
+		"eslint": [
+			{
+				"name": "unicorn/consistent-existence-index-check",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/consistent-existence-index-check.md"
+			}
+		],
 		"oxlint": [
 			{
 				"name": "unicorn/consistent-existence-index-check",
@@ -15984,12 +15984,6 @@
 		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "unicorn/prefer-array-find",
-				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prefer-array-find.md"
-			}
-		],
 		"flint": {
 			"name": "arrayFilteredFinds",
 			"plugin": "ts",
@@ -15997,6 +15991,12 @@
 			"status": "implemented",
 			"strictness": "strict"
 		},
+		"eslint": [
+			{
+				"name": "unicorn/prefer-array-find",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prefer-array-find.md"
+			}
+		],
 		"oxlint": [
 			{
 				"name": "unicorn/prefer-array-find",
@@ -16005,6 +16005,12 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "arrayFinds",
+			"plugin": "ts",
+			"preset": "stylistic",
+			"status": "implemented"
+		},
 		"biome": [
 			{
 				"name": "useFind",
@@ -16017,12 +16023,6 @@
 				"url": "https://typescript-eslint.io/rules/prefer-find"
 			}
 		],
-		"flint": {
-			"name": "arrayFinds",
-			"plugin": "ts",
-			"preset": "stylistic",
-			"status": "implemented"
-		},
 		"oxlint": [
 			{
 				"name": "typescript/prefer-find",
@@ -16031,17 +16031,17 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "arrayFlatDepthMagicNumbers",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "unicorn/no-magic-array-flat-depth",
 				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-magic-array-flat-depth.md"
 			}
 		],
-		"flint": {
-			"name": "arrayFlatDepthMagicNumbers",
-			"plugin": "ts",
-			"status": "skipped"
-		},
 		"oxlint": [
 			{
 				"name": "unicorn/no-magic-array-flat-depth",
@@ -16050,6 +16050,13 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "arrayFlatMapMethods",
+			"plugin": "ts",
+			"preset": "stylistic",
+			"status": "implemented",
+			"strictness": "strict"
+		},
 		"biome": [
 			{
 				"name": "useFlatMap",
@@ -16062,13 +16069,6 @@
 				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prefer-array-flat-map.md"
 			}
 		],
-		"flint": {
-			"name": "arrayFlatMapMethods",
-			"plugin": "ts",
-			"preset": "stylistic",
-			"status": "implemented",
-			"strictness": "strict"
-		},
 		"oxlint": [
 			{
 				"name": "unicorn/prefer-array-flat-map",
@@ -16077,12 +16077,6 @@
 		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "unicorn/prefer-array-flat",
-				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prefer-array-flat.md"
-			}
-		],
 		"flint": {
 			"name": "arrayFlatMethods",
 			"plugin": "ts",
@@ -16090,6 +16084,12 @@
 			"status": "implemented",
 			"strictness": "strict"
 		},
+		"eslint": [
+			{
+				"name": "unicorn/prefer-array-flat",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prefer-array-flat.md"
+			}
+		],
 		"oxlint": [
 			{
 				"name": "unicorn/prefer-array-flat",
@@ -16098,18 +16098,18 @@
 		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "unicorn/no-unnecessary-array-flat-depth",
-				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-unnecessary-array-flat-depth.md"
-			}
-		],
 		"flint": {
 			"name": "arrayFlatUnnecessaryDepths",
 			"plugin": "ts",
 			"preset": "stylistic",
 			"status": "implemented"
 		},
+		"eslint": [
+			{
+				"name": "unicorn/no-unnecessary-array-flat-depth",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-unnecessary-array-flat-depth.md"
+			}
+		],
 		"oxlint": [
 			{
 				"name": "unicorn/no-unnecessary-array-flat-depth",
@@ -16118,18 +16118,18 @@
 		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "@typescript-eslint/prefer-includes",
-				"url": "https://typescript-eslint.io/rules/prefer-includes"
-			}
-		],
 		"flint": {
 			"name": "arrayIncludes",
 			"plugin": "ts",
 			"preset": "stylistic",
 			"status": "implemented"
 		},
+		"eslint": [
+			{
+				"name": "@typescript-eslint/prefer-includes",
+				"url": "https://typescript-eslint.io/rules/prefer-includes"
+			}
+		],
 		"oxlint": [
 			{
 				"name": "typescript/prefer-includes",
@@ -16138,12 +16138,6 @@
 		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "unicorn/prefer-includes",
-				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prefer-includes.md"
-			}
-		],
 		"flint": {
 			"name": "arrayIncludesMethods",
 			"plugin": "ts",
@@ -16151,6 +16145,12 @@
 			"status": "implemented",
 			"strictness": "strict"
 		},
+		"eslint": [
+			{
+				"name": "unicorn/prefer-includes",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prefer-includes.md"
+			}
+		],
 		"oxlint": [
 			{
 				"name": "unicorn/prefer-includes",
@@ -16159,18 +16159,25 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "arrayIncludesOrder",
+			"plugin": "ts"
+		},
 		"eslint": [
 			{
 				"name": "perfectionist/sort-array-includes",
 				"url": "https://perfectionist.dev/rules/sort-array-includes"
 			}
-		],
-		"flint": {
-			"name": "arrayIncludesOrder",
-			"plugin": "ts"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "arrayIndexOfMethods",
+			"plugin": "ts",
+			"preset": "stylistic",
+			"status": "implemented",
+			"strictness": "strict"
+		},
 		"biome": [
 			{
 				"name": "useIndexOf",
@@ -16183,13 +16190,6 @@
 				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prefer-array-index-of.md"
 			}
 		],
-		"flint": {
-			"name": "arrayIndexOfMethods",
-			"plugin": "ts",
-			"preset": "stylistic",
-			"status": "implemented",
-			"strictness": "strict"
-		},
 		"oxlint": [
 			{
 				"name": "unicorn/prefer-array-index-of",
@@ -16198,30 +16198,30 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "arrayInstanceOfChecks",
+			"plugin": "ts",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "unicorn/no-instanceof-array",
 				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v64.0.0/docs/deleted-and-deprecated-rules.md#no-instanceof-array"
 			}
-		],
-		"flint": {
-			"name": "arrayInstanceOfChecks",
-			"plugin": "ts",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "arrayJoinSeparators",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "unicorn/require-array-join-separator",
 				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/require-array-join-separator.md"
 			}
 		],
-		"flint": {
-			"name": "arrayJoinSeparators",
-			"plugin": "ts",
-			"status": "skipped"
-		},
 		"oxlint": [
 			{
 				"name": "unicorn/require-array-join-separator",
@@ -16230,6 +16230,12 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "arrayLoops",
+			"plugin": "ts",
+			"preset": "stylistic",
+			"status": "implemented"
+		},
 		"biome": [
 			{
 				"name": "noForEach",
@@ -16254,12 +16260,6 @@
 				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-for-loop.md"
 			}
 		],
-		"flint": {
-			"name": "arrayLoops",
-			"plugin": "ts",
-			"preset": "stylistic",
-			"status": "implemented"
-		},
 		"oxlint": [
 			{
 				"name": "typescript/prefer-for-of",
@@ -16272,31 +16272,31 @@
 		]
 	},
 	{
-		"biome": [
-			{
-				"name": "noFlatMapIdentity",
-				"url": "https://biomejs.dev/linter/rules/no-flat-map-identity"
-			}
-		],
 		"flint": {
 			"name": "arrayMapIdentities",
 			"plugin": "ts",
 			"preset": "logical",
 			"status": "implemented"
-		}
+		},
+		"biome": [
+			{
+				"name": "noFlatMapIdentity",
+				"url": "https://biomejs.dev/linter/rules/no-flat-map-identity"
+			}
+		]
 	},
 	{
+		"flint": {
+			"name": "arrayMethodThisArguments",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "unicorn/no-array-method-this-argument",
 				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-array-method-this-argument.md"
 			}
 		],
-		"flint": {
-			"name": "arrayMethodThisArguments",
-			"plugin": "ts",
-			"status": "skipped"
-		},
 		"oxlint": [
 			{
 				"name": "unicorn/no-array-method-this-argument",
@@ -16305,18 +16305,18 @@
 		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "unicorn/no-array-reverse",
-				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-array-reverse.md"
-			}
-		],
 		"flint": {
 			"name": "arrayMutableReverses",
 			"plugin": "ts",
 			"preset": "stylistic",
 			"status": "implemented"
 		},
+		"eslint": [
+			{
+				"name": "unicorn/no-array-reverse",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-array-reverse.md"
+			}
+		],
 		"oxlint": [
 			{
 				"name": "unicorn/no-array-reverse",
@@ -16325,18 +16325,18 @@
 		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "unicorn/no-array-sort",
-				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-array-sort.md"
-			}
-		],
 		"flint": {
 			"name": "arrayMutableSorts",
 			"plugin": "ts",
 			"preset": "stylistic",
 			"status": "implemented"
 		},
+		"eslint": [
+			{
+				"name": "unicorn/no-array-sort",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-array-sort.md"
+			}
+		],
 		"oxlint": [
 			{
 				"name": "unicorn/no-array-sort",
@@ -16345,30 +16345,30 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "arrayPushCalls",
+			"plugin": "ts",
+			"preset": "stylistic"
+		},
 		"eslint": [
 			{
 				"name": "unicorn/no-array-push-push",
 				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v64.0.0/docs/deleted-and-deprecated-rules.md#no-array-push-push"
 			}
-		],
-		"flint": {
-			"name": "arrayPushCalls",
-			"plugin": "ts",
-			"preset": "stylistic"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "arrayReducers",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "unicorn/no-array-reduce",
 				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-array-reduce.md"
 			}
 		],
-		"flint": {
-			"name": "arrayReducers",
-			"plugin": "ts",
-			"status": "skipped"
-		},
 		"oxlint": [
 			{
 				"name": "unicorn/no-array-reduce",
@@ -16377,6 +16377,13 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "arrayReduceTypeArguments",
+			"plugin": "ts",
+			"preset": "logical",
+			"status": "implemented",
+			"strictness": "strict"
+		},
 		"biome": [
 			{
 				"name": "useReduceTypeParameter",
@@ -16389,13 +16396,6 @@
 				"url": "https://typescript-eslint.io/rules/prefer-reduce-type-parameter"
 			}
 		],
-		"flint": {
-			"name": "arrayReduceTypeArguments",
-			"plugin": "ts",
-			"preset": "logical",
-			"status": "implemented",
-			"strictness": "strict"
-		},
 		"oxlint": [
 			{
 				"name": "typescript/prefer-reduce-type-parameter",
@@ -16404,18 +16404,18 @@
 		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "unicorn/no-unnecessary-slice-end",
-				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-unnecessary-slice-end.md"
-			}
-		],
 		"flint": {
 			"name": "arraySliceUnnecessaryEnd",
 			"plugin": "ts",
 			"preset": "stylistic",
 			"status": "implemented"
 		},
+		"eslint": [
+			{
+				"name": "unicorn/no-unnecessary-slice-end",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-unnecessary-slice-end.md"
+			}
+		],
 		"oxlint": [
 			{
 				"name": "unicorn/no-length-as-slice-end",
@@ -16428,6 +16428,13 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "arraySomeMethods",
+			"plugin": "ts",
+			"preset": "stylistic",
+			"status": "implemented",
+			"strictness": "strict"
+		},
 		"biome": [
 			{
 				"name": "useArraySome",
@@ -16440,13 +16447,6 @@
 				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prefer-array-some.md"
 			}
 		],
-		"flint": {
-			"name": "arraySomeMethods",
-			"plugin": "ts",
-			"preset": "stylistic",
-			"status": "implemented",
-			"strictness": "strict"
-		},
 		"oxlint": [
 			{
 				"name": "unicorn/prefer-array-some",
@@ -16455,18 +16455,23 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "arraysOrder",
+			"plugin": "ts"
+		},
 		"eslint": [
 			{
 				"name": "perfectionist/sort-arrays",
 				"url": "https://perfectionist.dev/rules/sort-arrays"
 			}
-		],
-		"flint": {
-			"name": "arraysOrder",
-			"plugin": "ts"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "arraySortCompareArgument",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"biome": [
 			{
 				"name": "useArraySortCompare",
@@ -16479,11 +16484,6 @@
 				"url": "https://typescript-eslint.io/rules/require-array-sort-compare"
 			}
 		],
-		"flint": {
-			"name": "arraySortCompareArgument",
-			"plugin": "ts",
-			"status": "skipped"
-		},
 		"oxlint": [
 			{
 				"name": "typescript/require-array-sort-compare",
@@ -16492,18 +16492,18 @@
 		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "unicorn/consistent-empty-array-spread",
-				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/consistent-empty-array-spread.md"
-			}
-		],
 		"flint": {
 			"name": "arrayTernarySpreadingConsistency",
 			"plugin": "ts",
 			"preset": "stylistic",
 			"status": "implemented"
 		},
+		"eslint": [
+			{
+				"name": "unicorn/consistent-empty-array-spread",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/consistent-empty-array-spread.md"
+			}
+		],
 		"oxlint": [
 			{
 				"name": "unicorn/consistent-empty-array-spread",
@@ -16512,6 +16512,12 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "arrayTypes",
+			"plugin": "ts",
+			"preset": "stylistic",
+			"status": "implemented"
+		},
 		"biome": [
 			{
 				"name": "useConsistentArrayType",
@@ -16524,12 +16530,6 @@
 				"url": "https://typescript-eslint.io/rules/array-type"
 			}
 		],
-		"flint": {
-			"name": "arrayTypes",
-			"plugin": "ts",
-			"preset": "stylistic",
-			"status": "implemented"
-		},
 		"oxlint": [
 			{
 				"name": "typescript/array-type",
@@ -16538,18 +16538,18 @@
 		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "unicorn/no-useless-length-check",
-				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-useless-length-check.md"
-			}
-		],
 		"flint": {
 			"name": "arrayUnnecessaryLengthChecks",
 			"plugin": "ts",
 			"preset": "logical",
 			"status": "implemented"
 		},
+		"eslint": [
+			{
+				"name": "unicorn/no-useless-length-check",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-useless-length-check.md"
+			}
+		],
 		"oxlint": [
 			{
 				"name": "unicorn/no-useless-length-check",
@@ -16558,6 +16558,11 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "arrowBodyBraces",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"biome": [
 			{
 				"name": "useConsistentArrowReturn",
@@ -16570,11 +16575,6 @@
 				"url": "https://eslint.org/docs/latest/rules/arrow-body-style"
 			}
 		],
-		"flint": {
-			"name": "arrowBodyBraces",
-			"plugin": "ts",
-			"status": "skipped"
-		},
 		"oxlint": [
 			{
 				"name": "eslint/arrow-body-style",
@@ -16583,6 +16583,11 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "arrowCallbacks",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"biome": [
 			{
 				"name": "useArrowFunction",
@@ -16595,11 +16600,6 @@
 				"url": "https://eslint.org/docs/latest/rules/prefer-arrow-callback"
 			}
 		],
-		"flint": {
-			"name": "arrowCallbacks",
-			"plugin": "ts",
-			"status": "skipped"
-		},
 		"oxlint": [
 			{
 				"name": "eslint/prefer-arrow-callback",
@@ -16608,6 +16608,12 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "asConstAssertions",
+			"plugin": "ts",
+			"preset": "stylistic",
+			"status": "implemented"
+		},
 		"biome": [
 			{
 				"name": "useAsConstAssertion",
@@ -16626,12 +16632,6 @@
 				"url": "https://typescript-eslint.io/rules/prefer-as-const"
 			}
 		],
-		"flint": {
-			"name": "asConstAssertions",
-			"plugin": "ts",
-			"preset": "stylistic",
-			"status": "implemented"
-		},
 		"oxlint": [
 			{
 				"name": "typescript/prefer-as-const",
@@ -16653,18 +16653,18 @@
 		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "logical-assignment-operators",
-				"url": "https://eslint.org/docs/latest/rules/logical-assignment-operators"
-			}
-		],
 		"flint": {
 			"name": "assignmentOperatorShorthands",
 			"plugin": "ts",
 			"preset": "stylistic",
 			"status": "implemented"
 		},
+		"eslint": [
+			{
+				"name": "logical-assignment-operators",
+				"url": "https://eslint.org/docs/latest/rules/logical-assignment-operators"
+			}
+		],
 		"oxlint": [
 			{
 				"name": "eslint/logical-assignment-operators",
@@ -16691,15 +16691,21 @@
 			"plugin": "ts",
 			"status": "skipped"
 		},
-		"notes": "Targeted to legacy Express async endpoint handlers.",
 		"oxlint": [
 			{
 				"name": "oxc/no-async-endpoint-handlers",
 				"url": "https://oxc.rs/docs/guide/usage/linter/rules/oxc/no-async-endpoint-handlers.html"
 			}
-		]
+		],
+		"notes": "Targeted to legacy Express async endpoint handlers."
 	},
 	{
+		"flint": {
+			"name": "asyncFunctionAwaits",
+			"plugin": "ts",
+			"preset": "logical",
+			"status": "implemented"
+		},
 		"biome": [
 			{
 				"name": "useAwait",
@@ -16722,12 +16728,6 @@
 				"url": "https://typescript-eslint.io/rules/require-await"
 			}
 		],
-		"flint": {
-			"name": "asyncFunctionAwaits",
-			"plugin": "ts",
-			"preset": "logical",
-			"status": "implemented"
-		},
 		"oxlint": [
 			{
 				"name": "eslint/require-await",
@@ -16740,6 +16740,12 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "asyncPromiseExecutors",
+			"plugin": "ts",
+			"preset": "logical",
+			"status": "implemented"
+		},
 		"biome": [
 			{
 				"name": "noAsyncPromiseExecutor",
@@ -16758,12 +16764,6 @@
 				"url": "https://eslint.org/docs/latest/rules/no-async-promise-executor"
 			}
 		],
-		"flint": {
-			"name": "asyncPromiseExecutors",
-			"plugin": "ts",
-			"preset": "logical",
-			"status": "implemented"
-		},
 		"oxlint": [
 			{
 				"name": "eslint/no-async-promise-executor",
@@ -16772,18 +16772,18 @@
 		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "unicorn/no-useless-promise-resolve-reject",
-				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-useless-promise-resolve-reject.md"
-			}
-		],
 		"flint": {
 			"name": "asyncUnnecessaryPromiseWrappers",
 			"plugin": "ts",
 			"preset": "logical",
 			"status": "implemented"
 		},
+		"eslint": [
+			{
+				"name": "unicorn/no-useless-promise-resolve-reject",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-useless-promise-resolve-reject.md"
+			}
+		],
 		"oxlint": [
 			{
 				"name": "unicorn/no-useless-promise-resolve-reject",
@@ -16792,6 +16792,13 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "atAccesses",
+			"plugin": "ts",
+			"preset": "stylistic",
+			"status": "implemented",
+			"strictness": "strict"
+		},
 		"biome": [
 			{
 				"name": "useAtIndex",
@@ -16804,13 +16811,6 @@
 				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prefer-at.md"
 			}
 		],
-		"flint": {
-			"name": "atAccesses",
-			"plugin": "ts",
-			"preset": "stylistic",
-			"status": "implemented",
-			"strictness": "strict"
-		},
 		"oxlint": [
 			{
 				"name": "unicorn/prefer-at",
@@ -16819,50 +16819,50 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "atomicUpdates",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "require-atomic-updates",
 				"url": "https://eslint.org/docs/latest/rules/require-atomic-updates"
 			}
-		],
-		"flint": {
-			"name": "atomicUpdates",
-			"plugin": "ts",
-			"status": "skipped"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "awaitInsidePromiseMethods",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "unicorn/no-await-in-promise-methods",
 				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-await-in-promise-methods.md"
 			}
 		],
-		"flint": {
-			"name": "awaitInsidePromiseMethods",
-			"plugin": "ts",
-			"status": "skipped"
-		},
-		"notes": "Superseded by awaitThenable.",
 		"oxlint": [
 			{
 				"name": "unicorn/no-await-in-promise-methods",
 				"url": "https://oxc.rs/docs/guide/usage/linter/rules/unicorn/no-await-in-promise-methods.html"
 			}
-		]
+		],
+		"notes": "Superseded by awaitThenable."
 	},
 	{
+		"flint": {
+			"name": "awaitMemberAccesses",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "unicorn/no-await-expression-member",
 				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-await-expression-member.md"
 			}
 		],
-		"flint": {
-			"name": "awaitMemberAccesses",
-			"plugin": "ts",
-			"status": "skipped"
-		},
 		"oxlint": [
 			{
 				"name": "unicorn/no-await-expression-member",
@@ -16871,6 +16871,11 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "awaitThenable",
+			"plugin": "ts",
+			"preset": "logical"
+		},
 		"biome": [
 			{
 				"name": "useAwaitThenable",
@@ -16887,11 +16892,6 @@
 				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-unnecessary-await.md"
 			}
 		],
-		"flint": {
-			"name": "awaitThenable",
-			"plugin": "ts",
-			"preset": "logical"
-		},
 		"oxlint": [
 			{
 				"name": "typescript/await-thenable",
@@ -16904,17 +16904,17 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "barrelFiles",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"biome": [
 			{
 				"name": "noBarrelFile",
 				"url": "https://biomejs.dev/linter/rules/no-barrel-file"
 			}
 		],
-		"flint": {
-			"name": "barrelFiles",
-			"plugin": "ts",
-			"status": "skipped"
-		},
 		"oxlint": [
 			{
 				"name": "oxc/no-barrel-file",
@@ -16936,6 +16936,11 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "bitwiseOperators",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"biome": [
 			{
 				"name": "noBitwiseOperators",
@@ -16948,11 +16953,6 @@
 				"url": "https://eslint.org/docs/latest/rules/no-bitwise"
 			}
 		],
-		"flint": {
-			"name": "bitwiseOperators",
-			"plugin": "ts",
-			"status": "skipped"
-		},
 		"oxlint": [
 			{
 				"name": "eslint/no-bitwise",
@@ -16961,6 +16961,11 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "blockStatements",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"biome": [
 			{
 				"name": "useBlockStatements",
@@ -16973,31 +16978,26 @@
 				"url": "https://eslint.org/docs/latest/rules/curly"
 			}
 		],
-		"flint": {
-			"name": "blockStatements",
-			"plugin": "ts",
-			"status": "skipped"
-		},
-		"notes": "Superseded by prettier-plugin-curly",
 		"oxlint": [
 			{
 				"name": "eslint/curly",
 				"url": "https://oxc.rs/docs/guide/usage/linter/rules/eslint/curly.html"
 			}
-		]
+		],
+		"notes": "Superseded by prettier-plugin-curly"
 	},
 	{
+		"flint": {
+			"name": "booleanLiteralParameterComments",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"deno": [
 			{
 				"name": "no-boolean-literal-for-arguments",
 				"url": "https://docs.deno.com/lint/rules/no-boolean-literal-for-arguments"
 			}
-		],
-		"flint": {
-			"name": "booleanLiteralParameterComments",
-			"plugin": "ts",
-			"status": "skipped"
-		}
+		]
 	},
 	{
 		"flint": {
@@ -17014,12 +17014,6 @@
 		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "unicorn/prefer-native-coercion-functions",
-				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prefer-native-coercion-functions.md"
-			}
-		],
 		"flint": {
 			"name": "builtinCoercions",
 			"plugin": "ts",
@@ -17027,6 +17021,12 @@
 			"status": "implemented",
 			"strictness": "strict"
 		},
+		"eslint": [
+			{
+				"name": "unicorn/prefer-native-coercion-functions",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prefer-native-coercion-functions.md"
+			}
+		],
 		"oxlint": [
 			{
 				"name": "unicorn/prefer-native-coercion-functions",
@@ -17035,6 +17035,12 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "builtinConstructorNews",
+			"plugin": "ts",
+			"preset": "stylistic",
+			"status": "implemented"
+		},
 		"biome": [
 			{
 				"name": "noInvalidBuiltinInstantiation",
@@ -17047,12 +17053,6 @@
 				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/new-for-builtins.md"
 			}
 		],
-		"flint": {
-			"name": "builtinConstructorNews",
-			"plugin": "ts",
-			"preset": "stylistic",
-			"status": "implemented"
-		},
 		"oxlint": [
 			{
 				"name": "unicorn/new-for-builtins",
@@ -17061,17 +17061,17 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "builtinPrototypeMethodAccesses",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "unicorn/prefer-prototype-methods",
 				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prefer-prototype-methods.md"
 			}
 		],
-		"flint": {
-			"name": "builtinPrototypeMethodAccesses",
-			"plugin": "ts",
-			"status": "skipped"
-		},
 		"oxlint": [
 			{
 				"name": "unicorn/prefer-prototype-methods",
@@ -17080,17 +17080,17 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "capitalizedConstructors",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "new-cap",
 				"url": "https://eslint.org/docs/latest/rules/new-cap"
 			}
 		],
-		"flint": {
-			"name": "capitalizedConstructors",
-			"plugin": "ts",
-			"status": "skipped"
-		},
 		"oxlint": [
 			{
 				"name": "eslint/new-cap",
@@ -17099,6 +17099,12 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "caseDeclarations",
+			"plugin": "ts",
+			"preset": "javascript",
+			"status": "implemented"
+		},
 		"biome": [
 			{
 				"name": "noSwitchDeclarations",
@@ -17117,12 +17123,6 @@
 				"url": "https://eslint.org/docs/latest/rules/no-case-declarations"
 			}
 		],
-		"flint": {
-			"name": "caseDeclarations",
-			"plugin": "ts",
-			"preset": "javascript",
-			"status": "implemented"
-		},
 		"oxlint": [
 			{
 				"name": "eslint/no-case-declarations",
@@ -17131,6 +17131,12 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "caseDuplicates",
+			"plugin": "ts",
+			"preset": "logical",
+			"status": "implemented"
+		},
 		"biome": [
 			{
 				"name": "noDuplicateCase",
@@ -17149,12 +17155,6 @@
 				"url": "https://eslint.org/docs/latest/rules/no-duplicate-case"
 			}
 		],
-		"flint": {
-			"name": "caseDuplicates",
-			"plugin": "ts",
-			"preset": "logical",
-			"status": "implemented"
-		},
 		"oxlint": [
 			{
 				"name": "eslint/no-duplicate-case",
@@ -17163,6 +17163,12 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "caseFallthroughs",
+			"plugin": "ts",
+			"preset": "logical",
+			"status": "implemented"
+		},
 		"biome": [
 			{
 				"name": "noFallthroughSwitchClause",
@@ -17181,12 +17187,6 @@
 				"url": "https://eslint.org/docs/latest/rules/no-fallthrough"
 			}
 		],
-		"flint": {
-			"name": "caseFallthroughs",
-			"plugin": "ts",
-			"preset": "logical",
-			"status": "implemented"
-		},
 		"oxlint": [
 			{
 				"name": "eslint/no-fallthrough",
@@ -17195,18 +17195,18 @@
 		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "@typescript-eslint/use-unknown-in-catch-callback-variable",
-				"url": "https://typescript-eslint.io/rules/use-unknown-in-catch-callback-variable"
-			}
-		],
 		"flint": {
 			"name": "catchCallbackTypes",
 			"plugin": "ts",
 			"preset": "logical",
 			"status": "implemented"
 		},
+		"eslint": [
+			{
+				"name": "@typescript-eslint/use-unknown-in-catch-callback-variable",
+				"url": "https://typescript-eslint.io/rules/use-unknown-in-catch-callback-variable"
+			}
+		],
 		"oxlint": [
 			{
 				"name": "typescript/use-unknown-in-catch-callback-variable",
@@ -17215,6 +17215,12 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "caughtErrorCauses",
+			"plugin": "ts",
+			"preset": "logical",
+			"strictness": "strict"
+		},
 		"biome": [
 			{
 				"name": "useErrorCause",
@@ -17227,12 +17233,6 @@
 				"url": "https://eslint.org/docs/latest/rules/preserve-caught-error"
 			}
 		],
-		"flint": {
-			"name": "caughtErrorCauses",
-			"plugin": "ts",
-			"preset": "logical",
-			"strictness": "strict"
-		},
 		"oxlint": [
 			{
 				"name": "eslint/preserve-caught-error",
@@ -17241,12 +17241,6 @@
 		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "unicorn/catch-error-name",
-				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/catch-error-name.md"
-			}
-		],
 		"flint": {
 			"name": "caughtVariableNames",
 			"plugin": "ts",
@@ -17254,6 +17248,12 @@
 			"status": "implemented",
 			"strictness": "strict"
 		},
+		"eslint": [
+			{
+				"name": "unicorn/catch-error-name",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/catch-error-name.md"
+			}
+		],
 		"oxlint": [
 			{
 				"name": "unicorn/catch-error-name",
@@ -17262,6 +17262,12 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "chainedAssignments",
+			"plugin": "ts",
+			"preset": "stylistic",
+			"status": "implemented"
+		},
 		"biome": [
 			{
 				"name": "noMultiAssign",
@@ -17274,12 +17280,6 @@
 				"url": "https://eslint.org/docs/latest/rules/no-multi-assign"
 			}
 		],
-		"flint": {
-			"name": "chainedAssignments",
-			"plugin": "ts",
-			"preset": "stylistic",
-			"status": "implemented"
-		},
 		"oxlint": [
 			{
 				"name": "eslint/no-multi-assign",
@@ -17288,16 +17288,16 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "characterClassElementsOrder",
+			"plugin": "ts"
+		},
 		"eslint": [
 			{
 				"name": "regexp/sort-character-class-elements",
 				"url": "https://ota-meshi.github.io/eslint-plugin-regexp/rules/sort-character-class-elements.html"
 			}
-		],
-		"flint": {
-			"name": "characterClassElementsOrder",
-			"plugin": "ts"
-		}
+		]
 	},
 	{
 		"flint": {
@@ -17314,6 +17314,12 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "classAssignments",
+			"plugin": "ts",
+			"preset": "javascript",
+			"status": "implemented"
+		},
 		"biome": [
 			{
 				"name": "noClassAssign",
@@ -17332,12 +17338,6 @@
 				"url": "https://eslint.org/docs/latest/rules/no-class-assign"
 			}
 		],
-		"flint": {
-			"name": "classAssignments",
-			"plugin": "ts",
-			"preset": "javascript",
-			"status": "implemented"
-		},
 		"oxlint": [
 			{
 				"name": "eslint/no-class-assign",
@@ -17346,6 +17346,11 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "classesOrder",
+			"plugin": "ts",
+			"preset": "sorting"
+		},
 		"biome": [
 			{
 				"name": "useSortedClasses",
@@ -17357,26 +17362,21 @@
 				"name": "perfectionist/sort-classes",
 				"url": "https://perfectionist.dev/rules/sort-classes"
 			}
-		],
-		"flint": {
-			"name": "classesOrder",
-			"plugin": "ts",
-			"preset": "sorting"
-		}
+		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "unicorn/prefer-class-fields",
-				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prefer-class-fields.md"
-			}
-		],
 		"flint": {
 			"name": "classFieldDeclarations",
 			"plugin": "ts",
 			"preset": "javascript",
 			"status": "implemented"
 		},
+		"eslint": [
+			{
+				"name": "unicorn/prefer-class-fields",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prefer-class-fields.md"
+			}
+		],
 		"oxlint": [
 			{
 				"name": "unicorn/prefer-class-fields",
@@ -17385,18 +17385,18 @@
 		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "@typescript-eslint/class-literal-property-style",
-				"url": "https://typescript-eslint.io/rules/class-literal-property-style"
-			}
-		],
 		"flint": {
 			"name": "classLiteralProperties",
 			"plugin": "ts",
 			"preset": "stylistic",
 			"status": "implemented"
 		},
+		"eslint": [
+			{
+				"name": "@typescript-eslint/class-literal-property-style",
+				"url": "https://typescript-eslint.io/rules/class-literal-property-style"
+			}
+		],
 		"oxlint": [
 			{
 				"name": "typescript/class-literal-property-style",
@@ -17405,6 +17405,12 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "classMemberDuplicates",
+			"plugin": "ts",
+			"preset": "javascript",
+			"status": "implemented"
+		},
 		"biome": [
 			{
 				"name": "noDuplicateClassMembers",
@@ -17427,12 +17433,6 @@
 				"url": "https://typescript-eslint.io/rules/no-dupe-class-members"
 			}
 		],
-		"flint": {
-			"name": "classMemberDuplicates",
-			"plugin": "ts",
-			"preset": "javascript",
-			"status": "implemented"
-		},
 		"oxlint": [
 			{
 				"name": "eslint/no-dupe-class-members",
@@ -17441,6 +17441,13 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "classMethodsThis",
+			"plugin": "ts",
+			"preset": "stylistic",
+			"status": "implemented",
+			"strictness": "strict"
+		},
 		"biome": [
 			{
 				"name": "useThisInClassMethods",
@@ -17457,13 +17464,6 @@
 				"url": "https://typescript-eslint.io/rules/class-methods-use-this"
 			}
 		],
-		"flint": {
-			"name": "classMethodsThis",
-			"plugin": "ts",
-			"preset": "stylistic",
-			"status": "implemented",
-			"strictness": "strict"
-		},
 		"oxlint": [
 			{
 				"name": "eslint/class-methods-use-this",
@@ -17472,12 +17472,6 @@
 		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "unicorn/prefer-single-call",
-				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prefer-single-call.md"
-			}
-		],
 		"flint": {
 			"name": "combinedPushes",
 			"plugin": "ts",
@@ -17485,20 +17479,26 @@
 			"status": "implemented",
 			"strictness": "strict"
 		},
+		"eslint": [
+			{
+				"name": "unicorn/prefer-single-call",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prefer-single-call.md"
+			}
+		],
 		"notes": "Just for Array#push(); the others would be their own rules."
 	},
 	{
+		"flint": {
+			"name": "commentCapitalization",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "capitalized-comments",
 				"url": "https://eslint.org/docs/latest/rules/capitalized-comments"
 			}
 		],
-		"flint": {
-			"name": "commentCapitalization",
-			"plugin": "ts",
-			"status": "skipped"
-		},
 		"oxlint": [
 			{
 				"name": "eslint/capitalized-comments",
@@ -17507,17 +17507,17 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "commentWarnings",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "no-warning-comments",
 				"url": "https://eslint.org/docs/latest/rules/no-warning-comments"
 			}
 		],
-		"flint": {
-			"name": "commentWarnings",
-			"plugin": "ts",
-			"status": "skipped"
-		},
 		"oxlint": [
 			{
 				"name": "eslint/no-warning-comments",
@@ -17526,16 +17526,16 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "commonjsModules",
+			"plugin": "ts"
+		},
 		"eslint": [
 			{
 				"name": "import/no-commonjs",
 				"url": "https://github.com/import-js/eslint-plugin-import/blob/v2.32.0/docs/rules/no-commonjs.md"
 			}
 		],
-		"flint": {
-			"name": "commonjsModules",
-			"plugin": "ts"
-		},
 		"oxlint": [
 			{
 				"name": "import/no-commonjs",
@@ -17549,15 +17549,20 @@
 			"plugin": "ts",
 			"status": "skipped"
 		},
-		"notes": "Handled by TypeScript / otherwise is stylistic.",
 		"oxlint": [
 			{
 				"name": "oxc/bad-comparison-sequence",
 				"url": "https://oxc.rs/docs/guide/usage/linter/rules/oxc/bad-comparison-sequence.html"
 			}
-		]
+		],
+		"notes": "Handled by TypeScript / otherwise is stylistic."
 	},
 	{
+		"flint": {
+			"name": "conditionalAssignments",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"biome": [
 			{
 				"name": "noAssignInExpressions",
@@ -17576,20 +17581,20 @@
 				"url": "https://eslint.org/docs/latest/rules/no-cond-assign"
 			}
 		],
-		"flint": {
-			"name": "conditionalAssignments",
-			"plugin": "ts",
-			"status": "skipped"
-		},
-		"notes": "Superseded by unnecessaryConditions.",
 		"oxlint": [
 			{
 				"name": "eslint/no-cond-assign",
 				"url": "https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-cond-assign.html"
 			}
-		]
+		],
+		"notes": "Superseded by unnecessaryConditions."
 	},
 	{
+		"flint": {
+			"name": "conditionNegations",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"biome": [
 			{
 				"name": "noNegationElse",
@@ -17606,11 +17611,6 @@
 				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-negated-condition.md"
 			}
 		],
-		"flint": {
-			"name": "conditionNegations",
-			"plugin": "ts",
-			"status": "skipped"
-		},
 		"oxlint": [
 			{
 				"name": "eslint/no-negated-condition",
@@ -17623,6 +17623,11 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "conditionOrdering",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"biome": [
 			{
 				"name": "noYodaExpression",
@@ -17635,11 +17640,6 @@
 				"url": "https://eslint.org/docs/latest/rules/yoda"
 			}
 		],
-		"flint": {
-			"name": "conditionOrdering",
-			"plugin": "ts",
-			"status": "skipped"
-		},
 		"oxlint": [
 			{
 				"name": "eslint/yoda",
@@ -17648,6 +17648,12 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "consecutiveNonNullAssertions",
+			"plugin": "ts",
+			"preset": "stylistic",
+			"status": "implemented"
+		},
 		"biome": [
 			{
 				"name": "noExtraNonNullAssertion",
@@ -17666,12 +17672,6 @@
 				"url": "https://typescript-eslint.io/rules/no-extra-non-null-assertion"
 			}
 		],
-		"flint": {
-			"name": "consecutiveNonNullAssertions",
-			"plugin": "ts",
-			"preset": "stylistic",
-			"status": "implemented"
-		},
 		"oxlint": [
 			{
 				"name": "typescript/no-extra-non-null-assertion",
@@ -17680,6 +17680,11 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "consistentReturns",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "consistent-return",
@@ -17690,11 +17695,6 @@
 				"url": "https://typescript-eslint.io/rules/consistent-return"
 			}
 		],
-		"flint": {
-			"name": "consistentReturns",
-			"plugin": "ts",
-			"status": "skipped"
-		},
 		"oxlint": [
 			{
 				"name": "typescript/consistent-return",
@@ -17703,6 +17703,11 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "consoleCalls",
+			"plugin": "ts",
+			"status": "implemented"
+		},
 		"biome": [
 			{
 				"name": "noConsole",
@@ -17721,11 +17726,6 @@
 				"url": "https://eslint.org/docs/latest/rules/no-console"
 			}
 		],
-		"flint": {
-			"name": "consoleCalls",
-			"plugin": "ts",
-			"status": "implemented"
-		},
 		"oxlint": [
 			{
 				"name": "eslint/no-console",
@@ -17734,6 +17734,12 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "constantAssignments",
+			"plugin": "ts",
+			"preset": "javascript",
+			"status": "implemented"
+		},
 		"biome": [
 			{
 				"name": "noConstAssign",
@@ -17752,12 +17758,6 @@
 				"url": "https://eslint.org/docs/latest/rules/no-const-assign"
 			}
 		],
-		"flint": {
-			"name": "constantAssignments",
-			"plugin": "ts",
-			"preset": "javascript",
-			"status": "implemented"
-		},
 		"oxlint": [
 			{
 				"name": "eslint/no-const-assign",
@@ -17766,6 +17766,11 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "constantBinaryExpressions",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"biome": [
 			{
 				"name": "noConstantBinaryExpressions",
@@ -17778,20 +17783,20 @@
 				"url": "https://eslint.org/docs/latest/rules/no-constant-binary-expression"
 			}
 		],
-		"flint": {
-			"name": "constantBinaryExpressions",
-			"plugin": "ts",
-			"status": "skipped"
-		},
-		"notes": "Superseded by unnecessaryConditions.",
 		"oxlint": [
 			{
 				"name": "eslint/no-constant-binary-expression",
 				"url": "https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-constant-binary-expression.html"
 			}
-		]
+		],
+		"notes": "Superseded by unnecessaryConditions."
 	},
 	{
+		"flint": {
+			"name": "constantConditions",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"biome": [
 			{
 				"name": "noConstantCondition",
@@ -17810,31 +17815,26 @@
 				"url": "https://eslint.org/docs/latest/rules/no-constant-condition"
 			}
 		],
-		"flint": {
-			"name": "constantConditions",
-			"plugin": "ts",
-			"status": "skipped"
-		},
-		"notes": "Superseded by unnecessaryConditions.",
 		"oxlint": [
 			{
 				"name": "eslint/no-constant-condition",
 				"url": "https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-constant-condition.html"
 			}
-		]
+		],
+		"notes": "Superseded by unnecessaryConditions."
 	},
 	{
+		"flint": {
+			"name": "constEnums",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"biome": [
 			{
 				"name": "noConstEnum",
 				"url": "https://biomejs.dev/linter/rules/no-const-enum"
 			}
 		],
-		"flint": {
-			"name": "constEnums",
-			"plugin": "ts",
-			"status": "skipped"
-		},
 		"oxlint": [
 			{
 				"name": "oxc/no-const-enum",
@@ -17843,18 +17843,18 @@
 		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "@typescript-eslint/consistent-generic-constructors",
-				"url": "https://typescript-eslint.io/rules/consistent-generic-constructors"
-			}
-		],
 		"flint": {
 			"name": "constructorGenericCalls",
 			"plugin": "ts",
 			"preset": "stylistic",
 			"status": "implemented"
 		},
+		"eslint": [
+			{
+				"name": "@typescript-eslint/consistent-generic-constructors",
+				"url": "https://typescript-eslint.io/rules/consistent-generic-constructors"
+			}
+		],
 		"oxlint": [
 			{
 				"name": "typescript/consistent-generic-constructors",
@@ -17863,6 +17863,12 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "constructorReturns",
+			"plugin": "ts",
+			"preset": "javascript",
+			"status": "implemented"
+		},
 		"biome": [
 			{
 				"name": "noConstructorReturn",
@@ -17875,12 +17881,6 @@
 				"url": "https://eslint.org/docs/latest/rules/no-constructor-return"
 			}
 		],
-		"flint": {
-			"name": "constructorReturns",
-			"plugin": "ts",
-			"preset": "javascript",
-			"status": "implemented"
-		},
 		"oxlint": [
 			{
 				"name": "eslint/no-constructor-return",
@@ -17889,6 +17889,12 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "constructorSupers",
+			"plugin": "ts",
+			"preset": "javascript",
+			"status": "implemented"
+		},
 		"biome": [
 			{
 				"name": "noInvalidConstructorSuper",
@@ -17907,12 +17913,6 @@
 				"url": "https://eslint.org/docs/latest/rules/constructor-super"
 			}
 		],
-		"flint": {
-			"name": "constructorSupers",
-			"plugin": "ts",
-			"preset": "javascript",
-			"status": "implemented"
-		},
 		"oxlint": [
 			{
 				"name": "eslint/constructor-super",
@@ -17921,6 +17921,11 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "constVariables",
+			"plugin": "ts",
+			"preset": "logical"
+		},
 		"biome": [
 			{
 				"name": "useConst",
@@ -17939,11 +17944,6 @@
 				"url": "https://eslint.org/docs/latest/rules/prefer-const"
 			}
 		],
-		"flint": {
-			"name": "constVariables",
-			"plugin": "ts",
-			"preset": "logical"
-		},
 		"oxlint": [
 			{
 				"name": "eslint/prefer-const",
@@ -17952,6 +17952,11 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "continues",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"biome": [
 			{
 				"name": "noContinue",
@@ -17964,11 +17969,6 @@
 				"url": "https://eslint.org/docs/latest/rules/no-continue"
 			}
 		],
-		"flint": {
-			"name": "continues",
-			"plugin": "ts",
-			"status": "skipped"
-		},
 		"oxlint": [
 			{
 				"name": "eslint/no-continue",
@@ -17977,27 +17977,34 @@
 		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "unicorn/consistent-date-clone",
-				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/consistent-date-clone.md"
-			}
-		],
 		"flint": {
 			"name": "dateConstructorClones",
 			"plugin": "ts",
 			"preset": "logical",
 			"status": "implemented"
 		},
-		"notes": "unicorn/consistent-date-clone",
+		"eslint": [
+			{
+				"name": "unicorn/consistent-date-clone",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/consistent-date-clone.md"
+			}
+		],
 		"oxlint": [
 			{
 				"name": "unicorn/consistent-date-clone",
 				"url": "https://oxc.rs/docs/guide/usage/linter/rules/unicorn/consistent-date-clone.html"
 			}
-		]
+		],
+		"notes": "unicorn/consistent-date-clone"
 	},
 	{
+		"flint": {
+			"name": "dateNowTimestamps",
+			"plugin": "ts",
+			"preset": "logical",
+			"status": "implemented",
+			"strictness": "strict"
+		},
 		"biome": [
 			{
 				"name": "useDateNow",
@@ -18010,13 +18017,6 @@
 				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prefer-date-now.md"
 			}
 		],
-		"flint": {
-			"name": "dateNowTimestamps",
-			"plugin": "ts",
-			"preset": "logical",
-			"status": "implemented",
-			"strictness": "strict"
-		},
 		"oxlint": [
 			{
 				"name": "unicorn/prefer-date-now",
@@ -18025,6 +18025,12 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "debuggerStatements",
+			"plugin": "ts",
+			"preset": "logical",
+			"status": "implemented"
+		},
 		"biome": [
 			{
 				"name": "noDebugger",
@@ -18043,12 +18049,6 @@
 				"url": "https://eslint.org/docs/latest/rules/no-debugger"
 			}
 		],
-		"flint": {
-			"name": "debuggerStatements",
-			"plugin": "ts",
-			"preset": "logical",
-			"status": "implemented"
-		},
 		"oxlint": [
 			{
 				"name": "eslint/no-debugger",
@@ -18057,19 +18057,25 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "decoratorsOrder",
+			"plugin": "ts",
+			"preset": "sorting"
+		},
 		"eslint": [
 			{
 				"name": "perfectionist/sort-decorators",
 				"url": "https://perfectionist.dev/rules/sort-decorators"
 			}
-		],
-		"flint": {
-			"name": "decoratorsOrder",
-			"plugin": "ts",
-			"preset": "sorting"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "defaultCaseLast",
+			"plugin": "ts",
+			"preset": "logical",
+			"status": "implemented"
+		},
 		"biome": [
 			{
 				"name": "useDefaultSwitchClauseLast",
@@ -18082,12 +18088,6 @@
 				"url": "https://eslint.org/docs/latest/rules/default-case-last"
 			}
 		],
-		"flint": {
-			"name": "defaultCaseLast",
-			"plugin": "ts",
-			"preset": "logical",
-			"status": "implemented"
-		},
 		"oxlint": [
 			{
 				"name": "eslint/default-case-last",
@@ -18096,6 +18096,11 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "defaultCases",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"biome": [
 			{
 				"name": "useDefaultSwitchClause",
@@ -18108,11 +18113,6 @@
 				"url": "https://eslint.org/docs/latest/rules/default-case"
 			}
 		],
-		"flint": {
-			"name": "defaultCases",
-			"plugin": "ts",
-			"status": "skipped"
-		},
 		"oxlint": [
 			{
 				"name": "eslint/default-case",
@@ -18121,20 +18121,24 @@
 		]
 	},
 	{
-		"biome": [
-			{
-				"name": "noRedundantDefaultExport",
-				"url": "https://biomejs.dev/linter/rules/no-redundant-default-export"
-			}
-		],
 		"flint": {
 			"name": "defaultExportRedundancies",
 			"plugin": "ts",
 			"preset": "stylistic",
 			"strictness": "strict"
-		}
+		},
+		"biome": [
+			{
+				"name": "noRedundantDefaultExport",
+				"url": "https://biomejs.dev/linter/rules/no-redundant-default-export"
+			}
+		]
 	},
 	{
+		"flint": {
+			"name": "defaultExports",
+			"plugin": "ts"
+		},
 		"biome": [
 			{
 				"name": "noDefaultExport",
@@ -18147,10 +18151,6 @@
 				"url": "https://github.com/import-js/eslint-plugin-import/blob/v2.32.0/docs/rules/no-default-export.md"
 			}
 		],
-		"flint": {
-			"name": "defaultExports",
-			"plugin": "ts"
-		},
 		"oxlint": [
 			{
 				"name": "import/no-default-export",
@@ -18159,17 +18159,17 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "defaultImportRenames",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "unicorn/no-named-default",
 				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-named-default.md"
 			}
 		],
-		"flint": {
-			"name": "defaultImportRenames",
-			"plugin": "ts",
-			"status": "skipped"
-		},
 		"oxlint": [
 			{
 				"name": "import/no-named-default",
@@ -18186,6 +18186,12 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "defaultParameterLast",
+			"plugin": "ts",
+			"preset": "javascript",
+			"status": "implemented"
+		},
 		"biome": [
 			{
 				"name": "useDefaultParameterLast",
@@ -18208,12 +18214,6 @@
 				"url": "https://typescript-eslint.io/rules/default-param-last"
 			}
 		],
-		"flint": {
-			"name": "defaultParameterLast",
-			"plugin": "ts",
-			"preset": "javascript",
-			"status": "implemented"
-		},
 		"oxlint": [
 			{
 				"name": "eslint/default-param-last",
@@ -18222,17 +18222,17 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "defaultParameterReassignments",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "unicorn/prefer-default-parameters",
 				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prefer-default-parameters.md"
 			}
 		],
-		"flint": {
-			"name": "defaultParameterReassignments",
-			"plugin": "ts",
-			"status": "skipped"
-		},
 		"oxlint": [
 			{
 				"name": "unicorn/prefer-default-parameters",
@@ -18241,6 +18241,12 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "deprecated",
+			"plugin": "ts",
+			"preset": "logical",
+			"status": "implemented"
+		},
 		"biome": [
 			{
 				"name": "noDeprecatedImports",
@@ -18253,12 +18259,6 @@
 				"url": "https://typescript-eslint.io/rules/no-deprecated"
 			}
 		],
-		"flint": {
-			"name": "deprecated",
-			"plugin": "ts",
-			"preset": "logical",
-			"status": "implemented"
-		},
 		"oxlint": [
 			{
 				"name": "typescript/no-deprecated",
@@ -18267,6 +18267,10 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "deprecatedImports",
+			"plugin": "ts"
+		},
 		"biome": [
 			{
 				"name": "noDeprecatedImports",
@@ -18278,13 +18282,14 @@
 				"name": "import/no-deprecated",
 				"url": "https://github.com/import-js/eslint-plugin-import/blob/v2.32.0/docs/rules/no-deprecated.md"
 			}
-		],
-		"flint": {
-			"name": "deprecatedImports",
-			"plugin": "ts"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "destructuring",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"biome": [
 			{
 				"name": "useDestructuring",
@@ -18301,11 +18306,6 @@
 				"url": "https://typescript-eslint.io/rules/prefer-destructuring"
 			}
 		],
-		"flint": {
-			"name": "destructuring",
-			"plugin": "ts",
-			"status": "skipped"
-		},
 		"oxlint": [
 			{
 				"name": "eslint/prefer-destructuring",
@@ -18314,207 +18314,213 @@
 		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "unicorn/consistent-destructuring",
-				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/consistent-destructuring.md"
-			}
-		],
 		"flint": {
 			"name": "destructuringConsistency",
 			"plugin": "ts",
 			"preset": "stylistic",
 			"status": "implemented",
 			"strictness": "strict"
-		}
+		},
+		"eslint": [
+			{
+				"name": "unicorn/consistent-destructuring",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/consistent-destructuring.md"
+			}
+		]
 	},
 	{
+		"flint": {
+			"name": "directiveDisableSelectors",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "unicorn/no-abusive-eslint-disable",
 				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-abusive-eslint-disable.md"
 			}
 		],
-		"flint": {
-			"name": "directiveDisableSelectors",
-			"plugin": "ts",
-			"status": "skipped"
-		},
-		"notes": "Core requires explicit disables",
 		"oxlint": [
 			{
 				"name": "unicorn/no-abusive-eslint-disable",
 				"url": "https://oxc.rs/docs/guide/usage/linter/rules/unicorn/no-abusive-eslint-disable.html"
 			}
-		]
+		],
+		"notes": "Core requires explicit disables"
 	},
 	{
+		"flint": {
+			"name": "directiveDuplicateDisables",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "@eslint-community/eslint-comments/no-duplicate-disable",
 				"url": "https://eslint-community.github.io/eslint-plugin-eslint-comments/rules/no-duplicate-disable.html"
 			}
 		],
-		"flint": {
-			"name": "directiveDuplicateDisables",
-			"plugin": "ts",
-			"status": "skipped"
-		},
 		"notes": "Core detects duplicate disables"
 	},
 	{
+		"flint": {
+			"name": "directiveMisleadingEnables",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "@eslint-community/eslint-comments/no-aggregating-enable",
 				"url": "https://eslint-community.github.io/eslint-plugin-eslint-comments/rules/no-aggregating-enable.html"
 			}
 		],
-		"flint": {
-			"name": "directiveMisleadingEnables",
-			"plugin": "ts",
-			"status": "skipped"
-		},
 		"notes": "Core requires explicit enables"
 	},
 	{
-		"eslint": [
-			{
-				"name": "@eslint-community/eslint-comments/disable-enable-pair",
-				"url": "https://eslint-community.github.io/eslint-plugin-eslint-comments/rules/disable-enable-pair.html"
-			}
-		],
 		"flint": {
 			"name": "directivePairs",
 			"plugin": "ts",
 			"preset": "logical",
 			"strictness": "strict"
-		}
-	},
-	{
+		},
 		"eslint": [
 			{
-				"name": "@eslint-community/eslint-comments/require-description",
-				"url": "https://eslint-community.github.io/eslint-plugin-eslint-comments/rules/require-description.html"
+				"name": "@eslint-community/eslint-comments/disable-enable-pair",
+				"url": "https://eslint-community.github.io/eslint-plugin-eslint-comments/rules/disable-enable-pair.html"
 			}
-		],
+		]
+	},
+	{
 		"flint": {
 			"name": "directiveRequireDescriptions",
 			"plugin": "ts",
 			"preset": "stylistic",
 			"strictness": "strict"
-		}
+		},
+		"eslint": [
+			{
+				"name": "@eslint-community/eslint-comments/require-description",
+				"url": "https://eslint-community.github.io/eslint-plugin-eslint-comments/rules/require-description.html"
+			}
+		]
 	},
 	{
+		"flint": {
+			"name": "directiveRestrictedDisables",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "@eslint-community/eslint-comments/no-restricted-disable",
 				"url": "https://eslint-community.github.io/eslint-plugin-eslint-comments/rules/no-restricted-disable.html"
 			}
-		],
-		"flint": {
-			"name": "directiveRestrictedDisables",
-			"plugin": "ts",
-			"status": "skipped"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "directiveSelectors",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"deno": [
 			{
 				"name": "ban-untagged-ignore",
 				"url": "https://docs.deno.com/lint/rules/ban-untagged-ignore"
 			}
 		],
-		"flint": {
-			"name": "directiveSelectors",
-			"plugin": "ts",
-			"status": "skipped"
-		},
 		"notes": "Handled by Flint core"
 	},
 	{
+		"flint": {
+			"name": "directiveUnknownRules",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"deno": [
 			{
 				"name": "ban-unknown-rule-code",
 				"url": "https://docs.deno.com/lint/rules/ban-unknown-rule-code"
 			}
 		],
-		"flint": {
-			"name": "directiveUnknownRules",
-			"plugin": "ts",
-			"status": "skipped"
-		},
 		"notes": "Handled by Flint core"
 	},
 	{
+		"flint": {
+			"name": "directiveUnlimitedDisables",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "@eslint-community/eslint-comments/no-unlimited-disable",
 				"url": "https://eslint-community.github.io/eslint-plugin-eslint-comments/rules/no-unlimited-disable.html"
 			}
 		],
-		"flint": {
-			"name": "directiveUnlimitedDisables",
-			"plugin": "ts",
-			"status": "skipped"
-		},
 		"notes": "Core requires explicit disables"
 	},
 	{
+		"flint": {
+			"name": "directiveUnused",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"deno": [
 			{
 				"name": "ban-unused-ignore",
 				"url": "https://docs.deno.com/lint/rules/ban-unused-ignore"
 			}
 		],
-		"flint": {
-			"name": "directiveUnused",
-			"plugin": "ts",
-			"status": "skipped"
-		},
 		"notes": "Handled by Flint core"
 	},
 	{
+		"flint": {
+			"name": "directiveUnusedDisables",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "@eslint-community/eslint-comments/no-unused-disable",
 				"url": "https://eslint-community.github.io/eslint-plugin-eslint-comments/rules/no-unused-disable.html"
 			}
 		],
-		"flint": {
-			"name": "directiveUnusedDisables",
-			"plugin": "ts",
-			"status": "skipped"
-		},
 		"notes": "Core detects unused disables"
 	},
 	{
+		"flint": {
+			"name": "directiveUnusedEnables",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "@eslint-community/eslint-comments/no-unused-enable",
 				"url": "https://eslint-community.github.io/eslint-plugin-eslint-comments/rules/no-unused-enable.html"
 			}
 		],
-		"flint": {
-			"name": "directiveUnusedEnables",
-			"plugin": "ts",
-			"status": "skipped"
-		},
 		"notes": "Core detects unused enables"
 	},
 	{
+		"flint": {
+			"name": "disposables",
+			"plugin": "ts",
+			"preset": "logical"
+		},
 		"biome": [
 			{
 				"name": "useDisposables",
 				"url": "https://biomejs.dev/linter/rules/use-disposables"
 			}
-		],
-		"flint": {
-			"name": "disposables",
-			"plugin": "ts",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "duplicateArguments",
+			"plugin": "ts",
+			"preset": "javascript",
+			"status": "implemented"
+		},
 		"biome": [
 			{
 				"name": "noDuplicateParameters",
@@ -18532,27 +18538,21 @@
 				"name": "no-dupe-args",
 				"url": "https://eslint.org/docs/latest/rules/no-dupe-args"
 			}
-		],
-		"flint": {
-			"name": "duplicateArguments",
-			"plugin": "ts",
-			"preset": "javascript",
-			"status": "implemented"
-		}
+		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "@typescript-eslint/no-dynamic-delete",
-				"url": "https://typescript-eslint.io/rules/no-dynamic-delete"
-			}
-		],
 		"flint": {
 			"name": "dynamicDeletes",
 			"plugin": "ts",
 			"preset": "logical",
 			"status": "implemented"
 		},
+		"eslint": [
+			{
+				"name": "@typescript-eslint/no-dynamic-delete",
+				"url": "https://typescript-eslint.io/rules/no-dynamic-delete"
+			}
+		],
 		"oxlint": [
 			{
 				"name": "typescript/no-dynamic-delete",
@@ -18561,28 +18561,28 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "dynamicImportChunkNames",
+			"plugin": "ts"
+		},
 		"eslint": [
 			{
 				"name": "import/dynamic-import-chunkname",
 				"url": "https://github.com/import-js/eslint-plugin-import/blob/v2.32.0/docs/rules/dynamic-import-chunkname.md"
 			}
-		],
-		"flint": {
-			"name": "dynamicImportChunkNames",
-			"plugin": "ts"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "dynamicRequires",
+			"plugin": "ts"
+		},
 		"eslint": [
 			{
 				"name": "import/no-dynamic-require",
 				"url": "https://github.com/import-js/eslint-plugin-import/blob/v2.32.0/docs/rules/no-dynamic-require.md"
 			}
 		],
-		"flint": {
-			"name": "dynamicRequires",
-			"plugin": "ts"
-		},
 		"oxlint": [
 			{
 				"name": "import/no-dynamic-require",
@@ -18591,6 +18591,12 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "elseIfDuplicates",
+			"plugin": "ts",
+			"preset": "logical",
+			"status": "implemented"
+		},
 		"biome": [
 			{
 				"name": "noDuplicateElseIf",
@@ -18603,12 +18609,6 @@
 				"url": "https://eslint.org/docs/latest/rules/no-dupe-else-if"
 			}
 		],
-		"flint": {
-			"name": "elseIfDuplicates",
-			"plugin": "ts",
-			"preset": "logical",
-			"status": "implemented"
-		},
 		"oxlint": [
 			{
 				"name": "eslint/no-dupe-else-if",
@@ -18617,6 +18617,13 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "elseReturns",
+			"plugin": "ts",
+			"preset": "stylistic",
+			"status": "implemented",
+			"strictness": "strict"
+		},
 		"biome": [
 			{
 				"name": "noUselessElse",
@@ -18629,13 +18636,6 @@
 				"url": "https://eslint.org/docs/latest/rules/no-else-return"
 			}
 		],
-		"flint": {
-			"name": "elseReturns",
-			"plugin": "ts",
-			"preset": "stylistic",
-			"status": "implemented",
-			"strictness": "strict"
-		},
 		"oxlint": [
 			{
 				"name": "eslint/no-else-return",
@@ -18644,6 +18644,12 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "emptyBlocks",
+			"plugin": "ts",
+			"preset": "stylistic",
+			"status": "implemented"
+		},
 		"biome": [
 			{
 				"name": "noEmptyBlockStatements",
@@ -18662,12 +18668,6 @@
 				"url": "https://eslint.org/docs/latest/rules/no-empty"
 			}
 		],
-		"flint": {
-			"name": "emptyBlocks",
-			"plugin": "ts",
-			"preset": "stylistic",
-			"status": "implemented"
-		},
 		"oxlint": [
 			{
 				"name": "eslint/no-empty",
@@ -18676,26 +18676,32 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "emptyBraceSpaces",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "unicorn/empty-brace-spaces",
 				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v64.0.0/docs/rules/empty-brace-spaces.md"
 			}
 		],
-		"flint": {
-			"name": "emptyBraceSpaces",
-			"plugin": "ts",
-			"status": "skipped"
-		},
-		"notes": "Formatting rule.",
 		"oxlint": [
 			{
 				"name": "unicorn/empty-brace-spaces",
 				"url": "https://oxc.rs/docs/guide/usage/linter/rules/unicorn/empty-brace-spaces.html"
 			}
-		]
+		],
+		"notes": "Formatting rule."
 	},
 	{
+		"flint": {
+			"name": "emptyDestructures",
+			"plugin": "ts",
+			"preset": "logical",
+			"status": "implemented"
+		},
 		"biome": [
 			{
 				"name": "noEmptyPattern",
@@ -18714,12 +18720,6 @@
 				"url": "https://eslint.org/docs/latest/rules/no-empty-pattern"
 			}
 		],
-		"flint": {
-			"name": "emptyDestructures",
-			"plugin": "ts",
-			"preset": "logical",
-			"status": "implemented"
-		},
 		"oxlint": [
 			{
 				"name": "eslint/no-empty-pattern",
@@ -18728,20 +18728,26 @@
 		]
 	},
 	{
-		"deno": [
-			{
-				"name": "no-empty-enum",
-				"url": "https://docs.deno.com/lint/rules/no-empty-enum"
-			}
-		],
 		"flint": {
 			"name": "emptyEnums",
 			"plugin": "ts",
 			"preset": "logical",
 			"status": "implemented"
-		}
+		},
+		"deno": [
+			{
+				"name": "no-empty-enum",
+				"url": "https://docs.deno.com/lint/rules/no-empty-enum"
+			}
+		]
 	},
 	{
+		"flint": {
+			"name": "emptyExports",
+			"plugin": "ts",
+			"preset": "logical",
+			"status": "implemented"
+		},
 		"biome": [
 			{
 				"name": "noUselessEmptyExport",
@@ -18754,12 +18760,6 @@
 				"url": "https://typescript-eslint.io/rules/no-useless-empty-export"
 			}
 		],
-		"flint": {
-			"name": "emptyExports",
-			"plugin": "ts",
-			"preset": "logical",
-			"status": "implemented"
-		},
 		"oxlint": [
 			{
 				"name": "typescript/no-useless-empty-export",
@@ -18768,6 +18768,13 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "emptyFiles",
+			"plugin": "ts",
+			"preset": "stylistic",
+			"status": "implemented",
+			"strictness": "strict"
+		},
 		"biome": [
 			{
 				"name": "noEmptySource",
@@ -18780,13 +18787,6 @@
 				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-empty-file.md"
 			}
 		],
-		"flint": {
-			"name": "emptyFiles",
-			"plugin": "ts",
-			"preset": "stylistic",
-			"status": "implemented",
-			"strictness": "strict"
-		},
 		"oxlint": [
 			{
 				"name": "unicorn/no-empty-file",
@@ -18795,6 +18795,13 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "emptyFunctions",
+			"plugin": "ts",
+			"preset": "stylistic",
+			"status": "implemented",
+			"strictness": "strict"
+		},
 		"biome": [
 			{
 				"name": "noEmptyBlockStatements",
@@ -18811,13 +18818,6 @@
 				"url": "https://typescript-eslint.io/rules/no-empty-function"
 			}
 		],
-		"flint": {
-			"name": "emptyFunctions",
-			"plugin": "ts",
-			"preset": "stylistic",
-			"status": "implemented",
-			"strictness": "strict"
-		},
 		"oxlint": [
 			{
 				"name": "eslint/no-empty-function",
@@ -18826,18 +18826,18 @@
 		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "unicorn/require-module-attributes",
-				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/require-module-attributes.md"
-			}
-		],
 		"flint": {
 			"name": "emptyModuleAttributes",
 			"plugin": "ts",
 			"preset": "stylistic",
 			"status": "implemented"
 		},
+		"eslint": [
+			{
+				"name": "unicorn/require-module-attributes",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/require-module-attributes.md"
+			}
+		],
 		"oxlint": [
 			{
 				"name": "unicorn/require-module-attributes",
@@ -18846,6 +18846,12 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "emptyObjectTypes",
+			"plugin": "ts",
+			"preset": "logical",
+			"status": "implemented"
+		},
 		"biome": [
 			{
 				"name": "noBannedTypes",
@@ -18876,12 +18882,6 @@
 				"url": "https://typescript-eslint.io/rules/no-empty-object-type"
 			}
 		],
-		"flint": {
-			"name": "emptyObjectTypes",
-			"plugin": "ts",
-			"preset": "logical",
-			"status": "implemented"
-		},
 		"oxlint": [
 			{
 				"name": "typescript/ban-types",
@@ -18898,6 +18898,12 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "emptyStaticBlocks",
+			"plugin": "ts",
+			"preset": "stylistic",
+			"status": "implemented"
+		},
 		"biome": [
 			{
 				"name": "noEmptyBlockStatements",
@@ -18910,12 +18916,6 @@
 				"url": "https://eslint.org/docs/latest/rules/no-empty-static-block"
 			}
 		],
-		"flint": {
-			"name": "emptyStaticBlocks",
-			"plugin": "ts",
-			"preset": "stylistic",
-			"status": "implemented"
-		},
 		"oxlint": [
 			{
 				"name": "eslint/no-empty-static-block",
@@ -18924,31 +18924,31 @@
 		]
 	},
 	{
-		"biome": [
-			{
-				"name": "noEmptyTypeParameters",
-				"url": "https://biomejs.dev/linter/rules/no-empty-type-parameters"
-			}
-		],
 		"flint": {
 			"name": "emptyTypeParameterLists",
 			"plugin": "ts",
 			"preset": "stylistic",
 			"status": "implemented"
-		}
+		},
+		"biome": [
+			{
+				"name": "noEmptyTypeParameters",
+				"url": "https://biomejs.dev/linter/rules/no-empty-type-parameters"
+			}
+		]
 	},
 	{
+		"flint": {
+			"name": "endingTernaryIfElses",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "unicorn/prefer-ternary",
 				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prefer-ternary.md"
 			}
 		],
-		"flint": {
-			"name": "endingTernaryIfElses",
-			"plugin": "ts",
-			"status": "skipped"
-		},
 		"oxlint": [
 			{
 				"name": "unicorn/prefer-ternary",
@@ -18957,6 +18957,11 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "enumInitializers",
+			"plugin": "ts",
+			"status": "implemented"
+		},
 		"biome": [
 			{
 				"name": "useEnumInitializers",
@@ -18969,11 +18974,6 @@
 				"url": "https://typescript-eslint.io/rules/prefer-enum-initializers"
 			}
 		],
-		"flint": {
-			"name": "enumInitializers",
-			"plugin": "ts",
-			"status": "implemented"
-		},
 		"oxlint": [
 			{
 				"name": "typescript/prefer-enum-initializers",
@@ -18982,6 +18982,13 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "enumMemberLiterals",
+			"plugin": "ts",
+			"preset": "logical",
+			"status": "implemented",
+			"strictness": "strict"
+		},
 		"biome": [
 			{
 				"name": "useLiteralEnumMembers",
@@ -18994,13 +19001,6 @@
 				"url": "https://typescript-eslint.io/rules/prefer-literal-enum-member"
 			}
 		],
-		"flint": {
-			"name": "enumMemberLiterals",
-			"plugin": "ts",
-			"preset": "logical",
-			"status": "implemented",
-			"strictness": "strict"
-		},
 		"oxlint": [
 			{
 				"name": "typescript/prefer-literal-enum-member",
@@ -19009,17 +19009,17 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "enumMixedValues",
+			"plugin": "ts",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "@typescript-eslint/no-misused-spread",
 				"url": "https://typescript-eslint.io/rules/no-misused-spread"
 			}
 		],
-		"flint": {
-			"name": "enumMixedValues",
-			"plugin": "ts",
-			"preset": "logical"
-		},
 		"oxlint": [
 			{
 				"name": "typescript/no-misused-spread",
@@ -19028,32 +19028,38 @@
 		]
 	},
 	{
-		"biome": [
-			{
-				"name": "noEnum",
-				"url": "https://biomejs.dev/linter/rules/no-enum"
-			}
-		],
 		"flint": {
 			"name": "enums",
 			"plugin": "ts",
 			"preset": "stylistic",
 			"strictness": "strict"
-		}
+		},
+		"biome": [
+			{
+				"name": "noEnum",
+				"url": "https://biomejs.dev/linter/rules/no-enum"
+			}
+		]
 	},
 	{
+		"flint": {
+			"name": "enumsOrder",
+			"plugin": "ts"
+		},
 		"eslint": [
 			{
 				"name": "perfectionist/sort-enums",
 				"url": "https://perfectionist.dev/rules/sort-enums"
 			}
-		],
-		"flint": {
-			"name": "enumsOrder",
-			"plugin": "ts"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "enumValueConsistency",
+			"plugin": "ts",
+			"preset": "logical",
+			"status": "implemented"
+		},
 		"biome": [
 			{
 				"name": "useConsistentEnumValueType",
@@ -19066,12 +19072,6 @@
 				"url": "https://typescript-eslint.io/rules/no-mixed-enums"
 			}
 		],
-		"flint": {
-			"name": "enumValueConsistency",
-			"plugin": "ts",
-			"preset": "logical",
-			"status": "implemented"
-		},
 		"oxlint": [
 			{
 				"name": "typescript/no-mixed-enums",
@@ -19080,6 +19080,12 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "enumValueDuplicates",
+			"plugin": "ts",
+			"preset": "logical",
+			"status": "implemented"
+		},
 		"biome": [
 			{
 				"name": "noDuplicateEnumValues",
@@ -19092,12 +19098,6 @@
 				"url": "https://typescript-eslint.io/rules/no-duplicate-enum-values"
 			}
 		],
-		"flint": {
-			"name": "enumValueDuplicates",
-			"plugin": "ts",
-			"preset": "logical",
-			"status": "implemented"
-		},
 		"oxlint": [
 			{
 				"name": "typescript/no-duplicate-enum-values",
@@ -19106,17 +19106,17 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "equalityOperatorNegations",
+			"plugin": "ts",
+			"status": "implemented"
+		},
 		"eslint": [
 			{
 				"name": "unicorn/no-negation-in-equality-check",
 				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-negation-in-equality-check.md"
 			}
 		],
-		"flint": {
-			"name": "equalityOperatorNegations",
-			"plugin": "ts",
-			"status": "implemented"
-		},
 		"oxlint": [
 			{
 				"name": "unicorn/no-negation-in-equality-check",
@@ -19125,6 +19125,12 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "equalityOperators",
+			"plugin": "ts",
+			"preset": "logical",
+			"status": "implemented"
+		},
 		"biome": [
 			{
 				"name": "noDoubleEquals",
@@ -19143,21 +19149,22 @@
 				"url": "https://eslint.org/docs/latest/rules/eqeqeq"
 			}
 		],
-		"flint": {
-			"name": "equalityOperators",
-			"plugin": "ts",
-			"preset": "logical",
-			"status": "implemented"
-		},
-		"notes": "Default similar to ESLint's \"{ \"null\": \"ignore\" }\" to true",
 		"oxlint": [
 			{
 				"name": "eslint/eqeqeq",
 				"url": "https://oxc.rs/docs/guide/usage/linter/rules/eslint/eqeqeq.html"
 			}
-		]
+		],
+		"notes": "Default similar to ESLint's \"{ \"null\": \"ignore\" }\" to true"
 	},
 	{
+		"flint": {
+			"name": "errorMessages",
+			"plugin": "ts",
+			"preset": "logical",
+			"status": "implemented",
+			"strictness": "strict"
+		},
 		"biome": [
 			{
 				"name": "useErrorMessage",
@@ -19170,13 +19177,6 @@
 				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/error-message.md"
 			}
 		],
-		"flint": {
-			"name": "errorMessages",
-			"plugin": "ts",
-			"preset": "logical",
-			"status": "implemented",
-			"strictness": "strict"
-		},
 		"oxlint": [
 			{
 				"name": "unicorn/error-message",
@@ -19185,12 +19185,6 @@
 		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "unicorn/custom-error-definition",
-				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/custom-error-definition.md"
-			}
-		],
 		"flint": {
 			"name": "errorSubclassProperties",
 			"plugin": "ts",
@@ -19198,6 +19192,12 @@
 			"status": "implemented",
 			"strictness": "strict"
 		},
+		"eslint": [
+			{
+				"name": "unicorn/custom-error-definition",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/custom-error-definition.md"
+			}
+		],
 		"oxlint": [
 			{
 				"name": "unicorn/custom-error-definition",
@@ -19206,18 +19206,18 @@
 		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "unicorn/no-useless-error-capture-stack-trace",
-				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-useless-error-capture-stack-trace.md"
-			}
-		],
 		"flint": {
 			"name": "errorUnnecessaryCaptureStackTraces",
 			"plugin": "ts",
 			"preset": "logical",
 			"status": "implemented"
 		},
+		"eslint": [
+			{
+				"name": "unicorn/no-useless-error-capture-stack-trace",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-useless-error-capture-stack-trace.md"
+			}
+		],
 		"oxlint": [
 			{
 				"name": "unicorn/no-useless-error-capture-stack-trace",
@@ -19226,12 +19226,6 @@
 		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "unicorn/escape-case",
-				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/escape-case.md"
-			}
-		],
 		"flint": {
 			"name": "escapeSequenceCasing",
 			"plugin": "ts",
@@ -19239,6 +19233,12 @@
 			"status": "implemented",
 			"strictness": "strict"
 		},
+		"eslint": [
+			{
+				"name": "unicorn/escape-case",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/escape-case.md"
+			}
+		],
 		"oxlint": [
 			{
 				"name": "unicorn/escape-case",
@@ -19247,6 +19247,12 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "evals",
+			"plugin": "ts",
+			"preset": "logical",
+			"status": "implemented"
+		},
 		"biome": [
 			{
 				"name": "noGlobalEval",
@@ -19265,12 +19271,6 @@
 				"url": "https://eslint.org/docs/latest/rules/no-eval"
 			}
 		],
-		"flint": {
-			"name": "evals",
-			"plugin": "ts",
-			"preset": "logical",
-			"status": "implemented"
-		},
 		"oxlint": [
 			{
 				"name": "eslint/no-eval",
@@ -19279,6 +19279,12 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "evolvingVariableTypes",
+			"plugin": "ts",
+			"status": "implemented",
+			"strictness": "strict"
+		},
 		"biome": [
 			{
 				"name": "noEvolvingTypes",
@@ -19288,15 +19294,15 @@
 				"name": "noImplicitAnyLet",
 				"url": "https://biomejs.dev/linter/rules/no-implicit-any-let"
 			}
-		],
-		"flint": {
-			"name": "evolvingVariableTypes",
-			"plugin": "ts",
-			"status": "implemented",
-			"strictness": "strict"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "exceptionAssignments",
+			"plugin": "ts",
+			"preset": "logical",
+			"status": "implemented"
+		},
 		"biome": [
 			{
 				"name": "noCatchAssign",
@@ -19315,12 +19321,6 @@
 				"url": "https://eslint.org/docs/latest/rules/no-ex-assign"
 			}
 		],
-		"flint": {
-			"name": "exceptionAssignments",
-			"plugin": "ts",
-			"preset": "logical",
-			"status": "implemented"
-		},
 		"oxlint": [
 			{
 				"name": "eslint/no-ex-assign",
@@ -19329,6 +19329,12 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "explicitAnys",
+			"plugin": "ts",
+			"preset": "logical",
+			"status": "implemented"
+		},
 		"biome": [
 			{
 				"name": "noExplicitAny",
@@ -19347,12 +19353,6 @@
 				"url": "https://typescript-eslint.io/rules/no-explicit-any"
 			}
 		],
-		"flint": {
-			"name": "explicitAnys",
-			"plugin": "ts",
-			"preset": "logical",
-			"status": "implemented"
-		},
 		"oxlint": [
 			{
 				"name": "typescript/no-explicit-any",
@@ -19361,6 +19361,12 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "exponentiationOperators",
+			"plugin": "ts",
+			"preset": "stylistic",
+			"status": "implemented"
+		},
 		"biome": [
 			{
 				"name": "useExponentiationOperator",
@@ -19373,12 +19379,6 @@
 				"url": "https://eslint.org/docs/latest/rules/prefer-exponentiation-operator"
 			}
 		],
-		"flint": {
-			"name": "exponentiationOperators",
-			"plugin": "ts",
-			"preset": "stylistic",
-			"status": "implemented"
-		},
 		"oxlint": [
 			{
 				"name": "eslint/prefer-exponentiation-operator",
@@ -19387,50 +19387,56 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "exportAttributesOrder",
+			"plugin": "ts"
+		},
 		"eslint": [
 			{
 				"name": "perfectionist/sort-export-attributes",
 				"url": "https://perfectionist.dev/rules/sort-export-attributes"
 			}
-		],
-		"flint": {
-			"name": "exportAttributesOrder",
-			"plugin": "ts"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "exportDeclarationsOrder",
+			"plugin": "ts"
+		},
 		"eslint": [
 			{
 				"name": "perfectionist/sort-exports",
 				"url": "https://perfectionist.dev/rules/sort-exports"
 			}
-		],
-		"flint": {
-			"name": "exportDeclarationsOrder",
-			"plugin": "ts"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "exportDefault",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "import/prefer-default-export",
 				"url": "https://github.com/import-js/eslint-plugin-import/blob/HEAD/docs/rules/prefer-default-export.md"
 			}
 		],
-		"flint": {
-			"name": "exportDefault",
-			"plugin": "ts",
-			"status": "skipped"
-		},
-		"notes": "Overly opinionated.",
 		"oxlint": [
 			{
 				"name": "import/prefer-default-export",
 				"url": "https://oxc.rs/docs/guide/usage/linter/rules/import/prefer-default-export.html"
 			}
-		]
+		],
+		"notes": "Overly opinionated."
 	},
 	{
+		"flint": {
+			"name": "exportFromImports",
+			"plugin": "ts",
+			"preset": "stylistic",
+			"status": "implemented"
+		},
 		"biome": [
 			{
 				"name": "noExportedImports",
@@ -19442,35 +19448,34 @@
 				"name": "unicorn/prefer-export-from",
 				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prefer-export-from.md"
 			}
-		],
-		"flint": {
-			"name": "exportFromImports",
-			"plugin": "ts",
-			"preset": "stylistic",
-			"status": "implemented"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "exportGroups",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "import/group-exports",
 				"url": "https://github.com/import-js/eslint-plugin-import/blob/HEAD/docs/rules/group-exports.md"
 			}
 		],
-		"flint": {
-			"name": "exportGroups",
-			"plugin": "ts",
-			"status": "skipped"
-		},
-		"notes": "Overly opinionated.",
 		"oxlint": [
 			{
 				"name": "import/group-exports",
 				"url": "https://oxc.rs/docs/guide/usage/linter/rules/import/group-exports.html"
 			}
-		]
+		],
+		"notes": "Overly opinionated."
 	},
 	{
+		"flint": {
+			"name": "exportLast",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"biome": [
 			{
 				"name": "useExportsLast",
@@ -19483,32 +19488,27 @@
 				"url": "https://github.com/import-js/eslint-plugin-import/blob/HEAD/docs/rules/exports-last.md"
 			}
 		],
-		"flint": {
-			"name": "exportLast",
-			"plugin": "ts",
-			"status": "skipped"
-		},
-		"notes": "Overly opinionated.",
 		"oxlint": [
 			{
 				"name": "import/exports-last",
 				"url": "https://oxc.rs/docs/guide/usage/linter/rules/import/exports-last.html"
 			}
-		]
+		],
+		"notes": "Overly opinionated."
 	},
 	{
-		"eslint": [
-			{
-				"name": "import/no-mutable-exports",
-				"url": "https://github.com/import-js/eslint-plugin-import/blob/HEAD/docs/rules/no-mutable-exports.md"
-			}
-		],
 		"flint": {
 			"name": "exportMutables",
 			"plugin": "ts",
 			"preset": "logical",
 			"status": "implemented"
 		},
+		"eslint": [
+			{
+				"name": "import/no-mutable-exports",
+				"url": "https://github.com/import-js/eslint-plugin-import/blob/HEAD/docs/rules/no-mutable-exports.md"
+			}
+		],
 		"oxlint": [
 			{
 				"name": "import/no-mutable-exports",
@@ -19517,31 +19517,31 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "exportsOrder",
+			"plugin": "ts",
+			"preset": "sorting"
+		},
 		"eslint": [
 			{
 				"name": "perfectionist/sort-named-exports",
 				"url": "https://perfectionist.dev/rules/sort-named-exports"
 			}
-		],
-		"flint": {
-			"name": "exportsOrder",
-			"plugin": "ts",
-			"preset": "sorting"
-		}
+		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "import/export",
-				"url": "https://github.com/import-js/eslint-plugin-import/blob/v2.32.0/docs/rules/export.md"
-			}
-		],
 		"flint": {
 			"name": "exportUniqueNames",
 			"plugin": "ts",
 			"preset": "javascript",
 			"status": "implemented"
 		},
+		"eslint": [
+			{
+				"name": "import/export",
+				"url": "https://github.com/import-js/eslint-plugin-import/blob/v2.32.0/docs/rules/export.md"
+			}
+		],
 		"oxlint": [
 			{
 				"name": "import/export",
@@ -19550,25 +19550,19 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "externalHttpImports",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"deno": [
 			{
 				"name": "no-external-import",
 				"url": "https://docs.deno.com/lint/rules/no-external-import"
 			}
-		],
-		"flint": {
-			"name": "externalHttpImports",
-			"plugin": "ts",
-			"status": "skipped"
-		}
+		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "@typescript-eslint/no-extraneous-class",
-				"url": "https://typescript-eslint.io/rules/no-extraneous-class"
-			}
-		],
 		"flint": {
 			"name": "extraneousClasses",
 			"plugin": "ts",
@@ -19576,6 +19570,12 @@
 			"status": "implemented",
 			"strictness": "strict"
 		},
+		"eslint": [
+			{
+				"name": "@typescript-eslint/no-extraneous-class",
+				"url": "https://typescript-eslint.io/rules/no-extraneous-class"
+			}
+		],
 		"oxlint": [
 			{
 				"name": "typescript/no-extraneous-class",
@@ -19584,18 +19584,18 @@
 		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "unicorn/no-invalid-fetch-options",
-				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-invalid-fetch-options.md"
-			}
-		],
 		"flint": {
 			"name": "fetchMethodBodies",
 			"plugin": "ts",
 			"preset": "logical",
 			"status": "implemented"
 		},
+		"eslint": [
+			{
+				"name": "unicorn/no-invalid-fetch-options",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-invalid-fetch-options.md"
+			}
+		],
 		"oxlint": [
 			{
 				"name": "unicorn/no-invalid-fetch-options",
@@ -19604,6 +19604,11 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "filenameCasing",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"biome": [
 			{
 				"name": "useFilenamingConvention",
@@ -19616,11 +19621,6 @@
 				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/filename-case.md"
 			}
 		],
-		"flint": {
-			"name": "filenameCasing",
-			"plugin": "ts",
-			"status": "skipped"
-		},
 		"oxlint": [
 			{
 				"name": "unicorn/filename-case",
@@ -19629,6 +19629,12 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "finallyStatementSafety",
+			"plugin": "ts",
+			"preset": "logical",
+			"status": "implemented"
+		},
 		"biome": [
 			{
 				"name": "noUnsafeFinally",
@@ -19647,12 +19653,6 @@
 				"url": "https://eslint.org/docs/latest/rules/no-unsafe-finally"
 			}
 		],
-		"flint": {
-			"name": "finallyStatementSafety",
-			"plugin": "ts",
-			"preset": "logical",
-			"status": "implemented"
-		},
 		"oxlint": [
 			{
 				"name": "eslint/no-unsafe-finally",
@@ -19661,6 +19661,11 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "floatingPromises",
+			"plugin": "ts",
+			"preset": "logical"
+		},
 		"biome": [
 			{
 				"name": "noFloatingPromises",
@@ -19673,11 +19678,6 @@
 				"url": "https://typescript-eslint.io/rules/no-floating-promises"
 			}
 		],
-		"flint": {
-			"name": "floatingPromises",
-			"plugin": "ts",
-			"preset": "logical"
-		},
 		"oxlint": [
 			{
 				"name": "typescript/no-floating-promises",
@@ -19686,6 +19686,12 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "forDirections",
+			"plugin": "ts",
+			"preset": "stylistic",
+			"status": "implemented"
+		},
 		"biome": [
 			{
 				"name": "useValidForDirection",
@@ -19704,12 +19710,6 @@
 				"url": "https://eslint.org/docs/latest/rules/for-direction"
 			}
 		],
-		"flint": {
-			"name": "forDirections",
-			"plugin": "ts",
-			"preset": "stylistic",
-			"status": "implemented"
-		},
 		"oxlint": [
 			{
 				"name": "eslint/for-direction",
@@ -19718,6 +19718,12 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "forInArrays",
+			"plugin": "ts",
+			"preset": "logical",
+			"status": "implemented"
+		},
 		"biome": [
 			{
 				"name": "noForIn",
@@ -19730,12 +19736,6 @@
 				"url": "https://typescript-eslint.io/rules/no-for-in-array"
 			}
 		],
-		"flint": {
-			"name": "forInArrays",
-			"plugin": "ts",
-			"preset": "logical",
-			"status": "implemented"
-		},
 		"oxlint": [
 			{
 				"name": "typescript/no-for-in-array",
@@ -19744,6 +19744,11 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "forInGuards",
+			"plugin": "ts",
+			"status": "implemented"
+		},
 		"biome": [
 			{
 				"name": "useGuardForIn",
@@ -19762,11 +19767,6 @@
 				"url": "https://eslint.org/docs/latest/rules/guard-for-in"
 			}
 		],
-		"flint": {
-			"name": "forInGuards",
-			"plugin": "ts",
-			"status": "implemented"
-		},
 		"oxlint": [
 			{
 				"name": "eslint/guard-for-in",
@@ -19775,6 +19775,12 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "functionApplySpreads",
+			"plugin": "ts",
+			"preset": "stylistic",
+			"status": "implemented"
+		},
 		"biome": [
 			{
 				"name": "useSpread",
@@ -19787,12 +19793,6 @@
 				"url": "https://eslint.org/docs/latest/rules/prefer-spread"
 			}
 		],
-		"flint": {
-			"name": "functionApplySpreads",
-			"plugin": "ts",
-			"preset": "stylistic",
-			"status": "implemented"
-		},
 		"oxlint": [
 			{
 				"name": "eslint/prefer-spread",
@@ -19801,6 +19801,12 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "functionAssignments",
+			"plugin": "ts",
+			"preset": "javascript",
+			"status": "implemented"
+		},
 		"biome": [
 			{
 				"name": "noFunctionAssign",
@@ -19819,12 +19825,6 @@
 				"url": "https://eslint.org/docs/latest/rules/no-func-assign"
 			}
 		],
-		"flint": {
-			"name": "functionAssignments",
-			"plugin": "ts",
-			"preset": "javascript",
-			"status": "implemented"
-		},
 		"oxlint": [
 			{
 				"name": "eslint/no-func-assign",
@@ -19833,18 +19833,18 @@
 		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "no-useless-call",
-				"url": "https://eslint.org/docs/latest/rules/no-useless-call"
-			}
-		],
 		"flint": {
 			"name": "functionCurryingRedundancy",
 			"plugin": "ts",
 			"preset": "logical",
 			"status": "implemented"
 		},
+		"eslint": [
+			{
+				"name": "no-useless-call",
+				"url": "https://eslint.org/docs/latest/rules/no-useless-call"
+			}
+		],
 		"oxlint": [
 			{
 				"name": "eslint/no-useless-call",
@@ -19853,17 +19853,17 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "functionDeclarationStyles",
+			"plugin": "ts",
+			"status": "implemented"
+		},
 		"eslint": [
 			{
 				"name": "func-style",
 				"url": "https://eslint.org/docs/latest/rules/func-style"
 			}
 		],
-		"flint": {
-			"name": "functionDeclarationStyles",
-			"plugin": "ts",
-			"status": "implemented"
-		},
 		"oxlint": [
 			{
 				"name": "eslint/func-style",
@@ -19872,18 +19872,18 @@
 		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "unicorn/consistent-function-scoping",
-				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/consistent-function-scoping.md"
-			}
-		],
 		"flint": {
 			"name": "functionDefinitionScopeConsistency",
 			"plugin": "ts",
 			"preset": "stylistic",
 			"strictness": "strict"
 		},
+		"eslint": [
+			{
+				"name": "unicorn/consistent-function-scoping",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/consistent-function-scoping.md"
+			}
+		],
 		"oxlint": [
 			{
 				"name": "unicorn/consistent-function-scoping",
@@ -19892,17 +19892,17 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "functionNameMatches",
+			"plugin": "ts",
+			"status": "implemented"
+		},
 		"eslint": [
 			{
 				"name": "func-name-matching",
 				"url": "https://eslint.org/docs/latest/rules/func-name-matching"
 			}
 		],
-		"flint": {
-			"name": "functionNameMatches",
-			"plugin": "ts",
-			"status": "implemented"
-		},
 		"oxlint": [
 			{
 				"name": "eslint/func-name-matching",
@@ -19911,17 +19911,17 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "functionNames",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "func-names",
 				"url": "https://eslint.org/docs/latest/rules/func-names"
 			}
 		],
-		"flint": {
-			"name": "functionNames",
-			"plugin": "ts",
-			"status": "skipped"
-		},
 		"oxlint": [
 			{
 				"name": "eslint/func-names",
@@ -19930,6 +19930,12 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "functionNewCalls",
+			"plugin": "ts",
+			"preset": "logical",
+			"status": "implemented"
+		},
 		"biome": [
 			{
 				"name": "noImpliedEval",
@@ -19942,12 +19948,6 @@
 				"url": "https://eslint.org/docs/latest/rules/no-new-func"
 			}
 		],
-		"flint": {
-			"name": "functionNewCalls",
-			"plugin": "ts",
-			"preset": "logical",
-			"status": "implemented"
-		},
 		"oxlint": [
 			{
 				"name": "eslint/no-new-func",
@@ -19956,6 +19956,11 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "functionReturnTypes",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"biome": [
 			{
 				"name": "useExplicitReturnType",
@@ -19978,20 +19983,20 @@
 				"url": "https://typescript-eslint.io/rules/explicit-function-return-type"
 			}
 		],
-		"flint": {
-			"name": "functionReturnTypes",
-			"plugin": "ts",
-			"status": "skipped"
-		},
-		"notes": "Overly opinionated.",
 		"oxlint": [
 			{
 				"name": "typescript/explicit-function-return-type",
 				"url": "https://oxc.rs/docs/guide/usage/linter/rules/typescript/explicit-function-return-type.html"
 			}
-		]
+		],
+		"notes": "Overly opinionated."
 	},
 	{
+		"flint": {
+			"name": "functionTypeDeclarations",
+			"plugin": "ts",
+			"preset": "stylistic"
+		},
 		"biome": [
 			{
 				"name": "useShorthandFunctionType",
@@ -20004,11 +20009,6 @@
 				"url": "https://typescript-eslint.io/rules/prefer-function-type"
 			}
 		],
-		"flint": {
-			"name": "functionTypeDeclarations",
-			"plugin": "ts",
-			"preset": "stylistic"
-		},
 		"oxlint": [
 			{
 				"name": "typescript/prefer-function-type",
@@ -20017,6 +20017,12 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "generatorFunctionYields",
+			"plugin": "ts",
+			"preset": "logical",
+			"status": "implemented"
+		},
 		"biome": [
 			{
 				"name": "useYield",
@@ -20035,12 +20041,6 @@
 				"url": "https://eslint.org/docs/latest/rules/require-yield"
 			}
 		],
-		"flint": {
-			"name": "generatorFunctionYields",
-			"plugin": "ts",
-			"preset": "logical",
-			"status": "implemented"
-		},
 		"oxlint": [
 			{
 				"name": "eslint/require-yield",
@@ -20049,6 +20049,12 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "getterReturns",
+			"plugin": "ts",
+			"preset": "javascript",
+			"status": "implemented"
+		},
 		"biome": [
 			{
 				"name": "useGetterReturn",
@@ -20067,12 +20073,6 @@
 				"url": "https://eslint.org/docs/latest/rules/getter-return"
 			}
 		],
-		"flint": {
-			"name": "getterReturns",
-			"plugin": "ts",
-			"preset": "javascript",
-			"status": "implemented"
-		},
 		"oxlint": [
 			{
 				"name": "eslint/getter-return",
@@ -20081,6 +20081,12 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "globalAssignments",
+			"plugin": "ts",
+			"preset": "javascript",
+			"status": "implemented"
+		},
 		"biome": [
 			{
 				"name": "noGlobalAssign",
@@ -20099,12 +20105,6 @@
 				"url": "https://eslint.org/docs/latest/rules/no-global-assign"
 			}
 		],
-		"flint": {
-			"name": "globalAssignments",
-			"plugin": "ts",
-			"preset": "javascript",
-			"status": "implemented"
-		},
 		"oxlint": [
 			{
 				"name": "eslint/no-global-assign",
@@ -20113,6 +20113,12 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "globalObjectCalls",
+			"plugin": "ts",
+			"preset": "javascript",
+			"status": "implemented"
+		},
 		"biome": [
 			{
 				"name": "noGlobalObjectCalls",
@@ -20131,12 +20137,6 @@
 				"url": "https://eslint.org/docs/latest/rules/no-obj-calls"
 			}
 		],
-		"flint": {
-			"name": "globalObjectCalls",
-			"plugin": "ts",
-			"preset": "javascript",
-			"status": "implemented"
-		},
 		"oxlint": [
 			{
 				"name": "eslint/no-obj-calls",
@@ -20145,6 +20145,13 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "globalThisAliases",
+			"plugin": "ts",
+			"preset": "stylistic",
+			"status": "implemented",
+			"strictness": "strict"
+		},
 		"biome": [
 			{
 				"name": "useGlobalThis",
@@ -20167,13 +20174,6 @@
 				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prefer-global-this.md"
 			}
 		],
-		"flint": {
-			"name": "globalThisAliases",
-			"plugin": "ts",
-			"preset": "stylistic",
-			"status": "implemented",
-			"strictness": "strict"
-		},
 		"oxlint": [
 			{
 				"name": "unicorn/prefer-global-this",
@@ -20182,30 +20182,30 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "heritageClausesOrder",
+			"plugin": "ts",
+			"preset": "sorting"
+		},
 		"eslint": [
 			{
 				"name": "perfectionist/sort-heritage-clauses",
 				"url": "https://perfectionist.dev/rules/sort-heritage-clauses"
 			}
-		],
-		"flint": {
-			"name": "heritageClausesOrder",
-			"plugin": "ts",
-			"preset": "sorting"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "hexEscapes",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "unicorn/no-hex-escape",
 				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-hex-escape.md"
 			}
 		],
-		"flint": {
-			"name": "hexEscapes",
-			"plugin": "ts",
-			"status": "skipped"
-		},
 		"oxlint": [
 			{
 				"name": "unicorn/no-hex-escape",
@@ -20214,17 +20214,17 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "identifierMatches",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "id-match",
 				"url": "https://eslint.org/docs/latest/rules/id-match"
 			}
 		],
-		"flint": {
-			"name": "identifierMatches",
-			"plugin": "ts",
-			"status": "skipped"
-		},
 		"oxlint": [
 			{
 				"name": "eslint/id-match",
@@ -20233,17 +20233,17 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "iifeReadability",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "unicorn/no-unreadable-iife",
 				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-unreadable-iife.md"
 			}
 		],
-		"flint": {
-			"name": "iifeReadability",
-			"plugin": "ts",
-			"status": "skipped"
-		},
 		"oxlint": [
 			{
 				"name": "unicorn/no-unreadable-iife",
@@ -20252,17 +20252,17 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "immediateMutations",
+			"plugin": "ts",
+			"preset": "stylistic"
+		},
 		"eslint": [
 			{
 				"name": "unicorn/no-immediate-mutation",
 				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v64.0.0/docs/rules/no-immediate-mutation.md"
 			}
 		],
-		"flint": {
-			"name": "immediateMutations",
-			"plugin": "ts",
-			"preset": "stylistic"
-		},
 		"oxlint": [
 			{
 				"name": "unicorn/no-immediate-mutation",
@@ -20271,6 +20271,11 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "implicitCoercions",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"biome": [
 			{
 				"name": "noImplicitCoercions",
@@ -20283,11 +20288,6 @@
 				"url": "https://eslint.org/docs/latest/rules/no-implicit-coercion"
 			}
 		],
-		"flint": {
-			"name": "implicitCoercions",
-			"plugin": "ts",
-			"status": "skipped"
-		},
 		"oxlint": [
 			{
 				"name": "eslint/no-implicit-coercion",
@@ -20296,6 +20296,12 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "impliedEvals",
+			"plugin": "ts",
+			"preset": "logical",
+			"status": "implemented"
+		},
 		"biome": [
 			{
 				"name": "noImpliedEval",
@@ -20312,12 +20318,6 @@
 				"url": "https://typescript-eslint.io/rules/no-implied-eval"
 			}
 		],
-		"flint": {
-			"name": "impliedEvals",
-			"plugin": "ts",
-			"preset": "logical",
-			"status": "implemented"
-		},
 		"oxlint": [
 			{
 				"name": "eslint/no-implied-eval",
@@ -20330,40 +20330,45 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "importAbsolutePaths",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "import/no-absolute-path",
 				"url": "https://github.com/import-js/eslint-plugin-import/blob/HEAD/docs/rules/no-absolute-path.md"
 			}
 		],
-		"flint": {
-			"name": "importAbsolutePaths",
-			"plugin": "ts",
-			"status": "skipped"
-		},
-		"notes": "Overly opinionated.",
 		"oxlint": [
 			{
 				"name": "import/no-absolute-path",
 				"url": "https://oxc.rs/docs/guide/usage/linter/rules/import/no-absolute-path.html"
 			}
-		]
+		],
+		"notes": "Overly opinionated."
 	},
 	{
+		"flint": {
+			"name": "importAssertions",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"deno": [
 			{
 				"name": "no-import-assertions",
 				"url": "https://docs.deno.com/lint/rules/no-import-assertions"
 			}
 		],
-		"flint": {
-			"name": "importAssertions",
-			"plugin": "ts",
-			"status": "skipped"
-		},
 		"notes": "Generally handled by parsers."
 	},
 	{
+		"flint": {
+			"name": "importAssignments",
+			"plugin": "ts",
+			"preset": "javascript"
+		},
 		"biome": [
 			{
 				"name": "noImportAssign",
@@ -20382,11 +20387,6 @@
 				"url": "https://eslint.org/docs/latest/rules/no-import-assign"
 			}
 		],
-		"flint": {
-			"name": "importAssignments",
-			"plugin": "ts",
-			"preset": "javascript"
-		},
 		"oxlint": [
 			{
 				"name": "eslint/no-import-assign",
@@ -20395,18 +20395,23 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "importAttributesOrder",
+			"plugin": "ts"
+		},
 		"eslint": [
 			{
 				"name": "perfectionist/sort-import-attributes",
 				"url": "https://perfectionist.dev/rules/sort-import-attributes"
 			}
-		],
-		"flint": {
-			"name": "importAttributesOrder",
-			"plugin": "ts"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "importCycles",
+			"plugin": "ts",
+			"preset": "stylistic"
+		},
 		"biome": [
 			{
 				"name": "noImportCycles",
@@ -20419,11 +20424,6 @@
 				"url": "https://github.com/import-js/eslint-plugin-import/blob/HEAD/docs/rules/no-cycle.md"
 			}
 		],
-		"flint": {
-			"name": "importCycles",
-			"plugin": "ts",
-			"preset": "stylistic"
-		},
 		"oxlint": [
 			{
 				"name": "import/no-cycle",
@@ -20432,51 +20432,56 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "importDeclarationsFirst",
+			"plugin": "ts"
+		},
 		"eslint": [
 			{
 				"name": "import/imports-first",
 				"url": "https://github.com/import-js/eslint-plugin-import/blob/7b25c1cb95ee18acc1531002fd343e1e6031f9ed/docs/rules/imports-first.md"
 			}
 		],
-		"flint": {
-			"name": "importDeclarationsFirst",
-			"plugin": "ts"
-		},
 		"notes": "Deprecated. Superseded by importFirst."
 	},
 	{
+		"flint": {
+			"name": "importDeclarationsOrder",
+			"plugin": "ts"
+		},
 		"eslint": [
 			{
 				"name": "import/order",
 				"url": "https://github.com/import-js/eslint-plugin-import/blob/v2.32.0/docs/rules/order.md"
 			}
-		],
-		"flint": {
-			"name": "importDeclarationsOrder",
-			"plugin": "ts"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "importDefaults",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "import/default",
 				"url": "https://github.com/import-js/eslint-plugin-import/blob/HEAD/docs/rules/default.md"
 			}
 		],
-		"flint": {
-			"name": "importDefaults",
-			"plugin": "ts",
-			"status": "skipped"
-		},
-		"notes": "Handled by TypeScript.",
 		"oxlint": [
 			{
 				"name": "import/default",
 				"url": "https://oxc.rs/docs/guide/usage/linter/rules/import/default.html"
 			}
-		]
+		],
+		"notes": "Handled by TypeScript."
 	},
 	{
+		"flint": {
+			"name": "importDuplicates",
+			"plugin": "ts",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "no-duplicate-imports",
@@ -20487,11 +20492,6 @@
 				"url": "https://github.com/import-js/eslint-plugin-import/blob/HEAD/docs/rules/no-duplicates.md"
 			}
 		],
-		"flint": {
-			"name": "importDuplicates",
-			"plugin": "ts",
-			"preset": "logical"
-		},
 		"oxlint": [
 			{
 				"name": "import/no-duplicates",
@@ -20504,18 +20504,18 @@
 		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "import/no-empty-named-blocks",
-				"url": "https://github.com/import-js/eslint-plugin-import/blob/HEAD/docs/rules/no-empty-named-blocks.md"
-			}
-		],
 		"flint": {
 			"name": "importEmptyBlocks",
 			"plugin": "ts",
 			"preset": "logical",
 			"status": "implemented"
 		},
+		"eslint": [
+			{
+				"name": "import/no-empty-named-blocks",
+				"url": "https://github.com/import-js/eslint-plugin-import/blob/HEAD/docs/rules/no-empty-named-blocks.md"
+			}
+		],
 		"oxlint": [
 			{
 				"name": "import/no-empty-named-blocks",
@@ -20524,18 +20524,23 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "importExtensions",
+			"plugin": "ts"
+		},
 		"eslint": [
 			{
 				"name": "import/extensions",
 				"url": "https://github.com/import-js/eslint-plugin-import/blob/v2.32.0/docs/rules/extensions.md"
 			}
-		],
-		"flint": {
-			"name": "importExtensions",
-			"plugin": "ts"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "importExtraneousDependencies",
+			"plugin": "ts",
+			"preset": "none"
+		},
 		"biome": [
 			{
 				"name": "noUndeclaredDependencies",
@@ -20552,14 +20557,14 @@
 				"url": "https://github.com/eslint-community/eslint-plugin-n/blob/HEAD/docs/rules/no-extraneous-import.md"
 			}
 		],
-		"flint": {
-			"name": "importExtraneousDependencies",
-			"plugin": "ts",
-			"preset": "none"
-		},
 		"notes": "Superseded by Knip."
 	},
 	{
+		"flint": {
+			"name": "importFirst",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"biome": [
 			{
 				"name": "useImportsFirst",
@@ -20572,40 +20577,40 @@
 				"url": "https://github.com/import-js/eslint-plugin-import/blob/HEAD/docs/rules/first.md"
 			}
 		],
-		"flint": {
-			"name": "importFirst",
-			"plugin": "ts",
-			"status": "skipped"
-		},
-		"notes": "Overly opinionated.",
 		"oxlint": [
 			{
 				"name": "import/first",
 				"url": "https://oxc.rs/docs/guide/usage/linter/rules/import/first.html"
 			}
-		]
+		],
+		"notes": "Overly opinionated."
 	},
 	{
+		"flint": {
+			"name": "importMaximumDependencies",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "import/max-dependencies",
 				"url": "https://github.com/import-js/eslint-plugin-import/blob/HEAD/docs/rules/max-dependencies.md"
 			}
 		],
-		"flint": {
-			"name": "importMaximumDependencies",
-			"plugin": "ts",
-			"status": "skipped"
-		},
-		"notes": "Overly opinionated.",
 		"oxlint": [
 			{
 				"name": "import/max-dependencies",
 				"url": "https://oxc.rs/docs/guide/usage/linter/rules/import/max-dependencies.html"
 			}
-		]
+		],
+		"notes": "Overly opinionated."
 	},
 	{
+		"flint": {
+			"name": "importNameMatches",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"biome": [
 			{
 				"name": "noUnresolvedImports",
@@ -20618,71 +20623,66 @@
 				"url": "https://github.com/import-js/eslint-plugin-import/blob/HEAD/docs/rules/named.md"
 			}
 		],
-		"flint": {
-			"name": "importNameMatches",
-			"plugin": "ts",
-			"status": "skipped"
-		},
-		"notes": "Handled by TypeScript.",
 		"oxlint": [
 			{
 				"name": "import/named",
 				"url": "https://oxc.rs/docs/guide/usage/linter/rules/import/named.html"
 			}
-		]
+		],
+		"notes": "Handled by TypeScript."
 	},
 	{
+		"flint": {
+			"name": "importNamespaceProperties",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "import/namespace",
 				"url": "https://github.com/import-js/eslint-plugin-import/blob/HEAD/docs/rules/namespace.md"
 			}
 		],
-		"flint": {
-			"name": "importNamespaceProperties",
-			"plugin": "ts",
-			"status": "skipped"
-		},
-		"notes": "Handled by TypeScript.",
 		"oxlint": [
 			{
 				"name": "import/namespace",
 				"url": "https://oxc.rs/docs/guide/usage/linter/rules/import/namespace.html"
 			}
-		]
+		],
+		"notes": "Handled by TypeScript."
 	},
 	{
+		"flint": {
+			"name": "importNamespaces",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "import/no-namespace",
 				"url": "https://github.com/import-js/eslint-plugin-import/blob/HEAD/docs/rules/no-namespace.md"
 			}
 		],
-		"flint": {
-			"name": "importNamespaces",
-			"plugin": "ts",
-			"status": "skipped"
-		},
-		"notes": "Overly opinionated.",
 		"oxlint": [
 			{
 				"name": "import/no-namespace",
 				"url": "https://oxc.rs/docs/guide/usage/linter/rules/import/no-namespace.html"
 			}
-		]
+		],
+		"notes": "Overly opinionated."
 	},
 	{
+		"flint": {
+			"name": "importSelf",
+			"plugin": "ts",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "import/no-self-import",
 				"url": "https://github.com/import-js/eslint-plugin-import/blob/HEAD/docs/rules/no-self-import.md"
 			}
 		],
-		"flint": {
-			"name": "importSelf",
-			"plugin": "ts",
-			"preset": "logical"
-		},
 		"oxlint": [
 			{
 				"name": "import/no-self-import",
@@ -20691,41 +20691,41 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "importsOrder",
+			"plugin": "ts"
+		},
 		"eslint": [
 			{
 				"name": "perfectionist/sort-imports",
 				"url": "https://perfectionist.dev/rules/sort-imports"
 			}
-		],
-		"flint": {
-			"name": "importsOrder",
-			"plugin": "ts"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "importSpecifiersOrder",
+			"plugin": "ts"
+		},
 		"eslint": [
 			{
 				"name": "perfectionist/sort-named-imports",
 				"url": "https://perfectionist.dev/rules/sort-named-imports"
 			}
-		],
-		"flint": {
-			"name": "importSpecifiersOrder",
-			"plugin": "ts"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "importsSorting",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "sort-imports",
 				"url": "https://eslint.org/docs/latest/rules/sort-imports"
 			}
 		],
-		"flint": {
-			"name": "importsSorting",
-			"plugin": "ts",
-			"status": "skipped"
-		},
 		"oxlint": [
 			{
 				"name": "eslint/sort-imports",
@@ -20734,38 +20734,38 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "importTrailingNewlines",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "import/newline-after-import",
 				"url": "https://github.com/import-js/eslint-plugin-import/blob/v2.32.0/docs/rules/newline-after-import.md"
 			}
 		],
-		"flint": {
-			"name": "importTrailingNewlines",
-			"plugin": "ts",
-			"status": "skipped"
-		},
-		"notes": "Formatting rule.",
 		"oxlint": [
 			{
 				"name": "import/newline-after-import",
 				"url": "https://oxc.rs/docs/guide/usage/linter/rules/import/newline-after-import.html"
 			}
-		]
+		],
+		"notes": "Formatting rule."
 	},
 	{
-		"eslint": [
-			{
-				"name": "@typescript-eslint/no-import-type-side-effects",
-				"url": "https://typescript-eslint.io/rules/no-import-type-side-effects"
-			}
-		],
 		"flint": {
 			"name": "importTypeSideEffects",
 			"plugin": "ts",
 			"preset": "logical",
 			"status": "implemented"
 		},
+		"eslint": [
+			{
+				"name": "@typescript-eslint/no-import-type-side-effects",
+				"url": "https://typescript-eslint.io/rules/no-import-type-side-effects"
+			}
+		],
 		"oxlint": [
 			{
 				"name": "typescript/no-import-type-side-effects",
@@ -20774,31 +20774,31 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "importUnnecessaryPathSegments",
+			"plugin": "ts",
+			"preset": "stylistic"
+		},
 		"eslint": [
 			{
 				"name": "import/no-useless-path-segments",
 				"url": "https://github.com/import-js/eslint-plugin-import/blob/HEAD/docs/rules/no-useless-path-segments.md"
 			}
-		],
-		"flint": {
-			"name": "importUnnecessaryPathSegments",
-			"plugin": "ts",
-			"preset": "stylistic"
-		}
+		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "@typescript-eslint/consistent-indexed-object-style",
-				"url": "https://typescript-eslint.io/rules/consistent-indexed-object-style"
-			}
-		],
 		"flint": {
 			"name": "indexedObjectTypes",
 			"plugin": "ts",
 			"preset": "stylistic",
 			"status": "implemented"
 		},
+		"eslint": [
+			{
+				"name": "@typescript-eslint/consistent-indexed-object-style",
+				"url": "https://typescript-eslint.io/rules/consistent-indexed-object-style"
+			}
+		],
 		"oxlint": [
 			{
 				"name": "typescript/consistent-indexed-object-style",
@@ -20807,17 +20807,17 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "inlineComments",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "no-inline-comments",
 				"url": "https://eslint.org/docs/latest/rules/no-inline-comments"
 			}
 		],
-		"flint": {
-			"name": "inlineComments",
-			"plugin": "ts",
-			"status": "skipped"
-		},
 		"oxlint": [
 			{
 				"name": "eslint/no-inline-comments",
@@ -20826,6 +20826,11 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "innerDeclarations",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"biome": [
 			{
 				"name": "noInnerDeclarations",
@@ -20844,11 +20849,6 @@
 				"url": "https://eslint.org/docs/latest/rules/no-inner-declarations"
 			}
 		],
-		"flint": {
-			"name": "innerDeclarations",
-			"plugin": "ts",
-			"status": "skipped"
-		},
 		"oxlint": [
 			{
 				"name": "eslint/no-inner-declarations",
@@ -20857,6 +20857,12 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "instanceOfArrays",
+			"plugin": "ts",
+			"preset": "logical",
+			"status": "implemented"
+		},
 		"biome": [
 			{
 				"name": "useIsArray",
@@ -20869,13 +20875,6 @@
 				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-instanceof-builtins.md"
 			}
 		],
-		"flint": {
-			"name": "instanceOfArrays",
-			"plugin": "ts",
-			"preset": "logical",
-			"status": "implemented"
-		},
-		"notes": "Only for built-ins with a static .is* (Array).",
 		"oxlint": [
 			{
 				"name": "unicorn/no-instanceof-array",
@@ -20885,47 +20884,53 @@
 				"name": "unicorn/no-instanceof-builtins",
 				"url": "https://oxc.rs/docs/guide/usage/linter/rules/unicorn/no-instanceof-builtins.html"
 			}
-		]
+		],
+		"notes": "Only for built-ins with a static .is* (Array)."
 	},
 	{
+		"flint": {
+			"name": "interfacesOrder",
+			"plugin": "ts",
+			"preset": "sorting"
+		},
 		"eslint": [
 			{
 				"name": "perfectionist/sort-interfaces",
 				"url": "https://perfectionist.dev/rules/sort-interfaces"
 			}
-		],
-		"flint": {
-			"name": "interfacesOrder",
-			"plugin": "ts",
-			"preset": "sorting"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "internalModules",
+			"plugin": "ts"
+		},
 		"eslint": [
 			{
 				"name": "import/no-internal-modules",
 				"url": "https://github.com/import-js/eslint-plugin-import/blob/v2.32.0/docs/rules/no-internal-modules.md"
 			}
-		],
-		"flint": {
-			"name": "internalModules",
-			"plugin": "ts"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "intersectionTypesOrder",
+			"plugin": "ts",
+			"preset": "sorting"
+		},
 		"eslint": [
 			{
 				"name": "perfectionist/sort-intersection-types",
 				"url": "https://perfectionist.dev/rules/sort-intersection-types"
 			}
-		],
-		"flint": {
-			"name": "intersectionTypesOrder",
-			"plugin": "ts",
-			"preset": "sorting"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "invalidThis",
+			"plugin": "ts",
+			"preset": "javascript"
+		},
 		"eslint": [
 			{
 				"name": "no-invalid-this",
@@ -20935,14 +20940,15 @@
 				"name": "@typescript-eslint/no-invalid-this",
 				"url": "https://typescript-eslint.io/rules/no-invalid-this"
 			}
-		],
-		"flint": {
-			"name": "invalidThis",
-			"plugin": "ts",
-			"preset": "javascript"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "invalidVoidTypes",
+			"plugin": "ts",
+			"preset": "logical",
+			"strictness": "strict"
+		},
 		"biome": [
 			{
 				"name": "noConfusingVoidType",
@@ -20955,12 +20961,6 @@
 				"url": "https://typescript-eslint.io/rules/no-invalid-void-type"
 			}
 		],
-		"flint": {
-			"name": "invalidVoidTypes",
-			"plugin": "ts",
-			"preset": "logical",
-			"strictness": "strict"
-		},
 		"oxlint": [
 			{
 				"name": "typescript/no-invalid-void-type",
@@ -20969,6 +20969,12 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "irregularWhitespaces",
+			"plugin": "ts",
+			"preset": "logical",
+			"status": "implemented"
+		},
 		"biome": [
 			{
 				"name": "noIrregularWhitespace",
@@ -20987,12 +20993,6 @@
 				"url": "https://eslint.org/docs/latest/rules/no-irregular-whitespace"
 			}
 		],
-		"flint": {
-			"name": "irregularWhitespaces",
-			"plugin": "ts",
-			"preset": "logical",
-			"status": "implemented"
-		},
 		"oxlint": [
 			{
 				"name": "eslint/no-irregular-whitespace",
@@ -21001,6 +21001,12 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "isNaNComparisons",
+			"plugin": "ts",
+			"preset": "logical",
+			"status": "implemented"
+		},
 		"biome": [
 			{
 				"name": "useIsNan",
@@ -21019,12 +21025,6 @@
 				"url": "https://eslint.org/docs/latest/rules/use-isnan"
 			}
 		],
-		"flint": {
-			"name": "isNaNComparisons",
-			"plugin": "ts",
-			"preset": "logical",
-			"status": "implemented"
-		},
 		"oxlint": [
 			{
 				"name": "eslint/use-isnan",
@@ -21033,30 +21033,30 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "isolatedFunctions",
+			"plugin": "ts",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "unicorn/isolated-functions",
 				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v64.0.0/docs/rules/isolated-functions.md"
 			}
-		],
-		"flint": {
-			"name": "isolatedFunctions",
-			"plugin": "ts",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "iteratorMethodFunctionReferences",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "unicorn/no-array-callback-reference",
 				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-array-callback-reference.md"
 			}
 		],
-		"flint": {
-			"name": "iteratorMethodFunctionReferences",
-			"plugin": "ts",
-			"status": "skipped"
-		},
 		"oxlint": [
 			{
 				"name": "unicorn/no-array-callback-reference",
@@ -21065,17 +21065,17 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "jsdocAccessTags",
+			"plugin": "ts",
+			"preset": "stylistic"
+		},
 		"eslint": [
 			{
 				"name": "jsdoc/check-access",
 				"url": "https://github.com/gajus/eslint-plugin-jsdoc/blob/HEAD/docs/rules/check-access.md"
 			}
 		],
-		"flint": {
-			"name": "jsdocAccessTags",
-			"plugin": "ts",
-			"preset": "stylistic"
-		},
 		"oxlint": [
 			{
 				"name": "jsdoc/check-access",
@@ -21084,33 +21084,39 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "jsdocAlignment",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "jsdoc/check-alignment",
 				"url": "https://github.com/gajus/eslint-plugin-jsdoc/blob/HEAD/docs/rules/check-alignment.md"
 			}
 		],
-		"flint": {
-			"name": "jsdocAlignment",
-			"plugin": "ts",
-			"status": "skipped"
-		},
 		"notes": "I intend to write a Prettier plugin."
 	},
 	{
+		"flint": {
+			"name": "jsdocAnyTypes",
+			"plugin": "ts",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "jsdoc/reject-any-type",
 				"url": "https://github.com/gajus/eslint-plugin-jsdoc/blob/main/docs/rules/reject-any-type.md#repos-sticky-header"
 			}
-		],
-		"flint": {
-			"name": "jsdocAnyTypes",
-			"plugin": "ts",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "jsdocAsterisks",
+			"plugin": "ts",
+			"preset": "stylistic",
+			"strictness": "strict"
+		},
 		"biome": [
 			{
 				"name": "useSingleJsDocAsterisk",
@@ -21126,66 +21132,60 @@
 				"name": "jsdoc/require-asterisk-prefix",
 				"url": "https://github.com/gajus/eslint-plugin-jsdoc/blob/HEAD/docs/rules/require-asterisk-prefix.md"
 			}
-		],
-		"flint": {
-			"name": "jsdocAsterisks",
-			"plugin": "ts",
-			"preset": "stylistic",
-			"strictness": "strict"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "jsdocBlankBlockDescriptions",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "jsdoc/no-blank-block-descriptions",
 				"url": "https://github.com/gajus/eslint-plugin-jsdoc/blob/HEAD/docs/rules/no-blank-block-descriptions.md"
 			}
-		],
-		"flint": {
-			"name": "jsdocBlankBlockDescriptions",
-			"plugin": "ts",
-			"status": "skipped"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "jsdocBlockPaddingLines",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "jsdoc/lines-before-block",
 				"url": "https://github.com/gajus/eslint-plugin-jsdoc/blob/main/docs/rules/lines-before-block.md#repos-sticky-header"
 			}
 		],
-		"flint": {
-			"name": "jsdocBlockPaddingLines",
-			"plugin": "ts",
-			"status": "skipped"
-		},
 		"notes": "Formatting rule."
 	},
 	{
+		"flint": {
+			"name": "jsdocConvertToJSDocComments",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "jsdoc/convert-to-jsdoc-comments",
 				"url": "https://github.com/gajus/eslint-plugin-jsdoc/blob/HEAD/docs/rules/convert-to-jsdoc-comments.md"
 			}
-		],
-		"flint": {
-			"name": "jsdocConvertToJSDocComments",
-			"plugin": "ts",
-			"status": "skipped"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "jsdocDefaults",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "jsdoc/no-defaults",
 				"url": "https://github.com/gajus/eslint-plugin-jsdoc/blob/HEAD/docs/rules/no-defaults.md"
 			}
 		],
-		"flint": {
-			"name": "jsdocDefaults",
-			"plugin": "ts",
-			"status": "skipped"
-		},
 		"oxlint": [
 			{
 				"name": "jsdoc/no-defaults",
@@ -21194,69 +21194,69 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "jsdocDefinedTypes",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "jsdoc/no-undefined-types",
 				"url": "https://github.com/gajus/eslint-plugin-jsdoc/blob/HEAD/docs/rules/no-undefined-types.md"
 			}
-		],
-		"flint": {
-			"name": "jsdocDefinedTypes",
-			"plugin": "ts",
-			"status": "skipped"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "jsdocDescriptionCompleteSentences",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "jsdoc/require-description-complete-sentence",
 				"url": "https://github.com/gajus/eslint-plugin-jsdoc/blob/HEAD/docs/rules/require-description-complete-sentence.md"
 			}
-		],
-		"flint": {
-			"name": "jsdocDescriptionCompleteSentences",
-			"plugin": "ts",
-			"status": "skipped"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "jsdocDescriptions",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "jsdoc/require-description",
 				"url": "https://github.com/gajus/eslint-plugin-jsdoc/blob/HEAD/docs/rules/require-description.md"
 			}
-		],
-		"flint": {
-			"name": "jsdocDescriptions",
-			"plugin": "ts",
-			"status": "skipped"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "jsdocEmptyBlocks",
+			"plugin": "ts",
+			"preset": "stylistic"
+		},
 		"eslint": [
 			{
 				"name": "jsdoc/no-blank-blocks",
 				"url": "https://github.com/gajus/eslint-plugin-jsdoc/blob/HEAD/docs/rules/no-blank-blocks.md"
 			}
-		],
-		"flint": {
-			"name": "jsdocEmptyBlocks",
-			"plugin": "ts",
-			"preset": "stylistic"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "jsdocEmptyTags",
+			"plugin": "ts",
+			"preset": "stylistic"
+		},
 		"eslint": [
 			{
 				"name": "jsdoc/empty-tags",
 				"url": "https://github.com/gajus/eslint-plugin-jsdoc/blob/HEAD/docs/rules/empty-tags.md"
 			}
 		],
-		"flint": {
-			"name": "jsdocEmptyTags",
-			"plugin": "ts",
-			"preset": "stylistic"
-		},
 		"oxlint": [
 			{
 				"name": "jsdoc/empty-tags",
@@ -21265,69 +21265,69 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "jsdocExampleCodeValidity",
+			"plugin": "ts",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "jsdoc/check-examples",
 				"url": "https://github.com/gajus/eslint-plugin-jsdoc/blob/main/docs/rules/check-examples.md#repos-sticky-header"
 			}
-		],
-		"flint": {
-			"name": "jsdocExampleCodeValidity",
-			"plugin": "ts",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "jsdocExamples",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "jsdoc/require-example",
 				"url": "https://github.com/gajus/eslint-plugin-jsdoc/blob/HEAD/docs/rules/require-example.md"
 			}
-		],
-		"flint": {
-			"name": "jsdocExamples",
-			"plugin": "ts",
-			"status": "skipped"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "jsdocFileOverviews",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "jsdoc/require-file-overview",
 				"url": "https://github.com/gajus/eslint-plugin-jsdoc/blob/HEAD/docs/rules/require-file-overview.md"
 			}
-		],
-		"flint": {
-			"name": "jsdocFileOverviews",
-			"plugin": "ts",
-			"status": "skipped"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "jsdocFunctionTypes",
+			"plugin": "ts",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "jsdoc/reject-function-type",
 				"url": "https://github.com/gajus/eslint-plugin-jsdoc/blob/main/docs/rules/reject-function-type.md#repos-sticky-header"
 			}
-		],
-		"flint": {
-			"name": "jsdocFunctionTypes",
-			"plugin": "ts",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "jsdocImplementsTags",
+			"plugin": "ts",
+			"preset": "stylistic"
+		},
 		"eslint": [
 			{
 				"name": "jsdoc/implements-on-classes",
 				"url": "https://github.com/gajus/eslint-plugin-jsdoc/blob/HEAD/docs/rules/implements-on-classes.md"
 			}
 		],
-		"flint": {
-			"name": "jsdocImplementsTags",
-			"plugin": "ts",
-			"preset": "stylistic"
-		},
 		"oxlint": [
 			{
 				"name": "jsdoc/implements-on-classes",
@@ -21336,205 +21336,205 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "jsdocImportsAsDependencies",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "jsdoc/imports-as-dependencies",
 				"url": "https://github.com/gajus/eslint-plugin-jsdoc/blob/HEAD/docs/rules/imports-as-dependencies.md"
 			}
-		],
-		"flint": {
-			"name": "jsdocImportsAsDependencies",
-			"plugin": "ts",
-			"status": "skipped"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "jsdocImportTags",
+			"plugin": "ts",
+			"preset": "stylistic"
+		},
 		"eslint": [
 			{
 				"name": "jsdoc/prefer-import-tag",
 				"url": "https://github.com/gajus/eslint-plugin-jsdoc/blob/main/docs/rules/prefer-import-tag.md#repos-sticky-header"
 			}
-		],
-		"flint": {
-			"name": "jsdocImportTags",
-			"plugin": "ts",
-			"preset": "stylistic"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "jsdocIndentation",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "jsdoc/check-indentation",
 				"url": "https://github.com/gajus/eslint-plugin-jsdoc/blob/HEAD/docs/rules/check-indentation.md"
 			}
 		],
-		"flint": {
-			"name": "jsdocIndentation",
-			"plugin": "ts",
-			"status": "skipped"
-		},
 		"notes": "I intend to write a Prettier plugin."
 	},
 	{
-		"eslint": [
-			{
-				"name": "jsdoc/informative-docs",
-				"url": "https://github.com/gajus/eslint-plugin-jsdoc/blob/HEAD/docs/rules/informative-docs.md"
-			}
-		],
 		"flint": {
 			"name": "jsdocInformativeDocs",
 			"plugin": "ts",
 			"preset": "stylistic",
 			"strictness": "strict"
-		}
+		},
+		"eslint": [
+			{
+				"name": "jsdoc/informative-docs",
+				"url": "https://github.com/gajus/eslint-plugin-jsdoc/blob/HEAD/docs/rules/informative-docs.md"
+			}
+		]
 	},
 	{
+		"flint": {
+			"name": "jsdocInlineTagEscapes",
+			"plugin": "ts",
+			"preset": "stylistic"
+		},
 		"eslint": [
 			{
 				"name": "jsdoc/escape-inline-tags",
 				"url": "https://github.com/gajus/eslint-plugin-jsdoc/blob/main/docs/rules/escape-inline-tags.md#repos-sticky-header"
 			}
-		],
-		"flint": {
-			"name": "jsdocInlineTagEscapes",
-			"plugin": "ts",
-			"preset": "stylistic"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "jsdocLineAlignment",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "jsdoc/check-line-alignment",
 				"url": "https://github.com/gajus/eslint-plugin-jsdoc/blob/HEAD/docs/rules/check-line-alignment.md"
 			}
 		],
-		"flint": {
-			"name": "jsdocLineAlignment",
-			"plugin": "ts",
-			"status": "skipped"
-		},
 		"notes": "I intend to write a Prettier plugin."
 	},
 	{
+		"flint": {
+			"name": "jsdocMatchDescriptions",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "jsdoc/match-description",
 				"url": "https://github.com/gajus/eslint-plugin-jsdoc/blob/HEAD/docs/rules/match-description.md"
 			}
-		],
-		"flint": {
-			"name": "jsdocMatchDescriptions",
-			"plugin": "ts",
-			"status": "skipped"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "jsdocMatchNames",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "jsdoc/match-name",
 				"url": "https://github.com/gajus/eslint-plugin-jsdoc/blob/main/docs/rules/match-name.md#repos-sticky-header"
 			}
-		],
-		"flint": {
-			"name": "jsdocMatchNames",
-			"plugin": "ts",
-			"status": "skipped"
-		}
+		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "jsdoc/no-bad-blocks",
-				"url": "https://github.com/gajus/eslint-plugin-jsdoc/blob/HEAD/docs/rules/no-bad-blocks.md"
-			}
-		],
 		"flint": {
 			"name": "jsdocMisleadingBlocks",
 			"plugin": "ts",
 			"preset": "stylistic",
 			"strictness": "strict"
-		}
+		},
+		"eslint": [
+			{
+				"name": "jsdoc/no-bad-blocks",
+				"url": "https://github.com/gajus/eslint-plugin-jsdoc/blob/HEAD/docs/rules/no-bad-blocks.md"
+			}
+		]
 	},
 	{
+		"flint": {
+			"name": "jsdocMissingSyntax",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "jsdoc/no-missing-syntax",
 				"url": "https://github.com/gajus/eslint-plugin-jsdoc/blob/HEAD/docs/rules/no-missing-syntax.md"
 			}
-		],
-		"flint": {
-			"name": "jsdocMissingSyntax",
-			"plugin": "ts",
-			"status": "skipped"
-		}
+		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "jsdoc/multiline-blocks",
-				"url": "https://github.com/gajus/eslint-plugin-jsdoc/blob/HEAD/docs/rules/multiline-blocks.md"
-			}
-		],
 		"flint": {
 			"name": "jsdocMultilineBlocks",
 			"plugin": "ts",
 			"preset": "stylistic",
 			"strictness": "strict"
-		}
+		},
+		"eslint": [
+			{
+				"name": "jsdoc/multiline-blocks",
+				"url": "https://github.com/gajus/eslint-plugin-jsdoc/blob/HEAD/docs/rules/multiline-blocks.md"
+			}
+		]
 	},
 	{
+		"flint": {
+			"name": "jsdocNextDescriptions",
+			"plugin": "ts",
+			"preset": "stylistic"
+		},
 		"eslint": [
 			{
 				"name": "jsdoc/require-next-description",
 				"url": "https://github.com/gajus/eslint-plugin-jsdoc/blob/main/docs/rules/require-next-description.md#repos-sticky-header"
 			}
-		],
-		"flint": {
-			"name": "jsdocNextDescriptions",
-			"plugin": "ts",
-			"preset": "stylistic"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "jsdocNextTypes",
+			"plugin": "ts",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "jsdoc/require-next-type",
 				"url": "https://github.com/gajus/eslint-plugin-jsdoc/blob/main/docs/rules/require-next-type.md#repos-sticky-header"
 			}
-		],
-		"flint": {
-			"name": "jsdocNextTypes",
-			"plugin": "ts",
-			"preset": "logical"
-		}
+		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "jsdoc/require-hyphen-before-param-description",
-				"url": "https://github.com/gajus/eslint-plugin-jsdoc/blob/HEAD/docs/rules/require-hyphen-before-param-description.md"
-			}
-		],
 		"flint": {
 			"name": "jsdocParameterDescriptionHyphens",
 			"plugin": "ts",
 			"preset": "stylistic",
 			"strictness": "strict"
-		}
+		},
+		"eslint": [
+			{
+				"name": "jsdoc/require-hyphen-before-param-description",
+				"url": "https://github.com/gajus/eslint-plugin-jsdoc/blob/HEAD/docs/rules/require-hyphen-before-param-description.md"
+			}
+		]
 	},
 	{
+		"flint": {
+			"name": "jsdocParameterDescriptions",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "jsdoc/require-param-description",
 				"url": "https://github.com/gajus/eslint-plugin-jsdoc/blob/HEAD/docs/rules/require-param-description.md"
 			}
 		],
-		"flint": {
-			"name": "jsdocParameterDescriptions",
-			"plugin": "ts",
-			"status": "skipped"
-		},
 		"oxlint": [
 			{
 				"name": "jsdoc/require-param-description",
@@ -21543,17 +21543,17 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "jsdocParameterNamePresence",
+			"plugin": "ts",
+			"preset": "stylistic"
+		},
 		"eslint": [
 			{
 				"name": "jsdoc/require-param-name",
 				"url": "https://github.com/gajus/eslint-plugin-jsdoc/blob/main/docs/rules/require-param-name.md#repos-sticky-header"
 			}
 		],
-		"flint": {
-			"name": "jsdocParameterNamePresence",
-			"plugin": "ts",
-			"preset": "stylistic"
-		},
 		"oxlint": [
 			{
 				"name": "jsdoc/require-param-name",
@@ -21562,30 +21562,30 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "jsdocParameterNames",
+			"plugin": "ts",
+			"preset": "stylistic"
+		},
 		"eslint": [
 			{
 				"name": "jsdoc/check-param-names",
 				"url": "https://github.com/gajus/eslint-plugin-jsdoc/blob/HEAD/docs/rules/check-param-names.md"
 			}
-		],
-		"flint": {
-			"name": "jsdocParameterNames",
-			"plugin": "ts",
-			"preset": "stylistic"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "jsdocParameters",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "jsdoc/require-param",
 				"url": "https://github.com/gajus/eslint-plugin-jsdoc/blob/HEAD/docs/rules/require-param.md"
 			}
 		],
-		"flint": {
-			"name": "jsdocParameters",
-			"plugin": "ts",
-			"status": "skipped"
-		},
 		"oxlint": [
 			{
 				"name": "jsdoc/require-param",
@@ -21594,17 +21594,17 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "jsdocParameterTypes",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "jsdoc/require-param-type",
 				"url": "https://github.com/gajus/eslint-plugin-jsdoc/blob/HEAD/docs/rules/require-param-type.md"
 			}
 		],
-		"flint": {
-			"name": "jsdocParameterTypes",
-			"plugin": "ts",
-			"status": "skipped"
-		},
 		"oxlint": [
 			{
 				"name": "jsdoc/require-param-type",
@@ -21613,17 +21613,17 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "jsdocProperties",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "jsdoc/require-property",
 				"url": "https://github.com/gajus/eslint-plugin-jsdoc/blob/HEAD/docs/rules/require-property.md"
 			}
 		],
-		"flint": {
-			"name": "jsdocProperties",
-			"plugin": "ts",
-			"status": "skipped"
-		},
 		"oxlint": [
 			{
 				"name": "jsdoc/require-property",
@@ -21632,17 +21632,17 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "jsdocPropertyDescriptions",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "jsdoc/require-property-description",
 				"url": "https://github.com/gajus/eslint-plugin-jsdoc/blob/HEAD/docs/rules/require-property-description.md"
 			}
 		],
-		"flint": {
-			"name": "jsdocPropertyDescriptions",
-			"plugin": "ts",
-			"status": "skipped"
-		},
 		"oxlint": [
 			{
 				"name": "jsdoc/require-property-description",
@@ -21651,17 +21651,17 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "jsdocPropertyNamePresence",
+			"plugin": "ts",
+			"preset": "stylistic"
+		},
 		"eslint": [
 			{
 				"name": "jsdoc/require-property-name",
 				"url": "https://github.com/gajus/eslint-plugin-jsdoc/blob/main/docs/rules/require-property-name.md#repos-sticky-header"
 			}
 		],
-		"flint": {
-			"name": "jsdocPropertyNamePresence",
-			"plugin": "ts",
-			"preset": "stylistic"
-		},
 		"oxlint": [
 			{
 				"name": "jsdoc/require-property-name",
@@ -21670,17 +21670,17 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "jsdocPropertyNames",
+			"plugin": "ts",
+			"preset": "stylistic"
+		},
 		"eslint": [
 			{
 				"name": "jsdoc/check-property-names",
 				"url": "https://github.com/gajus/eslint-plugin-jsdoc/blob/HEAD/docs/rules/check-property-names.md"
 			}
 		],
-		"flint": {
-			"name": "jsdocPropertyNames",
-			"plugin": "ts",
-			"preset": "stylistic"
-		},
 		"oxlint": [
 			{
 				"name": "jsdoc/check-property-names",
@@ -21689,17 +21689,17 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "jsdocPropertyTypes",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "jsdoc/require-property-type",
 				"url": "https://github.com/gajus/eslint-plugin-jsdoc/blob/HEAD/docs/rules/require-property-type.md"
 			}
 		],
-		"flint": {
-			"name": "jsdocPropertyTypes",
-			"plugin": "ts",
-			"status": "skipped"
-		},
 		"oxlint": [
 			{
 				"name": "jsdoc/require-property-type",
@@ -21708,69 +21708,69 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "jsdocRedundantTypes",
+			"plugin": "ts",
+			"preset": "stylistic"
+		},
 		"eslint": [
 			{
 				"name": "jsdoc/no-types",
 				"url": "https://github.com/gajus/eslint-plugin-jsdoc/blob/HEAD/docs/rules/no-types.md"
 			}
-		],
-		"flint": {
-			"name": "jsdocRedundantTypes",
-			"plugin": "ts",
-			"preset": "stylistic"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "jsdocRejects",
+			"plugin": "ts",
+			"preset": "stylistic"
+		},
 		"eslint": [
 			{
 				"name": "jsdoc/require-rejects",
 				"url": "https://github.com/gajus/eslint-plugin-jsdoc/blob/main/docs/rules/require-rejects.md#repos-sticky-header"
 			}
-		],
-		"flint": {
-			"name": "jsdocRejects",
-			"plugin": "ts",
-			"preset": "stylistic"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "jsdocRequired",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "jsdoc/require-jsdoc",
 				"url": "https://github.com/gajus/eslint-plugin-jsdoc/blob/HEAD/docs/rules/require-jsdoc.md"
 			}
-		],
-		"flint": {
-			"name": "jsdocRequired",
-			"plugin": "ts",
-			"status": "skipped"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "jsdocRequiredTags",
+			"plugin": "ts",
+			"preset": "stylistic"
+		},
 		"eslint": [
 			{
 				"name": "jsdoc/require-tags",
 				"url": "https://github.com/gajus/eslint-plugin-jsdoc/blob/main/docs/rules/require-tags.md#repos-sticky-header"
 			}
-		],
-		"flint": {
-			"name": "jsdocRequiredTags",
-			"plugin": "ts",
-			"preset": "stylistic"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "jsdocReturnDescriptions",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "jsdoc/require-returns-description",
 				"url": "https://github.com/gajus/eslint-plugin-jsdoc/blob/HEAD/docs/rules/require-returns-description.md"
 			}
 		],
-		"flint": {
-			"name": "jsdocReturnDescriptions",
-			"plugin": "ts",
-			"status": "skipped"
-		},
 		"oxlint": [
 			{
 				"name": "jsdoc/require-returns-description",
@@ -21779,17 +21779,17 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "jsdocReturns",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "jsdoc/require-returns",
 				"url": "https://github.com/gajus/eslint-plugin-jsdoc/blob/HEAD/docs/rules/require-returns.md"
 			}
 		],
-		"flint": {
-			"name": "jsdocReturns",
-			"plugin": "ts",
-			"status": "skipped"
-		},
 		"oxlint": [
 			{
 				"name": "jsdoc/require-returns",
@@ -21798,17 +21798,17 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "jsdocReturnTypes",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "jsdoc/require-returns-type",
 				"url": "https://github.com/gajus/eslint-plugin-jsdoc/blob/HEAD/docs/rules/require-returns-type.md"
 			}
 		],
-		"flint": {
-			"name": "jsdocReturnTypes",
-			"plugin": "ts",
-			"status": "skipped"
-		},
 		"oxlint": [
 			{
 				"name": "jsdoc/require-returns-type",
@@ -21817,31 +21817,31 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "jsdocTagLines",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "jsdoc/tag-lines",
 				"url": "https://github.com/gajus/eslint-plugin-jsdoc/blob/HEAD/docs/rules/tag-lines.md"
 			}
-		],
-		"flint": {
-			"name": "jsdocTagLines",
-			"plugin": "ts",
-			"status": "skipped"
-		}
+		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "jsdoc/check-tag-names",
-				"url": "https://github.com/gajus/eslint-plugin-jsdoc/blob/HEAD/docs/rules/check-tag-names.md"
-			}
-		],
 		"flint": {
 			"name": "jsdocTagNames",
 			"plugin": "ts",
 			"preset": "stylistic",
 			"strictness": "strict"
 		},
+		"eslint": [
+			{
+				"name": "jsdoc/check-tag-names",
+				"url": "https://github.com/gajus/eslint-plugin-jsdoc/blob/HEAD/docs/rules/check-tag-names.md"
+			}
+		],
 		"oxlint": [
 			{
 				"name": "jsdoc/check-tag-names",
@@ -21850,82 +21850,82 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "jsdocTagsOrder",
+			"plugin": "ts",
+			"preset": "sorting"
+		},
 		"eslint": [
 			{
 				"name": "jsdoc/sort-tags",
 				"url": "https://github.com/gajus/eslint-plugin-jsdoc/blob/HEAD/docs/rules/sort-tags.md"
 			}
-		],
-		"flint": {
-			"name": "jsdocTagsOrder",
-			"plugin": "ts",
-			"preset": "sorting"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "jsdocTemplateDescriptions",
+			"plugin": "ts",
+			"preset": "stylistic"
+		},
 		"eslint": [
 			{
 				"name": "jsdoc/require-template-description",
 				"url": "https://github.com/gajus/eslint-plugin-jsdoc/blob/main/docs/rules/require-template-description.md#repos-sticky-header"
 			}
-		],
-		"flint": {
-			"name": "jsdocTemplateDescriptions",
-			"plugin": "ts",
-			"preset": "stylistic"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "jsdocTemplateNames",
+			"plugin": "ts",
+			"preset": "stylistic"
+		},
 		"eslint": [
 			{
 				"name": "jsdoc/check-template-names",
 				"url": "https://github.com/gajus/eslint-plugin-jsdoc/blob/HEAD/docs/rules/check-template-names.md"
 			}
-		],
-		"flint": {
-			"name": "jsdocTemplateNames",
-			"plugin": "ts",
-			"preset": "stylistic"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "jsdocTemplates",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "jsdoc/require-template",
 				"url": "https://github.com/gajus/eslint-plugin-jsdoc/blob/HEAD/docs/rules/require-template.md"
 			}
-		],
-		"flint": {
-			"name": "jsdocTemplates",
-			"plugin": "ts",
-			"status": "skipped"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "jsdocTextEscaping",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "jsdoc/text-escaping",
 				"url": "https://github.com/gajus/eslint-plugin-jsdoc/blob/HEAD/docs/rules/text-escaping.md"
 			}
-		],
-		"flint": {
-			"name": "jsdocTextEscaping",
-			"plugin": "ts",
-			"status": "skipped"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "jsdocThrowDescriptions",
+			"plugin": "ts",
+			"preset": "stylistic"
+		},
 		"eslint": [
 			{
 				"name": "jsdoc/require-throws-description",
 				"url": "https://github.com/gajus/eslint-plugin-jsdoc/blob/main/docs/rules/require-throws-description.md#repos-sticky-header"
 			}
 		],
-		"flint": {
-			"name": "jsdocThrowDescriptions",
-			"plugin": "ts",
-			"preset": "stylistic"
-		},
 		"oxlint": [
 			{
 				"name": "jsdoc/require-throws-description",
@@ -21934,30 +21934,30 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "jsdocThrows",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "jsdoc/require-throws",
 				"url": "https://github.com/gajus/eslint-plugin-jsdoc/blob/HEAD/docs/rules/require-throws.md"
 			}
-		],
-		"flint": {
-			"name": "jsdocThrows",
-			"plugin": "ts",
-			"status": "skipped"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "jsdocThrowTypes",
+			"plugin": "ts",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "jsdoc/require-throws-type",
 				"url": "https://github.com/gajus/eslint-plugin-jsdoc/blob/main/docs/rules/require-throws-type.md#repos-sticky-header"
 			}
 		],
-		"flint": {
-			"name": "jsdocThrowTypes",
-			"plugin": "ts",
-			"preset": "logical"
-		},
 		"oxlint": [
 			{
 				"name": "jsdoc/require-throws-type",
@@ -21966,161 +21966,161 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "jsdocTypeChecks",
+			"plugin": "ts",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "jsdoc/check-types",
 				"url": "https://github.com/gajus/eslint-plugin-jsdoc/blob/main/docs/rules/check-types.md#repos-sticky-header"
 			}
-		],
-		"flint": {
-			"name": "jsdocTypeChecks",
-			"plugin": "ts",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "jsdocTypeFormatting",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "jsdoc/type-formatting",
 				"url": "https://github.com/gajus/eslint-plugin-jsdoc/blob/main/docs/rules/type-formatting.md#repos-sticky-header"
 			}
 		],
-		"flint": {
-			"name": "jsdocTypeFormatting",
-			"plugin": "ts",
-			"status": "skipped"
-		},
 		"notes": "Formatting rule."
 	},
 	{
+		"flint": {
+			"name": "jsdocTypeScriptEmptyObjectTypes",
+			"plugin": "ts",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "jsdoc/ts-no-empty-object-type",
 				"url": "https://github.com/gajus/eslint-plugin-jsdoc/blob/main/docs/rules/ts-no-empty-object-type.md#repos-sticky-header"
 			}
-		],
-		"flint": {
-			"name": "jsdocTypeScriptEmptyObjectTypes",
-			"plugin": "ts",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "jsdocTypeScriptFunctionTypes",
+			"plugin": "ts",
+			"preset": "stylistic"
+		},
 		"eslint": [
 			{
 				"name": "jsdoc/ts-prefer-function-type",
 				"url": "https://github.com/gajus/eslint-plugin-jsdoc/blob/main/docs/rules/ts-prefer-function-type.md#repos-sticky-header"
 			}
-		],
-		"flint": {
-			"name": "jsdocTypeScriptFunctionTypes",
-			"plugin": "ts",
-			"preset": "stylistic"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "jsdocTypeScriptMethodSignatureStyles",
+			"plugin": "ts",
+			"preset": "stylistic"
+		},
 		"eslint": [
 			{
 				"name": "jsdoc/ts-method-signature-style",
 				"url": "https://github.com/gajus/eslint-plugin-jsdoc/blob/main/docs/rules/ts-method-signature-style.md#repos-sticky-header"
 			}
-		],
-		"flint": {
-			"name": "jsdocTypeScriptMethodSignatureStyles",
-			"plugin": "ts",
-			"preset": "stylistic"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "jsdocTypeScriptUnnecessaryTemplateExpressions",
+			"plugin": "ts",
+			"preset": "stylistic"
+		},
 		"eslint": [
 			{
 				"name": "jsdoc/ts-no-unnecessary-template-expression",
 				"url": "https://github.com/gajus/eslint-plugin-jsdoc/blob/main/docs/rules/ts-no-unnecessary-template-expression.md#repos-sticky-header"
 			}
-		],
-		"flint": {
-			"name": "jsdocTypeScriptUnnecessaryTemplateExpressions",
-			"plugin": "ts",
-			"preset": "stylistic"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "jsdocTypesSyntax",
+			"plugin": "ts",
+			"preset": "stylistic"
+		},
 		"eslint": [
 			{
 				"name": "jsdoc/check-syntax",
 				"url": "https://github.com/gajus/eslint-plugin-jsdoc/blob/main/docs/rules/check-syntax.md#repos-sticky-header"
 			}
-		],
-		"flint": {
-			"name": "jsdocTypesSyntax",
-			"plugin": "ts",
-			"preset": "stylistic"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "jsdocUnnecessaryReturns",
+			"plugin": "ts",
+			"preset": "stylistic"
+		},
 		"eslint": [
 			{
 				"name": "jsdoc/require-returns-check",
 				"url": "https://github.com/gajus/eslint-plugin-jsdoc/blob/HEAD/docs/rules/require-returns-check.md"
 			}
-		],
-		"flint": {
-			"name": "jsdocUnnecessaryReturns",
-			"plugin": "ts",
-			"preset": "stylistic"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "jsdocUnnecessaryYields",
+			"plugin": "ts",
+			"preset": "stylistic"
+		},
 		"eslint": [
 			{
 				"name": "jsdoc/require-yields-check",
 				"url": "https://github.com/gajus/eslint-plugin-jsdoc/blob/HEAD/docs/rules/require-yields-check.md"
 			}
-		],
-		"flint": {
-			"name": "jsdocUnnecessaryYields",
-			"plugin": "ts",
-			"preset": "stylistic"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "jsdocValidTypes",
+			"plugin": "ts",
+			"preset": "stylistic"
+		},
 		"eslint": [
 			{
 				"name": "jsdoc/valid-types",
 				"url": "https://github.com/gajus/eslint-plugin-jsdoc/blob/HEAD/docs/rules/valid-types.md"
 			}
-		],
-		"flint": {
-			"name": "jsdocValidTypes",
-			"plugin": "ts",
-			"preset": "stylistic"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "jsdocValues",
+			"plugin": "ts",
+			"preset": "stylistic"
+		},
 		"eslint": [
 			{
 				"name": "jsdoc/check-values",
 				"url": "https://github.com/gajus/eslint-plugin-jsdoc/blob/HEAD/docs/rules/check-values.md"
 			}
-		],
-		"flint": {
-			"name": "jsdocValues",
-			"plugin": "ts",
-			"preset": "stylistic"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "jsdocYieldDescriptions",
+			"plugin": "ts",
+			"preset": "stylistic"
+		},
 		"eslint": [
 			{
 				"name": "jsdoc/require-yields-description",
 				"url": "https://github.com/gajus/eslint-plugin-jsdoc/blob/main/docs/rules/require-yields-description.md#repos-sticky-header"
 			}
 		],
-		"flint": {
-			"name": "jsdocYieldDescriptions",
-			"plugin": "ts",
-			"preset": "stylistic"
-		},
 		"oxlint": [
 			{
 				"name": "jsdoc/require-yields-description",
@@ -22129,17 +22129,17 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "jsdocYields",
+			"plugin": "ts",
+			"preset": "stylistic"
+		},
 		"eslint": [
 			{
 				"name": "jsdoc/require-yields",
 				"url": "https://github.com/gajus/eslint-plugin-jsdoc/blob/HEAD/docs/rules/require-yields.md"
 			}
 		],
-		"flint": {
-			"name": "jsdocYields",
-			"plugin": "ts",
-			"preset": "stylistic"
-		},
 		"oxlint": [
 			{
 				"name": "jsdoc/require-yields",
@@ -22148,17 +22148,17 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "jsdocYieldTypes",
+			"plugin": "ts",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "jsdoc/require-yields-type",
 				"url": "https://github.com/gajus/eslint-plugin-jsdoc/blob/main/docs/rules/require-yields-type.md#repos-sticky-header"
 			}
 		],
-		"flint": {
-			"name": "jsdocYieldTypes",
-			"plugin": "ts",
-			"preset": "logical"
-		},
 		"oxlint": [
 			{
 				"name": "jsdoc/require-yields-type",
@@ -22167,19 +22167,24 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "jsonImportAttributes",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"biome": [
 			{
 				"name": "useJsonImportAttributes",
 				"url": "https://biomejs.dev/linter/rules/use-json-import-attributes"
 			}
-		],
-		"flint": {
-			"name": "jsonImportAttributes",
-			"plugin": "ts",
-			"status": "skipped"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "labels",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"biome": [
 			{
 				"name": "noConfusingLabels",
@@ -22192,11 +22197,6 @@
 				"url": "https://eslint.org/docs/latest/rules/no-labels"
 			}
 		],
-		"flint": {
-			"name": "labels",
-			"plugin": "ts",
-			"status": "skipped"
-		},
 		"oxlint": [
 			{
 				"name": "eslint/no-labels",
@@ -22205,6 +22205,11 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "labelVariableNames",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"biome": [
 			{
 				"name": "noLabelVar",
@@ -22217,11 +22222,6 @@
 				"url": "https://eslint.org/docs/latest/rules/no-label-var"
 			}
 		],
-		"flint": {
-			"name": "labelVariableNames",
-			"plugin": "ts",
-			"status": "skipped"
-		},
 		"oxlint": [
 			{
 				"name": "eslint/no-label-var",
@@ -22230,38 +22230,38 @@
 		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "unicorn/prefer-bigint-literals",
-				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prefer-bigint-literals.md"
-			}
-		],
 		"flint": {
 			"name": "literalConstructorWrappers",
 			"plugin": "ts",
 			"preset": "stylistic",
 			"status": "implemented"
 		},
-		"notes": "Will apply to all literals, not just bigint",
+		"eslint": [
+			{
+				"name": "unicorn/prefer-bigint-literals",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prefer-bigint-literals.md"
+			}
+		],
 		"oxlint": [
 			{
 				"name": "unicorn/prefer-bigint-literals",
 				"url": "https://oxc.rs/docs/guide/usage/linter/rules/unicorn/prefer-bigint-literals.html"
 			}
-		]
+		],
+		"notes": "Will apply to all literals, not just bigint"
 	},
 	{
+		"flint": {
+			"name": "loopConditionConstants",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "no-unmodified-loop-condition",
 				"url": "https://eslint.org/docs/latest/rules/no-unmodified-loop-condition"
 			}
 		],
-		"flint": {
-			"name": "loopConditionConstants",
-			"plugin": "ts",
-			"status": "skipped"
-		},
 		"oxlint": [
 			{
 				"name": "eslint/no-unmodified-loop-condition",
@@ -22270,6 +22270,11 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "magicNumbers",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"biome": [
 			{
 				"name": "noMagicNumbers",
@@ -22286,39 +22291,28 @@
 				"url": "https://typescript-eslint.io/rules/no-magic-numbers"
 			}
 		],
-		"flint": {
-			"name": "magicNumbers",
-			"plugin": "ts",
-			"status": "skipped"
-		},
-		"notes": "Overly opinionated.",
 		"oxlint": [
 			{
 				"name": "eslint/no-magic-numbers",
 				"url": "https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-magic-numbers.html"
 			}
-		]
+		],
+		"notes": "Overly opinionated."
 	},
 	{
+		"flint": {
+			"name": "mapsOrder",
+			"plugin": "ts",
+			"preset": "sorting"
+		},
 		"eslint": [
 			{
 				"name": "perfectionist/sort-maps",
 				"url": "https://perfectionist.dev/rules/sort-maps"
 			}
-		],
-		"flint": {
-			"name": "mapsOrder",
-			"plugin": "ts",
-			"preset": "sorting"
-		}
+		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "unicorn/prefer-modern-math-apis",
-				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prefer-modern-math-apis.md"
-			}
-		],
 		"flint": {
 			"name": "mathMethods",
 			"plugin": "ts",
@@ -22326,6 +22320,12 @@
 			"status": "implemented",
 			"strictness": "strict"
 		},
+		"eslint": [
+			{
+				"name": "unicorn/prefer-modern-math-apis",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prefer-modern-math-apis.md"
+			}
+		],
 		"oxlint": [
 			{
 				"name": "unicorn/prefer-modern-math-apis",
@@ -22334,6 +22334,11 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "mathRangeTernaries",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"biome": [
 			{
 				"name": "useMathMinMax",
@@ -22346,11 +22351,6 @@
 				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prefer-math-min-max.md"
 			}
 		],
-		"flint": {
-			"name": "mathRangeTernaries",
-			"plugin": "ts",
-			"status": "skipped"
-		},
 		"oxlint": [
 			{
 				"name": "unicorn/prefer-math-min-max",
@@ -22359,17 +22359,17 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "mathTruncationOperators",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "unicorn/prefer-math-trunc",
 				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prefer-math-trunc.md"
 			}
 		],
-		"flint": {
-			"name": "mathTruncationOperators",
-			"plugin": "ts",
-			"status": "skipped"
-		},
 		"oxlint": [
 			{
 				"name": "unicorn/prefer-math-trunc",
@@ -22378,6 +22378,11 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "maximumClassesPerFile",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"biome": [
 			{
 				"name": "noExcessiveClassesPerFile",
@@ -22390,11 +22395,6 @@
 				"url": "https://eslint.org/docs/latest/rules/max-classes-per-file"
 			}
 		],
-		"flint": {
-			"name": "maximumClassesPerFile",
-			"plugin": "ts",
-			"status": "skipped"
-		},
 		"oxlint": [
 			{
 				"name": "eslint/max-classes-per-file",
@@ -22403,6 +22403,11 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "maximumComplexity",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"biome": [
 			{
 				"name": "noExcessiveCognitiveComplexity",
@@ -22415,11 +22420,6 @@
 				"url": "https://eslint.org/docs/latest/rules/complexity"
 			}
 		],
-		"flint": {
-			"name": "maximumComplexity",
-			"plugin": "ts",
-			"status": "skipped"
-		},
 		"oxlint": [
 			{
 				"name": "eslint/complexity",
@@ -22428,17 +22428,17 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "maximumDepth",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "max-depth",
 				"url": "https://eslint.org/docs/latest/rules/max-depth"
 			}
 		],
-		"flint": {
-			"name": "maximumDepth",
-			"plugin": "ts",
-			"status": "skipped"
-		},
 		"oxlint": [
 			{
 				"name": "eslint/max-depth",
@@ -22447,17 +22447,17 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "maximumIdentifierLengths",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "id-length",
 				"url": "https://eslint.org/docs/latest/rules/id-length"
 			}
 		],
-		"flint": {
-			"name": "maximumIdentifierLengths",
-			"plugin": "ts",
-			"status": "skipped"
-		},
 		"oxlint": [
 			{
 				"name": "eslint/id-length",
@@ -22466,6 +22466,11 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "maximumLinesPerFile",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"biome": [
 			{
 				"name": "noExcessiveLinesPerFile",
@@ -22478,11 +22483,6 @@
 				"url": "https://eslint.org/docs/latest/rules/max-lines"
 			}
 		],
-		"flint": {
-			"name": "maximumLinesPerFile",
-			"plugin": "ts",
-			"status": "skipped"
-		},
 		"oxlint": [
 			{
 				"name": "eslint/max-lines",
@@ -22491,6 +22491,11 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "maximumLinesPerFunction",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"biome": [
 			{
 				"name": "noExcessiveLinesPerFunction",
@@ -22503,11 +22508,6 @@
 				"url": "https://eslint.org/docs/latest/rules/max-lines-per-function"
 			}
 		],
-		"flint": {
-			"name": "maximumLinesPerFunction",
-			"plugin": "ts",
-			"status": "skipped"
-		},
 		"oxlint": [
 			{
 				"name": "eslint/max-lines-per-function",
@@ -22516,6 +22516,11 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "maximumNestedCallbacks",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"biome": [
 			{
 				"name": "noExcessiveNestedCallbacks",
@@ -22528,11 +22533,6 @@
 				"url": "https://eslint.org/docs/latest/rules/max-nested-callbacks"
 			}
 		],
-		"flint": {
-			"name": "maximumNestedCallbacks",
-			"plugin": "ts",
-			"status": "skipped"
-		},
 		"oxlint": [
 			{
 				"name": "eslint/max-nested-callbacks",
@@ -22541,6 +22541,11 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "maximumParameters",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"biome": [
 			{
 				"name": "useMaxParams",
@@ -22557,31 +22562,26 @@
 				"url": "https://typescript-eslint.io/rules/max-params"
 			}
 		],
-		"flint": {
-			"name": "maximumParameters",
-			"plugin": "ts",
-			"status": "skipped"
-		},
-		"notes": "Overly opinionated.",
 		"oxlint": [
 			{
 				"name": "eslint/max-params",
 				"url": "https://oxc.rs/docs/guide/usage/linter/rules/eslint/max-params.html"
 			}
-		]
+		],
+		"notes": "Overly opinionated."
 	},
 	{
+		"flint": {
+			"name": "maximumStatements",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "max-statements",
 				"url": "https://eslint.org/docs/latest/rules/max-statements"
 			}
 		],
-		"flint": {
-			"name": "maximumStatements",
-			"plugin": "ts",
-			"status": "skipped"
-		},
 		"oxlint": [
 			{
 				"name": "eslint/max-statements",
@@ -22590,18 +22590,18 @@
 		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "@typescript-eslint/no-meaningless-void-operator",
-				"url": "https://typescript-eslint.io/rules/no-meaningless-void-operator"
-			}
-		],
 		"flint": {
 			"name": "meaninglessVoidOperators",
 			"plugin": "ts",
 			"preset": "logical",
 			"status": "implemented"
 		},
+		"eslint": [
+			{
+				"name": "@typescript-eslint/no-meaningless-void-operator",
+				"url": "https://typescript-eslint.io/rules/no-meaningless-void-operator"
+			}
+		],
 		"oxlint": [
 			{
 				"name": "typescript/no-meaningless-void-operator",
@@ -22610,6 +22610,11 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "memberAccessibility",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"biome": [
 			{
 				"name": "useConsistentMemberAccessibility",
@@ -22622,11 +22627,6 @@
 				"url": "https://typescript-eslint.io/rules/explicit-member-accessibility"
 			}
 		],
-		"flint": {
-			"name": "memberAccessibility",
-			"plugin": "ts",
-			"status": "skipped"
-		},
 		"oxlint": [
 			{
 				"name": "typescript/explicit-member-accessibility",
@@ -22635,20 +22635,25 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "memberOrderings",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "@typescript-eslint/member-ordering",
 				"url": "https://typescript-eslint.io/rules/member-ordering"
 			}
 		],
-		"flint": {
-			"name": "memberOrderings",
-			"plugin": "ts",
-			"status": "skipped"
-		},
 		"notes": "Superseded by sorting plugin rules."
 	},
 	{
+		"flint": {
+			"name": "methodSignatureStyles",
+			"plugin": "ts",
+			"preset": "stylistic"
+		},
 		"biome": [
 			{
 				"name": "useConsistentMethodSignatures",
@@ -22661,11 +22666,6 @@
 				"url": "https://typescript-eslint.io/rules/method-signature-style"
 			}
 		],
-		"flint": {
-			"name": "methodSignatureStyles",
-			"plugin": "ts",
-			"preset": "stylistic"
-		},
 		"oxlint": [
 			{
 				"name": "typescript/method-signature-style",
@@ -22681,6 +22681,11 @@
 		}
 	},
 	{
+		"flint": {
+			"name": "misleadingThenProperties",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"biome": [
 			{
 				"name": "noThenProperty",
@@ -22693,11 +22698,6 @@
 				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-thenable.md"
 			}
 		],
-		"flint": {
-			"name": "misleadingThenProperties",
-			"plugin": "ts",
-			"status": "skipped"
-		},
 		"oxlint": [
 			{
 				"name": "unicorn/no-thenable",
@@ -22706,6 +22706,12 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "misleadingVoidExpressions",
+			"plugin": "ts",
+			"preset": "logical",
+			"status": "implemented"
+		},
 		"biome": [
 			{
 				"name": "noVoidTypeReturn",
@@ -22718,12 +22724,6 @@
 				"url": "https://typescript-eslint.io/rules/no-confusing-void-expression"
 			}
 		],
-		"flint": {
-			"name": "misleadingVoidExpressions",
-			"plugin": "ts",
-			"preset": "logical",
-			"status": "implemented"
-		},
 		"oxlint": [
 			{
 				"name": "typescript/no-confusing-void-expression",
@@ -22732,6 +22732,11 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "misusedPromises",
+			"plugin": "ts",
+			"preset": "logical"
+		},
 		"biome": [
 			{
 				"name": "noMisusedPromises",
@@ -22744,11 +22749,6 @@
 				"url": "https://typescript-eslint.io/rules/no-misused-promises"
 			}
 		],
-		"flint": {
-			"name": "misusedPromises",
-			"plugin": "ts",
-			"preset": "logical"
-		},
 		"oxlint": [
 			{
 				"name": "typescript/no-misused-promises",
@@ -22757,6 +22757,11 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "moduleBoundaryTypes",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"biome": [
 			{
 				"name": "useExplicitType",
@@ -22775,32 +22780,32 @@
 				"url": "https://typescript-eslint.io/rules/explicit-module-boundary-types"
 			}
 		],
-		"flint": {
-			"name": "moduleBoundaryTypes",
-			"plugin": "ts",
-			"status": "skipped"
-		},
-		"notes": "Conflicts with Flint's preference for inferred return types.",
 		"oxlint": [
 			{
 				"name": "typescript/explicit-module-boundary-types",
 				"url": "https://oxc.rs/docs/guide/usage/linter/rules/typescript/explicit-module-boundary-types.html"
 			}
-		]
+		],
+		"notes": "Conflicts with Flint's preference for inferred return types."
 	},
 	{
+		"flint": {
+			"name": "moduleExportImports",
+			"plugin": "ts"
+		},
 		"eslint": [
 			{
 				"name": "import/no-import-module-exports",
 				"url": "https://github.com/import-js/eslint-plugin-import/blob/v2.32.0/docs/rules/no-import-module-exports.md"
 			}
-		],
-		"flint": {
-			"name": "moduleExportImports",
-			"plugin": "ts"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "moduleFormats",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"biome": [
 			{
 				"name": "noGlobalDirnameFilename",
@@ -22813,11 +22818,6 @@
 				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prefer-module.md"
 			}
 		],
-		"flint": {
-			"name": "moduleFormats",
-			"plugin": "ts",
-			"status": "skipped"
-		},
 		"oxlint": [
 			{
 				"name": "unicorn/prefer-module",
@@ -22826,17 +22826,17 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "moduleImportStyles",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "unicorn/import-style",
 				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/import-style.md"
 			}
 		],
-		"flint": {
-			"name": "moduleImportStyles",
-			"plugin": "ts",
-			"status": "skipped"
-		},
 		"oxlint": [
 			{
 				"name": "unicorn/import-style",
@@ -22845,31 +22845,31 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "modulesOrder",
+			"plugin": "ts",
+			"preset": "sorting"
+		},
 		"eslint": [
 			{
 				"name": "perfectionist/sort-modules",
 				"url": "https://perfectionist.dev/rules/sort-modules"
 			}
-		],
-		"flint": {
-			"name": "modulesOrder",
-			"plugin": "ts",
-			"preset": "sorting"
-		}
+		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "unicorn/require-module-specifiers",
-				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/require-module-specifiers.md"
-			}
-		],
 		"flint": {
 			"name": "moduleSpecifierLists",
 			"plugin": "ts",
 			"preset": "logical",
 			"status": "implemented"
 		},
+		"eslint": [
+			{
+				"name": "unicorn/require-module-specifiers",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/require-module-specifiers.md"
+			}
+		],
 		"oxlint": [
 			{
 				"name": "unicorn/require-module-specifiers",
@@ -22878,16 +22878,16 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "moduleSyntaxDeclarations",
+			"plugin": "ts"
+		},
 		"eslint": [
 			{
 				"name": "import/unambiguous",
 				"url": "https://github.com/import-js/eslint-plugin-import/blob/v2.32.0/docs/rules/unambiguous.md"
 			}
 		],
-		"flint": {
-			"name": "moduleSyntaxDeclarations",
-			"plugin": "ts"
-		},
 		"oxlint": [
 			{
 				"name": "import/unambiguous",
@@ -22896,18 +22896,18 @@
 		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "no-unexpected-multiline",
-				"url": "https://eslint.org/docs/latest/rules/no-unexpected-multiline"
-			}
-		],
 		"flint": {
 			"name": "multilineAmbiguities",
 			"plugin": "ts",
 			"preset": "stylistic",
 			"status": "implemented"
 		},
+		"eslint": [
+			{
+				"name": "no-unexpected-multiline",
+				"url": "https://eslint.org/docs/latest/rules/no-unexpected-multiline"
+			}
+		],
 		"oxlint": [
 			{
 				"name": "eslint/no-unexpected-multiline",
@@ -22916,6 +22916,11 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "multilineStrings",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"biome": [
 			{
 				"name": "noMultiStr",
@@ -22928,11 +22933,6 @@
 				"url": "https://eslint.org/docs/latest/rules/no-multi-str"
 			}
 		],
-		"flint": {
-			"name": "multilineStrings",
-			"plugin": "ts",
-			"status": "skipped"
-		},
 		"oxlint": [
 			{
 				"name": "eslint/no-multi-str",
@@ -22941,25 +22941,19 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "multipleElseIfSwitches",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "unicorn/prefer-switch",
 				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prefer-switch.md"
 			}
-		],
-		"flint": {
-			"name": "multipleElseIfSwitches",
-			"plugin": "ts",
-			"status": "skipped"
-		}
+		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "unicorn/no-anonymous-default-export",
-				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-anonymous-default-export.md"
-			}
-		],
 		"flint": {
 			"name": "namedDefaultExports",
 			"plugin": "ts",
@@ -22967,6 +22961,12 @@
 			"status": "implemented",
 			"strictness": "strict"
 		},
+		"eslint": [
+			{
+				"name": "unicorn/no-anonymous-default-export",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-anonymous-default-export.md"
+			}
+		],
 		"oxlint": [
 			{
 				"name": "import/no-anonymous-default-export",
@@ -22979,52 +22979,52 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "namedDefaultImports",
+			"plugin": "ts"
+		},
 		"eslint": [
 			{
 				"name": "import/no-named-as-default",
 				"url": "https://github.com/import-js/eslint-plugin-import/blob/v2.32.0/docs/rules/no-named-as-default.md"
 			}
-		],
-		"flint": {
-			"name": "namedDefaultImports",
-			"plugin": "ts"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "namedDefaultMembers",
+			"plugin": "ts"
+		},
 		"eslint": [
 			{
 				"name": "import/no-named-as-default-member",
 				"url": "https://github.com/import-js/eslint-plugin-import/blob/v2.32.0/docs/rules/no-named-as-default-member.md"
 			}
-		],
-		"flint": {
-			"name": "namedDefaultMembers",
-			"plugin": "ts"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "namedDefaultSpecifiers",
+			"plugin": "ts"
+		},
 		"eslint": [
 			{
 				"name": "import/no-named-default",
 				"url": "https://github.com/import-js/eslint-plugin-import/blob/v2.32.0/docs/rules/no-named-default.md"
 			}
-		],
-		"flint": {
-			"name": "namedDefaultSpecifiers",
-			"plugin": "ts"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "namedExports",
+			"plugin": "ts"
+		},
 		"eslint": [
 			{
 				"name": "import/no-named-export",
 				"url": "https://github.com/import-js/eslint-plugin-import/blob/v2.32.0/docs/rules/no-named-export.md"
 			}
 		],
-		"flint": {
-			"name": "namedExports",
-			"plugin": "ts"
-		},
 		"oxlint": [
 			{
 				"name": "import/no-named-export",
@@ -23033,6 +23033,12 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "namespaceDeclarations",
+			"plugin": "ts",
+			"preset": "logical",
+			"status": "implemented"
+		},
 		"biome": [
 			{
 				"name": "noNamespace",
@@ -23051,12 +23057,6 @@
 				"url": "https://typescript-eslint.io/rules/no-namespace"
 			}
 		],
-		"flint": {
-			"name": "namespaceDeclarations",
-			"plugin": "ts",
-			"preset": "logical",
-			"status": "implemented"
-		},
 		"oxlint": [
 			{
 				"name": "typescript/no-namespace",
@@ -23065,35 +23065,41 @@
 		]
 	},
 	{
-		"deno": [
-			{
-				"name": "no-implicit-declare-namespace-export",
-				"url": "https://docs.deno.com/lint/rules/no-implicit-declare-namespace-export"
-			}
-		],
 		"flint": {
 			"name": "namespaceImplicitAmbientImports",
 			"plugin": "ts",
 			"preset": "stylistic",
 			"status": "implemented",
 			"strictness": "strict"
-		}
+		},
+		"deno": [
+			{
+				"name": "no-implicit-declare-namespace-export",
+				"url": "https://docs.deno.com/lint/rules/no-implicit-declare-namespace-export"
+			}
+		]
 	},
 	{
-		"biome": [
-			{
-				"name": "noNamespaceImport",
-				"url": "https://biomejs.dev/linter/rules/no-namespace-import"
-			}
-		],
 		"flint": {
 			"name": "namespaceImports",
 			"plugin": "ts",
 			"preset": "logical",
 			"strictness": "strict"
-		}
+		},
+		"biome": [
+			{
+				"name": "noNamespaceImport",
+				"url": "https://biomejs.dev/linter/rules/no-namespace-import"
+			}
+		]
 	},
 	{
+		"flint": {
+			"name": "namespaceKeywords",
+			"plugin": "ts",
+			"preset": "stylistic",
+			"status": "implemented"
+		},
 		"biome": [
 			{
 				"name": "useNamespaceKeyword",
@@ -23112,12 +23118,6 @@
 				"url": "https://typescript-eslint.io/rules/prefer-namespace-keyword"
 			}
 		],
-		"flint": {
-			"name": "namespaceKeywords",
-			"plugin": "ts",
-			"preset": "stylistic",
-			"status": "implemented"
-		},
 		"oxlint": [
 			{
 				"name": "typescript/prefer-namespace-keyword",
@@ -23126,6 +23126,11 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "namingConventions",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"biome": [
 			{
 				"name": "useNamingConvention",
@@ -23148,26 +23153,21 @@
 				"url": "https://typescript-eslint.io/rules/naming-convention"
 			}
 		],
-		"flint": {
-			"name": "namingConventions",
-			"plugin": "ts",
-			"status": "skipped"
-		},
 		"notes": "Overly opinionated."
 	},
 	{
-		"eslint": [
-			{
-				"name": "no-extend-native",
-				"url": "https://eslint.org/docs/latest/rules/no-extend-native"
-			}
-		],
 		"flint": {
 			"name": "nativeObjectExtensions",
 			"plugin": "ts",
 			"preset": "javascript",
 			"status": "implemented"
 		},
+		"eslint": [
+			{
+				"name": "no-extend-native",
+				"url": "https://eslint.org/docs/latest/rules/no-extend-native"
+			}
+		],
 		"oxlint": [
 			{
 				"name": "eslint/no-extend-native",
@@ -23176,25 +23176,19 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "nativePromises",
+			"plugin": "ts"
+		},
 		"eslint": [
 			{
 				"name": "promise/no-native",
 				"url": "https://github.com/eslint-community/eslint-plugin-promise/blob/main/docs/rules/no-native.md"
 			}
 		],
-		"flint": {
-			"name": "nativePromises",
-			"plugin": "ts"
-		},
 		"notes": "Obsolete for modern runtimes."
 	},
 	{
-		"eslint": [
-			{
-				"name": "unicorn/prefer-negative-index",
-				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prefer-negative-index.md"
-			}
-		],
 		"flint": {
 			"name": "negativeIndexLengthMethods",
 			"plugin": "ts",
@@ -23202,6 +23196,12 @@
 			"status": "implemented",
 			"strictness": "strict"
 		},
+		"eslint": [
+			{
+				"name": "unicorn/prefer-negative-index",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prefer-negative-index.md"
+			}
+		],
 		"oxlint": [
 			{
 				"name": "unicorn/prefer-negative-index",
@@ -23210,6 +23210,12 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "negativeZeroComparisons",
+			"plugin": "ts",
+			"preset": "logical",
+			"status": "implemented"
+		},
 		"biome": [
 			{
 				"name": "noCompareNegZero",
@@ -23228,12 +23234,6 @@
 				"url": "https://eslint.org/docs/latest/rules/no-compare-neg-zero"
 			}
 		],
-		"flint": {
-			"name": "negativeZeroComparisons",
-			"plugin": "ts",
-			"preset": "logical",
-			"status": "implemented"
-		},
 		"oxlint": [
 			{
 				"name": "eslint/no-compare-neg-zero",
@@ -23242,6 +23242,12 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "nestedStandaloneIfs",
+			"plugin": "ts",
+			"preset": "stylistic",
+			"status": "implemented"
+		},
 		"biome": [
 			{
 				"name": "useCollapsedElseIf",
@@ -23262,12 +23268,6 @@
 				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-lonely-if.md"
 			}
 		],
-		"flint": {
-			"name": "nestedStandaloneIfs",
-			"plugin": "ts",
-			"preset": "stylistic",
-			"status": "implemented"
-		},
 		"oxlint": [
 			{
 				"name": "eslint/no-lonely-if",
@@ -23280,6 +23280,12 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "newDefinitions",
+			"plugin": "ts",
+			"preset": "logical",
+			"status": "implemented"
+		},
 		"biome": [
 			{
 				"name": "noMisleadingInstantiator",
@@ -23298,12 +23304,6 @@
 				"url": "https://typescript-eslint.io/rules/no-misused-new"
 			}
 		],
-		"flint": {
-			"name": "newDefinitions",
-			"plugin": "ts",
-			"preset": "logical",
-			"status": "implemented"
-		},
 		"oxlint": [
 			{
 				"name": "typescript/no-misused-new",
@@ -23312,6 +23312,12 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "newExpressions",
+			"plugin": "ts",
+			"preset": "logical",
+			"status": "implemented"
+		},
 		"biome": [
 			{
 				"name": "noFloatingClasses",
@@ -23324,13 +23330,6 @@
 				"url": "https://eslint.org/docs/latest/rules/no-new"
 			}
 		],
-		"flint": {
-			"name": "newExpressions",
-			"plugin": "ts",
-			"preset": "logical",
-			"status": "implemented"
-		},
-		"notes": "oxc/missing-throw is a subset",
 		"oxlint": [
 			{
 				"name": "eslint/no-new",
@@ -23340,9 +23339,16 @@
 				"name": "oxc/missing-throw",
 				"url": "https://oxc.rs/docs/guide/usage/linter/rules/oxc/missing-throw.html"
 			}
-		]
+		],
+		"notes": "oxc/missing-throw is a subset"
 	},
 	{
+		"flint": {
+			"name": "newNativeNonConstructors",
+			"plugin": "ts",
+			"preset": "javascript",
+			"status": "implemented"
+		},
 		"biome": [
 			{
 				"name": "noInvalidBuiltinInstantiation",
@@ -23361,12 +23367,6 @@
 				"url": "https://eslint.org/docs/latest/rules/no-new-native-nonconstructor"
 			}
 		],
-		"flint": {
-			"name": "newNativeNonConstructors",
-			"plugin": "ts",
-			"preset": "javascript",
-			"status": "implemented"
-		},
 		"oxlint": [
 			{
 				"name": "eslint/no-new-native-nonconstructor",
@@ -23375,6 +23375,10 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "nodeBuiltinImports",
+			"plugin": "ts"
+		},
 		"biome": [
 			{
 				"name": "noNodejsModules",
@@ -23387,10 +23391,6 @@
 				"url": "https://github.com/import-js/eslint-plugin-import/blob/v2.32.0/docs/rules/no-nodejs-modules.md"
 			}
 		],
-		"flint": {
-			"name": "nodeBuiltinImports",
-			"plugin": "ts"
-		},
 		"oxlint": [
 			{
 				"name": "import/no-nodejs-modules",
@@ -23399,18 +23399,18 @@
 		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "@typescript-eslint/non-nullable-type-assertion-style",
-				"url": "https://typescript-eslint.io/rules/non-nullable-type-assertion-style"
-			}
-		],
 		"flint": {
 			"name": "nonNullableTypeAssertions",
 			"plugin": "ts",
 			"preset": "stylistic",
 			"status": "implemented"
 		},
+		"eslint": [
+			{
+				"name": "@typescript-eslint/non-nullable-type-assertion-style",
+				"url": "https://typescript-eslint.io/rules/non-nullable-type-assertion-style"
+			}
+		],
 		"oxlint": [
 			{
 				"name": "typescript/non-nullable-type-assertion-style",
@@ -23419,12 +23419,6 @@
 		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "@typescript-eslint/no-non-null-asserted-nullish-coalescing",
-				"url": "https://typescript-eslint.io/rules/no-non-null-asserted-nullish-coalescing"
-			}
-		],
 		"flint": {
 			"name": "nonNullAssertedNullishCoalesces",
 			"plugin": "ts",
@@ -23432,6 +23426,12 @@
 			"status": "implemented",
 			"strictness": "strict"
 		},
+		"eslint": [
+			{
+				"name": "@typescript-eslint/no-non-null-asserted-nullish-coalescing",
+				"url": "https://typescript-eslint.io/rules/no-non-null-asserted-nullish-coalescing"
+			}
+		],
 		"oxlint": [
 			{
 				"name": "typescript/no-non-null-asserted-nullish-coalescing",
@@ -23440,6 +23440,12 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "nonNullAssertedOptionalChains",
+			"plugin": "ts",
+			"preset": "logical",
+			"status": "implemented"
+		},
 		"biome": [
 			{
 				"name": "noNonNullAssertedOptionalChain",
@@ -23458,12 +23464,6 @@
 				"url": "https://typescript-eslint.io/rules/no-non-null-asserted-optional-chain"
 			}
 		],
-		"flint": {
-			"name": "nonNullAssertedOptionalChains",
-			"plugin": "ts",
-			"preset": "logical",
-			"status": "implemented"
-		},
 		"oxlint": [
 			{
 				"name": "typescript/no-non-null-asserted-optional-chain",
@@ -23472,12 +23472,6 @@
 		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "@typescript-eslint/no-confusing-non-null-assertion",
-				"url": "https://typescript-eslint.io/rules/no-confusing-non-null-assertion"
-			}
-		],
 		"flint": {
 			"name": "nonNullAssertionPlacement",
 			"plugin": "ts",
@@ -23485,6 +23479,12 @@
 			"status": "implemented",
 			"strictness": "strict"
 		},
+		"eslint": [
+			{
+				"name": "@typescript-eslint/no-confusing-non-null-assertion",
+				"url": "https://typescript-eslint.io/rules/no-confusing-non-null-assertion"
+			}
+		],
 		"oxlint": [
 			{
 				"name": "typescript/no-confusing-non-null-assertion",
@@ -23493,6 +23493,12 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "nonNullAssertions",
+			"plugin": "ts",
+			"preset": "logical",
+			"strictness": "strict"
+		},
 		"biome": [
 			{
 				"name": "noNonNullAssertion",
@@ -23511,12 +23517,6 @@
 				"url": "https://typescript-eslint.io/rules/no-non-null-assertion"
 			}
 		],
-		"flint": {
-			"name": "nonNullAssertions",
-			"plugin": "ts",
-			"preset": "logical",
-			"strictness": "strict"
-		},
 		"oxlint": [
 			{
 				"name": "typescript/no-non-null-assertion",
@@ -23525,6 +23525,12 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "nonOctalDecimalEscapes",
+			"plugin": "ts",
+			"preset": "logical",
+			"status": "implemented"
+		},
 		"biome": [
 			{
 				"name": "noNonoctalDecimalEscape",
@@ -23537,12 +23543,6 @@
 				"url": "https://eslint.org/docs/latest/rules/no-nonoctal-decimal-escape"
 			}
 		],
-		"flint": {
-			"name": "nonOctalDecimalEscapes",
-			"plugin": "ts",
-			"preset": "logical",
-			"status": "implemented"
-		},
 		"oxlint": [
 			{
 				"name": "eslint/no-nonoctal-decimal-escape",
@@ -23551,6 +23551,11 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "nullishCheckStyle",
+			"plugin": "ts",
+			"status": "implemented"
+		},
 		"biome": [
 			{
 				"name": "noEqualsToNull",
@@ -23563,11 +23568,6 @@
 				"url": "https://eslint.org/docs/latest/rules/no-eq-null"
 			}
 		],
-		"flint": {
-			"name": "nullishCheckStyle",
-			"plugin": "ts",
-			"status": "implemented"
-		},
 		"oxlint": [
 			{
 				"name": "eslint/no-eq-null",
@@ -23576,6 +23576,12 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "nullishCoalescingOperators",
+			"plugin": "ts",
+			"preset": "stylistic",
+			"status": "implemented"
+		},
 		"biome": [
 			{
 				"name": "useNullishCoalescing",
@@ -23588,12 +23594,6 @@
 				"url": "https://typescript-eslint.io/rules/prefer-nullish-coalescing"
 			}
 		],
-		"flint": {
-			"name": "nullishCoalescingOperators",
-			"plugin": "ts",
-			"preset": "stylistic",
-			"status": "implemented"
-		},
 		"oxlint": [
 			{
 				"name": "typescript/prefer-nullish-coalescing",
@@ -23602,17 +23602,17 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "nulls",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "unicorn/no-null",
 				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-null.md"
 			}
 		],
-		"flint": {
-			"name": "nulls",
-			"plugin": "ts",
-			"status": "skipped"
-		},
 		"oxlint": [
 			{
 				"name": "unicorn/no-null",
@@ -23621,17 +23621,17 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "numberKeyLiterals",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"biome": [
 			{
 				"name": "useSimpleNumberKeys",
 				"url": "https://biomejs.dev/linter/rules/use-simple-number-keys"
 			}
-		],
-		"flint": {
-			"name": "numberKeyLiterals",
-			"plugin": "ts",
-			"status": "skipped"
-		}
+		]
 	},
 	{
 		"flint": {
@@ -23648,6 +23648,13 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "numberStaticMethods",
+			"plugin": "ts",
+			"preset": "logical",
+			"status": "implemented",
+			"strictness": "strict"
+		},
 		"biome": [
 			{
 				"name": "noGlobalIsFinite",
@@ -23668,13 +23675,6 @@
 				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prefer-number-properties.md"
 			}
 		],
-		"flint": {
-			"name": "numberStaticMethods",
-			"plugin": "ts",
-			"preset": "logical",
-			"status": "implemented",
-			"strictness": "strict"
-		},
 		"oxlint": [
 			{
 				"name": "unicorn/prefer-number-properties",
@@ -23683,6 +23683,11 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "numberToFixedDigits",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"biome": [
 			{
 				"name": "useNumberToFixedDigitsArgument",
@@ -23695,11 +23700,6 @@
 				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/require-number-to-fixed-digits-argument.md"
 			}
 		],
-		"flint": {
-			"name": "numberToFixedDigits",
-			"plugin": "ts",
-			"status": "skipped"
-		},
 		"oxlint": [
 			{
 				"name": "unicorn/require-number-to-fixed-digits-argument",
@@ -23708,17 +23708,17 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "numericConstantApproximations",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"biome": [
 			{
 				"name": "noApproximativeNumericConstant",
 				"url": "https://biomejs.dev/linter/rules/no-approximative-numeric-constant"
 			}
 		],
-		"flint": {
-			"name": "numericConstantApproximations",
-			"plugin": "ts",
-			"status": "skipped"
-		},
 		"oxlint": [
 			{
 				"name": "oxc/approx-constant",
@@ -23741,26 +23741,32 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "numericLiteralCasing",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "unicorn/number-literal-case",
 				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/number-literal-case.md"
 			}
 		],
-		"flint": {
-			"name": "numericLiteralCasing",
-			"plugin": "ts",
-			"status": "skipped"
-		},
-		"notes": "Formatting rule.",
 		"oxlint": [
 			{
 				"name": "unicorn/number-literal-case",
 				"url": "https://oxc.rs/docs/guide/usage/linter/rules/unicorn/number-literal-case.html"
 			}
-		]
+		],
+		"notes": "Formatting rule."
 	},
 	{
+		"flint": {
+			"name": "numericLiteralParsing",
+			"plugin": "ts",
+			"preset": "stylistic",
+			"status": "implemented"
+		},
 		"biome": [
 			{
 				"name": "useNumericLiterals",
@@ -23773,12 +23779,6 @@
 				"url": "https://eslint.org/docs/latest/rules/prefer-numeric-literals"
 			}
 		],
-		"flint": {
-			"name": "numericLiteralParsing",
-			"plugin": "ts",
-			"preset": "stylistic",
-			"status": "implemented"
-		},
 		"oxlint": [
 			{
 				"name": "eslint/prefer-numeric-literals",
@@ -23787,6 +23787,12 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "numericPrecision",
+			"plugin": "ts",
+			"preset": "logical",
+			"status": "implemented"
+		},
 		"biome": [
 			{
 				"name": "noPrecisionLoss",
@@ -23803,12 +23809,6 @@
 				"url": "https://typescript-eslint.io/rules/no-loss-of-precision"
 			}
 		],
-		"flint": {
-			"name": "numericPrecision",
-			"plugin": "ts",
-			"preset": "logical",
-			"status": "implemented"
-		},
 		"oxlint": [
 			{
 				"name": "eslint/no-loss-of-precision",
@@ -23817,6 +23817,13 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "numericSeparatorGroups",
+			"plugin": "ts",
+			"preset": "stylistic",
+			"status": "implemented",
+			"strictness": "strict"
+		},
 		"biome": [
 			{
 				"name": "useNumericSeparators",
@@ -23829,13 +23836,6 @@
 				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/numeric-separators-style.md"
 			}
 		],
-		"flint": {
-			"name": "numericSeparatorGroups",
-			"plugin": "ts",
-			"preset": "stylistic",
-			"status": "implemented",
-			"strictness": "strict"
-		},
 		"oxlint": [
 			{
 				"name": "unicorn/numeric-separators-style",
@@ -23844,6 +23844,12 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "objectAssignSpreads",
+			"plugin": "ts",
+			"preset": "stylistic",
+			"status": "implemented"
+		},
 		"biome": [
 			{
 				"name": "useObjectSpread",
@@ -23856,12 +23862,6 @@
 				"url": "https://eslint.org/docs/latest/rules/prefer-object-spread"
 			}
 		],
-		"flint": {
-			"name": "objectAssignSpreads",
-			"plugin": "ts",
-			"preset": "stylistic",
-			"status": "implemented"
-		},
 		"oxlint": [
 			{
 				"name": "eslint/prefer-object-spread",
@@ -23870,18 +23870,18 @@
 		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "no-object-constructor",
-				"url": "https://eslint.org/docs/latest/rules/no-object-constructor"
-			}
-		],
 		"flint": {
 			"name": "objectCalls",
 			"plugin": "ts",
 			"preset": "logical",
 			"status": "implemented"
 		},
+		"eslint": [
+			{
+				"name": "no-object-constructor",
+				"url": "https://eslint.org/docs/latest/rules/no-object-constructor"
+			}
+		],
 		"oxlint": [
 			{
 				"name": "eslint/no-object-constructor",
@@ -23890,17 +23890,17 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "objectDefaultParameters",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "unicorn/no-object-as-default-parameter",
 				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-object-as-default-parameter.md"
 			}
 		],
-		"flint": {
-			"name": "objectDefaultParameters",
-			"plugin": "ts",
-			"status": "skipped"
-		},
 		"oxlint": [
 			{
 				"name": "unicorn/no-object-as-default-parameter",
@@ -23909,12 +23909,6 @@
 		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "unicorn/prefer-object-from-entries",
-				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prefer-object-from-entries.md"
-			}
-		],
 		"flint": {
 			"name": "objectEntriesMethods",
 			"plugin": "ts",
@@ -23922,6 +23916,12 @@
 			"status": "implemented",
 			"strictness": "strict"
 		},
+		"eslint": [
+			{
+				"name": "unicorn/prefer-object-from-entries",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prefer-object-from-entries.md"
+			}
+		],
 		"oxlint": [
 			{
 				"name": "unicorn/prefer-object-from-entries",
@@ -23930,6 +23930,12 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "objectHasOwns",
+			"plugin": "ts",
+			"preset": "stylistic",
+			"status": "implemented"
+		},
 		"biome": [
 			{
 				"name": "noPrototypeBuiltins",
@@ -23942,12 +23948,6 @@
 				"url": "https://eslint.org/docs/latest/rules/prefer-object-has-own"
 			}
 		],
-		"flint": {
-			"name": "objectHasOwns",
-			"plugin": "ts",
-			"preset": "stylistic",
-			"status": "implemented"
-		},
 		"oxlint": [
 			{
 				"name": "eslint/prefer-object-has-own",
@@ -23956,6 +23956,12 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "objectKeyDuplicates",
+			"plugin": "ts",
+			"preset": "javascript",
+			"status": "implemented"
+		},
 		"biome": [
 			{
 				"name": "noDuplicateObjectKeys",
@@ -23968,12 +23974,6 @@
 				"url": "https://eslint.org/docs/latest/rules/no-dupe-keys"
 			}
 		],
-		"flint": {
-			"name": "objectKeyDuplicates",
-			"plugin": "ts",
-			"preset": "javascript",
-			"status": "implemented"
-		},
 		"oxlint": [
 			{
 				"name": "eslint/no-dupe-keys",
@@ -23995,6 +23995,12 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "objectProto",
+			"plugin": "ts",
+			"preset": "javascript",
+			"status": "implemented"
+		},
 		"biome": [
 			{
 				"name": "noProto",
@@ -24007,12 +24013,6 @@
 				"url": "https://eslint.org/docs/latest/rules/no-proto"
 			}
 		],
-		"flint": {
-			"name": "objectProto",
-			"plugin": "ts",
-			"preset": "javascript",
-			"status": "implemented"
-		},
 		"oxlint": [
 			{
 				"name": "eslint/no-proto",
@@ -24021,6 +24021,12 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "objectPrototypeBuiltIns",
+			"plugin": "ts",
+			"preset": "logical",
+			"status": "implemented"
+		},
 		"biome": [
 			{
 				"name": "noPrototypeBuiltins",
@@ -24039,12 +24045,6 @@
 				"url": "https://eslint.org/docs/latest/rules/no-prototype-builtins"
 			}
 		],
-		"flint": {
-			"name": "objectPrototypeBuiltIns",
-			"plugin": "ts",
-			"preset": "logical",
-			"status": "implemented"
-		},
 		"oxlint": [
 			{
 				"name": "eslint/no-prototype-builtins",
@@ -24053,6 +24053,12 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "objectShorthand",
+			"plugin": "ts",
+			"preset": "stylistic",
+			"status": "implemented"
+		},
 		"biome": [
 			{
 				"name": "useConsistentObjectDefinitions",
@@ -24065,12 +24071,6 @@
 				"url": "https://eslint.org/docs/latest/rules/object-shorthand"
 			}
 		],
-		"flint": {
-			"name": "objectShorthand",
-			"plugin": "ts",
-			"preset": "stylistic",
-			"status": "implemented"
-		},
 		"oxlint": [
 			{
 				"name": "eslint/object-shorthand",
@@ -24079,6 +24079,11 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "objectsOrder",
+			"plugin": "ts",
+			"preset": "sorting"
+		},
 		"eslint": [
 			{
 				"name": "sort-keys",
@@ -24089,11 +24094,6 @@
 				"url": "https://perfectionist.dev/rules/sort-objects"
 			}
 		],
-		"flint": {
-			"name": "objectsOrder",
-			"plugin": "ts",
-			"preset": "sorting"
-		},
 		"oxlint": [
 			{
 				"name": "eslint/sort-keys",
@@ -24102,18 +24102,18 @@
 		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "unicorn/no-useless-fallback-in-spread",
-				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-useless-fallback-in-spread.md"
-			}
-		],
 		"flint": {
 			"name": "objectSpreadUnnecessaryFallbacks",
 			"plugin": "ts",
 			"preset": "logical",
 			"status": "implemented"
 		},
+		"eslint": [
+			{
+				"name": "unicorn/no-useless-fallback-in-spread",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-useless-fallback-in-spread.md"
+			}
+		],
 		"oxlint": [
 			{
 				"name": "unicorn/no-useless-fallback-in-spread",
@@ -24122,6 +24122,12 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "objectTypeDefinitions",
+			"plugin": "ts",
+			"preset": "stylistic",
+			"status": "implemented"
+		},
 		"biome": [
 			{
 				"name": "useConsistentTypeDefinitions",
@@ -24134,12 +24140,6 @@
 				"url": "https://typescript-eslint.io/rules/consistent-type-definitions"
 			}
 		],
-		"flint": {
-			"name": "objectTypeDefinitions",
-			"plugin": "ts",
-			"preset": "stylistic",
-			"status": "implemented"
-		},
 		"oxlint": [
 			{
 				"name": "typescript/consistent-type-definitions",
@@ -24148,19 +24148,25 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "objectTypesOrder",
+			"plugin": "ts",
+			"preset": "sorting"
+		},
 		"eslint": [
 			{
 				"name": "perfectionist/sort-object-types",
 				"url": "https://perfectionist.dev/rules/sort-object-types"
 			}
-		],
-		"flint": {
-			"name": "objectTypesOrder",
-			"plugin": "ts",
-			"preset": "sorting"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "octalEscapes",
+			"plugin": "ts",
+			"preset": "javascript",
+			"status": "implemented"
+		},
 		"biome": [
 			{
 				"name": "noOctalEscape",
@@ -24172,29 +24178,29 @@
 				"name": "no-octal-escape",
 				"url": "https://eslint.org/docs/latest/rules/no-octal-escape"
 			}
-		],
-		"flint": {
-			"name": "octalEscapes",
-			"plugin": "ts",
-			"preset": "javascript",
-			"status": "implemented"
-		}
+		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "no-octal",
-				"url": "https://eslint.org/docs/latest/rules/no-octal"
-			}
-		],
 		"flint": {
 			"name": "octalNumbers",
 			"plugin": "ts",
 			"preset": "javascript",
 			"status": "implemented"
-		}
+		},
+		"eslint": [
+			{
+				"name": "no-octal",
+				"url": "https://eslint.org/docs/latest/rules/no-octal"
+			}
+		]
 	},
 	{
+		"flint": {
+			"name": "operatorAssignmentShorthand",
+			"plugin": "ts",
+			"preset": "stylistic",
+			"status": "implemented"
+		},
 		"biome": [
 			{
 				"name": "useShorthandAssign",
@@ -24207,12 +24213,6 @@
 				"url": "https://eslint.org/docs/latest/rules/operator-assignment"
 			}
 		],
-		"flint": {
-			"name": "operatorAssignmentShorthand",
-			"plugin": "ts",
-			"preset": "stylistic",
-			"status": "implemented"
-		},
 		"oxlint": [
 			{
 				"name": "eslint/operator-assignment",
@@ -24234,6 +24234,11 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "optionalChainOperators",
+			"plugin": "ts",
+			"preset": "stylistic"
+		},
 		"biome": [
 			{
 				"name": "useOptionalChain",
@@ -24246,11 +24251,6 @@
 				"url": "https://typescript-eslint.io/rules/prefer-optional-chain"
 			}
 		],
-		"flint": {
-			"name": "optionalChainOperators",
-			"plugin": "ts",
-			"preset": "stylistic"
-		},
 		"oxlint": [
 			{
 				"name": "typescript/prefer-optional-chain",
@@ -24259,6 +24259,12 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "overloadSignaturesAdjacent",
+			"plugin": "ts",
+			"preset": "stylistic",
+			"status": "implemented"
+		},
 		"biome": [
 			{
 				"name": "useAdjacentOverloadSignatures",
@@ -24277,12 +24283,6 @@
 				"url": "https://typescript-eslint.io/rules/adjacent-overload-signatures"
 			}
 		],
-		"flint": {
-			"name": "overloadSignaturesAdjacent",
-			"plugin": "ts",
-			"preset": "stylistic",
-			"status": "implemented"
-		},
 		"oxlint": [
 			{
 				"name": "typescript/adjacent-overload-signatures",
@@ -24291,6 +24291,11 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "parameterProperties",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"biome": [
 			{
 				"name": "noParameterProperties",
@@ -24307,11 +24312,6 @@
 				"url": "https://github.com/JoshuaKGoldberg/eslint-plugin-erasable-syntax-only/blob/HEAD/docs/rules/parameter-properties.md"
 			}
 		],
-		"flint": {
-			"name": "parameterProperties",
-			"plugin": "ts",
-			"status": "skipped"
-		},
 		"oxlint": [
 			{
 				"name": "typescript/parameter-properties",
@@ -24320,17 +24320,17 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "parameterPropertyAssignment",
+			"plugin": "ts",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "@typescript-eslint/no-unnecessary-parameter-property-assignment",
 				"url": "https://typescript-eslint.io/rules/no-unnecessary-parameter-property-assignment"
 			}
 		],
-		"flint": {
-			"name": "parameterPropertyAssignment",
-			"plugin": "ts",
-			"preset": "logical"
-		},
 		"oxlint": [
 			{
 				"name": "typescript/no-unnecessary-parameter-property-assignment",
@@ -24339,6 +24339,12 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "parameterReassignments",
+			"plugin": "ts",
+			"preset": "logical",
+			"status": "implemented"
+		},
 		"biome": [
 			{
 				"name": "noParameterAssign",
@@ -24351,12 +24357,6 @@
 				"url": "https://eslint.org/docs/latest/rules/no-param-reassign"
 			}
 		],
-		"flint": {
-			"name": "parameterReassignments",
-			"plugin": "ts",
-			"preset": "logical",
-			"status": "implemented"
-		},
 		"oxlint": [
 			{
 				"name": "eslint/no-param-reassign",
@@ -24365,16 +24365,16 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "parentRelativeImports",
+			"plugin": "ts"
+		},
 		"eslint": [
 			{
 				"name": "import/no-relative-parent-imports",
 				"url": "https://github.com/import-js/eslint-plugin-import/blob/v2.32.0/docs/rules/no-relative-parent-imports.md"
 			}
 		],
-		"flint": {
-			"name": "parentRelativeImports",
-			"plugin": "ts"
-		},
 		"oxlint": [
 			{
 				"name": "import/no-relative-parent-imports",
@@ -24383,6 +24383,12 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "parseIntRadixes",
+			"plugin": "ts",
+			"preset": "logical",
+			"status": "implemented"
+		},
 		"biome": [
 			{
 				"name": "useParseIntRadix",
@@ -24395,12 +24401,6 @@
 				"url": "https://eslint.org/docs/latest/rules/radix"
 			}
 		],
-		"flint": {
-			"name": "parseIntRadixes",
-			"plugin": "ts",
-			"preset": "logical",
-			"status": "implemented"
-		},
 		"oxlint": [
 			{
 				"name": "eslint/radix",
@@ -24409,6 +24409,11 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "plusOperands",
+			"plugin": "ts",
+			"preset": "logical"
+		},
 		"biome": [
 			{
 				"name": "noUnsafePlusOperands",
@@ -24421,11 +24426,6 @@
 				"url": "https://typescript-eslint.io/rules/restrict-plus-operands"
 			}
 		],
-		"flint": {
-			"name": "plusOperands",
-			"plugin": "ts",
-			"preset": "logical"
-		},
 		"oxlint": [
 			{
 				"name": "typescript/restrict-plus-operands",
@@ -24434,6 +24434,11 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "plusPlusOperators",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"biome": [
 			{
 				"name": "noIncrementDecrement",
@@ -24446,11 +24451,6 @@
 				"url": "https://eslint.org/docs/latest/rules/no-plusplus"
 			}
 		],
-		"flint": {
-			"name": "plusPlusOperators",
-			"plugin": "ts",
-			"status": "skipped"
-		},
 		"oxlint": [
 			{
 				"name": "eslint/no-plusplus",
@@ -24459,30 +24459,30 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "prefixedClassLikes",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "unicorn/no-keyword-prefix",
 				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-keyword-prefix.md"
 			}
-		],
-		"flint": {
-			"name": "prefixedClassLikes",
-			"plugin": "ts",
-			"status": "skipped"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "privateImports",
+			"plugin": "ts",
+			"preset": "logical"
+		},
 		"biome": [
 			{
 				"name": "noPrivateImports",
 				"url": "https://biomejs.dev/linter/rules/no-private-imports"
 			}
-		],
-		"flint": {
-			"name": "privateImports",
-			"plugin": "ts",
-			"preset": "logical"
-		}
+		]
 	},
 	{
 		"flint": {
@@ -24490,13 +24490,13 @@
 			"plugin": "ts",
 			"status": "skipped"
 		},
-		"notes": "Superseded by floatingPromises.",
 		"oxlint": [
 			{
 				"name": "promise/always-return",
 				"url": "https://oxc.rs/docs/guide/usage/linter/rules/promise/always-return.html"
 			}
-		]
+		],
+		"notes": "Superseded by floatingPromises."
 	},
 	{
 		"flint": {
@@ -24512,37 +24512,37 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "promiseAwaitableCallbacks",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "promise/prefer-await-to-callbacks",
 				"url": "https://github.com/eslint-community/eslint-plugin-promise/blob/HEAD/docs/rules/prefer-await-to-callbacks.md"
 			}
 		],
-		"flint": {
-			"name": "promiseAwaitableCallbacks",
-			"plugin": "ts",
-			"status": "skipped"
-		},
-		"notes": "Overly opinionated.",
 		"oxlint": [
 			{
 				"name": "promise/prefer-await-to-callbacks",
 				"url": "https://oxc.rs/docs/guide/usage/linter/rules/promise/prefer-await-to-callbacks.html"
 			}
-		]
+		],
+		"notes": "Overly opinionated."
 	},
 	{
+		"flint": {
+			"name": "promiseAwaitableThens",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "promise/prefer-await-to-then",
 				"url": "https://github.com/eslint-community/eslint-plugin-promise/blob/HEAD/docs/rules/prefer-await-to-then.md"
 			}
 		],
-		"flint": {
-			"name": "promiseAwaitableThens",
-			"plugin": "ts",
-			"status": "skipped"
-		},
 		"oxlint": [
 			{
 				"name": "promise/prefer-await-to-then",
@@ -24551,29 +24551,29 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "promiseCallbackCreations",
+			"plugin": "ts"
+		},
 		"eslint": [
 			{
 				"name": "promise/no-promise-in-callback",
 				"url": "https://github.com/eslint-community/eslint-plugin-promise/blob/main/docs/rules/no-promise-in-callback.md"
 			}
-		],
-		"flint": {
-			"name": "promiseCallbackCreations",
-			"plugin": "ts"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "promiseCatchableThens",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "promise/prefer-catch",
 				"url": "https://github.com/eslint-community/eslint-plugin-promise/blob/HEAD/docs/rules/prefer-catch.md"
 			}
 		],
-		"flint": {
-			"name": "promiseCatchableThens",
-			"plugin": "ts",
-			"status": "skipped"
-		},
 		"oxlint": [
 			{
 				"name": "promise/prefer-catch",
@@ -24587,25 +24587,25 @@
 			"plugin": "ts",
 			"status": "skipped"
 		},
-		"notes": "Superseded by floatingPromises.",
 		"oxlint": [
 			{
 				"name": "promise/catch-or-return",
 				"url": "https://oxc.rs/docs/guide/usage/linter/rules/promise/catch-or-return.html"
 			}
-		]
+		],
+		"notes": "Superseded by floatingPromises."
 	},
 	{
+		"flint": {
+			"name": "promiseCatchReturns",
+			"plugin": "ts"
+		},
 		"eslint": [
 			{
 				"name": "promise/catch-or-return",
 				"url": "https://github.com/eslint-community/eslint-plugin-promise/blob/main/docs/rules/catch-or-return.md"
 			}
-		],
-		"flint": {
-			"name": "promiseCatchReturns",
-			"plugin": "ts"
-		}
+		]
 	},
 	{
 		"flint": {
@@ -24613,66 +24613,66 @@
 			"plugin": "ts",
 			"status": "skipped"
 		},
-		"notes": "Superseded by floatingPromises.",
 		"oxlint": [
 			{
 				"name": "promise/no-promise-in-callback",
 				"url": "https://oxc.rs/docs/guide/usage/linter/rules/promise/no-promise-in-callback.html"
 			}
-		]
+		],
+		"notes": "Superseded by floatingPromises."
 	},
 	{
+		"flint": {
+			"name": "promiseExecutorReturns",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "no-promise-executor-return",
 				"url": "https://eslint.org/docs/latest/rules/no-promise-executor-return"
 			}
 		],
-		"flint": {
-			"name": "promiseExecutorReturns",
-			"plugin": "ts",
-			"status": "skipped"
-		},
-		"notes": "Superseded by awaitThenable.",
 		"oxlint": [
 			{
 				"name": "eslint/no-promise-executor-return",
 				"url": "https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-promise-executor-return.html"
 			}
-		]
+		],
+		"notes": "Superseded by awaitThenable."
 	},
 	{
+		"flint": {
+			"name": "promiseFinallyReturns",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "promise/no-return-in-finally",
 				"url": "https://github.com/eslint-community/eslint-plugin-promise/blob/HEAD/docs/rules/no-return-in-finally.md"
 			}
 		],
-		"flint": {
-			"name": "promiseFinallyReturns",
-			"plugin": "ts",
-			"status": "skipped"
-		},
-		"notes": "Largely covered by returnVoidSafety.",
 		"oxlint": [
 			{
 				"name": "promise/no-return-in-finally",
 				"url": "https://oxc.rs/docs/guide/usage/linter/rules/promise/no-return-in-finally.html"
 			}
-		]
+		],
+		"notes": "Largely covered by returnVoidSafety."
 	},
 	{
+		"flint": {
+			"name": "promiseFunctionAsync",
+			"plugin": "ts",
+			"preset": "stylistic"
+		},
 		"eslint": [
 			{
 				"name": "@typescript-eslint/promise-function-async",
 				"url": "https://typescript-eslint.io/rules/promise-function-async"
 			}
 		],
-		"flint": {
-			"name": "promiseFunctionAsync",
-			"plugin": "ts",
-			"preset": "stylistic"
-		},
 		"oxlint": [
 			{
 				"name": "typescript/promise-function-async",
@@ -24681,17 +24681,17 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "promiseMethodSingleArrayArguments",
+			"plugin": "ts",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "unicorn/no-single-promise-in-promise-methods",
 				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-single-promise-in-promise-methods.md"
 			}
 		],
-		"flint": {
-			"name": "promiseMethodSingleArrayArguments",
-			"plugin": "ts",
-			"preset": "logical"
-		},
 		"oxlint": [
 			{
 				"name": "unicorn/no-single-promise-in-promise-methods",
@@ -24700,16 +24700,16 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "promiseMultipleResolutions",
+			"plugin": "ts"
+		},
 		"eslint": [
 			{
 				"name": "promise/no-multiple-resolved",
 				"url": "https://github.com/eslint-community/eslint-plugin-promise/blob/main/docs/rules/no-multiple-resolved.md"
 			}
 		],
-		"flint": {
-			"name": "promiseMultipleResolutions",
-			"plugin": "ts"
-		},
 		"oxlint": [
 			{
 				"name": "promise/no-multiple-resolved",
@@ -24718,6 +24718,11 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "promiseNesting",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"biome": [
 			{
 				"name": "noNestedPromises",
@@ -24730,38 +24735,33 @@
 				"url": "https://github.com/eslint-community/eslint-plugin-promise/blob/HEAD/docs/rules/no-nesting.md"
 			}
 		],
-		"flint": {
-			"name": "promiseNesting",
-			"plugin": "ts",
-			"status": "skipped"
-		},
-		"notes": "Overly opinionated.",
 		"oxlint": [
 			{
 				"name": "promise/no-nesting",
 				"url": "https://oxc.rs/docs/guide/usage/linter/rules/promise/no-nesting.html"
 			}
-		]
+		],
+		"notes": "Overly opinionated."
 	},
 	{
+		"flint": {
+			"name": "promiseNews",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "promise/avoid-new",
 				"url": "https://github.com/eslint-community/eslint-plugin-promise/blob/HEAD/docs/rules/avoid-new.md"
 			}
 		],
-		"flint": {
-			"name": "promiseNews",
-			"plugin": "ts",
-			"status": "skipped"
-		},
-		"notes": "Overly opinionated.",
 		"oxlint": [
 			{
 				"name": "promise/avoid-new",
 				"url": "https://oxc.rs/docs/guide/usage/linter/rules/promise/avoid-new.html"
 			}
-		]
+		],
+		"notes": "Overly opinionated."
 	},
 	{
 		"flint": {
@@ -24782,47 +24782,52 @@
 			"plugin": "ts",
 			"status": "skipped"
 		},
-		"notes": "Superseded by floatingPromises.",
 		"oxlint": [
 			{
 				"name": "promise/spec-only",
 				"url": "https://oxc.rs/docs/guide/usage/linter/rules/promise/spec-only.html"
 			}
-		]
+		],
+		"notes": "Superseded by floatingPromises."
 	},
 	{
+		"flint": {
+			"name": "promiseParameterNames",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "promise/param-names",
 				"url": "https://github.com/eslint-community/eslint-plugin-promise/blob/HEAD/docs/rules/param-names.md"
 			}
 		],
-		"flint": {
-			"name": "promiseParameterNames",
-			"plugin": "ts",
-			"status": "skipped"
-		},
-		"notes": "Overly opinionated.",
 		"oxlint": [
 			{
 				"name": "promise/param-names",
 				"url": "https://oxc.rs/docs/guide/usage/linter/rules/promise/param-names.html"
 			}
-		]
+		],
+		"notes": "Overly opinionated."
 	},
 	{
+		"flint": {
+			"name": "promiseParameterValidity",
+			"plugin": "ts"
+		},
 		"eslint": [
 			{
 				"name": "promise/valid-params",
 				"url": "https://github.com/eslint-community/eslint-plugin-promise/blob/main/docs/rules/valid-params.md"
 			}
-		],
-		"flint": {
-			"name": "promiseParameterValidity",
-			"plugin": "ts"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "promiseRejectErrors",
+			"plugin": "ts",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "prefer-promise-reject-errors",
@@ -24833,11 +24838,6 @@
 				"url": "https://typescript-eslint.io/rules/prefer-promise-reject-errors"
 			}
 		],
-		"flint": {
-			"name": "promiseRejectErrors",
-			"plugin": "ts",
-			"preset": "logical"
-		},
 		"oxlint": [
 			{
 				"name": "eslint/prefer-promise-reject-errors",
@@ -24850,28 +24850,28 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "promiseReturns",
+			"plugin": "ts"
+		},
 		"eslint": [
 			{
 				"name": "promise/always-return",
 				"url": "https://github.com/eslint-community/eslint-plugin-promise/blob/main/docs/rules/always-return.md"
 			}
-		],
-		"flint": {
-			"name": "promiseReturns",
-			"plugin": "ts"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "promiseReturnWrappers",
+			"plugin": "ts"
+		},
 		"eslint": [
 			{
 				"name": "promise/no-return-wrap",
 				"url": "https://github.com/eslint-community/eslint-plugin-promise/blob/main/docs/rules/no-return-wrap.md"
 			}
 		],
-		"flint": {
-			"name": "promiseReturnWrappers",
-			"plugin": "ts"
-		},
 		"oxlint": [
 			{
 				"name": "promise/no-return-wrap",
@@ -24880,30 +24880,36 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "promiseSpecMethods",
+			"plugin": "ts"
+		},
 		"eslint": [
 			{
 				"name": "promise/spec-only",
 				"url": "https://github.com/eslint-community/eslint-plugin-promise/blob/main/docs/rules/spec-only.md"
 			}
-		],
-		"flint": {
-			"name": "promiseSpecMethods",
-			"plugin": "ts"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "promiseStaticConstructors",
+			"plugin": "ts"
+		},
 		"eslint": [
 			{
 				"name": "promise/no-new-statics",
 				"url": "https://github.com/eslint-community/eslint-plugin-promise/blob/main/docs/rules/no-new-statics.md"
 			}
-		],
-		"flint": {
-			"name": "promiseStaticConstructors",
-			"plugin": "ts"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "propertyAccessNotation",
+			"plugin": "ts",
+			"preset": "stylistic",
+			"status": "implemented"
+		},
 		"biome": [
 			{
 				"name": "useLiteralKeys",
@@ -24920,12 +24926,6 @@
 				"url": "https://typescript-eslint.io/rules/dot-notation"
 			}
 		],
-		"flint": {
-			"name": "propertyAccessNotation",
-			"plugin": "ts",
-			"preset": "stylistic",
-			"status": "implemented"
-		},
 		"oxlint": [
 			{
 				"name": "typescript/dot-notation",
@@ -24934,17 +24934,17 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "prototypeIterators",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "no-iterator",
 				"url": "https://eslint.org/docs/latest/rules/no-iterator"
 			}
 		],
-		"flint": {
-			"name": "prototypeIterators",
-			"plugin": "ts",
-			"status": "skipped"
-		},
 		"oxlint": [
 			{
 				"name": "eslint/no-iterator",
@@ -24953,6 +24953,11 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "readonlyClassProperties",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"biome": [
 			{
 				"name": "useReadonlyClassProperties",
@@ -24965,38 +24970,33 @@
 				"url": "https://typescript-eslint.io/rules/prefer-readonly"
 			}
 		],
-		"flint": {
-			"name": "readonlyClassProperties",
-			"plugin": "ts",
-			"status": "skipped"
-		},
-		"notes": "Better suited to a functional/immutable-focused plugin.",
 		"oxlint": [
 			{
 				"name": "typescript/prefer-readonly",
 				"url": "https://oxc.rs/docs/guide/usage/linter/rules/typescript/prefer-readonly.html"
 			}
-		]
+		],
+		"notes": "Better suited to a functional/immutable-focused plugin."
 	},
 	{
+		"flint": {
+			"name": "readonlyParameterTypes",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "@typescript-eslint/prefer-readonly-parameter-types",
 				"url": "https://typescript-eslint.io/rules/prefer-readonly-parameter-types"
 			}
 		],
-		"flint": {
-			"name": "readonlyParameterTypes",
-			"plugin": "ts",
-			"status": "skipped"
-		},
-		"notes": "Better suited to a functional/immutable-focused plugin.",
 		"oxlint": [
 			{
 				"name": "typescript/prefer-readonly-parameter-types",
 				"url": "https://oxc.rs/docs/guide/usage/linter/rules/typescript/prefer-readonly-parameter-types.html"
 			}
-		]
+		],
+		"notes": "Better suited to a functional/immutable-focused plugin."
 	},
 	{
 		"flint": {
@@ -25013,32 +25013,32 @@
 		]
 	},
 	{
-		"biome": [
-			{
-				"name": "noParametersOnlyUsedInRecursion",
-				"url": "https://biomejs.dev/linter/rules/no-parameters-only-used-in-recursion"
-			}
-		],
 		"flint": {
 			"name": "recursiveParameters",
 			"plugin": "ts",
 			"preset": "logical",
 			"strictness": "strict"
-		}
+		},
+		"biome": [
+			{
+				"name": "noParametersOnlyUsedInRecursion",
+				"url": "https://biomejs.dev/linter/rules/no-parameters-only-used-in-recursion"
+			}
+		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "@typescript-eslint/no-redundant-type-constituents",
-				"url": "https://typescript-eslint.io/rules/no-redundant-type-constituents"
-			}
-		],
 		"flint": {
 			"name": "redundantTypeConstituents",
 			"plugin": "ts",
 			"preset": "logical",
 			"status": "implemented"
 		},
+		"eslint": [
+			{
+				"name": "@typescript-eslint/no-redundant-type-constituents",
+				"url": "https://typescript-eslint.io/rules/no-redundant-type-constituents"
+			}
+		],
 		"oxlint": [
 			{
 				"name": "typescript/no-redundant-type-constituents",
@@ -25047,31 +25047,31 @@
 		]
 	},
 	{
-		"biome": [
-			{
-				"name": "noReExportAll",
-				"url": "https://biomejs.dev/linter/rules/no-re-export-all"
-			}
-		],
 		"flint": {
 			"name": "reExportAlls",
 			"plugin": "ts",
 			"preset": "logical",
 			"strictness": "strict"
-		}
+		},
+		"biome": [
+			{
+				"name": "noReExportAll",
+				"url": "https://biomejs.dev/linter/rules/no-re-export-all"
+			}
+		]
 	},
 	{
+		"flint": {
+			"name": "reflectApplies",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "unicorn/prefer-reflect-apply",
 				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prefer-reflect-apply.md"
 			}
 		],
-		"flint": {
-			"name": "reflectApplies",
-			"plugin": "ts",
-			"status": "skipped"
-		},
 		"oxlint": [
 			{
 				"name": "unicorn/prefer-reflect-apply",
@@ -25080,18 +25080,18 @@
 		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "regexp/no-missing-g-flag",
-				"url": "https://ota-meshi.github.io/eslint-plugin-regexp/rules/no-missing-g-flag.html"
-			}
-		],
 		"flint": {
 			"name": "regexAllGlobalFlags",
 			"plugin": "ts",
 			"preset": "logical",
 			"status": "implemented"
 		},
+		"eslint": [
+			{
+				"name": "regexp/no-missing-g-flag",
+				"url": "https://ota-meshi.github.io/eslint-plugin-regexp/rules/no-missing-g-flag.html"
+			}
+		],
 		"oxlint": [
 			{
 				"name": "oxc/bad-replace-all-arg",
@@ -25100,91 +25100,96 @@
 		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "regexp/strict",
-				"url": "https://ota-meshi.github.io/eslint-plugin-regexp/rules/strict.html"
-			}
-		],
 		"flint": {
 			"name": "regexAmbiguousInvalidity",
 			"plugin": "ts",
 			"preset": "logical",
 			"status": "implemented"
-		}
-	},
-	{
+		},
 		"eslint": [
 			{
-				"name": "regexp/prefer-character-class",
-				"url": "https://ota-meshi.github.io/eslint-plugin-regexp/rules/prefer-character-class.html"
+				"name": "regexp/strict",
+				"url": "https://ota-meshi.github.io/eslint-plugin-regexp/rules/strict.html"
 			}
-		],
+		]
+	},
+	{
 		"flint": {
 			"name": "regexCharacterClasses",
 			"plugin": "ts",
 			"preset": "stylistic",
 			"status": "implemented",
 			"strictness": "strict"
-		}
-	},
-	{
+		},
 		"eslint": [
 			{
-				"name": "regexp/prefer-range",
-				"url": "https://ota-meshi.github.io/eslint-plugin-regexp/rules/prefer-range.html"
+				"name": "regexp/prefer-character-class",
+				"url": "https://ota-meshi.github.io/eslint-plugin-regexp/rules/prefer-character-class.html"
 			}
-		],
+		]
+	},
+	{
 		"flint": {
 			"name": "regexCharacterClassRanges",
 			"plugin": "ts",
 			"preset": "stylistic",
 			"status": "implemented"
-		}
-	},
-	{
+		},
 		"eslint": [
 			{
-				"name": "regexp/prefer-set-operation",
-				"url": "https://ota-meshi.github.io/eslint-plugin-regexp/rules/prefer-set-operation.html"
+				"name": "regexp/prefer-range",
+				"url": "https://ota-meshi.github.io/eslint-plugin-regexp/rules/prefer-range.html"
 			}
-		],
+		]
+	},
+	{
 		"flint": {
 			"name": "regexCharacterClassSetOperations",
 			"plugin": "ts",
 			"preset": "stylistic",
 			"status": "implemented"
-		}
-	},
-	{
+		},
 		"eslint": [
 			{
-				"name": "regexp/negation",
-				"url": "https://ota-meshi.github.io/eslint-plugin-regexp/rules/negation.html"
+				"name": "regexp/prefer-set-operation",
+				"url": "https://ota-meshi.github.io/eslint-plugin-regexp/rules/prefer-set-operation.html"
 			}
-		],
+		]
+	},
+	{
 		"flint": {
 			"name": "regexConciseCharacterClassNegations",
 			"plugin": "ts",
 			"preset": "stylistic",
 			"status": "implemented"
-		}
+		},
+		"eslint": [
+			{
+				"name": "regexp/negation",
+				"url": "https://ota-meshi.github.io/eslint-plugin-regexp/rules/negation.html"
+			}
+		]
 	},
 	{
+		"flint": {
+			"name": "regexConciseness",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "unicorn/better-regex",
 				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/better-regex.md"
 			}
 		],
-		"flint": {
-			"name": "regexConciseness",
-			"plugin": "ts",
-			"status": "skipped"
-		},
 		"notes": "Superseded by other regex cleanliness rules."
 	},
 	{
+		"flint": {
+			"name": "regexConsecutiveSpaces",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"biome": [
 			{
 				"name": "noAdjacentSpacesInRegex",
@@ -25203,11 +25208,6 @@
 				"url": "https://eslint.org/docs/latest/rules/no-regex-spaces"
 			}
 		],
-		"flint": {
-			"name": "regexConsecutiveSpaces",
-			"plugin": "ts",
-			"status": "skipped"
-		},
 		"oxlint": [
 			{
 				"name": "eslint/no-regex-spaces",
@@ -25216,34 +25216,40 @@
 		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "regexp/no-contradiction-with-assertion",
-				"url": "https://ota-meshi.github.io/eslint-plugin-regexp/rules/no-contradiction-with-assertion.html"
-			}
-		],
 		"flint": {
 			"name": "regexContradictoryAssertions",
 			"plugin": "ts",
 			"preset": "logical",
 			"status": "implemented"
-		}
-	},
-	{
+		},
 		"eslint": [
 			{
-				"name": "regexp/control-character-escape",
-				"url": "https://ota-meshi.github.io/eslint-plugin-regexp/rules/control-character-escape.html"
+				"name": "regexp/no-contradiction-with-assertion",
+				"url": "https://ota-meshi.github.io/eslint-plugin-regexp/rules/no-contradiction-with-assertion.html"
 			}
-		],
+		]
+	},
+	{
 		"flint": {
 			"name": "regexControlCharacterEscapes",
 			"plugin": "ts",
 			"preset": "logical",
 			"status": "implemented"
-		}
+		},
+		"eslint": [
+			{
+				"name": "regexp/control-character-escape",
+				"url": "https://ota-meshi.github.io/eslint-plugin-regexp/rules/control-character-escape.html"
+			}
+		]
 	},
 	{
+		"flint": {
+			"name": "regexControlCharacters",
+			"plugin": "ts",
+			"preset": "logical",
+			"status": "implemented"
+		},
 		"biome": [
 			{
 				"name": "noControlCharactersInRegex",
@@ -25266,12 +25272,6 @@
 				"url": "https://ota-meshi.github.io/eslint-plugin-regexp/rules/no-control-character.html"
 			}
 		],
-		"flint": {
-			"name": "regexControlCharacters",
-			"plugin": "ts",
-			"preset": "logical",
-			"status": "implemented"
-		},
 		"oxlint": [
 			{
 				"name": "eslint/no-control-regex",
@@ -25280,21 +25280,26 @@
 		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "regexp/prefer-d",
-				"url": "https://ota-meshi.github.io/eslint-plugin-regexp/rules/prefer-d.html"
-			}
-		],
 		"flint": {
 			"name": "regexDigitMatchers",
 			"plugin": "ts",
 			"preset": "stylistic",
 			"status": "implemented",
 			"strictness": "strict"
-		}
+		},
+		"eslint": [
+			{
+				"name": "regexp/prefer-d",
+				"url": "https://ota-meshi.github.io/eslint-plugin-regexp/rules/prefer-d.html"
+			}
+		]
 	},
 	{
+		"flint": {
+			"name": "regexDivisionStarts",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"biome": [
 			{
 				"name": "noDivRegex",
@@ -25307,11 +25312,6 @@
 				"url": "https://eslint.org/docs/latest/rules/no-div-regex"
 			}
 		],
-		"flint": {
-			"name": "regexDivisionStarts",
-			"plugin": "ts",
-			"status": "skipped"
-		},
 		"oxlint": [
 			{
 				"name": "eslint/no-div-regex",
@@ -25320,75 +25320,81 @@
 		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "regexp/prefer-escape-replacement-dollar-char",
-				"url": "https://ota-meshi.github.io/eslint-plugin-regexp/rules/prefer-escape-replacement-dollar-char.html"
-			}
-		],
 		"flint": {
 			"name": "regexDollarEscapes",
 			"plugin": "ts",
 			"preset": "stylistic",
 			"status": "implemented"
-		}
-	},
-	{
+		},
 		"eslint": [
 			{
-				"name": "regexp/no-dupe-characters-character-class",
-				"url": "https://ota-meshi.github.io/eslint-plugin-regexp/rules/no-dupe-characters-character-class.html"
+				"name": "regexp/prefer-escape-replacement-dollar-char",
+				"url": "https://ota-meshi.github.io/eslint-plugin-regexp/rules/prefer-escape-replacement-dollar-char.html"
 			}
-		],
+		]
+	},
+	{
 		"flint": {
 			"name": "regexDuplicateCharacterClassCharacters",
 			"plugin": "ts",
 			"preset": "logical",
 			"status": "implemented"
-		}
+		},
+		"eslint": [
+			{
+				"name": "regexp/no-dupe-characters-character-class",
+				"url": "https://ota-meshi.github.io/eslint-plugin-regexp/rules/no-dupe-characters-character-class.html"
+			}
+		]
 	},
 	{
+		"flint": {
+			"name": "regexDuplicateDisjunctions",
+			"plugin": "ts",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "regexp/no-dupe-disjunctions",
 				"url": "https://ota-meshi.github.io/eslint-plugin-regexp/rules/no-dupe-disjunctions.html"
 			}
-		],
-		"flint": {
-			"name": "regexDuplicateDisjunctions",
-			"plugin": "ts",
-			"preset": "logical"
-		}
+		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "regexp/no-empty-alternative",
-				"url": "https://ota-meshi.github.io/eslint-plugin-regexp/rules/no-empty-alternative.html"
-			}
-		],
 		"flint": {
 			"name": "regexEmptyAlternatives",
 			"plugin": "ts",
 			"preset": "logical",
 			"status": "implemented"
-		}
-	},
-	{
+		},
 		"eslint": [
 			{
-				"name": "regexp/no-empty-capturing-group",
-				"url": "https://ota-meshi.github.io/eslint-plugin-regexp/rules/no-empty-capturing-group.html"
+				"name": "regexp/no-empty-alternative",
+				"url": "https://ota-meshi.github.io/eslint-plugin-regexp/rules/no-empty-alternative.html"
 			}
-		],
+		]
+	},
+	{
 		"flint": {
 			"name": "regexEmptyCapturingGroups",
 			"plugin": "ts",
 			"preset": "logical",
 			"status": "implemented"
-		}
+		},
+		"eslint": [
+			{
+				"name": "regexp/no-empty-capturing-group",
+				"url": "https://ota-meshi.github.io/eslint-plugin-regexp/rules/no-empty-capturing-group.html"
+			}
+		]
 	},
 	{
+		"flint": {
+			"name": "regexEmptyCharacterClasses",
+			"plugin": "ts",
+			"preset": "logical",
+			"status": "implemented"
+		},
 		"biome": [
 			{
 				"name": "noEmptyCharacterClassInRegex",
@@ -25411,12 +25417,6 @@
 				"url": "https://eslint.org/docs/latest/rules/no-empty-character-class"
 			}
 		],
-		"flint": {
-			"name": "regexEmptyCharacterClasses",
-			"plugin": "ts",
-			"preset": "logical",
-			"status": "implemented"
-		},
 		"oxlint": [
 			{
 				"name": "eslint/no-empty-character-class",
@@ -25425,76 +25425,83 @@
 		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "regexp/no-empty-group",
-				"url": "https://ota-meshi.github.io/eslint-plugin-regexp/rules/no-empty-group.html"
-			}
-		],
 		"flint": {
 			"name": "regexEmptyGroups",
 			"plugin": "ts",
 			"preset": "logical",
 			"status": "implemented"
-		}
-	},
-	{
+		},
 		"eslint": [
 			{
-				"name": "regexp/no-lazy-ends",
-				"url": "https://ota-meshi.github.io/eslint-plugin-regexp/rules/no-lazy-ends.html"
+				"name": "regexp/no-empty-group",
+				"url": "https://ota-meshi.github.io/eslint-plugin-regexp/rules/no-empty-group.html"
 			}
-		],
+		]
+	},
+	{
 		"flint": {
 			"name": "regexEmptyLazyQuantifiers",
 			"plugin": "ts",
 			"preset": "logical",
 			"status": "implemented"
-		}
-	},
-	{
+		},
 		"eslint": [
 			{
-				"name": "regexp/no-empty-lookarounds-assertion",
-				"url": "https://ota-meshi.github.io/eslint-plugin-regexp/rules/no-empty-lookarounds-assertion.html"
+				"name": "regexp/no-lazy-ends",
+				"url": "https://ota-meshi.github.io/eslint-plugin-regexp/rules/no-lazy-ends.html"
 			}
-		],
+		]
+	},
+	{
 		"flint": {
 			"name": "regexEmptyLookaroundsAssertions",
 			"plugin": "ts",
 			"preset": "logical",
 			"status": "implemented"
-		}
-	},
-	{
+		},
 		"eslint": [
 			{
-				"name": "regexp/no-empty-string-literal",
-				"url": "https://ota-meshi.github.io/eslint-plugin-regexp/rules/no-empty-string-literal.html"
+				"name": "regexp/no-empty-lookarounds-assertion",
+				"url": "https://ota-meshi.github.io/eslint-plugin-regexp/rules/no-empty-lookarounds-assertion.html"
 			}
-		],
+		]
+	},
+	{
 		"flint": {
 			"name": "regexEmptyStringLiterals",
 			"plugin": "ts",
 			"preset": "logical",
 			"status": "implemented"
-		}
-	},
-	{
+		},
 		"eslint": [
 			{
-				"name": "regexp/no-escape-backspace",
-				"url": "https://ota-meshi.github.io/eslint-plugin-regexp/rules/no-escape-backspace.html"
+				"name": "regexp/no-empty-string-literal",
+				"url": "https://ota-meshi.github.io/eslint-plugin-regexp/rules/no-empty-string-literal.html"
 			}
-		],
+		]
+	},
+	{
 		"flint": {
 			"name": "regexEscapeBackspaces",
 			"plugin": "ts",
 			"preset": "stylistic",
 			"status": "implemented"
-		}
+		},
+		"eslint": [
+			{
+				"name": "regexp/no-escape-backspace",
+				"url": "https://ota-meshi.github.io/eslint-plugin-regexp/rules/no-escape-backspace.html"
+			}
+		]
 	},
 	{
+		"flint": {
+			"name": "regexExecutors",
+			"plugin": "ts",
+			"preset": "stylistic",
+			"status": "implemented",
+			"strictness": "strict"
+		},
 		"biome": [
 			{
 				"name": "useRegexpExec",
@@ -25511,13 +25518,6 @@
 				"url": "https://ota-meshi.github.io/eslint-plugin-regexp/rules/prefer-regexp-exec.html"
 			}
 		],
-		"flint": {
-			"name": "regexExecutors",
-			"plugin": "ts",
-			"preset": "stylistic",
-			"status": "implemented",
-			"strictness": "strict"
-		},
 		"oxlint": [
 			{
 				"name": "typescript/prefer-regexp-exec",
@@ -25526,119 +25526,125 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "regexFlagsOrder",
+			"plugin": "ts",
+			"preset": "sorting"
+		},
 		"eslint": [
 			{
 				"name": "regexp/sort-flags",
 				"url": "https://ota-meshi.github.io/eslint-plugin-regexp/rules/sort-flags.html"
 			}
-		],
-		"flint": {
-			"name": "regexFlagsOrder",
-			"plugin": "ts",
-			"preset": "sorting"
-		}
+		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "regexp/grapheme-string-literal",
-				"url": "https://ota-meshi.github.io/eslint-plugin-regexp/rules/grapheme-string-literal.html"
-			}
-		],
 		"flint": {
 			"name": "regexGraphemeStringLiterals",
 			"plugin": "ts",
 			"preset": "stylistic",
 			"status": "implemented",
 			"strictness": "strict"
-		}
-	},
-	{
+		},
 		"eslint": [
 			{
-				"name": "regexp/hexadecimal-escape",
-				"url": "https://ota-meshi.github.io/eslint-plugin-regexp/rules/hexadecimal-escape.html"
+				"name": "regexp/grapheme-string-literal",
+				"url": "https://ota-meshi.github.io/eslint-plugin-regexp/rules/grapheme-string-literal.html"
 			}
-		],
+		]
+	},
+	{
 		"flint": {
 			"name": "regexHexadecimalEscapes",
 			"plugin": "ts",
 			"preset": "stylistic",
 			"status": "implemented",
 			"strictness": "strict"
-		}
-	},
-	{
+		},
 		"eslint": [
 			{
-				"name": "regexp/use-ignore-case",
-				"url": "https://ota-meshi.github.io/eslint-plugin-regexp/rules/use-ignore-case.html"
+				"name": "regexp/hexadecimal-escape",
+				"url": "https://ota-meshi.github.io/eslint-plugin-regexp/rules/hexadecimal-escape.html"
 			}
-		],
+		]
+	},
+	{
 		"flint": {
 			"name": "regexIgnoreCaseFlags",
 			"plugin": "ts",
 			"preset": "logical",
 			"status": "implemented"
-		}
-	},
-	{
+		},
 		"eslint": [
 			{
-				"name": "regexp/no-invisible-character",
-				"url": "https://ota-meshi.github.io/eslint-plugin-regexp/rules/no-invisible-character.html"
+				"name": "regexp/use-ignore-case",
+				"url": "https://ota-meshi.github.io/eslint-plugin-regexp/rules/use-ignore-case.html"
 			}
-		],
+		]
+	},
+	{
 		"flint": {
 			"name": "regexInvisibleCharacters",
 			"plugin": "ts",
 			"preset": "logical",
 			"status": "implemented"
-		}
+		},
+		"eslint": [
+			{
+				"name": "regexp/no-invisible-character",
+				"url": "https://ota-meshi.github.io/eslint-plugin-regexp/rules/no-invisible-character.html"
+			}
+		]
 	},
 	{
+		"flint": {
+			"name": "regexLegacyFeatures",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "regexp/no-legacy-features",
 				"url": "https://ota-meshi.github.io/eslint-plugin-regexp/rules/no-legacy-features.html"
 			}
 		],
-		"flint": {
-			"name": "regexLegacyFeatures",
-			"plugin": "ts",
-			"status": "skipped"
-		},
 		"notes": "Superseded by deprecated."
 	},
 	{
-		"eslint": [
-			{
-				"name": "regexp/letter-case",
-				"url": "https://ota-meshi.github.io/eslint-plugin-regexp/rules/letter-case.html"
-			}
-		],
 		"flint": {
 			"name": "regexLetterCasing",
 			"plugin": "ts",
 			"preset": "stylistic",
 			"status": "implemented",
 			"strictness": "strict"
-		}
+		},
+		"eslint": [
+			{
+				"name": "regexp/letter-case",
+				"url": "https://ota-meshi.github.io/eslint-plugin-regexp/rules/letter-case.html"
+			}
+		]
 	},
 	{
+		"flint": {
+			"name": "regexListsOrder",
+			"plugin": "ts",
+			"preset": "sorting"
+		},
 		"eslint": [
 			{
 				"name": "regexp/sort-alternatives",
 				"url": "https://ota-meshi.github.io/eslint-plugin-regexp/rules/sort-alternatives.html"
 			}
-		],
-		"flint": {
-			"name": "regexListsOrder",
-			"plugin": "ts",
-			"preset": "sorting"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "regexLiterals",
+			"plugin": "ts",
+			"preset": "logical",
+			"status": "implemented"
+		},
 		"biome": [
 			{
 				"name": "useRegexLiterals",
@@ -25651,12 +25657,6 @@
 				"url": "https://eslint.org/docs/latest/rules/prefer-regex-literals"
 			}
 		],
-		"flint": {
-			"name": "regexLiterals",
-			"plugin": "ts",
-			"preset": "logical",
-			"status": "implemented"
-		},
 		"oxlint": [
 			{
 				"name": "eslint/prefer-regex-literals",
@@ -25665,78 +25665,84 @@
 		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "regexp/prefer-lookaround",
-				"url": "https://ota-meshi.github.io/eslint-plugin-regexp/rules/prefer-lookaround.html"
-			}
-		],
 		"flint": {
 			"name": "regexLookaroundAssertions",
 			"plugin": "ts",
 			"preset": "stylistic",
 			"status": "implemented",
 			"strictness": "strict"
-		}
-	},
-	{
+		},
 		"eslint": [
 			{
-				"name": "regexp/optimal-lookaround-quantifier",
-				"url": "https://ota-meshi.github.io/eslint-plugin-regexp/rules/optimal-lookaround-quantifier.html"
+				"name": "regexp/prefer-lookaround",
+				"url": "https://ota-meshi.github.io/eslint-plugin-regexp/rules/prefer-lookaround.html"
 			}
-		],
+		]
+	},
+	{
 		"flint": {
 			"name": "regexLookaroundQuantifierOptimizations",
 			"plugin": "ts",
 			"preset": "logical",
 			"status": "implemented"
-		}
-	},
-	{
+		},
 		"eslint": [
 			{
-				"name": "regexp/match-any",
-				"url": "https://ota-meshi.github.io/eslint-plugin-regexp/rules/match-any.html"
+				"name": "regexp/optimal-lookaround-quantifier",
+				"url": "https://ota-meshi.github.io/eslint-plugin-regexp/rules/optimal-lookaround-quantifier.html"
 			}
-		],
+		]
+	},
+	{
 		"flint": {
 			"name": "regexMatchNotation",
 			"plugin": "ts",
 			"preset": "stylistic",
 			"status": "implemented",
 			"strictness": "strict"
-		}
-	},
-	{
+		},
 		"eslint": [
 			{
-				"name": "regexp/no-misleading-capturing-group",
-				"url": "https://ota-meshi.github.io/eslint-plugin-regexp/rules/no-misleading-capturing-group.html"
+				"name": "regexp/match-any",
+				"url": "https://ota-meshi.github.io/eslint-plugin-regexp/rules/match-any.html"
 			}
-		],
+		]
+	},
+	{
 		"flint": {
 			"name": "regexMisleadingCapturingGroups",
 			"plugin": "ts",
 			"preset": "logical",
 			"status": "implemented"
-		}
-	},
-	{
+		},
 		"eslint": [
 			{
-				"name": "regexp/confusing-quantifier",
-				"url": "https://ota-meshi.github.io/eslint-plugin-regexp/rules/confusing-quantifier.html"
+				"name": "regexp/no-misleading-capturing-group",
+				"url": "https://ota-meshi.github.io/eslint-plugin-regexp/rules/no-misleading-capturing-group.html"
 			}
-		],
+		]
+	},
+	{
 		"flint": {
 			"name": "regexMisleadingQuantifiers",
 			"plugin": "ts",
 			"preset": "logical",
 			"status": "implemented"
-		}
+		},
+		"eslint": [
+			{
+				"name": "regexp/confusing-quantifier",
+				"url": "https://ota-meshi.github.io/eslint-plugin-regexp/rules/confusing-quantifier.html"
+			}
+		]
 	},
 	{
+		"flint": {
+			"name": "regexMisleadingUnicodeCharacters",
+			"plugin": "ts",
+			"preset": "logical",
+			"status": "implemented"
+		},
 		"biome": [
 			{
 				"name": "noMisleadingCharacterClass",
@@ -25753,12 +25759,6 @@
 				"url": "https://ota-meshi.github.io/eslint-plugin-regexp/rules/no-misleading-unicode-character.html"
 			}
 		],
-		"flint": {
-			"name": "regexMisleadingUnicodeCharacters",
-			"plugin": "ts",
-			"preset": "logical",
-			"status": "implemented"
-		},
 		"oxlint": [
 			{
 				"name": "eslint/no-misleading-character-class",
@@ -25767,21 +25767,26 @@
 		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "regexp/prefer-named-backreference",
-				"url": "https://ota-meshi.github.io/eslint-plugin-regexp/rules/prefer-named-backreference.html"
-			}
-		],
 		"flint": {
 			"name": "regexNamedBackreferences",
 			"plugin": "ts",
 			"preset": "stylistic",
 			"status": "implemented",
 			"strictness": "strict"
-		}
+		},
+		"eslint": [
+			{
+				"name": "regexp/prefer-named-backreference",
+				"url": "https://ota-meshi.github.io/eslint-plugin-regexp/rules/prefer-named-backreference.html"
+			}
+		]
 	},
 	{
+		"flint": {
+			"name": "regexNamedCaptureGroups",
+			"plugin": "ts",
+			"status": "implemented"
+		},
 		"biome": [
 			{
 				"name": "useNamedCaptureGroup",
@@ -25798,11 +25803,6 @@
 				"url": "https://ota-meshi.github.io/eslint-plugin-regexp/rules/prefer-named-capture-group.html"
 			}
 		],
-		"flint": {
-			"name": "regexNamedCaptureGroups",
-			"plugin": "ts",
-			"status": "implemented"
-		},
 		"oxlint": [
 			{
 				"name": "eslint/prefer-named-capture-group",
@@ -25811,220 +25811,226 @@
 		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "regexp/prefer-named-replacement",
-				"url": "https://ota-meshi.github.io/eslint-plugin-regexp/rules/prefer-named-replacement.html"
-			}
-		],
 		"flint": {
 			"name": "regexNamedReplacements",
 			"plugin": "ts",
 			"preset": "stylistic",
 			"status": "implemented",
 			"strictness": "strict"
-		}
-	},
-	{
+		},
 		"eslint": [
 			{
-				"name": "regexp/no-non-standard-flag",
-				"url": "https://ota-meshi.github.io/eslint-plugin-regexp/rules/no-non-standard-flag.html"
+				"name": "regexp/prefer-named-replacement",
+				"url": "https://ota-meshi.github.io/eslint-plugin-regexp/rules/prefer-named-replacement.html"
 			}
-		],
+		]
+	},
+	{
 		"flint": {
 			"name": "regexNonStandardFlags",
 			"plugin": "ts",
 			"preset": "logical",
 			"status": "implemented"
-		}
-	},
-	{
+		},
 		"eslint": [
 			{
-				"name": "regexp/no-obscure-range",
-				"url": "https://ota-meshi.github.io/eslint-plugin-regexp/rules/no-obscure-range.html"
+				"name": "regexp/no-non-standard-flag",
+				"url": "https://ota-meshi.github.io/eslint-plugin-regexp/rules/no-non-standard-flag.html"
 			}
-		],
+		]
+	},
+	{
 		"flint": {
 			"name": "regexObscureRanges",
 			"plugin": "ts",
 			"preset": "logical",
 			"status": "implemented"
-		}
-	},
-	{
+		},
 		"eslint": [
 			{
-				"name": "regexp/no-octal",
-				"url": "https://ota-meshi.github.io/eslint-plugin-regexp/rules/no-octal.html"
+				"name": "regexp/no-obscure-range",
+				"url": "https://ota-meshi.github.io/eslint-plugin-regexp/rules/no-obscure-range.html"
 			}
-		],
+		]
+	},
+	{
 		"flint": {
 			"name": "regexOctalEscapes",
 			"plugin": "ts",
 			"preset": "logical",
 			"status": "implemented"
-		}
-	},
-	{
+		},
 		"eslint": [
 			{
-				"name": "regexp/prefer-plus-quantifier",
-				"url": "https://ota-meshi.github.io/eslint-plugin-regexp/rules/prefer-plus-quantifier.html"
+				"name": "regexp/no-octal",
+				"url": "https://ota-meshi.github.io/eslint-plugin-regexp/rules/no-octal.html"
 			}
-		],
+		]
+	},
+	{
 		"flint": {
 			"name": "regexPlusQuantifiers",
 			"plugin": "ts",
 			"preset": "stylistic",
 			"status": "implemented",
 			"strictness": "strict"
-		}
-	},
-	{
+		},
 		"eslint": [
 			{
-				"name": "regexp/prefer-predefined-assertion",
-				"url": "https://ota-meshi.github.io/eslint-plugin-regexp/rules/prefer-predefined-assertion.html"
+				"name": "regexp/prefer-plus-quantifier",
+				"url": "https://ota-meshi.github.io/eslint-plugin-regexp/rules/prefer-plus-quantifier.html"
 			}
-		],
+		]
+	},
+	{
 		"flint": {
 			"name": "regexPredefinedAssertions",
 			"plugin": "ts",
 			"preset": "stylistic",
 			"status": "implemented"
-		}
+		},
+		"eslint": [
+			{
+				"name": "regexp/prefer-predefined-assertion",
+				"url": "https://ota-meshi.github.io/eslint-plugin-regexp/rules/prefer-predefined-assertion.html"
+			}
+		]
 	},
 	{
+		"flint": {
+			"name": "regexQuantifierOptimizations",
+			"plugin": "ts",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "regexp/optimal-quantifier-concatenation",
 				"url": "https://ota-meshi.github.io/eslint-plugin-regexp/rules/optimal-quantifier-concatenation.html"
 			}
-		],
-		"flint": {
-			"name": "regexQuantifierOptimizations",
-			"plugin": "ts",
-			"preset": "logical"
-		}
+		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "regexp/prefer-question-quantifier",
-				"url": "https://ota-meshi.github.io/eslint-plugin-regexp/rules/prefer-question-quantifier.html"
-			}
-		],
 		"flint": {
 			"name": "regexQuestionQuantifiers",
 			"plugin": "ts",
 			"preset": "stylistic",
 			"status": "implemented",
 			"strictness": "strict"
-		}
-	},
-	{
+		},
 		"eslint": [
 			{
-				"name": "regexp/prefer-quantifier",
-				"url": "https://ota-meshi.github.io/eslint-plugin-regexp/rules/prefer-quantifier.html"
+				"name": "regexp/prefer-question-quantifier",
+				"url": "https://ota-meshi.github.io/eslint-plugin-regexp/rules/prefer-question-quantifier.html"
 			}
-		],
+		]
+	},
+	{
 		"flint": {
 			"name": "regexRepeatQuantifiers",
 			"plugin": "ts",
 			"preset": "stylistic",
 			"status": "implemented"
-		}
-	},
-	{
+		},
 		"eslint": [
 			{
-				"name": "regexp/prefer-result-array-groups",
-				"url": "https://ota-meshi.github.io/eslint-plugin-regexp/rules/prefer-result-array-groups.html"
+				"name": "regexp/prefer-quantifier",
+				"url": "https://ota-meshi.github.io/eslint-plugin-regexp/rules/prefer-quantifier.html"
 			}
-		],
+		]
+	},
+	{
 		"flint": {
 			"name": "regexResultArrayGroups",
 			"plugin": "ts",
 			"preset": "stylistic",
 			"status": "implemented",
 			"strictness": "strict"
-		}
-	},
-	{
+		},
 		"eslint": [
 			{
-				"name": "regexp/simplify-set-operations",
-				"url": "https://ota-meshi.github.io/eslint-plugin-regexp/rules/simplify-set-operations.html"
+				"name": "regexp/prefer-result-array-groups",
+				"url": "https://ota-meshi.github.io/eslint-plugin-regexp/rules/prefer-result-array-groups.html"
 			}
-		],
+		]
+	},
+	{
 		"flint": {
 			"name": "regexSetOperationOptimizations",
 			"plugin": "ts",
 			"preset": "logical",
 			"status": "implemented"
-		}
-	},
-	{
+		},
 		"eslint": [
 			{
-				"name": "regexp/no-standalone-backslash",
-				"url": "https://ota-meshi.github.io/eslint-plugin-regexp/rules/no-standalone-backslash.html"
+				"name": "regexp/simplify-set-operations",
+				"url": "https://ota-meshi.github.io/eslint-plugin-regexp/rules/simplify-set-operations.html"
 			}
-		],
+		]
+	},
+	{
 		"flint": {
 			"name": "regexStandaloneBackslashes",
 			"plugin": "ts",
 			"preset": "logical",
 			"status": "implemented"
-		}
-	},
-	{
+		},
 		"eslint": [
 			{
-				"name": "regexp/prefer-star-quantifier",
-				"url": "https://ota-meshi.github.io/eslint-plugin-regexp/rules/prefer-star-quantifier.html"
+				"name": "regexp/no-standalone-backslash",
+				"url": "https://ota-meshi.github.io/eslint-plugin-regexp/rules/no-standalone-backslash.html"
 			}
-		],
+		]
+	},
+	{
 		"flint": {
 			"name": "regexStarQuantifiers",
 			"plugin": "ts",
 			"preset": "stylistic",
 			"status": "implemented",
 			"strictness": "strict"
-		}
-	},
-	{
+		},
 		"eslint": [
 			{
-				"name": "regexp/no-super-linear-backtracking",
-				"url": "https://ota-meshi.github.io/eslint-plugin-regexp/rules/no-super-linear-backtracking.html"
+				"name": "regexp/prefer-star-quantifier",
+				"url": "https://ota-meshi.github.io/eslint-plugin-regexp/rules/prefer-star-quantifier.html"
 			}
-		],
+		]
+	},
+	{
 		"flint": {
 			"name": "regexSuperLinearBacktracking",
 			"plugin": "ts",
 			"preset": "logical",
 			"status": "implemented"
-		}
-	},
-	{
+		},
 		"eslint": [
 			{
-				"name": "regexp/no-super-linear-move",
-				"url": "https://ota-meshi.github.io/eslint-plugin-regexp/rules/no-super-linear-move.html"
+				"name": "regexp/no-super-linear-backtracking",
+				"url": "https://ota-meshi.github.io/eslint-plugin-regexp/rules/no-super-linear-backtracking.html"
 			}
-		],
+		]
+	},
+	{
 		"flint": {
 			"name": "regexSuperLinearMoves",
 			"plugin": "ts",
 			"preset": "logical",
 			"status": "implemented"
-		}
+		},
+		"eslint": [
+			{
+				"name": "regexp/no-super-linear-move",
+				"url": "https://ota-meshi.github.io/eslint-plugin-regexp/rules/no-super-linear-move.html"
+			}
+		]
 	},
 	{
+		"flint": {
+			"name": "regexTestMethods",
+			"plugin": "ts",
+			"preset": "stylistic",
+			"status": "implemented"
+		},
 		"biome": [
 			{
 				"name": "useRegexpTest",
@@ -26041,12 +26047,6 @@
 				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prefer-regexp-test.md"
 			}
 		],
-		"flint": {
-			"name": "regexTestMethods",
-			"plugin": "ts",
-			"preset": "stylistic",
-			"status": "implemented"
-		},
 		"oxlint": [
 			{
 				"name": "unicorn/prefer-regexp-test",
@@ -26055,47 +26055,52 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "regexTopLevelDeclarations",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"biome": [
 			{
 				"name": "useTopLevelRegex",
 				"url": "https://biomejs.dev/linter/rules/use-top-level-regex"
 			}
-		],
-		"flint": {
-			"name": "regexTopLevelDeclarations",
-			"plugin": "ts",
-			"status": "skipped"
-		}
+		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "regexp/prefer-unicode-codepoint-escapes",
-				"url": "https://ota-meshi.github.io/eslint-plugin-regexp/rules/prefer-unicode-codepoint-escapes.html"
-			}
-		],
 		"flint": {
 			"name": "regexUnicodeCodepointEscapes",
 			"plugin": "ts",
 			"preset": "stylistic",
 			"status": "implemented",
 			"strictness": "strict"
-		}
+		},
+		"eslint": [
+			{
+				"name": "regexp/prefer-unicode-codepoint-escapes",
+				"url": "https://ota-meshi.github.io/eslint-plugin-regexp/rules/prefer-unicode-codepoint-escapes.html"
+			}
+		]
 	},
 	{
+		"flint": {
+			"name": "regexUnicodeEscapes",
+			"plugin": "ts",
+			"status": "implemented"
+		},
 		"eslint": [
 			{
 				"name": "regexp/unicode-escape",
 				"url": "https://ota-meshi.github.io/eslint-plugin-regexp/rules/unicode-escape.html"
 			}
-		],
-		"flint": {
-			"name": "regexUnicodeEscapes",
-			"plugin": "ts",
-			"status": "implemented"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "regexUnicodeFlag",
+			"plugin": "ts",
+			"status": "implemented"
+		},
 		"biome": [
 			{
 				"name": "useUnicodeRegex",
@@ -26112,11 +26117,6 @@
 				"url": "https://ota-meshi.github.io/eslint-plugin-regexp/rules/require-unicode-regexp.html"
 			}
 		],
-		"flint": {
-			"name": "regexUnicodeFlag",
-			"plugin": "ts",
-			"status": "implemented"
-		},
 		"oxlint": [
 			{
 				"name": "eslint/require-unicode-regexp",
@@ -26125,47 +26125,53 @@
 		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "regexp/unicode-property",
-				"url": "https://ota-meshi.github.io/eslint-plugin-regexp/rules/unicode-property.html"
-			}
-		],
 		"flint": {
 			"name": "regexUnicodeProperties",
 			"plugin": "ts",
 			"preset": "stylistic",
 			"status": "implemented"
-		}
+		},
+		"eslint": [
+			{
+				"name": "regexp/unicode-property",
+				"url": "https://ota-meshi.github.io/eslint-plugin-regexp/rules/unicode-property.html"
+			}
+		]
 	},
 	{
+		"flint": {
+			"name": "regexUnicodeSetsFlag",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "regexp/require-unicode-sets-regexp",
 				"url": "https://ota-meshi.github.io/eslint-plugin-regexp/rules/require-unicode-sets-regexp.html"
 			}
-		],
-		"flint": {
-			"name": "regexUnicodeSetsFlag",
-			"plugin": "ts",
-			"status": "skipped"
-		}
+		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "regexp/no-useless-assertions",
-				"url": "https://ota-meshi.github.io/eslint-plugin-regexp/rules/no-useless-assertions.html"
-			}
-		],
 		"flint": {
 			"name": "regexUnnecessaryAssertions",
 			"plugin": "ts",
 			"preset": "logical",
 			"status": "implemented"
-		}
+		},
+		"eslint": [
+			{
+				"name": "regexp/no-useless-assertions",
+				"url": "https://ota-meshi.github.io/eslint-plugin-regexp/rules/no-useless-assertions.html"
+			}
+		]
 	},
 	{
+		"flint": {
+			"name": "regexUnnecessaryBackreferences",
+			"plugin": "ts",
+			"preset": "logical",
+			"status": "implemented"
+		},
 		"biome": [
 			{
 				"name": "noUselessRegexBackrefs",
@@ -26182,12 +26188,6 @@
 				"url": "https://ota-meshi.github.io/eslint-plugin-regexp/rules/no-useless-backreference.html"
 			}
 		],
-		"flint": {
-			"name": "regexUnnecessaryBackreferences",
-			"plugin": "ts",
-			"preset": "logical",
-			"status": "implemented"
-		},
 		"oxlint": [
 			{
 				"name": "eslint/no-useless-backreference",
@@ -26196,245 +26196,251 @@
 		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "regexp/no-useless-character-class",
-				"url": "https://ota-meshi.github.io/eslint-plugin-regexp/rules/no-useless-character-class.html"
-			}
-		],
 		"flint": {
 			"name": "regexUnnecessaryCharacterClasses",
 			"plugin": "ts",
 			"preset": "logical",
 			"status": "implemented"
-		}
-	},
-	{
+		},
 		"eslint": [
 			{
-				"name": "regexp/no-useless-range",
-				"url": "https://ota-meshi.github.io/eslint-plugin-regexp/rules/no-useless-range.html"
+				"name": "regexp/no-useless-character-class",
+				"url": "https://ota-meshi.github.io/eslint-plugin-regexp/rules/no-useless-character-class.html"
 			}
-		],
+		]
+	},
+	{
 		"flint": {
 			"name": "regexUnnecessaryCharacterRanges",
 			"plugin": "ts",
 			"preset": "logical",
 			"status": "implemented"
-		}
-	},
-	{
+		},
 		"eslint": [
 			{
-				"name": "regexp/no-useless-string-literal",
-				"url": "https://ota-meshi.github.io/eslint-plugin-regexp/rules/no-useless-string-literal.html"
+				"name": "regexp/no-useless-range",
+				"url": "https://ota-meshi.github.io/eslint-plugin-regexp/rules/no-useless-range.html"
 			}
-		],
+		]
+	},
+	{
 		"flint": {
 			"name": "regexUnnecessaryDisjunctions",
 			"plugin": "ts",
 			"preset": "logical",
 			"status": "implemented"
-		}
-	},
-	{
+		},
 		"eslint": [
 			{
-				"name": "regexp/no-useless-dollar-replacements",
-				"url": "https://ota-meshi.github.io/eslint-plugin-regexp/rules/no-useless-dollar-replacements.html"
+				"name": "regexp/no-useless-string-literal",
+				"url": "https://ota-meshi.github.io/eslint-plugin-regexp/rules/no-useless-string-literal.html"
 			}
-		],
+		]
+	},
+	{
 		"flint": {
 			"name": "regexUnnecessaryDollarReplacements",
 			"plugin": "ts",
 			"preset": "logical",
 			"status": "implemented"
-		}
-	},
-	{
+		},
 		"eslint": [
 			{
-				"name": "regexp/no-useless-escape",
-				"url": "https://ota-meshi.github.io/eslint-plugin-regexp/rules/no-useless-escape.html"
+				"name": "regexp/no-useless-dollar-replacements",
+				"url": "https://ota-meshi.github.io/eslint-plugin-regexp/rules/no-useless-dollar-replacements.html"
 			}
-		],
+		]
+	},
+	{
 		"flint": {
 			"name": "regexUnnecessaryEscapes",
 			"plugin": "ts",
 			"preset": "stylistic",
 			"status": "implemented"
-		}
-	},
-	{
+		},
 		"eslint": [
 			{
-				"name": "regexp/no-extra-lookaround-assertions",
-				"url": "https://ota-meshi.github.io/eslint-plugin-regexp/rules/no-extra-lookaround-assertions.html"
+				"name": "regexp/no-useless-escape",
+				"url": "https://ota-meshi.github.io/eslint-plugin-regexp/rules/no-useless-escape.html"
 			}
-		],
+		]
+	},
+	{
 		"flint": {
 			"name": "regexUnnecessaryLookaroundAssertions",
 			"plugin": "ts",
 			"preset": "logical",
 			"status": "implemented"
-		}
-	},
-	{
+		},
 		"eslint": [
 			{
-				"name": "regexp/no-trivially-nested-assertion",
-				"url": "https://ota-meshi.github.io/eslint-plugin-regexp/rules/no-trivially-nested-assertion.html"
+				"name": "regexp/no-extra-lookaround-assertions",
+				"url": "https://ota-meshi.github.io/eslint-plugin-regexp/rules/no-extra-lookaround-assertions.html"
 			}
-		],
+		]
+	},
+	{
 		"flint": {
 			"name": "regexUnnecessaryNestedAssertions",
 			"plugin": "ts",
 			"preset": "logical",
 			"status": "implemented"
-		}
-	},
-	{
+		},
 		"eslint": [
 			{
-				"name": "regexp/no-trivially-nested-quantifier",
-				"url": "https://ota-meshi.github.io/eslint-plugin-regexp/rules/no-trivially-nested-quantifier.html"
+				"name": "regexp/no-trivially-nested-assertion",
+				"url": "https://ota-meshi.github.io/eslint-plugin-regexp/rules/no-trivially-nested-assertion.html"
 			}
-		],
+		]
+	},
+	{
 		"flint": {
 			"name": "regexUnnecessaryNestedQuantifiers",
 			"plugin": "ts",
 			"preset": "logical",
 			"status": "implemented"
-		}
-	},
-	{
+		},
 		"eslint": [
 			{
-				"name": "regexp/no-useless-non-capturing-group",
-				"url": "https://ota-meshi.github.io/eslint-plugin-regexp/rules/no-useless-non-capturing-group.html"
+				"name": "regexp/no-trivially-nested-quantifier",
+				"url": "https://ota-meshi.github.io/eslint-plugin-regexp/rules/no-trivially-nested-quantifier.html"
 			}
-		],
+		]
+	},
+	{
 		"flint": {
 			"name": "regexUnnecessaryNonCapturingGroups",
 			"plugin": "ts",
 			"preset": "stylistic",
 			"status": "implemented",
 			"strictness": "strict"
-		}
-	},
-	{
+		},
 		"eslint": [
 			{
-				"name": "regexp/no-useless-two-nums-quantifier",
-				"url": "https://ota-meshi.github.io/eslint-plugin-regexp/rules/no-useless-two-nums-quantifier.html"
+				"name": "regexp/no-useless-non-capturing-group",
+				"url": "https://ota-meshi.github.io/eslint-plugin-regexp/rules/no-useless-non-capturing-group.html"
 			}
-		],
+		]
+	},
+	{
 		"flint": {
 			"name": "regexUnnecessaryNumericQuantifiers",
 			"plugin": "ts",
 			"preset": "logical",
 			"status": "implemented"
-		}
-	},
-	{
+		},
 		"eslint": [
 			{
-				"name": "regexp/no-optional-assertion",
-				"url": "https://ota-meshi.github.io/eslint-plugin-regexp/rules/no-optional-assertion.html"
+				"name": "regexp/no-useless-two-nums-quantifier",
+				"url": "https://ota-meshi.github.io/eslint-plugin-regexp/rules/no-useless-two-nums-quantifier.html"
 			}
-		],
+		]
+	},
+	{
 		"flint": {
 			"name": "regexUnnecessaryOptionalAssertions",
 			"plugin": "ts",
 			"preset": "logical",
 			"status": "implemented"
-		}
-	},
-	{
+		},
 		"eslint": [
 			{
-				"name": "regexp/no-potentially-useless-backreference",
-				"url": "https://ota-meshi.github.io/eslint-plugin-regexp/rules/no-potentially-useless-backreference.html"
+				"name": "regexp/no-optional-assertion",
+				"url": "https://ota-meshi.github.io/eslint-plugin-regexp/rules/no-optional-assertion.html"
 			}
-		],
+		]
+	},
+	{
 		"flint": {
 			"name": "regexUnnecessaryReferentialBackreferences",
 			"plugin": "ts",
 			"preset": "logical",
 			"status": "implemented"
-		}
-	},
-	{
+		},
 		"eslint": [
 			{
-				"name": "regexp/no-useless-set-operand",
-				"url": "https://ota-meshi.github.io/eslint-plugin-regexp/rules/no-useless-set-operand.html"
+				"name": "regexp/no-potentially-useless-backreference",
+				"url": "https://ota-meshi.github.io/eslint-plugin-regexp/rules/no-potentially-useless-backreference.html"
 			}
-		],
+		]
+	},
+	{
 		"flint": {
 			"name": "regexUnnecessarySetOperands",
 			"plugin": "ts",
 			"preset": "logical",
 			"status": "implemented"
-		}
-	},
-	{
+		},
 		"eslint": [
 			{
-				"name": "regexp/no-unused-capturing-group",
-				"url": "https://ota-meshi.github.io/eslint-plugin-regexp/rules/no-unused-capturing-group.html"
+				"name": "regexp/no-useless-set-operand",
+				"url": "https://ota-meshi.github.io/eslint-plugin-regexp/rules/no-useless-set-operand.html"
 			}
-		],
+		]
+	},
+	{
 		"flint": {
 			"name": "regexUnusedCapturingGroups",
 			"plugin": "ts",
 			"preset": "logical",
 			"status": "implemented"
-		}
-	},
-	{
+		},
 		"eslint": [
 			{
-				"name": "regexp/no-useless-flag",
-				"url": "https://ota-meshi.github.io/eslint-plugin-regexp/rules/no-useless-flag.html"
+				"name": "regexp/no-unused-capturing-group",
+				"url": "https://ota-meshi.github.io/eslint-plugin-regexp/rules/no-unused-capturing-group.html"
 			}
-		],
+		]
+	},
+	{
 		"flint": {
 			"name": "regexUnusedFlags",
 			"plugin": "ts",
 			"preset": "logical",
 			"status": "implemented"
-		}
-	},
-	{
+		},
 		"eslint": [
 			{
-				"name": "regexp/no-useless-lazy",
-				"url": "https://ota-meshi.github.io/eslint-plugin-regexp/rules/no-useless-lazy.html"
+				"name": "regexp/no-useless-flag",
+				"url": "https://ota-meshi.github.io/eslint-plugin-regexp/rules/no-useless-flag.html"
 			}
-		],
+		]
+	},
+	{
 		"flint": {
 			"name": "regexUnusedLazyQuantifiers",
 			"plugin": "ts",
 			"preset": "logical",
 			"status": "implemented"
-		}
-	},
-	{
+		},
 		"eslint": [
 			{
-				"name": "regexp/no-useless-quantifier",
-				"url": "https://ota-meshi.github.io/eslint-plugin-regexp/rules/no-useless-quantifier.html"
+				"name": "regexp/no-useless-lazy",
+				"url": "https://ota-meshi.github.io/eslint-plugin-regexp/rules/no-useless-lazy.html"
 			}
-		],
+		]
+	},
+	{
 		"flint": {
 			"name": "regexUnusedQuantifiers",
 			"plugin": "ts",
 			"preset": "logical",
 			"status": "implemented"
-		}
+		},
+		"eslint": [
+			{
+				"name": "regexp/no-useless-quantifier",
+				"url": "https://ota-meshi.github.io/eslint-plugin-regexp/rules/no-useless-quantifier.html"
+			}
+		]
 	},
 	{
+		"flint": {
+			"name": "regexValidity",
+			"plugin": "ts",
+			"preset": "logical",
+			"status": "implemented"
+		},
 		"deno": [
 			{
 				"name": "no-invalid-regexp",
@@ -26451,12 +26457,6 @@
 				"url": "https://ota-meshi.github.io/eslint-plugin-regexp/rules/no-invalid-regexp.html"
 			}
 		],
-		"flint": {
-			"name": "regexValidity",
-			"plugin": "ts",
-			"preset": "logical",
-			"status": "implemented"
-		},
 		"oxlint": [
 			{
 				"name": "eslint/no-invalid-regexp",
@@ -26465,47 +26465,53 @@
 		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "regexp/prefer-w",
-				"url": "https://ota-meshi.github.io/eslint-plugin-regexp/rules/prefer-w.html"
-			}
-		],
 		"flint": {
 			"name": "regexWordMatchers",
 			"plugin": "ts",
 			"preset": "stylistic",
 			"status": "implemented",
 			"strictness": "strict"
-		}
-	},
-	{
+		},
 		"eslint": [
 			{
-				"name": "regexp/no-zero-quantifier",
-				"url": "https://ota-meshi.github.io/eslint-plugin-regexp/rules/no-zero-quantifier.html"
+				"name": "regexp/prefer-w",
+				"url": "https://ota-meshi.github.io/eslint-plugin-regexp/rules/prefer-w.html"
 			}
-		],
+		]
+	},
+	{
 		"flint": {
 			"name": "regexZeroQuantifiers",
 			"plugin": "ts",
 			"preset": "logical",
 			"status": "implemented"
-		}
+		},
+		"eslint": [
+			{
+				"name": "regexp/no-zero-quantifier",
+				"url": "https://ota-meshi.github.io/eslint-plugin-regexp/rules/no-zero-quantifier.html"
+			}
+		]
 	},
 	{
+		"flint": {
+			"name": "relativePackageImports",
+			"plugin": "ts"
+		},
 		"eslint": [
 			{
 				"name": "import/no-relative-packages",
 				"url": "https://github.com/import-js/eslint-plugin-import/blob/v2.32.0/docs/rules/no-relative-packages.md"
 			}
-		],
-		"flint": {
-			"name": "relativePackageImports",
-			"plugin": "ts"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "requireImports",
+			"plugin": "ts",
+			"preset": "logical",
+			"status": "implemented"
+		},
 		"biome": [
 			{
 				"name": "noCommonJs",
@@ -26518,12 +26524,6 @@
 				"url": "https://typescript-eslint.io/rules/no-require-imports"
 			}
 		],
-		"flint": {
-			"name": "requireImports",
-			"plugin": "ts",
-			"preset": "logical",
-			"status": "implemented"
-		},
 		"oxlint": [
 			{
 				"name": "typescript/no-require-imports",
@@ -26532,51 +26532,51 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "requireVariables",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "@typescript-eslint/no-var-requires",
 				"url": "https://typescript-eslint.io/rules/no-var-requires"
 			}
 		],
-		"flint": {
-			"name": "requireVariables",
-			"plugin": "ts",
-			"status": "skipped"
-		},
-		"notes": "Deprecated in favor of requireImports.",
 		"oxlint": [
 			{
 				"name": "typescript/no-var-requires",
 				"url": "https://oxc.rs/docs/guide/usage/linter/rules/typescript/no-var-requires.html"
 			}
-		]
+		],
+		"notes": "Deprecated in favor of requireImports."
 	},
 	{
-		"biome": [
-			{
-				"name": "useStaticResponseMethods",
-				"url": "https://biomejs.dev/linter/rules/use-static-response-methods"
-			}
-		],
 		"flint": {
 			"name": "responseJsonMethods",
 			"plugin": "ts",
 			"preset": "stylistic",
 			"status": "implemented"
-		}
+		},
+		"biome": [
+			{
+				"name": "useStaticResponseMethods",
+				"url": "https://biomejs.dev/linter/rules/use-static-response-methods"
+			}
+		]
 	},
 	{
+		"flint": {
+			"name": "responseStaticJsonMethods",
+			"plugin": "ts",
+			"preset": "stylistic"
+		},
 		"eslint": [
 			{
 				"name": "unicorn/prefer-response-static-json",
 				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v64.0.0/docs/rules/prefer-response-static-json.md"
 			}
 		],
-		"flint": {
-			"name": "responseStaticJsonMethods",
-			"plugin": "ts",
-			"preset": "stylistic"
-		},
 		"oxlint": [
 			{
 				"name": "unicorn/prefer-response-static-json",
@@ -26585,30 +26585,30 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "restrictedDirectives",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "@eslint-community/eslint-comments/no-use",
 				"url": "https://eslint-community.github.io/eslint-plugin-eslint-comments/rules/no-use.html"
 			}
-		],
-		"flint": {
-			"name": "restrictedDirectives",
-			"plugin": "ts",
-			"status": "skipped"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "restrictedExports",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "no-restricted-exports",
 				"url": "https://eslint.org/docs/latest/rules/no-restricted-exports"
 			}
 		],
-		"flint": {
-			"name": "restrictedExports",
-			"plugin": "ts",
-			"status": "skipped"
-		},
 		"oxlint": [
 			{
 				"name": "eslint/no-restricted-exports",
@@ -26617,6 +26617,10 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "restrictedGlobals",
+			"plugin": "ts"
+		},
 		"biome": [
 			{
 				"name": "noRestrictedGlobals",
@@ -26629,10 +26633,6 @@
 				"url": "https://eslint.org/docs/latest/rules/no-restricted-globals"
 			}
 		],
-		"flint": {
-			"name": "restrictedGlobals",
-			"plugin": "ts"
-		},
 		"oxlint": [
 			{
 				"name": "eslint/no-restricted-globals",
@@ -26641,31 +26641,36 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "restrictedIdentifiers",
+			"plugin": "ts",
+			"status": "implemented"
+		},
 		"eslint": [
 			{
 				"name": "id-denylist",
 				"url": "https://eslint.org/docs/latest/rules/id-denylist"
 			}
-		],
-		"flint": {
-			"name": "restrictedIdentifiers",
-			"plugin": "ts",
-			"status": "implemented"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "restrictedImportPaths",
+			"plugin": "ts"
+		},
 		"eslint": [
 			{
 				"name": "import/no-restricted-paths",
 				"url": "https://github.com/import-js/eslint-plugin-import/blob/v2.32.0/docs/rules/no-restricted-paths.md"
 			}
-		],
-		"flint": {
-			"name": "restrictedImportPaths",
-			"plugin": "ts"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "restrictedImports",
+			"plugin": "ts",
+			"status": "implemented"
+		},
 		"biome": [
 			{
 				"name": "noRestrictedImports",
@@ -26682,11 +26687,6 @@
 				"url": "https://typescript-eslint.io/rules/no-restricted-imports"
 			}
 		],
-		"flint": {
-			"name": "restrictedImports",
-			"plugin": "ts",
-			"status": "implemented"
-		},
 		"oxlint": [
 			{
 				"name": "eslint/no-restricted-imports",
@@ -26695,29 +26695,29 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "restrictedJSDocs",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "jsdoc/no-restricted-syntax",
 				"url": "https://github.com/gajus/eslint-plugin-jsdoc/blob/HEAD/docs/rules/no-restricted-syntax.md"
 			}
-		],
-		"flint": {
-			"name": "restrictedJSDocs",
-			"plugin": "ts",
-			"status": "skipped"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "restrictedProperties",
+			"plugin": "ts"
+		},
 		"eslint": [
 			{
 				"name": "no-restricted-properties",
 				"url": "https://eslint.org/docs/latest/rules/no-restricted-properties"
 			}
 		],
-		"flint": {
-			"name": "restrictedProperties",
-			"plugin": "ts"
-		},
 		"oxlint": [
 			{
 				"name": "eslint/no-restricted-properties",
@@ -26726,18 +26726,22 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "restrictedSyntax",
+			"plugin": "ts"
+		},
 		"eslint": [
 			{
 				"name": "no-restricted-syntax",
 				"url": "https://eslint.org/docs/latest/rules/no-restricted-syntax"
 			}
-		],
-		"flint": {
-			"name": "restrictedSyntax",
-			"plugin": "ts"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "restrictedTypes",
+			"plugin": "ts"
+		},
 		"biome": [
 			{
 				"name": "noBannedTypes",
@@ -26754,10 +26758,6 @@
 				"url": "https://typescript-eslint.io/rules/no-restricted-types"
 			}
 		],
-		"flint": {
-			"name": "restrictedTypes",
-			"plugin": "ts"
-		},
 		"oxlint": [
 			{
 				"name": "typescript/no-restricted-types",
@@ -26779,6 +26779,12 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "returnAssignments",
+			"plugin": "ts",
+			"preset": "stylistic",
+			"status": "implemented"
+		},
 		"biome": [
 			{
 				"name": "noReturnAssign",
@@ -26791,12 +26797,6 @@
 				"url": "https://eslint.org/docs/latest/rules/no-return-assign"
 			}
 		],
-		"flint": {
-			"name": "returnAssignments",
-			"plugin": "ts",
-			"preset": "stylistic",
-			"status": "implemented"
-		},
 		"oxlint": [
 			{
 				"name": "eslint/no-return-assign",
@@ -26805,17 +26805,17 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "returnAwaitPromises",
+			"plugin": "ts",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "@typescript-eslint/return-await",
 				"url": "https://typescript-eslint.io/rules/return-await"
 			}
 		],
-		"flint": {
-			"name": "returnAwaitPromises",
-			"plugin": "ts",
-			"preset": "logical"
-		},
 		"oxlint": [
 			{
 				"name": "typescript/return-await",
@@ -26824,12 +26824,6 @@
 		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "@typescript-eslint/prefer-return-this-type",
-				"url": "https://typescript-eslint.io/rules/prefer-return-this-type"
-			}
-		],
 		"flint": {
 			"name": "returnThisTypes",
 			"plugin": "ts",
@@ -26837,6 +26831,12 @@
 			"status": "implemented",
 			"strictness": "strict"
 		},
+		"eslint": [
+			{
+				"name": "@typescript-eslint/prefer-return-this-type",
+				"url": "https://typescript-eslint.io/rules/prefer-return-this-type"
+			}
+		],
 		"oxlint": [
 			{
 				"name": "typescript/prefer-return-this-type",
@@ -26845,31 +26845,31 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "returnTypeSpecificity",
+			"plugin": "ts",
+			"preset": "logical"
+		},
 		"biome": [
 			{
 				"name": "noMisleadingReturnType",
 				"url": "https://biomejs.dev/linter/rules/no-misleading-return-type"
 			}
-		],
-		"flint": {
-			"name": "returnTypeSpecificity",
-			"plugin": "ts",
-			"preset": "logical"
-		}
+		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "@typescript-eslint/strict-void-return",
-				"url": "https://typescript-eslint.io/rules/strict-void-return"
-			}
-		],
 		"flint": {
 			"name": "returnVoidSafety",
 			"plugin": "ts",
 			"preset": "logical",
 			"strictness": "strict"
 		},
+		"eslint": [
+			{
+				"name": "@typescript-eslint/strict-void-return",
+				"url": "https://typescript-eslint.io/rules/strict-void-return"
+			}
+		],
 		"oxlint": [
 			{
 				"name": "typescript/strict-void-return",
@@ -26878,6 +26878,12 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "selfAssignments",
+			"plugin": "ts",
+			"preset": "logical",
+			"status": "implemented"
+		},
 		"biome": [
 			{
 				"name": "noSelfAssign",
@@ -26896,12 +26902,6 @@
 				"url": "https://eslint.org/docs/latest/rules/no-self-assign"
 			}
 		],
-		"flint": {
-			"name": "selfAssignments",
-			"plugin": "ts",
-			"preset": "logical",
-			"status": "implemented"
-		},
 		"oxlint": [
 			{
 				"name": "eslint/no-self-assign",
@@ -26910,6 +26910,12 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "sequences",
+			"plugin": "ts",
+			"preset": "javascript",
+			"status": "implemented"
+		},
 		"biome": [
 			{
 				"name": "noCommaOperator",
@@ -26922,12 +26928,6 @@
 				"url": "https://eslint.org/docs/latest/rules/no-sequences"
 			}
 		],
-		"flint": {
-			"name": "sequences",
-			"plugin": "ts",
-			"preset": "javascript",
-			"status": "implemented"
-		},
 		"oxlint": [
 			{
 				"name": "eslint/no-sequences",
@@ -26936,18 +26936,18 @@
 		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "unicorn/prefer-set-has",
-				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prefer-set-has.md"
-			}
-		],
 		"flint": {
 			"name": "setHasExistenceChecks",
 			"plugin": "ts",
 			"preset": "stylistic",
 			"strictness": "strict"
 		},
+		"eslint": [
+			{
+				"name": "unicorn/prefer-set-has",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prefer-set-has.md"
+			}
+		],
 		"oxlint": [
 			{
 				"name": "unicorn/prefer-set-has",
@@ -26956,12 +26956,6 @@
 		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "unicorn/prefer-set-size",
-				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prefer-set-size.md"
-			}
-		],
 		"flint": {
 			"name": "setSizeLengthChecks",
 			"plugin": "ts",
@@ -26969,6 +26963,12 @@
 			"status": "implemented",
 			"strictness": "strict"
 		},
+		"eslint": [
+			{
+				"name": "unicorn/prefer-set-size",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prefer-set-size.md"
+			}
+		],
 		"oxlint": [
 			{
 				"name": "unicorn/prefer-set-size",
@@ -26977,19 +26977,25 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "setsOrder",
+			"plugin": "ts",
+			"preset": "sorting"
+		},
 		"eslint": [
 			{
 				"name": "perfectionist/sort-sets",
 				"url": "https://perfectionist.dev/rules/sort-sets"
 			}
-		],
-		"flint": {
-			"name": "setsOrder",
-			"plugin": "ts",
-			"preset": "sorting"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "setterReturns",
+			"plugin": "ts",
+			"preset": "javascript",
+			"status": "implemented"
+		},
 		"biome": [
 			{
 				"name": "noSetterReturn",
@@ -27008,12 +27014,6 @@
 				"url": "https://eslint.org/docs/latest/rules/no-setter-return"
 			}
 		],
-		"flint": {
-			"name": "setterReturns",
-			"plugin": "ts",
-			"preset": "javascript",
-			"status": "implemented"
-		},
 		"oxlint": [
 			{
 				"name": "eslint/no-setter-return",
@@ -27022,6 +27022,12 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "shadowedRestrictedNames",
+			"plugin": "ts",
+			"preset": "javascript",
+			"status": "implemented"
+		},
 		"biome": [
 			{
 				"name": "noShadowRestrictedNames",
@@ -27040,12 +27046,6 @@
 				"url": "https://eslint.org/docs/latest/rules/no-shadow-restricted-names"
 			}
 		],
-		"flint": {
-			"name": "shadowedRestrictedNames",
-			"plugin": "ts",
-			"preset": "javascript",
-			"status": "implemented"
-		},
 		"oxlint": [
 			{
 				"name": "eslint/no-shadow-restricted-names",
@@ -27054,6 +27054,11 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "shadows",
+			"plugin": "ts",
+			"preset": "stylistic"
+		},
 		"biome": [
 			{
 				"name": "noShadow",
@@ -27070,11 +27075,6 @@
 				"url": "https://typescript-eslint.io/rules/no-shadow"
 			}
 		],
-		"flint": {
-			"name": "shadows",
-			"plugin": "ts",
-			"preset": "stylistic"
-		},
 		"oxlint": [
 			{
 				"name": "eslint/no-shadow",
@@ -27083,45 +27083,51 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "shorthandAssignmentRefactors",
+			"plugin": "ts",
+			"preset": "logical"
+		},
 		"biome": [
 			{
 				"name": "noMisrefactoredShorthandAssign",
 				"url": "https://biomejs.dev/linter/rules/no-misrefactored-shorthand-assign"
 			}
-		],
-		"flint": {
-			"name": "shorthandAssignmentRefactors",
-			"plugin": "ts",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "shoutyConstants",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"biome": [
 			{
 				"name": "noShoutyConstants",
 				"url": "https://biomejs.dev/linter/rules/no-shouty-constants"
 			}
-		],
-		"flint": {
-			"name": "shoutyConstants",
-			"plugin": "ts",
-			"status": "skipped"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "simpleConditionOrder",
+			"plugin": "ts",
+			"preset": "stylistic"
+		},
 		"eslint": [
 			{
 				"name": "unicorn/prefer-simple-condition-first",
 				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v64.0.0/docs/rules/prefer-simple-condition-first.md"
 			}
-		],
-		"flint": {
-			"name": "simpleConditionOrder",
-			"plugin": "ts",
-			"preset": "stylistic"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "singleVariableDeclarations",
+			"plugin": "ts",
+			"preset": "logical",
+			"status": "implemented"
+		},
 		"biome": [
 			{
 				"name": "useSingleVarDeclarator",
@@ -27139,15 +27145,16 @@
 				"name": "one-var",
 				"url": "https://eslint.org/docs/latest/rules/one-var"
 			}
-		],
-		"flint": {
-			"name": "singleVariableDeclarations",
-			"plugin": "ts",
-			"preset": "logical",
-			"status": "implemented"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "sizeComparisonOperators",
+			"plugin": "ts",
+			"preset": "stylistic",
+			"status": "implemented",
+			"strictness": "strict"
+		},
 		"biome": [
 			{
 				"name": "useExplicitLengthCheck",
@@ -27160,13 +27167,6 @@
 				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/explicit-length-check.md"
 			}
 		],
-		"flint": {
-			"name": "sizeComparisonOperators",
-			"plugin": "ts",
-			"preset": "stylistic",
-			"status": "implemented",
-			"strictness": "strict"
-		},
 		"oxlint": [
 			{
 				"name": "unicorn/explicit-length-check",
@@ -27175,32 +27175,38 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "sliceEndLengths",
+			"plugin": "ts",
+			"preset": "stylistic"
+		},
 		"eslint": [
 			{
 				"name": "unicorn/no-length-as-slice-end",
 				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v64.0.0/docs/deleted-and-deprecated-rules.md#no-length-as-slice-end"
 			}
-		],
-		"flint": {
-			"name": "sliceEndLengths",
-			"plugin": "ts",
-			"preset": "stylistic"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "slowTypes",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"deno": [
 			{
 				"name": "no-slow-types",
 				"url": "https://docs.deno.com/lint/rules/no-slow-types"
 			}
-		],
-		"flint": {
-			"name": "slowTypes",
-			"plugin": "ts",
-			"status": "skipped"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "sparseArrays",
+			"plugin": "ts",
+			"preset": "logical",
+			"status": "implemented"
+		},
 		"biome": [
 			{
 				"name": "noSparseArray",
@@ -27219,12 +27225,6 @@
 				"url": "https://eslint.org/docs/latest/rules/no-sparse-arrays"
 			}
 		],
-		"flint": {
-			"name": "sparseArrays",
-			"plugin": "ts",
-			"preset": "logical",
-			"status": "implemented"
-		},
 		"oxlint": [
 			{
 				"name": "eslint/no-sparse-arrays",
@@ -27233,17 +27233,17 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "spreadSyntaxes",
+			"plugin": "ts",
+			"preset": "stylistic"
+		},
 		"eslint": [
 			{
 				"name": "unicorn/prefer-spread",
 				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v64.0.0/docs/rules/prefer-spread.md"
 			}
 		],
-		"flint": {
-			"name": "spreadSyntaxes",
-			"plugin": "ts",
-			"preset": "stylistic"
-		},
 		"oxlint": [
 			{
 				"name": "unicorn/prefer-spread",
@@ -27252,6 +27252,13 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "staticMemberOnlyClasses",
+			"plugin": "ts",
+			"preset": "stylistic",
+			"status": "implemented",
+			"strictness": "strict"
+		},
 		"biome": [
 			{
 				"name": "noStaticOnlyClass",
@@ -27264,13 +27271,6 @@
 				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-static-only-class.md"
 			}
 		],
-		"flint": {
-			"name": "staticMemberOnlyClasses",
-			"plugin": "ts",
-			"preset": "stylistic",
-			"status": "implemented",
-			"strictness": "strict"
-		},
 		"oxlint": [
 			{
 				"name": "unicorn/no-static-only-class",
@@ -27279,17 +27279,17 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "strictBooleanExpressions",
+			"plugin": "ts",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "@typescript-eslint/strict-boolean-expressions",
 				"url": "https://typescript-eslint.io/rules/strict-boolean-expressions"
 			}
 		],
-		"flint": {
-			"name": "strictBooleanExpressions",
-			"plugin": "ts",
-			"preset": "logical"
-		},
 		"oxlint": [
 			{
 				"name": "typescript/strict-boolean-expressions",
@@ -27298,39 +27298,33 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "strictMode",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"biome": [
 			{
 				"name": "useStrictMode",
 				"url": "https://biomejs.dev/linter/rules/use-strict-mode"
 			}
-		],
-		"flint": {
-			"name": "strictMode",
-			"plugin": "ts",
-			"status": "skipped"
-		}
+		]
 	},
 	{
-		"biome": [
-			{
-				"name": "noStringCaseMismatch",
-				"url": "https://biomejs.dev/linter/rules/no-string-case-mismatch"
-			}
-		],
 		"flint": {
 			"name": "stringCaseMismatches",
 			"plugin": "ts",
 			"preset": "logical",
 			"status": "implemented"
-		}
+		},
+		"biome": [
+			{
+				"name": "noStringCaseMismatch",
+				"url": "https://biomejs.dev/linter/rules/no-string-case-mismatch"
+			}
+		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "unicorn/prefer-code-point",
-				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prefer-code-point.md"
-			}
-		],
 		"flint": {
 			"name": "stringCodePoints",
 			"plugin": "ts",
@@ -27338,6 +27332,12 @@
 			"status": "implemented",
 			"strictness": "strict"
 		},
+		"eslint": [
+			{
+				"name": "unicorn/prefer-code-point",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prefer-code-point.md"
+			}
+		],
 		"oxlint": [
 			{
 				"name": "unicorn/prefer-code-point",
@@ -27346,6 +27346,11 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "stringConcatenationTemplates",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"biome": [
 			{
 				"name": "useTemplate",
@@ -27358,11 +27363,6 @@
 				"url": "https://eslint.org/docs/latest/rules/prefer-template"
 			}
 		],
-		"flint": {
-			"name": "stringConcatenationTemplates",
-			"plugin": "ts",
-			"status": "skipped"
-		},
 		"oxlint": [
 			{
 				"name": "eslint/prefer-template",
@@ -27371,30 +27371,30 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "stringContents",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "unicorn/string-content",
 				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/string-content.md"
 			}
-		],
-		"flint": {
-			"name": "stringContents",
-			"plugin": "ts",
-			"status": "skipped"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "stringRawEscapes",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "unicorn/prefer-string-raw",
 				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prefer-string-raw.md"
 			}
 		],
-		"flint": {
-			"name": "stringRawEscapes",
-			"plugin": "ts",
-			"status": "skipped"
-		},
 		"oxlint": [
 			{
 				"name": "unicorn/prefer-string-raw",
@@ -27403,17 +27403,17 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "stringReplaceAllRegexSearches",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "unicorn/prefer-string-replace-all",
 				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prefer-string-replace-all.md"
 			}
 		],
-		"flint": {
-			"name": "stringReplaceAllRegexSearches",
-			"plugin": "ts",
-			"status": "skipped"
-		},
 		"oxlint": [
 			{
 				"name": "unicorn/prefer-string-replace-all",
@@ -27422,6 +27422,13 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "stringSliceMethods",
+			"plugin": "ts",
+			"preset": "stylistic",
+			"status": "implemented",
+			"strictness": "strict"
+		},
 		"biome": [
 			{
 				"name": "noSubstr",
@@ -27434,13 +27441,6 @@
 				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prefer-string-slice.md"
 			}
 		],
-		"flint": {
-			"name": "stringSliceMethods",
-			"plugin": "ts",
-			"preset": "stylistic",
-			"status": "implemented",
-			"strictness": "strict"
-		},
 		"oxlint": [
 			{
 				"name": "unicorn/prefer-string-slice",
@@ -27449,6 +27449,12 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "stringStartsEndsWith",
+			"plugin": "ts",
+			"preset": "stylistic",
+			"status": "implemented"
+		},
 		"biome": [
 			{
 				"name": "useStringStartsEndsWith",
@@ -27461,12 +27467,6 @@
 				"url": "https://typescript-eslint.io/rules/prefer-string-starts-ends-with"
 			}
 		],
-		"flint": {
-			"name": "stringStartsEndsWith",
-			"plugin": "ts",
-			"preset": "stylistic",
-			"status": "implemented"
-		},
 		"oxlint": [
 			{
 				"name": "typescript/prefer-string-starts-ends-with",
@@ -27479,19 +27479,24 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "stringStartsEndsWithMethods",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "unicorn/prefer-string-starts-ends-with",
 				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prefer-string-starts-ends-with.md"
 			}
-		],
-		"flint": {
-			"name": "stringStartsEndsWithMethods",
-			"plugin": "ts",
-			"status": "skipped"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "stringTemplateCurlies",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"biome": [
 			{
 				"name": "noTemplateCurlyInString",
@@ -27504,11 +27509,6 @@
 				"url": "https://eslint.org/docs/latest/rules/no-template-curly-in-string"
 			}
 		],
-		"flint": {
-			"name": "stringTemplateCurlies",
-			"plugin": "ts",
-			"status": "skipped"
-		},
 		"oxlint": [
 			{
 				"name": "eslint/no-template-curly-in-string",
@@ -27517,6 +27517,11 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "stringTrimMethods",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"biome": [
 			{
 				"name": "useTrimStartEnd",
@@ -27529,26 +27534,15 @@
 				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prefer-string-trim-start-end.md"
 			}
 		],
-		"flint": {
-			"name": "stringTrimMethods",
-			"plugin": "ts",
-			"status": "skipped"
-		},
-		"notes": "Superseded by deprecated.",
 		"oxlint": [
 			{
 				"name": "unicorn/prefer-string-trim-start-end",
 				"url": "https://oxc.rs/docs/guide/usage/linter/rules/unicorn/prefer-string-trim-start-end.html"
 			}
-		]
+		],
+		"notes": "Superseded by deprecated."
 	},
 	{
-		"eslint": [
-			{
-				"name": "unicorn/prefer-structured-clone",
-				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prefer-structured-clone.md"
-			}
-		],
 		"flint": {
 			"name": "structuredCloneMethods",
 			"plugin": "ts",
@@ -27556,6 +27550,12 @@
 			"status": "implemented",
 			"strictness": "strict"
 		},
+		"eslint": [
+			{
+				"name": "unicorn/prefer-structured-clone",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prefer-structured-clone.md"
+			}
+		],
 		"oxlint": [
 			{
 				"name": "unicorn/prefer-structured-clone",
@@ -27564,17 +27564,17 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "switchCaseBraces",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "unicorn/switch-case-braces",
 				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/switch-case-braces.md"
 			}
 		],
-		"flint": {
-			"name": "switchCaseBraces",
-			"plugin": "ts",
-			"status": "skipped"
-		},
 		"oxlint": [
 			{
 				"name": "unicorn/switch-case-braces",
@@ -27583,17 +27583,17 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "switchCaseBreakPositions",
+			"plugin": "ts",
+			"preset": "stylistic"
+		},
 		"eslint": [
 			{
 				"name": "unicorn/switch-case-break-position",
 				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v64.0.0/docs/rules/switch-case-break-position.md"
 			}
 		],
-		"flint": {
-			"name": "switchCaseBreakPositions",
-			"plugin": "ts",
-			"preset": "stylistic"
-		},
 		"oxlint": [
 			{
 				"name": "unicorn/switch-case-break-position",
@@ -27602,19 +27602,24 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "switchCasesOrder",
+			"plugin": "ts",
+			"preset": "sorting"
+		},
 		"eslint": [
 			{
 				"name": "perfectionist/sort-switch-case",
 				"url": "https://perfectionist.dev/rules/sort-switch-case"
 			}
-		],
-		"flint": {
-			"name": "switchCasesOrder",
-			"plugin": "ts",
-			"preset": "sorting"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "switchExhaustiveness",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"biome": [
 			{
 				"name": "useExhaustiveSwitchCases",
@@ -27627,11 +27632,6 @@
 				"url": "https://typescript-eslint.io/rules/switch-exhaustiveness-check"
 			}
 		],
-		"flint": {
-			"name": "switchExhaustiveness",
-			"plugin": "ts",
-			"status": "skipped"
-		},
 		"oxlint": [
 			{
 				"name": "typescript/switch-exhaustiveness-check",
@@ -27640,6 +27640,12 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "symbolDescriptions",
+			"plugin": "ts",
+			"preset": "stylistic",
+			"status": "implemented"
+		},
 		"biome": [
 			{
 				"name": "useSymbolDescription",
@@ -27652,12 +27658,6 @@
 				"url": "https://eslint.org/docs/latest/rules/symbol-description"
 			}
 		],
-		"flint": {
-			"name": "symbolDescriptions",
-			"plugin": "ts",
-			"preset": "stylistic",
-			"status": "implemented"
-		},
 		"oxlint": [
 			{
 				"name": "eslint/symbol-description",
@@ -27666,31 +27666,31 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "syncFunctionAwaits",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"deno": [
 			{
 				"name": "no-await-in-sync-fun",
 				"url": "https://docs.deno.com/lint/rules/no-await-in-sync-fun"
 			}
 		],
-		"flint": {
-			"name": "syncFunctionAwaits",
-			"plugin": "ts",
-			"status": "skipped"
-		},
 		"notes": "Generally handled by parsers."
 	},
 	{
+		"flint": {
+			"name": "templateExpressionValues",
+			"plugin": "ts",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "@typescript-eslint/restrict-template-expressions",
 				"url": "https://typescript-eslint.io/rules/restrict-template-expressions"
 			}
 		],
-		"flint": {
-			"name": "templateExpressionValues",
-			"plugin": "ts",
-			"preset": "logical"
-		},
 		"oxlint": [
 			{
 				"name": "typescript/restrict-template-expressions",
@@ -27699,30 +27699,30 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "templateIndents",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "unicorn/template-indent",
 				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/template-indent.md"
 			}
-		],
-		"flint": {
-			"name": "templateIndents",
-			"plugin": "ts",
-			"status": "skipped"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "templateLiteralEscapesConsistency",
+			"plugin": "ts",
+			"preset": "stylistic"
+		},
 		"eslint": [
 			{
 				"name": "unicorn/consistent-template-literal-escape",
 				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v64.0.0/docs/rules/consistent-template-literal-escape.md"
 			}
 		],
-		"flint": {
-			"name": "templateLiteralEscapesConsistency",
-			"plugin": "ts",
-			"preset": "stylistic"
-		},
 		"oxlint": [
 			{
 				"name": "unicorn/consistent-template-literal-escape",
@@ -27731,6 +27731,11 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "ternaryNesting",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"biome": [
 			{
 				"name": "noNestedTernary",
@@ -27747,11 +27752,6 @@
 				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-nested-ternary.md"
 			}
 		],
-		"flint": {
-			"name": "ternaryNesting",
-			"plugin": "ts",
-			"status": "skipped"
-		},
 		"oxlint": [
 			{
 				"name": "eslint/no-nested-ternary",
@@ -27764,6 +27764,11 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "ternaryOperators",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"biome": [
 			{
 				"name": "noTernary",
@@ -27776,11 +27781,6 @@
 				"url": "https://eslint.org/docs/latest/rules/no-ternary"
 			}
 		],
-		"flint": {
-			"name": "ternaryOperators",
-			"plugin": "ts",
-			"status": "skipped"
-		},
 		"oxlint": [
 			{
 				"name": "eslint/no-ternary",
@@ -27789,17 +27789,17 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "textEncodingCases",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "unicorn/text-encoding-identifier-case",
 				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/text-encoding-identifier-case.md"
 			}
 		],
-		"flint": {
-			"name": "textEncodingCases",
-			"plugin": "ts",
-			"status": "skipped"
-		},
 		"oxlint": [
 			{
 				"name": "unicorn/text-encoding-identifier-case",
@@ -27808,6 +27808,12 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "thisAliases",
+			"plugin": "ts",
+			"preset": "logical",
+			"status": "implemented"
+		},
 		"biome": [
 			{
 				"name": "noUselessThisAlias",
@@ -27824,12 +27830,6 @@
 				"url": "https://typescript-eslint.io/rules/no-this-alias"
 			}
 		],
-		"flint": {
-			"name": "thisAliases",
-			"plugin": "ts",
-			"preset": "logical",
-			"status": "implemented"
-		},
 		"oxlint": [
 			{
 				"name": "typescript/no-this-alias",
@@ -27838,17 +27838,17 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "thisAssignments",
+			"plugin": "ts",
+			"preset": "stylistic"
+		},
 		"eslint": [
 			{
 				"name": "unicorn/no-this-assignment",
 				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v64.0.0/docs/rules/no-this-assignment.md"
 			}
 		],
-		"flint": {
-			"name": "thisAssignments",
-			"plugin": "ts",
-			"preset": "stylistic"
-		},
 		"oxlint": [
 			{
 				"name": "unicorn/no-this-assignment",
@@ -27857,6 +27857,12 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "thisBeforeSuper",
+			"plugin": "ts",
+			"preset": "javascript",
+			"status": "implemented"
+		},
 		"biome": [
 			{
 				"name": "noUnreachableSuper",
@@ -27875,12 +27881,6 @@
 				"url": "https://eslint.org/docs/latest/rules/no-this-before-super"
 			}
 		],
-		"flint": {
-			"name": "thisBeforeSuper",
-			"plugin": "ts",
-			"preset": "javascript",
-			"status": "implemented"
-		},
 		"oxlint": [
 			{
 				"name": "eslint/no-this-before-super",
@@ -27902,19 +27902,25 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "thisInStatic",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"biome": [
 			{
 				"name": "noThisInStatic",
 				"url": "https://biomejs.dev/linter/rules/no-this-in-static"
 			}
-		],
-		"flint": {
-			"name": "thisInStatic",
-			"plugin": "ts",
-			"status": "skipped"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "throwErrors",
+			"plugin": "ts",
+			"preset": "logical",
+			"status": "implemented"
+		},
 		"biome": [
 			{
 				"name": "useThrowNewError",
@@ -27945,12 +27951,6 @@
 				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/throw-new-error.md"
 			}
 		],
-		"flint": {
-			"name": "throwErrors",
-			"plugin": "ts",
-			"preset": "logical",
-			"status": "implemented"
-		},
 		"oxlint": [
 			{
 				"name": "eslint/no-throw-literal",
@@ -27967,6 +27967,11 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "todoExpirations",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"deno": [
 			{
 				"name": "ban-untagged-todo",
@@ -27978,20 +27983,9 @@
 				"name": "unicorn/expiring-todo-comments",
 				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/expiring-todo-comments.md"
 			}
-		],
-		"flint": {
-			"name": "todoExpirations",
-			"plugin": "ts",
-			"status": "skipped"
-		}
+		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "unicorn/prefer-top-level-await",
-				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prefer-top-level-await.md"
-			}
-		],
 		"flint": {
 			"name": "topLevelAwaits",
 			"plugin": "ts",
@@ -27999,6 +27993,12 @@
 			"status": "implemented",
 			"strictness": "strict"
 		},
+		"eslint": [
+			{
+				"name": "unicorn/prefer-top-level-await",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prefer-top-level-await.md"
+			}
+		],
 		"oxlint": [
 			{
 				"name": "unicorn/prefer-top-level-await",
@@ -28007,6 +28007,12 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "tripleSlashReferences",
+			"plugin": "ts",
+			"preset": "logical",
+			"status": "implemented"
+		},
 		"deno": [
 			{
 				"name": "triple-slash-reference",
@@ -28019,12 +28025,6 @@
 				"url": "https://typescript-eslint.io/rules/triple-slash-reference"
 			}
 		],
-		"flint": {
-			"name": "tripleSlashReferences",
-			"plugin": "ts",
-			"preset": "logical",
-			"status": "implemented"
-		},
 		"oxlint": [
 			{
 				"name": "typescript/triple-slash-reference",
@@ -28033,20 +28033,26 @@
 		]
 	},
 	{
-		"deno": [
-			{
-				"name": "no-invalid-triple-slash-references",
-				"url": "https://docs.deno.com/lint/rules/no-invalid-triple-slash-references"
-			}
-		],
 		"flint": {
 			"name": "tripleSlashReferenceValidity",
 			"plugin": "ts",
 			"preset": "logical",
 			"status": "implemented"
-		}
+		},
+		"deno": [
+			{
+				"name": "no-invalid-triple-slash-references",
+				"url": "https://docs.deno.com/lint/rules/no-invalid-triple-slash-references"
+			}
+		]
 	},
 	{
+		"flint": {
+			"name": "tsComments",
+			"plugin": "ts",
+			"preset": "logical",
+			"status": "implemented"
+		},
 		"biome": [
 			{
 				"name": "noTsIgnore",
@@ -28069,12 +28075,6 @@
 				"url": "https://typescript-eslint.io/rules/prefer-ts-expect-error"
 			}
 		],
-		"flint": {
-			"name": "tsComments",
-			"plugin": "ts",
-			"preset": "logical",
-			"status": "implemented"
-		},
 		"oxlint": [
 			{
 				"name": "typescript/ban-ts-comment",
@@ -28087,18 +28087,18 @@
 		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "@typescript-eslint/ban-tslint-comment",
-				"url": "https://typescript-eslint.io/rules/ban-tslint-comment"
-			}
-		],
 		"flint": {
 			"name": "tslintComments",
 			"plugin": "ts",
 			"preset": "stylistic",
 			"status": "implemented"
 		},
+		"eslint": [
+			{
+				"name": "@typescript-eslint/ban-tslint-comment",
+				"url": "https://typescript-eslint.io/rules/ban-tslint-comment"
+			}
+		],
 		"oxlint": [
 			{
 				"name": "typescript/ban-tslint-comment",
@@ -28107,46 +28107,46 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "typeAliases",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "@typescript-eslint/no-type-alias",
 				"url": "https://typescript-eslint.io/rules/no-type-alias"
 			}
 		],
-		"flint": {
-			"name": "typeAliases",
-			"plugin": "ts",
-			"status": "skipped"
-		},
 		"notes": "Deprecated by typescript-eslint."
 	},
 	{
+		"flint": {
+			"name": "typeAnnotations",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "@typescript-eslint/typedef",
 				"url": "https://typescript-eslint.io/rules/typedef"
 			}
 		],
-		"flint": {
-			"name": "typeAnnotations",
-			"plugin": "ts",
-			"status": "skipped"
-		},
 		"notes": "Deprecated by typescript-eslint."
 	},
 	{
-		"eslint": [
-			{
-				"name": "@typescript-eslint/consistent-type-assertions",
-				"url": "https://typescript-eslint.io/rules/consistent-type-assertions"
-			}
-		],
 		"flint": {
 			"name": "typeAssertionStyles",
 			"plugin": "ts",
 			"preset": "stylistic",
 			"status": "implemented"
 		},
+		"eslint": [
+			{
+				"name": "@typescript-eslint/consistent-type-assertions",
+				"url": "https://typescript-eslint.io/rules/consistent-type-assertions"
+			}
+		],
 		"oxlint": [
 			{
 				"name": "typescript/consistent-type-assertions",
@@ -28155,17 +28155,17 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "typeChecksTypeErrors",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "unicorn/prefer-type-error",
 				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prefer-type-error.md"
 			}
 		],
-		"flint": {
-			"name": "typeChecksTypeErrors",
-			"plugin": "ts",
-			"status": "skipped"
-		},
 		"oxlint": [
 			{
 				"name": "unicorn/prefer-type-error",
@@ -28174,17 +28174,17 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "typeConstituentDuplicates",
+			"plugin": "ts",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "@typescript-eslint/no-duplicate-type-constituents",
 				"url": "https://typescript-eslint.io/rules/no-duplicate-type-constituents"
 			}
 		],
-		"flint": {
-			"name": "typeConstituentDuplicates",
-			"plugin": "ts",
-			"preset": "logical"
-		},
 		"oxlint": [
 			{
 				"name": "typescript/no-duplicate-type-constituents",
@@ -28193,19 +28193,24 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "typeConstituentsOrder",
+			"plugin": "ts",
+			"preset": "sorting"
+		},
 		"eslint": [
 			{
 				"name": "@typescript-eslint/sort-type-constituents",
 				"url": "https://typescript-eslint.io/rules/sort-type-constituents"
 			}
-		],
-		"flint": {
-			"name": "typeConstituentsOrder",
-			"plugin": "ts",
-			"preset": "sorting"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "typeExports",
+			"plugin": "ts",
+			"preset": "stylistic"
+		},
 		"biome": [
 			{
 				"name": "useExportType",
@@ -28218,11 +28223,6 @@
 				"url": "https://typescript-eslint.io/rules/consistent-type-exports"
 			}
 		],
-		"flint": {
-			"name": "typeExports",
-			"plugin": "ts",
-			"preset": "stylistic"
-		},
 		"oxlint": [
 			{
 				"name": "typescript/consistent-type-exports",
@@ -28231,6 +28231,12 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "typeImports",
+			"plugin": "ts",
+			"preset": "stylistic",
+			"status": "implemented"
+		},
 		"biome": [
 			{
 				"name": "useImportType",
@@ -28247,12 +28253,6 @@
 				"url": "https://github.com/import-js/eslint-plugin-import/blob/HEAD/docs/rules/consistent-type-specifier-style.md"
 			}
 		],
-		"flint": {
-			"name": "typeImports",
-			"plugin": "ts",
-			"preset": "stylistic",
-			"status": "implemented"
-		},
 		"oxlint": [
 			{
 				"name": "import/consistent-type-specifier-style",
@@ -28265,6 +28265,12 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "typeofComparisons",
+			"plugin": "ts",
+			"preset": "javascript",
+			"status": "implemented"
+		},
 		"biome": [
 			{
 				"name": "useValidTypeof",
@@ -28283,12 +28289,6 @@
 				"url": "https://eslint.org/docs/latest/rules/valid-typeof"
 			}
 		],
-		"flint": {
-			"name": "typeofComparisons",
-			"plugin": "ts",
-			"preset": "javascript",
-			"status": "implemented"
-		},
 		"oxlint": [
 			{
 				"name": "eslint/valid-typeof",
@@ -28297,26 +28297,32 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "unassignedImports",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "import/no-unassigned-import",
 				"url": "https://github.com/import-js/eslint-plugin-import/blob/HEAD/docs/rules/no-unassigned-import.md"
 			}
 		],
-		"flint": {
-			"name": "unassignedImports",
-			"plugin": "ts",
-			"status": "skipped"
-		},
-		"notes": "Overly opinionated.",
 		"oxlint": [
 			{
 				"name": "import/no-unassigned-import",
 				"url": "https://oxc.rs/docs/guide/usage/linter/rules/import/no-unassigned-import.html"
 			}
-		]
+		],
+		"notes": "Overly opinionated."
 	},
 	{
+		"flint": {
+			"name": "unassignedVariables",
+			"plugin": "ts",
+			"preset": "javascript",
+			"status": "implemented"
+		},
 		"biome": [
 			{
 				"name": "noUnassignedVariables",
@@ -28329,12 +28335,6 @@
 				"url": "https://eslint.org/docs/latest/rules/no-unassigned-vars"
 			}
 		],
-		"flint": {
-			"name": "unassignedVariables",
-			"plugin": "ts",
-			"preset": "javascript",
-			"status": "implemented"
-		},
 		"oxlint": [
 			{
 				"name": "eslint/no-unassigned-vars",
@@ -28343,17 +28343,17 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "unboundMethods",
+			"plugin": "ts",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "@typescript-eslint/unbound-method",
 				"url": "https://typescript-eslint.io/rules/unbound-method"
 			}
 		],
-		"flint": {
-			"name": "unboundMethods",
-			"plugin": "ts",
-			"preset": "logical"
-		},
 		"oxlint": [
 			{
 				"name": "typescript/unbound-method",
@@ -28362,6 +28362,11 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "undefinedInitialValues",
+			"plugin": "ts",
+			"preset": "stylistic"
+		},
 		"biome": [
 			{
 				"name": "noUselessUndefinedInitialization",
@@ -28379,25 +28384,20 @@
 				"name": "no-undef-init",
 				"url": "https://eslint.org/docs/latest/rules/no-undef-init"
 			}
-		],
-		"flint": {
-			"name": "undefinedInitialValues",
-			"plugin": "ts",
-			"preset": "stylistic"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "undefinedNames",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "no-undefined",
 				"url": "https://eslint.org/docs/latest/rules/no-undefined"
 			}
 		],
-		"flint": {
-			"name": "undefinedNames",
-			"plugin": "ts",
-			"status": "skipped"
-		},
 		"oxlint": [
 			{
 				"name": "eslint/no-undefined",
@@ -28406,12 +28406,6 @@
 		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "unicorn/no-typeof-undefined",
-				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-typeof-undefined.md"
-			}
-		],
 		"flint": {
 			"name": "undefinedTypeofChecks",
 			"plugin": "ts",
@@ -28419,6 +28413,12 @@
 			"status": "implemented",
 			"strictness": "strict"
 		},
+		"eslint": [
+			{
+				"name": "unicorn/no-typeof-undefined",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-typeof-undefined.md"
+			}
+		],
 		"oxlint": [
 			{
 				"name": "unicorn/no-typeof-undefined",
@@ -28427,6 +28427,12 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "undefinedVariables",
+			"plugin": "ts",
+			"preset": "javascript",
+			"status": "implemented"
+		},
 		"biome": [
 			{
 				"name": "noUndeclaredVariables",
@@ -28439,12 +28445,6 @@
 				"url": "https://eslint.org/docs/latest/rules/no-undef"
 			}
 		],
-		"flint": {
-			"name": "undefinedVariables",
-			"plugin": "ts",
-			"preset": "javascript",
-			"status": "implemented"
-		},
 		"oxlint": [
 			{
 				"name": "eslint/no-undef",
@@ -28453,17 +28453,17 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "underscoreNames",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "no-underscore-dangle",
 				"url": "https://eslint.org/docs/latest/rules/no-underscore-dangle"
 			}
 		],
-		"flint": {
-			"name": "underscoreNames",
-			"plugin": "ts",
-			"status": "skipped"
-		},
 		"oxlint": [
 			{
 				"name": "eslint/no-underscore-dangle",
@@ -28472,18 +28472,18 @@
 		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "unicode-bom",
-				"url": "https://eslint.org/docs/latest/rules/unicode-bom"
-			}
-		],
 		"flint": {
 			"name": "unicodeBOMs",
 			"plugin": "ts",
 			"preset": "stylistic",
 			"status": "implemented"
 		},
+		"eslint": [
+			{
+				"name": "unicode-bom",
+				"url": "https://eslint.org/docs/latest/rules/unicode-bom"
+			}
+		],
 		"oxlint": [
 			{
 				"name": "eslint/unicode-bom",
@@ -28492,6 +28492,12 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "unifiedSignatures",
+			"plugin": "ts",
+			"preset": "logical",
+			"strictness": "strict"
+		},
 		"biome": [
 			{
 				"name": "useUnifiedTypeSignatures",
@@ -28504,12 +28510,6 @@
 				"url": "https://typescript-eslint.io/rules/unified-signatures"
 			}
 		],
-		"flint": {
-			"name": "unifiedSignatures",
-			"plugin": "ts",
-			"preset": "logical",
-			"strictness": "strict"
-		},
 		"oxlint": [
 			{
 				"name": "typescript/unified-signatures",
@@ -28518,31 +28518,31 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "unionTypesOrder",
+			"plugin": "ts",
+			"preset": "sorting"
+		},
 		"eslint": [
 			{
 				"name": "perfectionist/sort-union-types",
 				"url": "https://perfectionist.dev/rules/sort-union-types"
 			}
-		],
-		"flint": {
-			"name": "unionTypesOrder",
-			"plugin": "ts",
-			"preset": "sorting"
-		}
+		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "no-extra-bind",
-				"url": "https://eslint.org/docs/latest/rules/no-extra-bind"
-			}
-		],
 		"flint": {
 			"name": "unnecessaryBinds",
 			"plugin": "ts",
 			"preset": "logical",
 			"status": "implemented"
 		},
+		"eslint": [
+			{
+				"name": "no-extra-bind",
+				"url": "https://eslint.org/docs/latest/rules/no-extra-bind"
+			}
+		],
 		"oxlint": [
 			{
 				"name": "eslint/no-extra-bind",
@@ -28551,6 +28551,12 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "unnecessaryBlocks",
+			"plugin": "ts",
+			"preset": "stylistic",
+			"status": "implemented"
+		},
 		"biome": [
 			{
 				"name": "noUselessLoneBlockStatements",
@@ -28563,12 +28569,6 @@
 				"url": "https://eslint.org/docs/latest/rules/no-lone-blocks"
 			}
 		],
-		"flint": {
-			"name": "unnecessaryBlocks",
-			"plugin": "ts",
-			"preset": "stylistic",
-			"status": "implemented"
-		},
 		"oxlint": [
 			{
 				"name": "eslint/no-lone-blocks",
@@ -28577,6 +28577,12 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "unnecessaryBooleanCasts",
+			"plugin": "ts",
+			"preset": "stylistic",
+			"status": "implemented"
+		},
 		"biome": [
 			{
 				"name": "noExtraBooleanCast",
@@ -28595,12 +28601,6 @@
 				"url": "https://eslint.org/docs/latest/rules/no-extra-boolean-cast"
 			}
 		],
-		"flint": {
-			"name": "unnecessaryBooleanCasts",
-			"plugin": "ts",
-			"preset": "stylistic",
-			"status": "implemented"
-		},
 		"oxlint": [
 			{
 				"name": "eslint/no-extra-boolean-cast",
@@ -28609,6 +28609,12 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "unnecessaryCatches",
+			"plugin": "ts",
+			"preset": "logical",
+			"status": "implemented"
+		},
 		"biome": [
 			{
 				"name": "noUselessCatch",
@@ -28621,12 +28627,6 @@
 				"url": "https://eslint.org/docs/latest/rules/no-useless-catch"
 			}
 		],
-		"flint": {
-			"name": "unnecessaryCatches",
-			"plugin": "ts",
-			"preset": "logical",
-			"status": "implemented"
-		},
 		"oxlint": [
 			{
 				"name": "eslint/no-useless-catch",
@@ -28635,17 +28635,17 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "unnecessaryCollectionArguments",
+			"plugin": "ts",
+			"preset": "stylistic"
+		},
 		"eslint": [
 			{
 				"name": "unicorn/no-useless-collection-argument",
 				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v64.0.0/docs/rules/no-useless-collection-argument.md"
 			}
 		],
-		"flint": {
-			"name": "unnecessaryCollectionArguments",
-			"plugin": "ts",
-			"preset": "stylistic"
-		},
 		"oxlint": [
 			{
 				"name": "unicorn/no-useless-collection-argument",
@@ -28654,6 +28654,12 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "unnecessaryComparisons",
+			"plugin": "ts",
+			"preset": "logical",
+			"status": "implemented"
+		},
 		"biome": [
 			{
 				"name": "noSelfCompare",
@@ -28672,12 +28678,6 @@
 				"url": "https://eslint.org/docs/latest/rules/no-self-compare"
 			}
 		],
-		"flint": {
-			"name": "unnecessaryComparisons",
-			"plugin": "ts",
-			"preset": "logical",
-			"status": "implemented"
-		},
 		"oxlint": [
 			{
 				"name": "eslint/no-self-compare",
@@ -28694,6 +28694,11 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "unnecessaryComputedKeys",
+			"plugin": "ts",
+			"preset": "stylistic"
+		},
 		"biome": [
 			{
 				"name": "useLiteralKeys",
@@ -28706,11 +28711,6 @@
 				"url": "https://eslint.org/docs/latest/rules/no-useless-computed-key"
 			}
 		],
-		"flint": {
-			"name": "unnecessaryComputedKeys",
-			"plugin": "ts",
-			"preset": "stylistic"
-		},
 		"oxlint": [
 			{
 				"name": "eslint/no-useless-computed-key",
@@ -28719,6 +28719,12 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "unnecessaryConcatenation",
+			"plugin": "ts",
+			"preset": "stylistic",
+			"status": "implemented"
+		},
 		"biome": [
 			{
 				"name": "noUselessStringConcat",
@@ -28731,12 +28737,6 @@
 				"url": "https://eslint.org/docs/latest/rules/no-useless-concat"
 			}
 		],
-		"flint": {
-			"name": "unnecessaryConcatenation",
-			"plugin": "ts",
-			"preset": "stylistic",
-			"status": "implemented"
-		},
 		"oxlint": [
 			{
 				"name": "eslint/no-useless-concat",
@@ -28745,6 +28745,11 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "unnecessaryConditions",
+			"plugin": "ts",
+			"preset": "logical"
+		},
 		"biome": [
 			{
 				"name": "noUnnecessaryConditions",
@@ -28757,11 +28762,6 @@
 				"url": "https://typescript-eslint.io/rules/no-unnecessary-condition"
 			}
 		],
-		"flint": {
-			"name": "unnecessaryConditions",
-			"plugin": "ts",
-			"preset": "logical"
-		},
 		"oxlint": [
 			{
 				"name": "typescript/no-unnecessary-condition",
@@ -28770,6 +28770,11 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "unnecessaryConstructors",
+			"plugin": "ts",
+			"preset": "stylistic"
+		},
 		"biome": [
 			{
 				"name": "noUselessConstructor",
@@ -28786,11 +28791,6 @@
 				"url": "https://typescript-eslint.io/rules/no-useless-constructor"
 			}
 		],
-		"flint": {
-			"name": "unnecessaryConstructors",
-			"plugin": "ts",
-			"preset": "stylistic"
-		},
 		"oxlint": [
 			{
 				"name": "eslint/no-useless-constructor",
@@ -28799,19 +28799,25 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "unnecessaryContinues",
+			"plugin": "ts",
+			"preset": "logical"
+		},
 		"biome": [
 			{
 				"name": "noUselessContinue",
 				"url": "https://biomejs.dev/linter/rules/no-useless-continue"
 			}
-		],
-		"flint": {
-			"name": "unnecessaryContinues",
-			"plugin": "ts",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "unnecessaryEscapes",
+			"plugin": "ts",
+			"preset": "stylistic",
+			"status": "implemented"
+		},
 		"biome": [
 			{
 				"name": "noUselessEscapeInRegex",
@@ -28828,12 +28834,6 @@
 				"url": "https://eslint.org/docs/latest/rules/no-useless-escape"
 			}
 		],
-		"flint": {
-			"name": "unnecessaryEscapes",
-			"plugin": "ts",
-			"preset": "stylistic",
-			"status": "implemented"
-		},
 		"oxlint": [
 			{
 				"name": "eslint/no-useless-escape",
@@ -28842,17 +28842,17 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "unnecessaryIteratorArrays",
+			"plugin": "ts",
+			"preset": "stylistic"
+		},
 		"eslint": [
 			{
 				"name": "unicorn/no-useless-iterator-to-array",
 				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v64.0.0/docs/rules/no-useless-iterator-to-array.md"
 			}
 		],
-		"flint": {
-			"name": "unnecessaryIteratorArrays",
-			"plugin": "ts",
-			"preset": "stylistic"
-		},
 		"oxlint": [
 			{
 				"name": "unicorn/no-useless-iterator-to-array",
@@ -28861,6 +28861,11 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "unnecessaryLabels",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"biome": [
 			{
 				"name": "noUselessLabel",
@@ -28873,11 +28878,6 @@
 				"url": "https://eslint.org/docs/latest/rules/no-extra-label"
 			}
 		],
-		"flint": {
-			"name": "unnecessaryLabels",
-			"plugin": "ts",
-			"status": "skipped"
-		},
 		"oxlint": [
 			{
 				"name": "eslint/no-extra-label",
@@ -28886,6 +28886,11 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "unnecessaryLogicalComparisons",
+			"plugin": "ts",
+			"preset": "logical"
+		},
 		"biome": [
 			{
 				"name": "useSimplifiedLogicExpression",
@@ -28898,11 +28903,6 @@
 				"url": "https://typescript-eslint.io/rules/no-unnecessary-boolean-literal-compare"
 			}
 		],
-		"flint": {
-			"name": "unnecessaryLogicalComparisons",
-			"plugin": "ts",
-			"preset": "logical"
-		},
 		"oxlint": [
 			{
 				"name": "typescript/no-unnecessary-boolean-literal-compare",
@@ -28911,18 +28911,18 @@
 		]
 	},
 	{
-		"biome": [
-			{
-				"name": "noConstantMathMinMaxClamp",
-				"url": "https://biomejs.dev/linter/rules/no-constant-math-min-max-clamp"
-			}
-		],
 		"flint": {
 			"name": "unnecessaryMathClamps",
 			"plugin": "ts",
 			"preset": "logical",
 			"status": "implemented"
 		},
+		"biome": [
+			{
+				"name": "noConstantMathMinMaxClamp",
+				"url": "https://biomejs.dev/linter/rules/no-constant-math-min-max-clamp"
+			}
+		],
 		"oxlint": [
 			{
 				"name": "oxc/bad-min-max-func",
@@ -28931,18 +28931,18 @@
 		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "unicorn/no-zero-fractions",
-				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-zero-fractions.md"
-			}
-		],
 		"flint": {
 			"name": "unnecessaryNumericFractions",
 			"plugin": "ts",
 			"preset": "stylistic",
 			"status": "implemented"
 		},
+		"eslint": [
+			{
+				"name": "unicorn/no-zero-fractions",
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-zero-fractions.md"
+			}
+		],
 		"oxlint": [
 			{
 				"name": "unicorn/no-zero-fractions",
@@ -28951,31 +28951,31 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "unnecessaryPolyfills",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "unicorn/no-unnecessary-polyfills",
 				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-unnecessary-polyfills.md"
 			}
 		],
-		"flint": {
-			"name": "unnecessaryPolyfills",
-			"plugin": "ts",
-			"status": "skipped"
-		},
 		"notes": "Superseded by the e18e initiative"
 	},
 	{
+		"flint": {
+			"name": "unnecessaryQualifiers",
+			"plugin": "ts",
+			"preset": "stylistic"
+		},
 		"eslint": [
 			{
 				"name": "@typescript-eslint/no-unnecessary-qualifier",
 				"url": "https://typescript-eslint.io/rules/no-unnecessary-qualifier"
 			}
 		],
-		"flint": {
-			"name": "unnecessaryQualifiers",
-			"plugin": "ts",
-			"preset": "stylistic"
-		},
 		"oxlint": [
 			{
 				"name": "typescript/no-unnecessary-qualifier",
@@ -28984,6 +28984,12 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "unnecessaryRenames",
+			"plugin": "ts",
+			"preset": "stylistic",
+			"status": "implemented"
+		},
 		"biome": [
 			{
 				"name": "noUselessRename",
@@ -29002,12 +29008,6 @@
 				"url": "https://eslint.org/docs/latest/rules/no-useless-rename"
 			}
 		],
-		"flint": {
-			"name": "unnecessaryRenames",
-			"plugin": "ts",
-			"preset": "stylistic",
-			"status": "implemented"
-		},
 		"oxlint": [
 			{
 				"name": "eslint/no-useless-rename",
@@ -29016,6 +29016,11 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "unnecessaryReturns",
+			"plugin": "ts",
+			"preset": "stylistic"
+		},
 		"biome": [
 			{
 				"name": "noUselessReturn",
@@ -29028,11 +29033,6 @@
 				"url": "https://eslint.org/docs/latest/rules/no-useless-return"
 			}
 		],
-		"flint": {
-			"name": "unnecessaryReturns",
-			"plugin": "ts",
-			"preset": "stylistic"
-		},
 		"oxlint": [
 			{
 				"name": "eslint/no-useless-return",
@@ -29041,17 +29041,17 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "unnecessarySpreads",
+			"plugin": "ts",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "unicorn/no-useless-spread",
 				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-useless-spread.md"
 			}
 		],
-		"flint": {
-			"name": "unnecessarySpreads",
-			"plugin": "ts",
-			"preset": "logical"
-		},
 		"oxlint": [
 			{
 				"name": "unicorn/no-useless-spread",
@@ -29060,19 +29060,24 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "unnecessaryStringRaws",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"biome": [
 			{
 				"name": "noUselessStringRaw",
 				"url": "https://biomejs.dev/linter/rules/no-useless-string-raw"
 			}
-		],
-		"flint": {
-			"name": "unnecessaryStringRaws",
-			"plugin": "ts",
-			"status": "skipped"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "unnecessaryTemplateExpressions",
+			"plugin": "ts",
+			"preset": "logical"
+		},
 		"biome": [
 			{
 				"name": "noUnnecessaryTemplateExpression",
@@ -29089,11 +29094,6 @@
 				"url": "https://typescript-eslint.io/rules/no-unnecessary-template-expression"
 			}
 		],
-		"flint": {
-			"name": "unnecessaryTemplateExpressions",
-			"plugin": "ts",
-			"preset": "logical"
-		},
 		"oxlint": [
 			{
 				"name": "typescript/no-unnecessary-template-expression",
@@ -29102,6 +29102,13 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "unnecessaryTernaries",
+			"plugin": "ts",
+			"preset": "stylistic",
+			"status": "implemented",
+			"strictness": "strict"
+		},
 		"biome": [
 			{
 				"name": "noUselessTernary",
@@ -29118,13 +29125,6 @@
 				"url": "https://eslint.org/docs/latest/rules/no-unneeded-ternary"
 			}
 		],
-		"flint": {
-			"name": "unnecessaryTernaries",
-			"plugin": "ts",
-			"preset": "stylistic",
-			"status": "implemented",
-			"strictness": "strict"
-		},
 		"oxlint": [
 			{
 				"name": "eslint/no-unneeded-ternary",
@@ -29137,6 +29137,11 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "unnecessaryTypeAnnotations",
+			"plugin": "ts",
+			"preset": "stylistic"
+		},
 		"biome": [
 			{
 				"name": "noInferrableTypes",
@@ -29155,11 +29160,6 @@
 				"url": "https://typescript-eslint.io/rules/no-inferrable-types"
 			}
 		],
-		"flint": {
-			"name": "unnecessaryTypeAnnotations",
-			"plugin": "ts",
-			"preset": "stylistic"
-		},
 		"oxlint": [
 			{
 				"name": "typescript/no-inferrable-types",
@@ -29168,17 +29168,17 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "unnecessaryTypeArguments",
+			"plugin": "ts",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "@typescript-eslint/no-unnecessary-type-arguments",
 				"url": "https://typescript-eslint.io/rules/no-unnecessary-type-arguments"
 			}
 		],
-		"flint": {
-			"name": "unnecessaryTypeArguments",
-			"plugin": "ts",
-			"preset": "logical"
-		},
 		"oxlint": [
 			{
 				"name": "typescript/no-unnecessary-type-arguments",
@@ -29187,17 +29187,17 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "unnecessaryTypeAssertions",
+			"plugin": "ts",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "@typescript-eslint/no-unnecessary-type-assertion",
 				"url": "https://typescript-eslint.io/rules/no-unnecessary-type-assertion"
 			}
 		],
-		"flint": {
-			"name": "unnecessaryTypeAssertions",
-			"plugin": "ts",
-			"preset": "logical"
-		},
 		"oxlint": [
 			{
 				"name": "typescript/no-unnecessary-type-assertion",
@@ -29206,6 +29206,11 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "unnecessaryTypeConstraints",
+			"plugin": "ts",
+			"preset": "logical"
+		},
 		"biome": [
 			{
 				"name": "noUselessTypeConstraint",
@@ -29218,11 +29223,6 @@
 				"url": "https://typescript-eslint.io/rules/no-unnecessary-type-constraint"
 			}
 		],
-		"flint": {
-			"name": "unnecessaryTypeConstraints",
-			"plugin": "ts",
-			"preset": "logical"
-		},
 		"oxlint": [
 			{
 				"name": "typescript/no-unnecessary-type-constraint",
@@ -29231,6 +29231,11 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "unnecessaryTypeConversions",
+			"plugin": "ts",
+			"preset": "logical"
+		},
 		"biome": [
 			{
 				"name": "noUselessTypeConversion",
@@ -29243,11 +29248,6 @@
 				"url": "https://typescript-eslint.io/rules/no-unnecessary-type-conversion"
 			}
 		],
-		"flint": {
-			"name": "unnecessaryTypeConversions",
-			"plugin": "ts",
-			"preset": "logical"
-		},
 		"oxlint": [
 			{
 				"name": "typescript/no-unnecessary-type-conversion",
@@ -29256,17 +29256,17 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "unnecessaryTypeParameters",
+			"plugin": "ts",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "@typescript-eslint/no-unnecessary-type-parameters",
 				"url": "https://typescript-eslint.io/rules/no-unnecessary-type-parameters"
 			}
 		],
-		"flint": {
-			"name": "unnecessaryTypeParameters",
-			"plugin": "ts",
-			"preset": "logical"
-		},
 		"oxlint": [
 			{
 				"name": "typescript/no-unnecessary-type-parameters",
@@ -29275,6 +29275,11 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "unnecessaryUndefinedDefaults",
+			"plugin": "ts",
+			"preset": "logical"
+		},
 		"biome": [
 			{
 				"name": "noUselessUndefined",
@@ -29287,11 +29292,6 @@
 				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-useless-undefined.md"
 			}
 		],
-		"flint": {
-			"name": "unnecessaryUndefinedDefaults",
-			"plugin": "ts",
-			"preset": "logical"
-		},
 		"oxlint": [
 			{
 				"name": "unicorn/no-useless-undefined",
@@ -29300,33 +29300,38 @@
 		]
 	},
 	{
-		"biome": [
-			{
-				"name": "noRedundantUseStrict",
-				"url": "https://biomejs.dev/linter/rules/no-redundant-use-strict"
-			}
-		],
 		"flint": {
 			"name": "unnecessaryUseStricts",
 			"plugin": "ts",
 			"preset": "logical",
 			"status": "implemented"
-		}
+		},
+		"biome": [
+			{
+				"name": "noRedundantUseStrict",
+				"url": "https://biomejs.dev/linter/rules/no-redundant-use-strict"
+			}
+		]
 	},
 	{
+		"flint": {
+			"name": "unreachableLoops",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "no-unreachable-loop",
 				"url": "https://eslint.org/docs/latest/rules/no-unreachable-loop"
 			}
-		],
-		"flint": {
-			"name": "unreachableLoops",
-			"plugin": "ts",
-			"status": "skipped"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "unreachableStatements",
+			"plugin": "ts",
+			"preset": "javascript"
+		},
 		"biome": [
 			{
 				"name": "noUnreachable",
@@ -29345,11 +29350,6 @@
 				"url": "https://eslint.org/docs/latest/rules/no-unreachable"
 			}
 		],
-		"flint": {
-			"name": "unreachableStatements",
-			"plugin": "ts",
-			"preset": "javascript"
-		},
 		"oxlint": [
 			{
 				"name": "eslint/no-unreachable",
@@ -29358,18 +29358,23 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "unresolvedImports",
+			"plugin": "ts"
+		},
 		"eslint": [
 			{
 				"name": "import/no-unresolved",
 				"url": "https://github.com/import-js/eslint-plugin-import/blob/v2.32.0/docs/rules/no-unresolved.md"
 			}
-		],
-		"flint": {
-			"name": "unresolvedImports",
-			"plugin": "ts"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "unsafeDeclarationmerging",
+			"plugin": "ts",
+			"preset": "logical"
+		},
 		"biome": [
 			{
 				"name": "noUnsafeDeclarationMerging",
@@ -29382,11 +29387,6 @@
 				"url": "https://typescript-eslint.io/rules/no-unsafe-declaration-merging"
 			}
 		],
-		"flint": {
-			"name": "unsafeDeclarationmerging",
-			"plugin": "ts",
-			"preset": "logical"
-		},
 		"oxlint": [
 			{
 				"name": "typescript/no-unsafe-declaration-merging",
@@ -29395,17 +29395,17 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "unsafeEnumComparisons",
+			"plugin": "ts",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "@typescript-eslint/no-unsafe-enum-comparison",
 				"url": "https://typescript-eslint.io/rules/no-unsafe-enum-comparison"
 			}
 		],
-		"flint": {
-			"name": "unsafeEnumComparisons",
-			"plugin": "ts",
-			"preset": "logical"
-		},
 		"oxlint": [
 			{
 				"name": "typescript/no-unsafe-enum-comparison",
@@ -29414,17 +29414,17 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "unsafeFunctionTypes",
+			"plugin": "ts",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "@typescript-eslint/no-unsafe-function-type",
 				"url": "https://typescript-eslint.io/rules/no-unsafe-function-type"
 			}
 		],
-		"flint": {
-			"name": "unsafeFunctionTypes",
-			"plugin": "ts",
-			"preset": "logical"
-		},
 		"oxlint": [
 			{
 				"name": "typescript/no-unsafe-function-type",
@@ -29433,6 +29433,12 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "unsafeNegations",
+			"plugin": "ts",
+			"preset": "javascript",
+			"status": "implemented"
+		},
 		"biome": [
 			{
 				"name": "noUnsafeNegation",
@@ -29451,12 +29457,6 @@
 				"url": "https://eslint.org/docs/latest/rules/no-unsafe-negation"
 			}
 		],
-		"flint": {
-			"name": "unsafeNegations",
-			"plugin": "ts",
-			"preset": "javascript",
-			"status": "implemented"
-		},
 		"oxlint": [
 			{
 				"name": "eslint/no-unsafe-negation",
@@ -29465,6 +29465,11 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "unsafeOptionalChains",
+			"plugin": "ts",
+			"preset": "javascript"
+		},
 		"biome": [
 			{
 				"name": "noUnsafeOptionalChaining",
@@ -29477,11 +29482,6 @@
 				"url": "https://eslint.org/docs/latest/rules/no-unsafe-optional-chaining"
 			}
 		],
-		"flint": {
-			"name": "unsafeOptionalChains",
-			"plugin": "ts",
-			"preset": "javascript"
-		},
 		"oxlint": [
 			{
 				"name": "eslint/no-unsafe-optional-chaining",
@@ -29490,6 +29490,11 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "unsafeToString",
+			"plugin": "ts",
+			"preset": "logical"
+		},
 		"biome": [
 			{
 				"name": "noBaseToString",
@@ -29502,11 +29507,6 @@
 				"url": "https://typescript-eslint.io/rules/no-base-to-string"
 			}
 		],
-		"flint": {
-			"name": "unsafeToString",
-			"plugin": "ts",
-			"preset": "logical"
-		},
 		"oxlint": [
 			{
 				"name": "typescript/no-base-to-string",
@@ -29515,17 +29515,17 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "unsafeTypeAssertions",
+			"plugin": "ts",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "@typescript-eslint/no-unsafe-type-assertion",
 				"url": "https://typescript-eslint.io/rules/no-unsafe-type-assertion"
 			}
 		],
-		"flint": {
-			"name": "unsafeTypeAssertions",
-			"plugin": "ts",
-			"preset": "logical"
-		},
 		"oxlint": [
 			{
 				"name": "typescript/no-unsafe-type-assertion",
@@ -29534,17 +29534,17 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "unsafeUnaryNegations",
+			"plugin": "ts",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "@typescript-eslint/no-unsafe-unary-minus",
 				"url": "https://typescript-eslint.io/rules/no-unsafe-unary-minus"
 			}
 		],
-		"flint": {
-			"name": "unsafeUnaryNegations",
-			"plugin": "ts",
-			"preset": "logical"
-		},
 		"oxlint": [
 			{
 				"name": "typescript/no-unsafe-unary-minus",
@@ -29553,6 +29553,11 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "unusedCatchBindings",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"biome": [
 			{
 				"name": "noUselessCatchBinding",
@@ -29565,20 +29570,20 @@
 				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/prefer-optional-catch-binding.md"
 			}
 		],
-		"flint": {
-			"name": "unusedCatchBindings",
-			"plugin": "ts",
-			"status": "skipped"
-		},
-		"notes": "Superseded by unusedVariables",
 		"oxlint": [
 			{
 				"name": "unicorn/prefer-optional-catch-binding",
 				"url": "https://oxc.rs/docs/guide/usage/linter/rules/unicorn/prefer-optional-catch-binding.html"
 			}
-		]
+		],
+		"notes": "Superseded by unusedVariables"
 	},
 	{
+		"flint": {
+			"name": "unusedExpressions",
+			"plugin": "ts",
+			"preset": "logical"
+		},
 		"biome": [
 			{
 				"name": "noUnusedExpressions",
@@ -29595,11 +29600,6 @@
 				"url": "https://typescript-eslint.io/rules/no-unused-expressions"
 			}
 		],
-		"flint": {
-			"name": "unusedExpressions",
-			"plugin": "ts",
-			"preset": "logical"
-		},
 		"oxlint": [
 			{
 				"name": "eslint/no-unused-expressions",
@@ -29608,19 +29608,24 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "unusedImports",
+			"plugin": "ts",
+			"preset": "logical"
+		},
 		"biome": [
 			{
 				"name": "noUnusedImports",
 				"url": "https://biomejs.dev/linter/rules/no-unused-imports"
 			}
-		],
-		"flint": {
-			"name": "unusedImports",
-			"plugin": "ts",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "unusedLabels",
+			"plugin": "ts",
+			"preset": "stylistic"
+		},
 		"biome": [
 			{
 				"name": "noUnusedLabels",
@@ -29639,11 +29644,6 @@
 				"url": "https://eslint.org/docs/latest/rules/no-unused-labels"
 			}
 		],
-		"flint": {
-			"name": "unusedLabels",
-			"plugin": "ts",
-			"preset": "stylistic"
-		},
 		"oxlint": [
 			{
 				"name": "eslint/no-unused-labels",
@@ -29652,31 +29652,36 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "unusedModules",
+			"plugin": "ts"
+		},
 		"eslint": [
 			{
 				"name": "import/no-unused-modules",
 				"url": "https://github.com/import-js/eslint-plugin-import/blob/v2.32.0/docs/rules/no-unused-modules.md"
 			}
-		],
-		"flint": {
-			"name": "unusedModules",
-			"plugin": "ts"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "unusedObjectProperties",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "unicorn/no-unused-properties",
 				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-unused-properties.md"
 			}
-		],
-		"flint": {
-			"name": "unusedObjectProperties",
-			"plugin": "ts",
-			"status": "skipped"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "unusedPrivateClassMembers",
+			"plugin": "ts",
+			"preset": "logical"
+		},
 		"biome": [
 			{
 				"name": "noUnusedPrivateClassMembers",
@@ -29693,11 +29698,6 @@
 				"url": "https://typescript-eslint.io/rules/no-unused-private-class-members"
 			}
 		],
-		"flint": {
-			"name": "unusedPrivateClassMembers",
-			"plugin": "ts",
-			"preset": "logical"
-		},
 		"oxlint": [
 			{
 				"name": "eslint/no-unused-private-class-members",
@@ -29706,6 +29706,11 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "unusedSwitchStatements",
+			"plugin": "ts",
+			"preset": "logical"
+		},
 		"biome": [
 			{
 				"name": "noUselessSwitchCase",
@@ -29718,11 +29723,6 @@
 				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/no-useless-switch-case.md"
 			}
 		],
-		"flint": {
-			"name": "unusedSwitchStatements",
-			"plugin": "ts",
-			"preset": "logical"
-		},
 		"oxlint": [
 			{
 				"name": "unicorn/no-useless-switch-case",
@@ -29731,17 +29731,17 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "unusedValues",
+			"plugin": "ts",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "no-useless-assignment",
 				"url": "https://eslint.org/docs/latest/rules/no-useless-assignment"
 			}
 		],
-		"flint": {
-			"name": "unusedValues",
-			"plugin": "ts",
-			"preset": "logical"
-		},
 		"oxlint": [
 			{
 				"name": "eslint/no-useless-assignment",
@@ -29750,6 +29750,11 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "unusedVariables",
+			"plugin": "ts",
+			"preset": "logical"
+		},
 		"biome": [
 			{
 				"name": "noUnusedFunctionParameters",
@@ -29776,11 +29781,6 @@
 				"url": "https://typescript-eslint.io/rules/no-unused-vars"
 			}
 		],
-		"flint": {
-			"name": "unusedVariables",
-			"plugin": "ts",
-			"preset": "logical"
-		},
 		"oxlint": [
 			{
 				"name": "eslint/no-unused-vars",
@@ -29789,17 +29789,17 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "urlRelativity",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "unicorn/relative-url-style",
 				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/HEAD/docs/rules/relative-url-style.md"
 			}
 		],
-		"flint": {
-			"name": "urlRelativity",
-			"plugin": "ts",
-			"status": "skipped"
-		},
 		"oxlint": [
 			{
 				"name": "unicorn/relative-url-style",
@@ -29808,6 +29808,11 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "usageBeforeDefinition",
+			"plugin": "ts",
+			"preset": "javascript"
+		},
 		"biome": [
 			{
 				"name": "noInvalidUseBeforeDeclaration",
@@ -29824,11 +29829,6 @@
 				"url": "https://typescript-eslint.io/rules/no-use-before-define"
 			}
 		],
-		"flint": {
-			"name": "usageBeforeDefinition",
-			"plugin": "ts",
-			"preset": "javascript"
-		},
 		"oxlint": [
 			{
 				"name": "eslint/no-use-before-define",
@@ -29837,17 +29837,17 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "uselessDefaultAssignments",
+			"plugin": "ts",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "@typescript-eslint/no-useless-default-assignment",
 				"url": "https://typescript-eslint.io/rules/no-useless-default-assignment"
 			}
 		],
-		"flint": {
-			"name": "uselessDefaultAssignments",
-			"plugin": "ts",
-			"preset": "logical"
-		},
 		"oxlint": [
 			{
 				"name": "typescript/no-useless-default-assignment",
@@ -29856,19 +29856,24 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "useStrictDirectives",
+			"plugin": "ts",
+			"preset": "javascript"
+		},
 		"eslint": [
 			{
 				"name": "strict",
 				"url": "https://eslint.org/docs/latest/rules/strict"
 			}
-		],
-		"flint": {
-			"name": "useStrictDirectives",
-			"plugin": "ts",
-			"preset": "javascript"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "varDeclarations",
+			"plugin": "ts",
+			"preset": "stylistic"
+		},
 		"biome": [
 			{
 				"name": "noVar",
@@ -29887,11 +29892,6 @@
 				"url": "https://eslint.org/docs/latest/rules/no-var"
 			}
 		],
-		"flint": {
-			"name": "varDeclarations",
-			"plugin": "ts",
-			"preset": "stylistic"
-		},
 		"oxlint": [
 			{
 				"name": "eslint/no-var",
@@ -29900,17 +29900,17 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "variableBlockScopeUsage",
+			"plugin": "ts",
+			"preset": "javascript"
+		},
 		"eslint": [
 			{
 				"name": "block-scoped-var",
 				"url": "https://eslint.org/docs/latest/rules/block-scoped-var"
 			}
 		],
-		"flint": {
-			"name": "variableBlockScopeUsage",
-			"plugin": "ts",
-			"preset": "javascript"
-		},
 		"oxlint": [
 			{
 				"name": "eslint/block-scoped-var",
@@ -29919,6 +29919,11 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "variableDeclarationInitializations",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "init-declarations",
@@ -29929,11 +29934,6 @@
 				"url": "https://typescript-eslint.io/rules/init-declarations"
 			}
 		],
-		"flint": {
-			"name": "variableDeclarationInitializations",
-			"plugin": "ts",
-			"status": "skipped"
-		},
 		"oxlint": [
 			{
 				"name": "eslint/init-declarations",
@@ -29942,30 +29942,30 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "variableDeclarationsOrder",
+			"plugin": "ts",
+			"preset": "sorting"
+		},
 		"eslint": [
 			{
 				"name": "perfectionist/sort-variable-declarations",
 				"url": "https://perfectionist.dev/rules/sort-variable-declarations"
 			}
-		],
-		"flint": {
-			"name": "variableDeclarationsOrder",
-			"plugin": "ts",
-			"preset": "sorting"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "variableDeclarationSorting",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "sort-vars",
 				"url": "https://eslint.org/docs/latest/rules/sort-vars"
 			}
 		],
-		"flint": {
-			"name": "variableDeclarationSorting",
-			"plugin": "ts",
-			"status": "skipped"
-		},
 		"oxlint": [
 			{
 				"name": "eslint/sort-vars",
@@ -29974,6 +29974,12 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "variableDeletions",
+			"plugin": "ts",
+			"preset": "javascript",
+			"status": "implemented"
+		},
 		"deno": [
 			{
 				"name": "no-delete-var",
@@ -29986,12 +29992,6 @@
 				"url": "https://eslint.org/docs/latest/rules/no-delete-var"
 			}
 		],
-		"flint": {
-			"name": "variableDeletions",
-			"plugin": "ts",
-			"preset": "javascript",
-			"status": "implemented"
-		},
 		"oxlint": [
 			{
 				"name": "eslint/no-delete-var",
@@ -30000,6 +30000,11 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "variableRedeclarations",
+			"plugin": "ts",
+			"preset": "javascript"
+		},
 		"biome": [
 			{
 				"name": "noRedeclare",
@@ -30022,11 +30027,6 @@
 				"url": "https://typescript-eslint.io/rules/no-redeclare"
 			}
 		],
-		"flint": {
-			"name": "variableRedeclarations",
-			"plugin": "ts",
-			"preset": "javascript"
-		},
 		"oxlint": [
 			{
 				"name": "eslint/no-redeclare",
@@ -30035,6 +30035,11 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "variablesOnTop",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"biome": [
 			{
 				"name": "useVarsOnTop",
@@ -30047,11 +30052,6 @@
 				"url": "https://eslint.org/docs/latest/rules/vars-on-top"
 			}
 		],
-		"flint": {
-			"name": "variablesOnTop",
-			"plugin": "ts",
-			"status": "skipped"
-		},
 		"oxlint": [
 			{
 				"name": "eslint/vars-on-top",
@@ -30060,19 +30060,25 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "verbatimModuleSyntax",
+			"plugin": "ts",
+			"status": "skipped"
+		},
 		"deno": [
 			{
 				"name": "verbatim-module-syntax",
 				"url": "https://docs.deno.com/lint/rules/verbatim-module-syntax"
 			}
-		],
-		"flint": {
-			"name": "verbatimModuleSyntax",
-			"plugin": "ts",
-			"status": "skipped"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "voidOperator",
+			"plugin": "ts",
+			"preset": "stylistic",
+			"status": "implemented"
+		},
 		"biome": [
 			{
 				"name": "noVoid",
@@ -30085,12 +30091,6 @@
 				"url": "https://eslint.org/docs/latest/rules/no-void"
 			}
 		],
-		"flint": {
-			"name": "voidOperator",
-			"plugin": "ts",
-			"preset": "stylistic",
-			"status": "implemented"
-		},
 		"oxlint": [
 			{
 				"name": "eslint/no-void",
@@ -30099,16 +30099,16 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "webpackLoaderSyntax",
+			"plugin": "ts"
+		},
 		"eslint": [
 			{
 				"name": "import/no-webpack-loader-syntax",
 				"url": "https://github.com/import-js/eslint-plugin-import/blob/v2.32.0/docs/rules/no-webpack-loader-syntax.md"
 			}
 		],
-		"flint": {
-			"name": "webpackLoaderSyntax",
-			"plugin": "ts"
-		},
 		"oxlint": [
 			{
 				"name": "import/no-webpack-loader-syntax",
@@ -30117,20 +30117,26 @@
 		]
 	},
 	{
-		"biome": [
-			{
-				"name": "useWhile",
-				"url": "https://biomejs.dev/linter/rules/use-while"
-			}
-		],
 		"flint": {
 			"name": "whileLoops",
 			"plugin": "ts",
 			"preset": "stylistic",
 			"strictness": "strict"
-		}
+		},
+		"biome": [
+			{
+				"name": "useWhile",
+				"url": "https://biomejs.dev/linter/rules/use-while"
+			}
+		]
 	},
 	{
+		"flint": {
+			"name": "withStatements",
+			"plugin": "ts",
+			"preset": "javascript",
+			"status": "implemented"
+		},
 		"biome": [
 			{
 				"name": "noWith",
@@ -30149,12 +30155,6 @@
 				"url": "https://eslint.org/docs/latest/rules/no-with"
 			}
 		],
-		"flint": {
-			"name": "withStatements",
-			"plugin": "ts",
-			"preset": "javascript",
-			"status": "implemented"
-		},
 		"oxlint": [
 			{
 				"name": "eslint/no-with",
@@ -30163,6 +30163,12 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "wrapperObjects",
+			"plugin": "ts",
+			"preset": "logical",
+			"status": "implemented"
+		},
 		"biome": [
 			{
 				"name": "useConsistentBuiltinInstantiation",
@@ -30175,12 +30181,6 @@
 				"url": "https://eslint.org/docs/latest/rules/no-new-wrappers"
 			}
 		],
-		"flint": {
-			"name": "wrapperObjects",
-			"plugin": "ts",
-			"preset": "logical",
-			"status": "implemented"
-		},
 		"oxlint": [
 			{
 				"name": "eslint/no-new-wrappers",
@@ -30189,17 +30189,17 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "wrapperObjectTypes",
+			"plugin": "ts",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "@typescript-eslint/no-wrapper-object-types",
 				"url": "https://typescript-eslint.io/rules/no-wrapper-object-types"
 			}
 		],
-		"flint": {
-			"name": "wrapperObjectTypes",
-			"plugin": "ts",
-			"preset": "logical"
-		},
 		"oxlint": [
 			{
 				"name": "typescript/no-wrapper-object-types",
@@ -30208,17 +30208,17 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "afterAllPaddingLines",
+			"plugin": "vitest",
+			"status": "implemented"
+		},
 		"eslint": [
 			{
 				"name": "vitest/padding-around-after-all-blocks",
 				"url": "https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/padding-around-after-all-blocks.md"
 			}
 		],
-		"flint": {
-			"name": "afterAllPaddingLines",
-			"plugin": "vitest",
-			"status": "implemented"
-		},
 		"oxlint": [
 			{
 				"name": "vitest/padding-around-after-all-blocks",
@@ -30227,30 +30227,30 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "afterEachPaddingLines",
+			"plugin": "vitest",
+			"status": "implemented"
+		},
 		"eslint": [
 			{
 				"name": "vitest/padding-around-after-each-blocks",
 				"url": "https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/padding-around-after-each-blocks.md"
 			}
-		],
-		"flint": {
-			"name": "afterEachPaddingLines",
-			"plugin": "vitest",
-			"status": "implemented"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "aliasMethods",
+			"plugin": "vitest",
+			"preset": "stylistic"
+		},
 		"eslint": [
 			{
 				"name": "vitest/no-alias-methods",
 				"url": "https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/no-alias-methods.md"
 			}
 		],
-		"flint": {
-			"name": "aliasMethods",
-			"plugin": "vitest",
-			"preset": "stylistic"
-		},
 		"oxlint": [
 			{
 				"name": "vitest/no-alias-methods",
@@ -30259,76 +30259,76 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "allPaddingLines",
+			"plugin": "vitest",
+			"status": "implemented"
+		},
 		"eslint": [
 			{
 				"name": "vitest/padding-around-all",
 				"url": "https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/padding-around-all.md"
 			}
-		],
-		"flint": {
-			"name": "allPaddingLines",
-			"plugin": "vitest",
-			"status": "implemented"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "beforeAllPaddingLines",
+			"plugin": "vitest",
+			"status": "implemented"
+		},
 		"eslint": [
 			{
 				"name": "vitest/padding-around-before-all-blocks",
 				"url": "https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/padding-around-before-all-blocks.md"
 			}
-		],
-		"flint": {
-			"name": "beforeAllPaddingLines",
-			"plugin": "vitest",
-			"status": "implemented"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "beforeEachPaddingLines",
+			"plugin": "vitest",
+			"status": "implemented"
+		},
 		"eslint": [
 			{
 				"name": "vitest/padding-around-before-each-blocks",
 				"url": "https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/padding-around-before-each-blocks.md"
 			}
-		],
-		"flint": {
-			"name": "beforeEachPaddingLines",
-			"plugin": "vitest",
-			"status": "implemented"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "booleanCoercionMatchers",
+			"plugin": "vitest",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "vitest/prefer-strict-boolean-matchers",
 				"url": "https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/prefer-strict-boolean-matchers.md"
 			}
 		],
-		"flint": {
-			"name": "booleanCoercionMatchers",
-			"plugin": "vitest",
-			"status": "skipped"
-		},
-		"notes": "Overly opinionated.",
 		"oxlint": [
 			{
 				"name": "vitest/prefer-strict-boolean-matchers",
 				"url": "https://oxc.rs/docs/guide/usage/linter/rules/vitest/prefer-strict-boolean-matchers.html"
 			}
-		]
+		],
+		"notes": "Overly opinionated."
 	},
 	{
+		"flint": {
+			"name": "calledOnceAssertions",
+			"plugin": "vitest",
+			"strictness": "strict"
+		},
 		"eslint": [
 			{
 				"name": "vitest/prefer-called-once",
 				"url": "https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/prefer-called-once.md"
 			}
 		],
-		"flint": {
-			"name": "calledOnceAssertions",
-			"plugin": "vitest",
-			"strictness": "strict"
-		},
 		"oxlint": [
 			{
 				"name": "vitest/prefer-called-once",
@@ -30337,18 +30337,18 @@
 		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "vitest/prefer-called-exactly-once-with",
-				"url": "https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/prefer-called-exactly-once-with.md"
-			}
-		],
 		"flint": {
 			"name": "calledOnceWithAssertions",
 			"plugin": "vitest",
 			"preset": "stylistic",
 			"strictness": "strict"
 		},
+		"eslint": [
+			{
+				"name": "vitest/prefer-called-exactly-once-with",
+				"url": "https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/prefer-called-exactly-once-with.md"
+			}
+		],
 		"oxlint": [
 			{
 				"name": "vitest/prefer-called-exactly-once-with",
@@ -30357,18 +30357,18 @@
 		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "vitest/prefer-called-times",
-				"url": "https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/prefer-called-times.md"
-			}
-		],
 		"flint": {
 			"name": "calledTimesAssertions",
 			"plugin": "vitest",
 			"preset": "stylistic",
 			"strictness": "strict"
 		},
+		"eslint": [
+			{
+				"name": "vitest/prefer-called-times",
+				"url": "https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/prefer-called-times.md"
+			}
+		],
 		"oxlint": [
 			{
 				"name": "vitest/prefer-called-times",
@@ -30377,18 +30377,18 @@
 		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "vitest/prefer-called-with",
-				"url": "https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/prefer-called-with.md"
-			}
-		],
 		"flint": {
 			"name": "calledWithAssertions",
 			"plugin": "vitest",
 			"preset": "stylistic",
 			"strictness": "strict"
 		},
+		"eslint": [
+			{
+				"name": "vitest/prefer-called-with",
+				"url": "https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/prefer-called-with.md"
+			}
+		],
 		"oxlint": [
 			{
 				"name": "vitest/prefer-called-with",
@@ -30397,18 +30397,18 @@
 		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "vitest/no-commented-out-tests",
-				"url": "https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/no-commented-out-tests.md"
-			}
-		],
 		"flint": {
 			"name": "commentedOutTests",
 			"plugin": "vitest",
 			"preset": "logical",
 			"strictness": "strict"
 		},
+		"eslint": [
+			{
+				"name": "vitest/no-commented-out-tests",
+				"url": "https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/no-commented-out-tests.md"
+			}
+		],
 		"oxlint": [
 			{
 				"name": "vitest/no-commented-out-tests",
@@ -30417,17 +30417,17 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "comparisonMatcherAssertions",
+			"plugin": "vitest",
+			"preset": "stylistic"
+		},
 		"eslint": [
 			{
 				"name": "vitest/prefer-comparison-matcher",
 				"url": "https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/prefer-comparison-matcher.md"
 			}
 		],
-		"flint": {
-			"name": "comparisonMatcherAssertions",
-			"plugin": "vitest",
-			"preset": "stylistic"
-		},
 		"oxlint": [
 			{
 				"name": "vitest/prefer-comparison-matcher",
@@ -30436,6 +30436,12 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "conditionalExpects",
+			"plugin": "vitest",
+			"preset": "stylistic",
+			"strictness": "strict"
+		},
 		"biome": [
 			{
 				"name": "noConditionalExpect",
@@ -30448,12 +30454,6 @@
 				"url": "https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/no-conditional-expect.md"
 			}
 		],
-		"flint": {
-			"name": "conditionalExpects",
-			"plugin": "vitest",
-			"preset": "stylistic",
-			"strictness": "strict"
-		},
 		"oxlint": [
 			{
 				"name": "vitest/no-conditional-expect",
@@ -30462,17 +30462,17 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "describeCallbackValidity",
+			"plugin": "vitest",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "vitest/valid-describe-callback",
 				"url": "https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/valid-describe-callback.md"
 			}
 		],
-		"flint": {
-			"name": "describeCallbackValidity",
-			"plugin": "vitest",
-			"preset": "logical"
-		},
 		"oxlint": [
 			{
 				"name": "vitest/valid-describe-callback",
@@ -30481,30 +30481,30 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "describePaddingLines",
+			"plugin": "vitest",
+			"status": "implemented"
+		},
 		"eslint": [
 			{
 				"name": "vitest/padding-around-describe-blocks",
 				"url": "https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/padding-around-describe-blocks.md"
 			}
-		],
-		"flint": {
-			"name": "describePaddingLines",
-			"plugin": "vitest",
-			"status": "implemented"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "describeTitleReferences",
+			"plugin": "vitest",
+			"preset": "stylistic"
+		},
 		"eslint": [
 			{
 				"name": "vitest/prefer-describe-function-title",
 				"url": "https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/prefer-describe-function-title.md"
 			}
 		],
-		"flint": {
-			"name": "describeTitleReferences",
-			"plugin": "vitest",
-			"preset": "stylistic"
-		},
 		"oxlint": [
 			{
 				"name": "vitest/prefer-describe-function-title",
@@ -30513,6 +30513,10 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "doneCallbacks",
+			"plugin": "vitest"
+		},
 		"biome": [
 			{
 				"name": "noDoneCallback",
@@ -30525,23 +30529,19 @@
 				"url": "https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/no-done-callback.md"
 			}
 		],
-		"flint": {
-			"name": "doneCallbacks",
-			"plugin": "vitest"
-		},
 		"notes": "Deprecated."
 	},
 	{
+		"flint": {
+			"name": "eachForConsistency",
+			"plugin": "vitest"
+		},
 		"eslint": [
 			{
 				"name": "vitest/consistent-each-for",
 				"url": "https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/consistent-each-for.md"
 			}
 		],
-		"flint": {
-			"name": "eachForConsistency",
-			"plugin": "vitest"
-		},
 		"oxlint": [
 			{
 				"name": "vitest/consistent-each-for",
@@ -30550,17 +30550,17 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "eachLoops",
+			"plugin": "vitest",
+			"preset": "stylistic"
+		},
 		"eslint": [
 			{
 				"name": "vitest/prefer-each",
 				"url": "https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/prefer-each.md"
 			}
 		],
-		"flint": {
-			"name": "eachLoops",
-			"plugin": "vitest",
-			"preset": "stylistic"
-		},
 		"oxlint": [
 			{
 				"name": "vitest/prefer-each",
@@ -30569,37 +30569,37 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "emptyTestTodos",
+			"plugin": "vitest",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "vitest/prefer-todo",
 				"url": "https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/prefer-todo.md"
 			}
 		],
-		"flint": {
-			"name": "emptyTestTodos",
-			"plugin": "vitest",
-			"status": "skipped"
-		},
-		"notes": "Overly opinionated.",
 		"oxlint": [
 			{
 				"name": "vitest/prefer-todo",
 				"url": "https://oxc.rs/docs/guide/usage/linter/rules/vitest/prefer-todo.html"
 			}
-		]
+		],
+		"notes": "Overly opinionated."
 	},
 	{
+		"flint": {
+			"name": "equalityMatchers",
+			"plugin": "vitest",
+			"preset": "stylistic"
+		},
 		"eslint": [
 			{
 				"name": "vitest/prefer-equality-matcher",
 				"url": "https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/prefer-equality-matcher.md"
 			}
 		],
-		"flint": {
-			"name": "equalityMatchers",
-			"plugin": "vitest",
-			"preset": "stylistic"
-		},
 		"oxlint": [
 			{
 				"name": "vitest/prefer-equality-matcher",
@@ -30608,30 +30608,30 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "expectGroupPaddingLines",
+			"plugin": "vitest",
+			"status": "implemented"
+		},
 		"eslint": [
 			{
 				"name": "vitest/padding-around-expect-groups",
 				"url": "https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/padding-around-expect-groups.md"
 			}
-		],
-		"flint": {
-			"name": "expectGroupPaddingLines",
-			"plugin": "vitest",
-			"status": "implemented"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "expectResolves",
+			"plugin": "vitest",
+			"preset": "stylistic"
+		},
 		"eslint": [
 			{
 				"name": "vitest/prefer-expect-resolves",
 				"url": "https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/prefer-expect-resolves.md"
 			}
 		],
-		"flint": {
-			"name": "expectResolves",
-			"plugin": "vitest",
-			"preset": "stylistic"
-		},
 		"oxlint": [
 			{
 				"name": "vitest/prefer-expect-resolves",
@@ -30640,6 +30640,12 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "expectsOutsideTests",
+			"plugin": "vitest",
+			"preset": "logical",
+			"strictness": "strict"
+		},
 		"biome": [
 			{
 				"name": "noMisplacedAssertion",
@@ -30652,12 +30658,6 @@
 				"url": "https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/no-standalone-expect.md"
 			}
 		],
-		"flint": {
-			"name": "expectsOutsideTests",
-			"plugin": "vitest",
-			"preset": "logical",
-			"strictness": "strict"
-		},
 		"oxlint": [
 			{
 				"name": "vitest/no-standalone-expect",
@@ -30666,17 +30666,17 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "expectValidity",
+			"plugin": "vitest",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "vitest/valid-expect",
 				"url": "https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/valid-expect.md"
 			}
 		],
-		"flint": {
-			"name": "expectValidity",
-			"plugin": "vitest",
-			"preset": "logical"
-		},
 		"oxlint": [
 			{
 				"name": "vitest/valid-expect",
@@ -30685,56 +30685,56 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "falsyMatchers",
+			"plugin": "vitest"
+		},
 		"eslint": [
 			{
 				"name": "vitest/prefer-to-be-falsy",
 				"url": "https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/prefer-to-be-falsy.md"
 			}
 		],
-		"flint": {
-			"name": "falsyMatchers",
-			"plugin": "vitest"
-		},
-		"notes": "Overly opinionated.",
 		"oxlint": [
 			{
 				"name": "vitest/prefer-to-be-falsy",
 				"url": "https://oxc.rs/docs/guide/usage/linter/rules/vitest/prefer-to-be-falsy.html"
 			}
-		]
+		],
+		"notes": "Overly opinionated."
 	},
 	{
+		"flint": {
+			"name": "filenames",
+			"plugin": "vitest"
+		},
 		"eslint": [
 			{
 				"name": "vitest/consistent-test-filename",
 				"url": "https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/consistent-test-filename.md"
 			}
 		],
-		"flint": {
-			"name": "filenames",
-			"plugin": "vitest"
-		},
-		"notes": "Overly opinionated.",
 		"oxlint": [
 			{
 				"name": "vitest/consistent-test-filename",
 				"url": "https://oxc.rs/docs/guide/usage/linter/rules/vitest/consistent-test-filename.html"
 			}
-		]
+		],
+		"notes": "Overly opinionated."
 	},
 	{
-		"eslint": [
-			{
-				"name": "vitest/hoisted-apis-on-top",
-				"url": "https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/hoisted-apis-on-top.md"
-			}
-		],
 		"flint": {
 			"name": "hoistedApiPositions",
 			"plugin": "vitest",
 			"preset": "logical",
 			"strictness": "strict"
 		},
+		"eslint": [
+			{
+				"name": "vitest/hoisted-apis-on-top",
+				"url": "https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/hoisted-apis-on-top.md"
+			}
+		],
 		"oxlint": [
 			{
 				"name": "vitest/hoisted-apis-on-top",
@@ -30743,26 +30743,32 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "hookContents",
+			"plugin": "vitest",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "vitest/require-hook",
 				"url": "https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/require-hook.md"
 			}
 		],
-		"flint": {
-			"name": "hookContents",
-			"plugin": "vitest",
-			"status": "skipped"
-		},
-		"notes": "Overly opinionated.",
 		"oxlint": [
 			{
 				"name": "vitest/require-hook",
 				"url": "https://oxc.rs/docs/guide/usage/linter/rules/vitest/require-hook.html"
 			}
-		]
+		],
+		"notes": "Overly opinionated."
 	},
 	{
+		"flint": {
+			"name": "hookDuplicates",
+			"plugin": "vitest",
+			"preset": "logical",
+			"strictness": "strict"
+		},
 		"biome": [
 			{
 				"name": "noDuplicateTestHooks",
@@ -30775,12 +30781,6 @@
 				"url": "https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/no-duplicate-hooks.md"
 			}
 		],
-		"flint": {
-			"name": "hookDuplicates",
-			"plugin": "vitest",
-			"preset": "logical",
-			"strictness": "strict"
-		},
 		"oxlint": [
 			{
 				"name": "vitest/no-duplicate-hooks",
@@ -30789,6 +30789,12 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "hookOrders",
+			"plugin": "vitest",
+			"preset": "stylistic",
+			"strictness": "strict"
+		},
 		"biome": [
 			{
 				"name": "useTestHooksInOrder",
@@ -30801,12 +30807,6 @@
 				"url": "https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/prefer-hooks-in-order.md"
 			}
 		],
-		"flint": {
-			"name": "hookOrders",
-			"plugin": "vitest",
-			"preset": "stylistic",
-			"strictness": "strict"
-		},
 		"oxlint": [
 			{
 				"name": "vitest/prefer-hooks-in-order",
@@ -30815,26 +30815,32 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "hooks",
+			"plugin": "vitest",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "vitest/no-hooks",
 				"url": "https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/no-hooks.md"
 			}
 		],
-		"flint": {
-			"name": "hooks",
-			"plugin": "vitest",
-			"status": "skipped"
-		},
-		"notes": "Overly opinionated.",
 		"oxlint": [
 			{
 				"name": "vitest/no-hooks",
 				"url": "https://oxc.rs/docs/guide/usage/linter/rules/vitest/no-hooks.html"
 			}
-		]
+		],
+		"notes": "Overly opinionated."
 	},
 	{
+		"flint": {
+			"name": "hooksBeforeTestCases",
+			"plugin": "vitest",
+			"preset": "stylistic",
+			"strictness": "strict"
+		},
 		"biome": [
 			{
 				"name": "useTestHooksOnTop",
@@ -30847,12 +30853,6 @@
 				"url": "https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/prefer-hooks-on-top.md"
 			}
 		],
-		"flint": {
-			"name": "hooksBeforeTestCases",
-			"plugin": "vitest",
-			"preset": "stylistic",
-			"strictness": "strict"
-		},
 		"oxlint": [
 			{
 				"name": "vitest/prefer-hooks-on-top",
@@ -30861,16 +30861,16 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "importsInMocks",
+			"plugin": "vitest"
+		},
 		"eslint": [
 			{
 				"name": "vitest/prefer-import-in-mock",
 				"url": "https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/prefer-import-in-mock.md"
 			}
 		],
-		"flint": {
-			"name": "importsInMocks",
-			"plugin": "vitest"
-		},
 		"oxlint": [
 			{
 				"name": "vitest/prefer-import-in-mock",
@@ -30879,46 +30879,51 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "maximumDescribesPerFile",
+			"plugin": "vitest",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "vitest/require-top-level-describe",
 				"url": "https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/require-top-level-describe.md"
 			}
 		],
-		"flint": {
-			"name": "maximumDescribesPerFile",
-			"plugin": "vitest",
-			"status": "skipped"
-		},
-		"notes": "Overly opinionated.",
 		"oxlint": [
 			{
 				"name": "vitest/require-top-level-describe",
 				"url": "https://oxc.rs/docs/guide/usage/linter/rules/vitest/require-top-level-describe.html"
 			}
-		]
+		],
+		"notes": "Overly opinionated."
 	},
 	{
+		"flint": {
+			"name": "maximumExpects",
+			"plugin": "vitest",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "vitest/max-expects",
 				"url": "https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/max-expects.md"
 			}
 		],
-		"flint": {
-			"name": "maximumExpects",
-			"plugin": "vitest",
-			"status": "skipped"
-		},
-		"notes": "Overly opinionated.",
 		"oxlint": [
 			{
 				"name": "vitest/max-expects",
 				"url": "https://oxc.rs/docs/guide/usage/linter/rules/vitest/max-expects.html"
 			}
-		]
+		],
+		"notes": "Overly opinionated."
 	},
 	{
+		"flint": {
+			"name": "maximumNestedDescribes",
+			"plugin": "vitest",
+			"status": "skipped"
+		},
 		"biome": [
 			{
 				"name": "noExcessiveNestedTestSuites",
@@ -30931,32 +30936,27 @@
 				"url": "https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/max-nested-describe.md"
 			}
 		],
-		"flint": {
-			"name": "maximumNestedDescribes",
-			"plugin": "vitest",
-			"status": "skipped"
-		},
-		"notes": "Overly opinionated.",
 		"oxlint": [
 			{
 				"name": "vitest/max-nested-describe",
 				"url": "https://oxc.rs/docs/guide/usage/linter/rules/vitest/max-nested-describe.html"
 			}
-		]
+		],
+		"notes": "Overly opinionated."
 	},
 	{
-		"eslint": [
-			{
-				"name": "vitest/prefer-vi-mocked",
-				"url": "https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/prefer-vi-mocked.md"
-			}
-		],
 		"flint": {
 			"name": "mockedFunctionInstances",
 			"plugin": "vitest",
 			"preset": "stylistic",
 			"strictness": "strict"
-		}
+		},
+		"eslint": [
+			{
+				"name": "vitest/prefer-vi-mocked",
+				"url": "https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/prefer-vi-mocked.md"
+			}
+		]
 	},
 	{
 		"flint": {
@@ -30973,38 +30973,38 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "mocksDirectoryImports",
+			"plugin": "vitest",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "vitest/no-mocks-import",
 				"url": "https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/no-mocks-import.md"
 			}
 		],
-		"flint": {
-			"name": "mocksDirectoryImports",
-			"plugin": "vitest",
-			"status": "skipped"
-		},
-		"notes": "Overly opinionated.",
 		"oxlint": [
 			{
 				"name": "vitest/no-mocks-import",
 				"url": "https://oxc.rs/docs/guide/usage/linter/rules/vitest/no-mocks-import.html"
 			}
-		]
+		],
+		"notes": "Overly opinionated."
 	},
 	{
-		"eslint": [
-			{
-				"name": "vitest/require-mock-type-parameters",
-				"url": "https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/require-mock-type-parameters.md"
-			}
-		],
 		"flint": {
 			"name": "mockTypeParameters",
 			"plugin": "vitest",
 			"preset": "stylistic",
 			"strictness": "strict"
 		},
+		"eslint": [
+			{
+				"name": "vitest/require-mock-type-parameters",
+				"url": "https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/require-mock-type-parameters.md"
+			}
+		],
 		"oxlint": [
 			{
 				"name": "vitest/require-mock-type-parameters",
@@ -31013,18 +31013,18 @@
 		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "vitest/no-import-node-test",
-				"url": "https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/no-import-node-test.md"
-			}
-		],
 		"flint": {
 			"name": "nodeTestImports",
 			"plugin": "vitest",
 			"preset": "logical",
 			"status": "implemented"
 		},
+		"eslint": [
+			{
+				"name": "vitest/no-import-node-test",
+				"url": "https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/no-import-node-test.md"
+			}
+		],
 		"oxlint": [
 			{
 				"name": "vitest/no-import-node-test",
@@ -31033,57 +31033,57 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "pollingAwaits",
+			"plugin": "vitest",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "vitest/require-awaited-expect-poll",
 				"url": "https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/require-awaited-expect-poll.md"
 			}
 		],
-		"flint": {
-			"name": "pollingAwaits",
-			"plugin": "vitest",
-			"status": "skipped"
-		},
-		"notes": "Superseded by floatingPromises.",
 		"oxlint": [
 			{
 				"name": "vitest/require-awaited-expect-poll",
 				"url": "https://oxc.rs/docs/guide/usage/linter/rules/vitest/require-awaited-expect-poll.html"
 			}
-		]
+		],
+		"notes": "Superseded by floatingPromises."
 	},
 	{
+		"flint": {
+			"name": "promiseExpectChains",
+			"plugin": "vitest",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "vitest/valid-expect-in-promise",
 				"url": "https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/valid-expect-in-promise.md"
 			}
 		],
-		"flint": {
-			"name": "promiseExpectChains",
-			"plugin": "vitest",
-			"status": "skipped"
-		},
-		"notes": "Superseded by floatingPromises.",
 		"oxlint": [
 			{
 				"name": "vitest/valid-expect-in-promise",
 				"url": "https://oxc.rs/docs/guide/usage/linter/rules/vitest/valid-expect-in-promise.html"
 			}
-		]
+		],
+		"notes": "Superseded by floatingPromises."
 	},
 	{
+		"flint": {
+			"name": "promiseSettleAssertions",
+			"plugin": "vitest",
+			"preset": "stylistic"
+		},
 		"eslint": [
 			{
 				"name": "vitest/prefer-mock-promise-shorthand",
 				"url": "https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/prefer-mock-promise-shorthand.md"
 			}
 		],
-		"flint": {
-			"name": "promiseSettleAssertions",
-			"plugin": "vitest",
-			"preset": "stylistic"
-		},
 		"oxlint": [
 			{
 				"name": "vitest/prefer-mock-promise-shorthand",
@@ -31092,16 +31092,16 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "restrictedMatchers",
+			"plugin": "vitest"
+		},
 		"eslint": [
 			{
 				"name": "vitest/no-restricted-matchers",
 				"url": "https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/no-restricted-matchers.md"
 			}
 		],
-		"flint": {
-			"name": "restrictedMatchers",
-			"plugin": "vitest"
-		},
 		"oxlint": [
 			{
 				"name": "vitest/no-restricted-matchers",
@@ -31110,16 +31110,16 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "restrictedViMethods",
+			"plugin": "vitest"
+		},
 		"eslint": [
 			{
 				"name": "vitest/no-restricted-vi-methods",
 				"url": "https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/no-restricted-vi-methods.md"
 			}
 		],
-		"flint": {
-			"name": "restrictedViMethods",
-			"plugin": "vitest"
-		},
 		"oxlint": [
 			{
 				"name": "vitest/no-restricted-vi-methods",
@@ -31128,57 +31128,57 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "snapshotHints",
+			"plugin": "vitest",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "vitest/prefer-snapshot-hint",
 				"url": "https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/prefer-snapshot-hint.md"
 			}
 		],
-		"flint": {
-			"name": "snapshotHints",
-			"plugin": "vitest",
-			"status": "skipped"
-		},
-		"notes": "Overly opinionated.",
 		"oxlint": [
 			{
 				"name": "vitest/prefer-snapshot-hint",
 				"url": "https://oxc.rs/docs/guide/usage/linter/rules/vitest/prefer-snapshot-hint.html"
 			}
-		]
+		],
+		"notes": "Overly opinionated."
 	},
 	{
+		"flint": {
+			"name": "snapshotInterpolations",
+			"plugin": "vitest",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "vitest/no-interpolation-in-snapshots",
 				"url": "https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/no-interpolation-in-snapshots.md"
 			}
 		],
-		"flint": {
-			"name": "snapshotInterpolations",
-			"plugin": "vitest",
-			"status": "skipped"
-		},
-		"notes": "Overly opinionated.",
 		"oxlint": [
 			{
 				"name": "vitest/no-interpolation-in-snapshots",
 				"url": "https://oxc.rs/docs/guide/usage/linter/rules/vitest/no-interpolation-in-snapshots.html"
 			}
-		]
+		],
+		"notes": "Overly opinionated."
 	},
 	{
+		"flint": {
+			"name": "snapshotLocalTextContexts",
+			"plugin": "vitest",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "vitest/require-local-test-context-for-concurrent-snapshots",
 				"url": "https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/require-local-test-context-for-concurrent-snapshots.md"
 			}
 		],
-		"flint": {
-			"name": "snapshotLocalTextContexts",
-			"plugin": "vitest",
-			"preset": "logical"
-		},
 		"oxlint": [
 			{
 				"name": "vitest/require-local-test-context-for-concurrent-snapshots",
@@ -31187,66 +31187,71 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "snapshotSizes",
+			"plugin": "vitest",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "vitest/no-large-snapshots",
 				"url": "https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/no-large-snapshots.md"
 			}
 		],
-		"flint": {
-			"name": "snapshotSizes",
-			"plugin": "vitest",
-			"status": "skipped"
-		},
-		"notes": "Overly opinionated.",
 		"oxlint": [
 			{
 				"name": "vitest/no-large-snapshots",
 				"url": "https://oxc.rs/docs/guide/usage/linter/rules/vitest/no-large-snapshots.html"
 			}
-		]
+		],
+		"notes": "Overly opinionated."
 	},
 	{
+		"flint": {
+			"name": "spyOnMocks",
+			"plugin": "vitest",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "vitest/prefer-spy-on",
 				"url": "https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/prefer-spy-on.md"
 			}
 		],
-		"flint": {
-			"name": "spyOnMocks",
-			"plugin": "vitest",
-			"status": "skipped"
-		},
-		"notes": "Overly opinionated.",
 		"oxlint": [
 			{
 				"name": "vitest/prefer-spy-on",
 				"url": "https://oxc.rs/docs/guide/usage/linter/rules/vitest/prefer-spy-on.html"
 			}
-		]
+		],
+		"notes": "Overly opinionated."
 	},
 	{
+		"flint": {
+			"name": "strictEqualityMatchers",
+			"plugin": "vitest",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "vitest/prefer-strict-equal",
 				"url": "https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/prefer-strict-equal.md"
 			}
 		],
-		"flint": {
-			"name": "strictEqualityMatchers",
-			"plugin": "vitest",
-			"status": "skipped"
-		},
-		"notes": "Overly opinionated.",
 		"oxlint": [
 			{
 				"name": "vitest/prefer-strict-equal",
 				"url": "https://oxc.rs/docs/guide/usage/linter/rules/vitest/prefer-strict-equal.html"
 			}
-		]
+		],
+		"notes": "Overly opinionated."
 	},
 	{
+		"flint": {
+			"name": "testBodyExpectations",
+			"plugin": "vitest",
+			"preset": "logical"
+		},
 		"biome": [
 			{
 				"name": "useExpect",
@@ -31259,11 +31264,6 @@
 				"url": "https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/expect-expect.md"
 			}
 		],
-		"flint": {
-			"name": "testBodyExpectations",
-			"plugin": "vitest",
-			"preset": "logical"
-		},
 		"oxlint": [
 			{
 				"name": "vitest/expect-expect",
@@ -31272,17 +31272,17 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "testCaseAssertions",
+			"plugin": "vitest",
+			"preset": "stylistic"
+		},
 		"eslint": [
 			{
 				"name": "vitest/prefer-expect-assertions",
 				"url": "https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/prefer-expect-assertions.md"
 			}
 		],
-		"flint": {
-			"name": "testCaseAssertions",
-			"plugin": "vitest",
-			"preset": "stylistic"
-		},
 		"oxlint": [
 			{
 				"name": "vitest/prefer-expect-assertions",
@@ -31291,6 +31291,11 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "testCaseOnlyFlags",
+			"plugin": "vitest",
+			"status": "skipped"
+		},
 		"biome": [
 			{
 				"name": "noFocusedTests",
@@ -31303,100 +31308,95 @@
 				"url": "https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/no-focused-tests.md"
 			}
 		],
-		"flint": {
-			"name": "testCaseOnlyFlags",
-			"plugin": "vitest",
-			"status": "skipped"
-		},
-		"notes": "Handled by Vitest in CI mode.",
 		"oxlint": [
 			{
 				"name": "vitest/no-focused-tests",
 				"url": "https://oxc.rs/docs/guide/usage/linter/rules/vitest/no-focused-tests.html"
 			}
-		]
+		],
+		"notes": "Handled by Vitest in CI mode."
 	},
 	{
+		"flint": {
+			"name": "testCasePaddingLines",
+			"plugin": "vitest",
+			"status": "implemented"
+		},
 		"eslint": [
 			{
 				"name": "vitest/padding-around-test-blocks",
 				"url": "https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/padding-around-test-blocks.md"
 			}
-		],
-		"flint": {
-			"name": "testCasePaddingLines",
-			"plugin": "vitest",
-			"status": "implemented"
-		}
+		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "vitest/require-top-level-describe",
-				"url": "https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/require-top-level-describe.md"
-			}
-		],
 		"flint": {
 			"name": "testCasesWithinDescribes",
 			"plugin": "vitest",
 			"preset": "stylistic",
 			"status": "implemented",
 			"strictness": "strict"
-		}
+		},
+		"eslint": [
+			{
+				"name": "vitest/require-top-level-describe",
+				"url": "https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/require-top-level-describe.md"
+			}
+		]
 	},
 	{
+		"flint": {
+			"name": "testCaseTitles",
+			"plugin": "vitest",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "vitest/prefer-lowercase-title",
 				"url": "https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/prefer-lowercase-title.md"
 			}
 		],
-		"flint": {
-			"name": "testCaseTitles",
-			"plugin": "vitest",
-			"status": "skipped"
-		},
-		"notes": "Overly opinionated.",
 		"oxlint": [
 			{
 				"name": "vitest/prefer-lowercase-title",
 				"url": "https://oxc.rs/docs/guide/usage/linter/rules/vitest/prefer-lowercase-title.html"
 			}
-		]
+		],
+		"notes": "Overly opinionated."
 	},
 	{
+		"flint": {
+			"name": "testConditionalDefinitions",
+			"plugin": "vitest",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "vitest/no-conditional-tests",
 				"url": "https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/no-conditional-tests.md"
 			}
 		],
-		"flint": {
-			"name": "testConditionalDefinitions",
-			"plugin": "vitest",
-			"status": "skipped"
-		},
-		"notes": "Overly opinionated.",
 		"oxlint": [
 			{
 				"name": "vitest/no-conditional-tests",
 				"url": "https://oxc.rs/docs/guide/usage/linter/rules/vitest/no-conditional-tests.html"
 			}
-		]
+		],
+		"notes": "Overly opinionated."
 	},
 	{
-		"eslint": [
-			{
-				"name": "vitest/no-conditional-in-test",
-				"url": "https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/no-conditional-in-test.md"
-			}
-		],
 		"flint": {
 			"name": "testConditionals",
 			"plugin": "vitest",
 			"preset": "logical",
 			"strictness": "strict"
 		},
+		"eslint": [
+			{
+				"name": "vitest/no-conditional-in-test",
+				"url": "https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/no-conditional-in-test.md"
+			}
+		],
 		"oxlint": [
 			{
 				"name": "vitest/no-conditional-in-test",
@@ -31405,6 +31405,10 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "testDefinitionFunctions",
+			"plugin": "vitest"
+		},
 		"biome": [
 			{
 				"name": "useConsistentTestIt",
@@ -31417,10 +31421,6 @@
 				"url": "https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/consistent-test-it.md"
 			}
 		],
-		"flint": {
-			"name": "testDefinitionFunctions",
-			"plugin": "vitest"
-		},
 		"oxlint": [
 			{
 				"name": "vitest/consistent-test-it",
@@ -31429,6 +31429,11 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "testDisables",
+			"plugin": "vitest",
+			"status": "skipped"
+		},
 		"biome": [
 			{
 				"name": "noSkippedTests",
@@ -31441,44 +31446,39 @@
 				"url": "https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/no-disabled-tests.md"
 			}
 		],
-		"flint": {
-			"name": "testDisables",
-			"plugin": "vitest",
-			"status": "skipped"
-		},
-		"notes": "Handled by Vitest in CI mode.",
 		"oxlint": [
 			{
 				"name": "vitest/no-disabled-tests",
 				"url": "https://oxc.rs/docs/guide/usage/linter/rules/vitest/no-disabled-tests.html"
 			}
-		]
+		],
+		"notes": "Handled by Vitest in CI mode."
 	},
 	{
+		"flint": {
+			"name": "testExports",
+			"plugin": "vitest",
+			"preset": "logical"
+		},
 		"biome": [
 			{
 				"name": "noExportsInTest",
 				"url": "https://biomejs.dev/linter/rules/no-exports-in-test"
 			}
-		],
-		"flint": {
-			"name": "testExports",
-			"plugin": "vitest",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "testPrefixes",
+			"plugin": "vitest",
+			"preset": "stylistic"
+		},
 		"eslint": [
 			{
 				"name": "vitest/no-test-prefixes",
 				"url": "https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/no-test-prefixes.md"
 			}
 		],
-		"flint": {
-			"name": "testPrefixes",
-			"plugin": "vitest",
-			"preset": "stylistic"
-		},
 		"oxlint": [
 			{
 				"name": "vitest/no-test-prefixes",
@@ -31487,24 +31487,24 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "testReturnStatements",
+			"plugin": "vitest",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "vitest/no-test-return-statement",
 				"url": "https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/no-test-return-statement.md"
 			}
 		],
-		"flint": {
-			"name": "testReturnStatements",
-			"plugin": "vitest",
-			"status": "skipped"
-		},
-		"notes": "Overly opinionated, and largely handled by TypeScript.",
 		"oxlint": [
 			{
 				"name": "vitest/no-test-return-statement",
 				"url": "https://oxc.rs/docs/guide/usage/linter/rules/vitest/no-test-return-statement.html"
 			}
-		]
+		],
+		"notes": "Overly opinionated, and largely handled by TypeScript."
 	},
 	{
 		"flint": {
@@ -31512,15 +31512,20 @@
 			"plugin": "vitest",
 			"status": "skipped"
 		},
-		"notes": "Overly opinionated.",
 		"oxlint": [
 			{
 				"name": "vitest/require-test-timeout",
 				"url": "https://oxc.rs/docs/guide/usage/linter/rules/vitest/require-test-timeout.html"
 			}
-		]
+		],
+		"notes": "Overly opinionated."
 	},
 	{
+		"flint": {
+			"name": "titleRepeats",
+			"plugin": "vitest",
+			"preset": "logical"
+		},
 		"biome": [
 			{
 				"name": "noIdenticalTestTitle",
@@ -31533,11 +31538,6 @@
 				"url": "https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/no-identical-title.md"
 			}
 		],
-		"flint": {
-			"name": "titleRepeats",
-			"plugin": "vitest",
-			"preset": "logical"
-		},
 		"oxlint": [
 			{
 				"name": "vitest/no-identical-title",
@@ -31546,17 +31546,17 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "titleValidity",
+			"plugin": "vitest",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "vitest/valid-title",
 				"url": "https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/valid-title.md"
 			}
 		],
-		"flint": {
-			"name": "titleValidity",
-			"plugin": "vitest",
-			"preset": "logical"
-		},
 		"oxlint": [
 			{
 				"name": "vitest/valid-title",
@@ -31565,57 +31565,57 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "toBeMatchers",
+			"plugin": "vitest",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "vitest/prefer-to-be",
 				"url": "https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/prefer-to-be.md"
 			}
 		],
-		"flint": {
-			"name": "toBeMatchers",
-			"plugin": "vitest",
-			"status": "skipped"
-		},
-		"notes": "Overly opinionated.",
 		"oxlint": [
 			{
 				"name": "vitest/prefer-to-be",
 				"url": "https://oxc.rs/docs/guide/usage/linter/rules/vitest/prefer-to-be.html"
 			}
-		]
+		],
+		"notes": "Overly opinionated."
 	},
 	{
+		"flint": {
+			"name": "toBeObjectMatchers",
+			"plugin": "vitest",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "vitest/prefer-to-be-object",
 				"url": "https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/prefer-to-be-object.md"
 			}
 		],
-		"flint": {
-			"name": "toBeObjectMatchers",
-			"plugin": "vitest",
-			"status": "skipped"
-		},
-		"notes": "Overly opinionated.",
 		"oxlint": [
 			{
 				"name": "vitest/prefer-to-be-object",
 				"url": "https://oxc.rs/docs/guide/usage/linter/rules/vitest/prefer-to-be-object.html"
 			}
-		]
+		],
+		"notes": "Overly opinionated."
 	},
 	{
+		"flint": {
+			"name": "toBeTypeOfs",
+			"plugin": "vitest",
+			"preset": "stylistic"
+		},
 		"eslint": [
 			{
 				"name": "vitest/prefer-expect-type-of",
 				"url": "https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/prefer-expect-type-of.md"
 			}
 		],
-		"flint": {
-			"name": "toBeTypeOfs",
-			"plugin": "vitest",
-			"preset": "stylistic"
-		},
 		"oxlint": [
 			{
 				"name": "vitest/prefer-expect-type-of",
@@ -31624,17 +31624,17 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "toContainMatchers",
+			"plugin": "vitest",
+			"preset": "stylistic"
+		},
 		"eslint": [
 			{
 				"name": "vitest/prefer-to-contain",
 				"url": "https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/prefer-to-contain.md"
 			}
 		],
-		"flint": {
-			"name": "toContainMatchers",
-			"plugin": "vitest",
-			"preset": "stylistic"
-		},
 		"oxlint": [
 			{
 				"name": "vitest/prefer-to-contain",
@@ -31643,36 +31643,36 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "todoTestSkips",
+			"plugin": "vitest",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "vitest/warn-todo",
 				"url": "https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/warn-todo.md"
 			}
 		],
-		"flint": {
-			"name": "todoTestSkips",
-			"plugin": "vitest",
-			"status": "skipped"
-		},
-		"notes": "Handled by Vitest in CI mode.",
 		"oxlint": [
 			{
 				"name": "vitest/warn-todo",
 				"url": "https://oxc.rs/docs/guide/usage/linter/rules/vitest/warn-todo.html"
 			}
-		]
+		],
+		"notes": "Handled by Vitest in CI mode."
 	},
 	{
+		"flint": {
+			"name": "toHaveBeenCalledTimesAssertions",
+			"plugin": "vitest"
+		},
 		"eslint": [
 			{
 				"name": "vitest/prefer-to-have-been-called-times",
 				"url": "https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/prefer-to-have-been-called-times.md"
 			}
 		],
-		"flint": {
-			"name": "toHaveBeenCalledTimesAssertions",
-			"plugin": "vitest"
-		},
 		"oxlint": [
 			{
 				"name": "vitest/prefer-to-have-been-called-times",
@@ -31681,17 +31681,17 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "toHaveLengthMatchers",
+			"plugin": "vitest",
+			"preset": "stylistic"
+		},
 		"eslint": [
 			{
 				"name": "vitest/prefer-to-have-length",
 				"url": "https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/prefer-to-have-length.md"
 			}
 		],
-		"flint": {
-			"name": "toHaveLengthMatchers",
-			"plugin": "vitest",
-			"preset": "stylistic"
-		},
 		"oxlint": [
 			{
 				"name": "vitest/prefer-to-have-length",
@@ -31700,55 +31700,55 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "toThrowMessages",
+			"plugin": "vitest",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "vitest/require-to-throw-message",
 				"url": "https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/require-to-throw-message.md"
 			}
 		],
-		"flint": {
-			"name": "toThrowMessages",
-			"plugin": "vitest",
-			"status": "skipped"
-		},
-		"notes": "Overly opinionated.",
 		"oxlint": [
 			{
 				"name": "vitest/require-to-throw-message",
 				"url": "https://oxc.rs/docs/guide/usage/linter/rules/vitest/require-to-throw-message.html"
 			}
-		]
+		],
+		"notes": "Overly opinionated."
 	},
 	{
+		"flint": {
+			"name": "truthyMatchers",
+			"plugin": "vitest"
+		},
 		"eslint": [
 			{
 				"name": "vitest/prefer-to-be-truthy",
 				"url": "https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/prefer-to-be-truthy.md"
 			}
 		],
-		"flint": {
-			"name": "truthyMatchers",
-			"plugin": "vitest"
-		},
-		"notes": "Overly opinionated.",
 		"oxlint": [
 			{
 				"name": "vitest/prefer-to-be-truthy",
 				"url": "https://oxc.rs/docs/guide/usage/linter/rules/vitest/prefer-to-be-truthy.html"
 			}
-		]
+		],
+		"notes": "Overly opinionated."
 	},
 	{
+		"flint": {
+			"name": "unnecessaryAsyncExpectFunctions",
+			"plugin": "vitest"
+		},
 		"eslint": [
 			{
 				"name": "vitest/no-unneeded-async-expect-function",
 				"url": "https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/no-unneeded-async-expect-function.md"
 			}
 		],
-		"flint": {
-			"name": "unnecessaryAsyncExpectFunctions",
-			"plugin": "vitest"
-		},
 		"oxlint": [
 			{
 				"name": "vitest/no-unneeded-async-expect-function",
@@ -31757,16 +31757,16 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "viNamespaceNames",
+			"plugin": "vitest"
+		},
 		"eslint": [
 			{
 				"name": "vitest/consistent-vitest-vi",
 				"url": "https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/consistent-vitest-vi.md"
 			}
 		],
-		"flint": {
-			"name": "viNamespaceNames",
-			"plugin": "vitest"
-		},
 		"oxlint": [
 			{
 				"name": "vitest/consistent-vitest-vi",
@@ -31775,36 +31775,36 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "vitestGlobalImporting",
+			"plugin": "vitest"
+		},
 		"eslint": [
 			{
 				"name": "vitest/no-importing-vitest-globals",
 				"url": "https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/no-importing-vitest-globals.md"
 			}
 		],
-		"flint": {
-			"name": "vitestGlobalImporting",
-			"plugin": "vitest"
-		},
-		"notes": "Conflicts with vitestGlobalImports.",
 		"oxlint": [
 			{
 				"name": "vitest/no-importing-vitest-globals",
 				"url": "https://oxc.rs/docs/guide/usage/linter/rules/vitest/no-importing-vitest-globals.html"
 			}
-		]
+		],
+		"notes": "Conflicts with vitestGlobalImports."
 	},
 	{
+		"flint": {
+			"name": "vitestGlobalImports",
+			"plugin": "vitest",
+			"preset": "stylistic"
+		},
 		"eslint": [
 			{
 				"name": "vitest/prefer-importing-vitest-globals",
 				"url": "https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/prefer-importing-vitest-globals.md"
 			}
 		],
-		"flint": {
-			"name": "vitestGlobalImports",
-			"plugin": "vitest",
-			"preset": "stylistic"
-		},
 		"oxlint": [
 			{
 				"name": "vitest/prefer-importing-vitest-globals",
@@ -31813,103 +31813,108 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "arrayBracketNewlines",
+			"plugin": "vue",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "vue/array-bracket-newline",
 				"url": "https://eslint.vuejs.org/rules/array-bracket-newline.html"
 			}
 		],
-		"flint": {
-			"name": "arrayBracketNewlines",
-			"plugin": "vue",
-			"status": "skipped"
-		},
 		"notes": "Formatting rule."
 	},
 	{
+		"flint": {
+			"name": "arrayBracketSpaces",
+			"plugin": "vue",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "vue/array-bracket-spacing",
 				"url": "https://eslint.vuejs.org/rules/array-bracket-spacing.html"
 			}
 		],
-		"flint": {
-			"name": "arrayBracketSpaces",
-			"plugin": "vue",
-			"status": "skipped"
-		},
 		"notes": "Formatting rule."
 	},
 	{
+		"flint": {
+			"name": "arrayElementNewlines",
+			"plugin": "vue",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "vue/array-element-newline",
 				"url": "https://eslint.vuejs.org/rules/array-element-newline.html"
 			}
 		],
-		"flint": {
-			"name": "arrayElementNewlines",
-			"plugin": "vue",
-			"status": "skipped"
-		},
 		"notes": "Formatting rule."
 	},
 	{
+		"flint": {
+			"name": "arrowSpaces",
+			"plugin": "vue",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "vue/arrow-spacing",
 				"url": "https://eslint.vuejs.org/rules/arrow-spacing.html"
 			}
 		],
-		"flint": {
-			"name": "arrowSpaces",
-			"plugin": "vue",
-			"status": "skipped"
-		},
 		"notes": "Formatting rule."
 	},
 	{
+		"flint": {
+			"name": "attributeEqualSignSpaces",
+			"plugin": "vue",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "vue/no-spaces-around-equal-signs-in-attribute",
 				"url": "https://eslint.vuejs.org/rules/no-spaces-around-equal-signs-in-attribute.html"
 			}
 		],
-		"flint": {
-			"name": "attributeEqualSignSpaces",
-			"plugin": "vue",
-			"status": "skipped"
-		},
 		"notes": "Formatting rule."
 	},
 	{
+		"flint": {
+			"name": "attributeInheritanceDuplicates",
+			"plugin": "vue",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "vue/no-duplicate-attr-inheritance",
 				"url": "https://eslint.vuejs.org/rules/no-duplicate-attr-inheritance.html"
 			}
-		],
-		"flint": {
-			"name": "attributeInheritanceDuplicates",
-			"plugin": "vue",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "attributeLinebreaks",
+			"plugin": "vue",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "vue/first-attribute-linebreak",
 				"url": "https://eslint.vuejs.org/rules/first-attribute-linebreak.html"
 			}
 		],
-		"flint": {
-			"name": "attributeLinebreaks",
-			"plugin": "vue",
-			"status": "skipped"
-		},
 		"notes": "Formatting rule."
 	},
 	{
+		"flint": {
+			"name": "attributeNameCasing",
+			"plugin": "vue",
+			"preset": "stylistic"
+		},
 		"biome": [
 			{
 				"name": "useVueHyphenatedAttributes",
@@ -31921,67 +31926,62 @@
 				"name": "vue/attribute-hyphenation",
 				"url": "https://eslint.vuejs.org/rules/attribute-hyphenation.html"
 			}
-		],
-		"flint": {
-			"name": "attributeNameCasing",
-			"plugin": "vue",
-			"preset": "stylistic"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "attributeNameValidity",
+			"plugin": "vue",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "vue/valid-attribute-name",
 				"url": "https://eslint.vuejs.org/rules/valid-attribute-name.html"
 			}
 		],
-		"flint": {
-			"name": "attributeNameValidity",
-			"plugin": "vue",
-			"status": "skipped"
-		},
 		"notes": "Generally handled by parsers."
 	},
 	{
-		"eslint": [
-			{
-				"name": "vue/attributes-order",
-				"url": "https://eslint.vuejs.org/rules/attributes-order.html"
-			}
-		],
 		"flint": {
 			"name": "attributeOrders",
 			"plugin": "vue",
 			"preset": "stylistic",
 			"strictness": "strict"
-		}
+		},
+		"eslint": [
+			{
+				"name": "vue/attributes-order",
+				"url": "https://eslint.vuejs.org/rules/attributes-order.html"
+			}
+		]
 	},
 	{
+		"flint": {
+			"name": "attributesPerLine",
+			"plugin": "vue",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "vue/max-attributes-per-line",
 				"url": "https://eslint.vuejs.org/rules/max-attributes-per-line.html"
 			}
 		],
-		"flint": {
-			"name": "attributesPerLine",
-			"plugin": "vue",
-			"status": "skipped"
-		},
 		"notes": "Formatting rule."
 	},
 	{
+		"flint": {
+			"name": "beforeRouteEnterThisAccesses",
+			"plugin": "vue",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "vue/no-this-in-before-route-enter",
 				"url": "https://eslint.vuejs.org/rules/no-this-in-before-route-enter.html"
 			}
 		],
-		"flint": {
-			"name": "beforeRouteEnterThisAccesses",
-			"plugin": "vue",
-			"preset": "logical"
-		},
 		"oxlint": [
 			{
 				"name": "vue/no-this-in-before-route-enter",
@@ -31990,6 +31990,11 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "bindDirectiveValidity",
+			"plugin": "vue",
+			"preset": "logical"
+		},
 		"biome": [
 			{
 				"name": "useVueValidVBind",
@@ -32001,14 +32006,14 @@
 				"name": "vue/valid-v-bind",
 				"url": "https://eslint.vuejs.org/rules/valid-v-bind.html"
 			}
-		],
-		"flint": {
-			"name": "bindDirectiveValidity",
-			"plugin": "vue",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "bindStyles",
+			"plugin": "vue",
+			"preset": "stylistic"
+		},
 		"biome": [
 			{
 				"name": "useVueConsistentVBindStyle",
@@ -32020,213 +32025,213 @@
 				"name": "vue/v-bind-style",
 				"url": "https://eslint.vuejs.org/rules/v-bind-style.html"
 			}
-		],
-		"flint": {
-			"name": "bindStyles",
-			"plugin": "vue",
-			"preset": "stylistic"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "bindSyncValidity",
+			"plugin": "vue",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "vue/valid-v-bind-sync",
 				"url": "https://eslint.vuejs.org/rules/valid-v-bind-sync.html"
 			}
-		],
-		"flint": {
-			"name": "bindSyncValidity",
-			"plugin": "vue",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "blockLanguages",
+			"plugin": "vue",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "vue/block-lang",
 				"url": "https://eslint.vuejs.org/rules/block-lang.html"
 			}
-		],
-		"flint": {
-			"name": "blockLanguages",
-			"plugin": "vue",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "blockLineLimits",
+			"plugin": "vue",
+			"preset": "stylistic"
+		},
 		"eslint": [
 			{
 				"name": "vue/max-lines-per-block",
 				"url": "https://eslint.vuejs.org/rules/max-lines-per-block.html"
 			}
-		],
-		"flint": {
-			"name": "blockLineLimits",
-			"plugin": "vue",
-			"preset": "stylistic"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "blockOrders",
+			"plugin": "vue",
+			"preset": "sorting"
+		},
 		"eslint": [
 			{
 				"name": "vue/block-order",
 				"url": "https://eslint.vuejs.org/rules/block-order.html"
 			}
-		],
-		"flint": {
-			"name": "blockOrders",
-			"plugin": "vue",
-			"preset": "sorting"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "blockPaddingLines",
+			"plugin": "vue",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "vue/padding-line-between-blocks",
 				"url": "https://eslint.vuejs.org/rules/padding-line-between-blocks.html"
 			}
 		],
-		"flint": {
-			"name": "blockPaddingLines",
-			"plugin": "vue",
-			"status": "skipped"
-		},
 		"notes": "Formatting rule."
 	},
 	{
+		"flint": {
+			"name": "blockSpaces",
+			"plugin": "vue",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "vue/block-spacing",
 				"url": "https://eslint.vuejs.org/rules/block-spacing.html"
 			}
 		],
-		"flint": {
-			"name": "blockSpaces",
-			"plugin": "vue",
-			"status": "skipped"
-		},
 		"notes": "Formatting rule."
 	},
 	{
+		"flint": {
+			"name": "blockTagNewlines",
+			"plugin": "vue",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "vue/block-tag-newline",
 				"url": "https://eslint.vuejs.org/rules/block-tag-newline.html"
 			}
 		],
-		"flint": {
-			"name": "blockTagNewlines",
-			"plugin": "vue",
-			"status": "skipped"
-		},
 		"notes": "Formatting rule."
 	},
 	{
+		"flint": {
+			"name": "booleanDefaults",
+			"plugin": "vue",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "vue/no-boolean-default",
 				"url": "https://eslint.vuejs.org/rules/no-boolean-default.html"
 			}
-		],
-		"flint": {
-			"name": "booleanDefaults",
-			"plugin": "vue",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "booleanPropTypePositions",
+			"plugin": "vue",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "vue/prefer-prop-type-boolean-first",
 				"url": "https://eslint.vuejs.org/rules/prefer-prop-type-boolean-first.html"
 			}
-		],
-		"flint": {
-			"name": "booleanPropTypePositions",
-			"plugin": "vue",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "braceStyles",
+			"plugin": "vue",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "vue/brace-style",
 				"url": "https://eslint.vuejs.org/rules/brace-style.html"
 			}
 		],
-		"flint": {
-			"name": "braceStyles",
-			"plugin": "vue",
-			"status": "skipped"
-		},
 		"notes": "Formatting rule."
 	},
 	{
+		"flint": {
+			"name": "buttonTypes",
+			"plugin": "vue",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "vue/html-button-has-type",
 				"url": "https://eslint.vuejs.org/rules/html-button-has-type.html"
 			}
-		],
-		"flint": {
-			"name": "buttonTypes",
-			"plugin": "vue",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "camelCaseNames",
+			"plugin": "vue",
+			"preset": "stylistic"
+		},
 		"eslint": [
 			{
 				"name": "vue/camelcase",
 				"url": "https://eslint.vuejs.org/rules/camelcase.html"
 			}
-		],
-		"flint": {
-			"name": "camelCaseNames",
-			"plugin": "vue",
-			"preset": "stylistic"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "childContentOverrides",
+			"plugin": "vue",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "vue/no-child-content",
 				"url": "https://eslint.vuejs.org/rules/no-child-content.html"
 			}
-		],
-		"flint": {
-			"name": "childContentOverrides",
-			"plugin": "vue",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "classMultipleObjects",
+			"plugin": "vue",
+			"preset": "stylistic"
+		},
 		"eslint": [
 			{
 				"name": "vue/no-multiple-objects-in-class",
 				"url": "https://eslint.vuejs.org/rules/no-multiple-objects-in-class.html"
 			}
-		],
-		"flint": {
-			"name": "classMultipleObjects",
-			"plugin": "vue",
-			"preset": "stylistic"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "classNameDuplicates",
+			"plugin": "vue",
+			"preset": "stylistic"
+		},
 		"eslint": [
 			{
 				"name": "vue/no-duplicate-class-names",
 				"url": "https://eslint.vuejs.org/rules/no-duplicate-class-names.html"
 			}
-		],
-		"flint": {
-			"name": "classNameDuplicates",
-			"plugin": "vue",
-			"preset": "stylistic"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "cloakDirectiveValidity",
+			"plugin": "vue",
+			"preset": "logical"
+		},
 		"biome": [
 			{
 				"name": "useVueValidVCloak",
@@ -32238,125 +32243,125 @@
 				"name": "vue/valid-v-cloak",
 				"url": "https://eslint.vuejs.org/rules/valid-v-cloak.html"
 			}
-		],
-		"flint": {
-			"name": "cloakDirectiveValidity",
-			"plugin": "vue",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "closingBracketNewlines",
+			"plugin": "vue",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "vue/html-closing-bracket-newline",
 				"url": "https://eslint.vuejs.org/rules/html-closing-bracket-newline.html"
 			}
 		],
-		"flint": {
-			"name": "closingBracketNewlines",
-			"plugin": "vue",
-			"status": "skipped"
-		},
 		"notes": "Formatting rule."
 	},
 	{
+		"flint": {
+			"name": "closingBracketSpacing",
+			"plugin": "vue",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "vue/html-closing-bracket-spacing",
 				"url": "https://eslint.vuejs.org/rules/html-closing-bracket-spacing.html"
 			}
 		],
-		"flint": {
-			"name": "closingBracketSpacing",
-			"plugin": "vue",
-			"status": "skipped"
-		},
 		"notes": "Formatting rule."
 	},
 	{
+		"flint": {
+			"name": "commaSpaces",
+			"plugin": "vue",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "vue/comma-spacing",
 				"url": "https://eslint.vuejs.org/rules/comma-spacing.html"
 			}
 		],
-		"flint": {
-			"name": "commaSpaces",
-			"plugin": "vue",
-			"status": "skipped"
-		},
 		"notes": "Formatting rule."
 	},
 	{
+		"flint": {
+			"name": "commaStyles",
+			"plugin": "vue",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "vue/comma-style",
 				"url": "https://eslint.vuejs.org/rules/comma-style.html"
 			}
 		],
-		"flint": {
-			"name": "commaStyles",
-			"plugin": "vue",
-			"status": "skipped"
-		},
 		"notes": "Formatting rule."
 	},
 	{
+		"flint": {
+			"name": "commentContentNewlines",
+			"plugin": "vue",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "vue/html-comment-content-newline",
 				"url": "https://eslint.vuejs.org/rules/html-comment-content-newline.html"
 			}
 		],
-		"flint": {
-			"name": "commentContentNewlines",
-			"plugin": "vue",
-			"status": "skipped"
-		},
 		"notes": "Formatting rule."
 	},
 	{
+		"flint": {
+			"name": "commentContentSpaces",
+			"plugin": "vue",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "vue/html-comment-content-spacing",
 				"url": "https://eslint.vuejs.org/rules/html-comment-content-spacing.html"
 			}
 		],
-		"flint": {
-			"name": "commentContentSpaces",
-			"plugin": "vue",
-			"status": "skipped"
-		},
 		"notes": "Formatting rule."
 	},
 	{
+		"flint": {
+			"name": "commentDirectives",
+			"plugin": "vue",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "vue/comment-directive",
 				"url": "https://eslint.vuejs.org/rules/comment-directive.html"
 			}
-		],
-		"flint": {
-			"name": "commentDirectives",
-			"plugin": "vue",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "commentIndentation",
+			"plugin": "vue",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "vue/html-comment-indent",
 				"url": "https://eslint.vuejs.org/rules/html-comment-indent.html"
 			}
 		],
-		"flint": {
-			"name": "commentIndentation",
-			"plugin": "vue",
-			"status": "skipped"
-		},
 		"notes": "Formatting rule."
 	},
 	{
+		"flint": {
+			"name": "compilerMacroImports",
+			"plugin": "vue",
+			"preset": "logical"
+		},
 		"biome": [
 			{
 				"name": "noVueImportCompilerMacros",
@@ -32369,11 +32374,6 @@
 				"url": "https://eslint.vuejs.org/rules/no-import-compiler-macros.html"
 			}
 		],
-		"flint": {
-			"name": "compilerMacroImports",
-			"plugin": "vue",
-			"preset": "logical"
-		},
 		"oxlint": [
 			{
 				"name": "vue/no-import-compiler-macros",
@@ -32382,19 +32382,24 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "componentApiStyles",
+			"plugin": "vue",
+			"preset": "stylistic"
+		},
 		"eslint": [
 			{
 				"name": "vue/component-api-style",
 				"url": "https://eslint.vuejs.org/rules/component-api-style.html"
 			}
-		],
-		"flint": {
-			"name": "componentApiStyles",
-			"plugin": "vue",
-			"preset": "stylistic"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "componentDataSharing",
+			"plugin": "vue",
+			"preset": "logical"
+		},
 		"biome": [
 			{
 				"name": "noVueDataObjectDeclaration",
@@ -32407,11 +32412,6 @@
 				"url": "https://eslint.vuejs.org/rules/no-shared-component-data.html"
 			}
 		],
-		"flint": {
-			"name": "componentDataSharing",
-			"plugin": "vue",
-			"preset": "logical"
-		},
 		"oxlint": [
 			{
 				"name": "vue/no-shared-component-data",
@@ -32420,70 +32420,70 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "componentDefinitionPaddingLines",
+			"plugin": "vue",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "vue/padding-lines-in-component-definition",
 				"url": "https://eslint.vuejs.org/rules/padding-lines-in-component-definition.html"
 			}
 		],
-		"flint": {
-			"name": "componentDefinitionPaddingLines",
-			"plugin": "vue",
-			"status": "skipped"
-		},
 		"notes": "Formatting rule."
 	},
 	{
+		"flint": {
+			"name": "componentFileNameMatches",
+			"plugin": "vue",
+			"preset": "stylistic"
+		},
 		"eslint": [
 			{
 				"name": "vue/match-component-file-name",
 				"url": "https://eslint.vuejs.org/rules/match-component-file-name.html"
 			}
-		],
-		"flint": {
-			"name": "componentFileNameMatches",
-			"plugin": "vue",
-			"preset": "stylistic"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "componentHtmlTextProps",
+			"plugin": "vue",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "vue/no-v-text-v-html-on-component",
 				"url": "https://eslint.vuejs.org/rules/no-v-text-v-html-on-component.html"
 			}
-		],
-		"flint": {
-			"name": "componentHtmlTextProps",
-			"plugin": "vue",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "componentImportNameMatches",
+			"plugin": "vue",
+			"preset": "stylistic"
+		},
 		"eslint": [
 			{
 				"name": "vue/match-component-import-name",
 				"url": "https://eslint.vuejs.org/rules/match-component-import-name.html"
 			}
-		],
-		"flint": {
-			"name": "componentImportNameMatches",
-			"plugin": "vue",
-			"preset": "stylistic"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "componentNameCasing",
+			"plugin": "vue",
+			"preset": "stylistic"
+		},
 		"eslint": [
 			{
 				"name": "vue/component-definition-name-casing",
 				"url": "https://eslint.vuejs.org/rules/component-definition-name-casing.html"
 			}
 		],
-		"flint": {
-			"name": "componentNameCasing",
-			"plugin": "vue",
-			"preset": "stylistic"
-		},
 		"oxlint": [
 			{
 				"name": "vue/component-definition-name-casing",
@@ -32492,6 +32492,11 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "componentNames",
+			"plugin": "vue",
+			"preset": "stylistic"
+		},
 		"biome": [
 			{
 				"name": "useVueMultiWordComponentNames",
@@ -32503,25 +32508,20 @@
 				"name": "vue/multi-word-component-names",
 				"url": "https://eslint.vuejs.org/rules/multi-word-component-names.html"
 			}
-		],
-		"flint": {
-			"name": "componentNames",
-			"plugin": "vue",
-			"preset": "stylistic"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "componentNameValidity",
+			"plugin": "vue",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "vue/no-reserved-component-names",
 				"url": "https://eslint.vuejs.org/rules/no-reserved-component-names.html"
 			}
 		],
-		"flint": {
-			"name": "componentNameValidity",
-			"plugin": "vue",
-			"preset": "logical"
-		},
 		"oxlint": [
 			{
 				"name": "vue/no-reserved-component-names",
@@ -32530,121 +32530,121 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "componentOptionNameCasing",
+			"plugin": "vue",
+			"preset": "stylistic"
+		},
 		"eslint": [
 			{
 				"name": "vue/component-options-name-casing",
 				"url": "https://eslint.vuejs.org/rules/component-options-name-casing.html"
 			}
-		],
-		"flint": {
-			"name": "componentOptionNameCasing",
-			"plugin": "vue",
-			"preset": "stylistic"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "componentOptionTypos",
+			"plugin": "vue",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "vue/no-potential-component-option-typo",
 				"url": "https://eslint.vuejs.org/rules/no-potential-component-option-typo.html"
 			}
-		],
-		"flint": {
-			"name": "componentOptionTypos",
-			"plugin": "vue",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "componentPropertyOrder",
+			"plugin": "vue",
+			"preset": "sorting"
+		},
 		"eslint": [
 			{
 				"name": "vue/order-in-components",
 				"url": "https://eslint.vuejs.org/rules/order-in-components.html"
 			}
-		],
-		"flint": {
-			"name": "componentPropertyOrder",
-			"plugin": "vue",
-			"preset": "sorting"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "componentPropMutations",
+			"plugin": "vue",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "vue/no-mutating-props",
 				"url": "https://eslint.vuejs.org/rules/no-mutating-props.html"
 			}
-		],
-		"flint": {
-			"name": "componentPropMutations",
-			"plugin": "vue",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "componentTemplateNameCasing",
+			"plugin": "vue",
+			"preset": "stylistic"
+		},
 		"eslint": [
 			{
 				"name": "vue/component-name-in-template-casing",
 				"url": "https://eslint.vuejs.org/rules/component-name-in-template-casing.html"
 			}
-		],
-		"flint": {
-			"name": "componentTemplateNameCasing",
-			"plugin": "vue",
-			"preset": "stylistic"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "componentVIsBinds",
+			"plugin": "vue",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "vue/require-component-is",
 				"url": "https://eslint.vuejs.org/rules/require-component-is.html"
 			}
-		],
-		"flint": {
-			"name": "componentVIsBinds",
-			"plugin": "vue",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "computedAsyncProperties",
+			"plugin": "vue",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "vue/no-async-in-computed-properties",
 				"url": "https://eslint.vuejs.org/rules/no-async-in-computed-properties.html"
 			}
-		],
-		"flint": {
-			"name": "computedAsyncProperties",
-			"plugin": "vue",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "computedPropertyLikeMethods",
+			"plugin": "vue",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "vue/no-use-computed-property-like-method",
 				"url": "https://eslint.vuejs.org/rules/no-use-computed-property-like-method.html"
 			}
-		],
-		"flint": {
-			"name": "computedPropertyLikeMethods",
-			"plugin": "vue",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "computedPropertyReturns",
+			"plugin": "vue",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "vue/return-in-computed-property",
 				"url": "https://eslint.vuejs.org/rules/return-in-computed-property.html"
 			}
 		],
-		"flint": {
-			"name": "computedPropertyReturns",
-			"plugin": "vue",
-			"preset": "logical"
-		},
 		"oxlint": [
 			{
 				"name": "vue/return-in-computed-property",
@@ -32653,82 +32653,82 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "computedPropertySideEffects",
+			"plugin": "vue",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "vue/no-side-effects-in-computed-properties",
 				"url": "https://eslint.vuejs.org/rules/no-side-effects-in-computed-properties.html"
 			}
-		],
-		"flint": {
-			"name": "computedPropertySideEffects",
-			"plugin": "vue",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "consoleCalls",
+			"plugin": "vue",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "vue/no-console",
 				"url": "https://eslint.vuejs.org/rules/no-console.html"
 			}
-		],
-		"flint": {
-			"name": "consoleCalls",
-			"plugin": "vue",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "constantConditions",
+			"plugin": "vue",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "vue/no-constant-condition",
 				"url": "https://eslint.vuejs.org/rules/no-constant-condition.html"
 			}
-		],
-		"flint": {
-			"name": "constantConditions",
-			"plugin": "vue",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "customEventNameCasing",
+			"plugin": "vue",
+			"preset": "stylistic"
+		},
 		"eslint": [
 			{
 				"name": "vue/custom-event-name-casing",
 				"url": "https://eslint.vuejs.org/rules/custom-event-name-casing.html"
 			}
-		],
-		"flint": {
-			"name": "customEventNameCasing",
-			"plugin": "vue",
-			"preset": "stylistic"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "customModelModifiers",
+			"plugin": "vue",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "vue/no-custom-modifiers-on-v-model",
 				"url": "https://eslint.vuejs.org/rules/no-custom-modifiers-on-v-model.html"
 			}
-		],
-		"flint": {
-			"name": "customModelModifiers",
-			"plugin": "vue",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "dataComputedProperties",
+			"plugin": "vue",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "vue/no-computed-properties-in-data",
 				"url": "https://eslint.vuejs.org/rules/no-computed-properties-in-data.html"
 			}
 		],
-		"flint": {
-			"name": "dataComputedProperties",
-			"plugin": "vue",
-			"preset": "logical"
-		},
 		"oxlint": [
 			{
 				"name": "vue/no-computed-properties-in-data",
@@ -32737,17 +32737,17 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "defaultExports",
+			"plugin": "vue",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "vue/require-default-export",
 				"url": "https://eslint.vuejs.org/rules/require-default-export.html"
 			}
 		],
-		"flint": {
-			"name": "defaultExports",
-			"plugin": "vue",
-			"preset": "logical"
-		},
 		"oxlint": [
 			{
 				"name": "vue/require-default-export",
@@ -32756,30 +32756,30 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "defaultPropTypes",
+			"plugin": "vue",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "vue/require-valid-default-prop",
 				"url": "https://eslint.vuejs.org/rules/require-valid-default-prop.html"
 			}
-		],
-		"flint": {
-			"name": "defaultPropTypes",
-			"plugin": "vue",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "defineEmitsDeclarations",
+			"plugin": "vue",
+			"preset": "stylistic"
+		},
 		"eslint": [
 			{
 				"name": "vue/define-emits-declaration",
 				"url": "https://eslint.vuejs.org/rules/define-emits-declaration.html"
 			}
 		],
-		"flint": {
-			"name": "defineEmitsDeclarations",
-			"plugin": "vue",
-			"preset": "stylistic"
-		},
 		"oxlint": [
 			{
 				"name": "vue/define-emits-declaration",
@@ -32788,17 +32788,17 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "defineEmitsValidity",
+			"plugin": "vue",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "vue/valid-define-emits",
 				"url": "https://eslint.vuejs.org/rules/valid-define-emits.html"
 			}
 		],
-		"flint": {
-			"name": "defineEmitsValidity",
-			"plugin": "vue",
-			"preset": "logical"
-		},
 		"oxlint": [
 			{
 				"name": "vue/valid-define-emits",
@@ -32807,6 +32807,11 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "defineMacrosOrder",
+			"plugin": "vue",
+			"preset": "sorting"
+		},
 		"biome": [
 			{
 				"name": "useVueDefineMacrosOrder",
@@ -32818,38 +32823,33 @@
 				"name": "vue/define-macros-order",
 				"url": "https://eslint.vuejs.org/rules/define-macros-order.html"
 			}
-		],
-		"flint": {
-			"name": "defineMacrosOrder",
-			"plugin": "vue",
-			"preset": "sorting"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "defineOptionsMacros",
+			"plugin": "vue",
+			"preset": "stylistic"
+		},
 		"eslint": [
 			{
 				"name": "vue/prefer-define-options",
 				"url": "https://eslint.vuejs.org/rules/prefer-define-options.html"
 			}
-		],
-		"flint": {
-			"name": "defineOptionsMacros",
-			"plugin": "vue",
-			"preset": "stylistic"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "defineOptionsValidity",
+			"plugin": "vue",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "vue/valid-define-options",
 				"url": "https://eslint.vuejs.org/rules/valid-define-options.html"
 			}
 		],
-		"flint": {
-			"name": "defineOptionsValidity",
-			"plugin": "vue",
-			"preset": "logical"
-		},
 		"oxlint": [
 			{
 				"name": "vue/valid-define-options",
@@ -32858,6 +32858,11 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "definePropsDeclarations",
+			"plugin": "vue",
+			"preset": "stylistic"
+		},
 		"biome": [
 			{
 				"name": "useVueConsistentDefinePropsDeclaration",
@@ -32870,11 +32875,6 @@
 				"url": "https://eslint.vuejs.org/rules/define-props-declaration.html"
 			}
 		],
-		"flint": {
-			"name": "definePropsDeclarations",
-			"plugin": "vue",
-			"preset": "stylistic"
-		},
 		"oxlint": [
 			{
 				"name": "vue/define-props-declaration",
@@ -32883,17 +32883,17 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "definePropsDestructuring",
+			"plugin": "vue",
+			"preset": "stylistic"
+		},
 		"eslint": [
 			{
 				"name": "vue/define-props-destructuring",
 				"url": "https://eslint.vuejs.org/rules/define-props-destructuring.html"
 			}
 		],
-		"flint": {
-			"name": "definePropsDestructuring",
-			"plugin": "vue",
-			"preset": "stylistic"
-		},
 		"oxlint": [
 			{
 				"name": "vue/define-props-destructuring",
@@ -32902,17 +32902,17 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "definePropsValidity",
+			"plugin": "vue",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "vue/valid-define-props",
 				"url": "https://eslint.vuejs.org/rules/valid-define-props.html"
 			}
 		],
-		"flint": {
-			"name": "definePropsValidity",
-			"plugin": "vue",
-			"preset": "logical"
-		},
 		"oxlint": [
 			{
 				"name": "vue/valid-define-props",
@@ -32921,20 +32921,25 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "deprecatedBindSyncs",
+			"plugin": "vue",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "vue/no-deprecated-v-bind-sync",
 				"url": "https://eslint.vuejs.org/rules/no-deprecated-v-bind-sync.html"
 			}
 		],
-		"flint": {
-			"name": "deprecatedBindSyncs",
-			"plugin": "vue",
-			"status": "skipped"
-		},
 		"notes": "Superseded by deprecated."
 	},
 	{
+		"flint": {
+			"name": "deprecatedDataObjectDeclarations",
+			"plugin": "vue",
+			"preset": "logical"
+		},
 		"biome": [
 			{
 				"name": "noVueDataObjectDeclaration",
@@ -32947,11 +32952,6 @@
 				"url": "https://eslint.vuejs.org/rules/no-deprecated-data-object-declaration.html"
 			}
 		],
-		"flint": {
-			"name": "deprecatedDataObjectDeclarations",
-			"plugin": "vue",
-			"preset": "logical"
-		},
 		"oxlint": [
 			{
 				"name": "vue/no-deprecated-data-object-declaration",
@@ -32960,17 +32960,17 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "deprecatedDestroyedLifecycleHooks",
+			"plugin": "vue",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "vue/no-deprecated-destroyed-lifecycle",
 				"url": "https://eslint.vuejs.org/rules/no-deprecated-destroyed-lifecycle.html"
 			}
 		],
-		"flint": {
-			"name": "deprecatedDestroyedLifecycleHooks",
-			"plugin": "vue",
-			"preset": "logical"
-		},
 		"oxlint": [
 			{
 				"name": "vue/no-deprecated-destroyed-lifecycle",
@@ -32979,215 +32979,215 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "deprecatedDollarListeners",
+			"plugin": "vue",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "vue/no-deprecated-dollar-listeners-api",
 				"url": "https://eslint.vuejs.org/rules/no-deprecated-dollar-listeners-api.html"
 			}
 		],
-		"flint": {
-			"name": "deprecatedDollarListeners",
-			"plugin": "vue",
-			"status": "skipped"
-		},
 		"notes": "Superseded by deprecated."
 	},
 	{
+		"flint": {
+			"name": "deprecatedDollarScopedSlots",
+			"plugin": "vue",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "vue/no-deprecated-dollar-scopedslots-api",
 				"url": "https://eslint.vuejs.org/rules/no-deprecated-dollar-scopedslots-api.html"
 			}
 		],
-		"flint": {
-			"name": "deprecatedDollarScopedSlots",
-			"plugin": "vue",
-			"status": "skipped"
-		},
 		"notes": "Superseded by deprecated."
 	},
 	{
+		"flint": {
+			"name": "deprecatedEvents",
+			"plugin": "vue",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "vue/no-deprecated-events-api",
 				"url": "https://eslint.vuejs.org/rules/no-deprecated-events-api.html"
 			}
 		],
-		"flint": {
-			"name": "deprecatedEvents",
-			"plugin": "vue",
-			"status": "skipped"
-		},
-		"notes": "Superseded by deprecated.",
 		"oxlint": [
 			{
 				"name": "vue/no-deprecated-events-api",
 				"url": "https://oxc.rs/docs/guide/usage/linter/rules/vue/no-deprecated-events-api.html"
 			}
-		]
+		],
+		"notes": "Superseded by deprecated."
 	},
 	{
+		"flint": {
+			"name": "deprecatedFilters",
+			"plugin": "vue",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "vue/no-deprecated-filter",
 				"url": "https://eslint.vuejs.org/rules/no-deprecated-filter.html"
 			}
-		],
-		"flint": {
-			"name": "deprecatedFilters",
-			"plugin": "vue",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "deprecatedFunctionalTemplates",
+			"plugin": "vue",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "vue/no-deprecated-functional-template",
 				"url": "https://eslint.vuejs.org/rules/no-deprecated-functional-template.html"
 			}
-		],
-		"flint": {
-			"name": "deprecatedFunctionalTemplates",
-			"plugin": "vue",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "deprecatedHtmlElementIs",
+			"plugin": "vue",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "vue/no-deprecated-html-element-is",
 				"url": "https://eslint.vuejs.org/rules/no-deprecated-html-element-is.html"
 			}
 		],
-		"flint": {
-			"name": "deprecatedHtmlElementIs",
-			"plugin": "vue",
-			"status": "skipped"
-		},
 		"notes": "Superseded by deprecated."
 	},
 	{
+		"flint": {
+			"name": "deprecatedInlineTemplates",
+			"plugin": "vue",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "vue/no-deprecated-inline-template",
 				"url": "https://eslint.vuejs.org/rules/no-deprecated-inline-template.html"
 			}
 		],
-		"flint": {
-			"name": "deprecatedInlineTemplates",
-			"plugin": "vue",
-			"status": "skipped"
-		},
 		"notes": "Superseded by deprecated."
 	},
 	{
+		"flint": {
+			"name": "deprecatedModelDefinitions",
+			"plugin": "vue",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "vue/no-deprecated-model-definition",
 				"url": "https://eslint.vuejs.org/rules/no-deprecated-model-definition.html"
 			}
 		],
-		"flint": {
-			"name": "deprecatedModelDefinitions",
-			"plugin": "vue",
-			"status": "skipped"
-		},
-		"notes": "Superseded by deprecated.",
 		"oxlint": [
 			{
 				"name": "vue/no-deprecated-model-definition",
 				"url": "https://oxc.rs/docs/guide/usage/linter/rules/vue/no-deprecated-model-definition.html"
 			}
-		]
+		],
+		"notes": "Superseded by deprecated."
 	},
 	{
+		"flint": {
+			"name": "deprecatedRouterLinkTagProps",
+			"plugin": "vue",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "vue/no-deprecated-router-link-tag-prop",
 				"url": "https://eslint.vuejs.org/rules/no-deprecated-router-link-tag-prop.html"
 			}
 		],
-		"flint": {
-			"name": "deprecatedRouterLinkTagProps",
-			"plugin": "vue",
-			"status": "skipped"
-		},
 		"notes": "Superseded by deprecated."
 	},
 	{
+		"flint": {
+			"name": "deprecatedScopeAttributes",
+			"plugin": "vue",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "vue/no-deprecated-scope-attribute",
 				"url": "https://eslint.vuejs.org/rules/no-deprecated-scope-attribute.html"
 			}
 		],
-		"flint": {
-			"name": "deprecatedScopeAttributes",
-			"plugin": "vue",
-			"status": "skipped"
-		},
 		"notes": "Superseded by deprecated."
 	},
 	{
+		"flint": {
+			"name": "deprecatedSetDeletes",
+			"plugin": "vue",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "vue/no-deprecated-delete-set",
 				"url": "https://eslint.vuejs.org/rules/no-deprecated-delete-set.html"
 			}
 		],
-		"flint": {
-			"name": "deprecatedSetDeletes",
-			"plugin": "vue",
-			"status": "skipped"
-		},
-		"notes": "Superseded by deprecated.",
 		"oxlint": [
 			{
 				"name": "vue/no-deprecated-delete-set",
 				"url": "https://oxc.rs/docs/guide/usage/linter/rules/vue/no-deprecated-delete-set.html"
 			}
-		]
+		],
+		"notes": "Superseded by deprecated."
 	},
 	{
+		"flint": {
+			"name": "deprecatedSlotAttributes",
+			"plugin": "vue",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "vue/no-deprecated-slot-attribute",
 				"url": "https://eslint.vuejs.org/rules/no-deprecated-slot-attribute.html"
 			}
 		],
-		"flint": {
-			"name": "deprecatedSlotAttributes",
-			"plugin": "vue",
-			"status": "skipped"
-		},
 		"notes": "Superseded by deprecated."
 	},
 	{
+		"flint": {
+			"name": "deprecatedSlotScopeAttributes",
+			"plugin": "vue",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "vue/no-deprecated-slot-scope-attribute",
 				"url": "https://eslint.vuejs.org/rules/no-deprecated-slot-scope-attribute.html"
 			}
 		],
-		"flint": {
-			"name": "deprecatedSlotScopeAttributes",
-			"plugin": "vue",
-			"status": "skipped"
-		},
 		"notes": "Superseded by deprecated."
 	},
 	{
+		"flint": {
+			"name": "deprecatedThisDefaultProps",
+			"plugin": "vue",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "vue/no-deprecated-props-default-this",
 				"url": "https://eslint.vuejs.org/rules/no-deprecated-props-default-this.html"
 			}
 		],
-		"flint": {
-			"name": "deprecatedThisDefaultProps",
-			"plugin": "vue",
-			"preset": "logical"
-		},
 		"oxlint": [
 			{
 				"name": "vue/no-deprecated-props-default-this",
@@ -33196,34 +33196,39 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "deprecatedVIs",
+			"plugin": "vue",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "vue/no-deprecated-v-is",
 				"url": "https://eslint.vuejs.org/rules/no-deprecated-v-is.html"
 			}
 		],
-		"flint": {
-			"name": "deprecatedVIs",
-			"plugin": "vue",
-			"status": "skipped"
-		},
 		"notes": "Superseded by deprecated."
 	},
 	{
+		"flint": {
+			"name": "deprecatedVOnNativeModifiers",
+			"plugin": "vue",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "vue/no-deprecated-v-on-native-modifier",
 				"url": "https://eslint.vuejs.org/rules/no-deprecated-v-on-native-modifier.html"
 			}
 		],
-		"flint": {
-			"name": "deprecatedVOnNativeModifiers",
-			"plugin": "vue",
-			"status": "skipped"
-		},
 		"notes": "Superseded by deprecated."
 	},
 	{
+		"flint": {
+			"name": "deprecatedVOnNumberModifiers",
+			"plugin": "vue",
+			"status": "skipped"
+		},
 		"biome": [
 			{
 				"name": "noVueVOnNumberValues",
@@ -33236,45 +33241,40 @@
 				"url": "https://eslint.vuejs.org/rules/no-deprecated-v-on-number-modifiers.html"
 			}
 		],
-		"flint": {
-			"name": "deprecatedVOnNumberModifiers",
-			"plugin": "vue",
-			"status": "skipped"
-		},
 		"notes": "Superseded by deprecated."
 	},
 	{
+		"flint": {
+			"name": "deprecatedVueConfigKeyCodes",
+			"plugin": "vue",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "vue/no-deprecated-vue-config-keycodes",
 				"url": "https://eslint.vuejs.org/rules/no-deprecated-vue-config-keycodes.html"
 			}
 		],
-		"flint": {
-			"name": "deprecatedVueConfigKeyCodes",
-			"plugin": "vue",
-			"status": "skipped"
-		},
-		"notes": "Superseded by deprecated.",
 		"oxlint": [
 			{
 				"name": "vue/no-deprecated-vue-config-keycodes",
 				"url": "https://oxc.rs/docs/guide/usage/linter/rules/vue/no-deprecated-vue-config-keycodes.html"
 			}
-		]
+		],
+		"notes": "Superseded by deprecated."
 	},
 	{
+		"flint": {
+			"name": "directExports",
+			"plugin": "vue",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "vue/require-direct-export",
 				"url": "https://eslint.vuejs.org/rules/require-direct-export.html"
 			}
 		],
-		"flint": {
-			"name": "directExports",
-			"plugin": "vue",
-			"preset": "logical"
-		},
 		"oxlint": [
 			{
 				"name": "vue/require-direct-export",
@@ -33283,33 +33283,38 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "dotLocations",
+			"plugin": "vue",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "vue/dot-location",
 				"url": "https://eslint.vuejs.org/rules/dot-location.html"
 			}
 		],
-		"flint": {
-			"name": "dotLocations",
-			"plugin": "vue",
-			"status": "skipped"
-		},
 		"notes": "Formatting rule."
 	},
 	{
+		"flint": {
+			"name": "dotNotation",
+			"plugin": "vue",
+			"preset": "stylistic"
+		},
 		"eslint": [
 			{
 				"name": "vue/dot-notation",
 				"url": "https://eslint.vuejs.org/rules/dot-notation.html"
 			}
-		],
-		"flint": {
-			"name": "dotNotation",
-			"plugin": "vue",
-			"preset": "stylistic"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "duplicateAttributes",
+			"plugin": "vue",
+			"preset": "logical"
+		},
 		"biome": [
 			{
 				"name": "noDuplicateAttributes",
@@ -33321,40 +33326,40 @@
 				"name": "vue/no-duplicate-attributes",
 				"url": "https://eslint.vuejs.org/rules/no-duplicate-attributes.html"
 			}
-		],
-		"flint": {
-			"name": "duplicateAttributes",
-			"plugin": "vue",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "duplicateVElseIfConditions",
+			"plugin": "vue",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "vue/no-dupe-v-else-if",
 				"url": "https://eslint.vuejs.org/rules/no-dupe-v-else-if.html"
 			}
-		],
-		"flint": {
-			"name": "duplicateVElseIfConditions",
-			"plugin": "vue",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "elseDirectivesWithForDirectives",
+			"plugin": "vue",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "vue/no-use-v-else-with-v-for",
 				"url": "https://eslint.vuejs.org/rules/no-use-v-else-with-v-for.html"
 			}
-		],
-		"flint": {
-			"name": "elseDirectivesWithForDirectives",
-			"plugin": "vue",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "elseDirectiveValidity",
+			"plugin": "vue",
+			"preset": "logical"
+		},
 		"biome": [
 			{
 				"name": "useVueValidVElse",
@@ -33366,14 +33371,14 @@
 				"name": "vue/valid-v-else",
 				"url": "https://eslint.vuejs.org/rules/valid-v-else.html"
 			}
-		],
-		"flint": {
-			"name": "elseDirectiveValidity",
-			"plugin": "vue",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "elseIfDirectiveValidity",
+			"plugin": "vue",
+			"preset": "logical"
+		},
 		"biome": [
 			{
 				"name": "useVueValidVElseIf",
@@ -33385,25 +33390,20 @@
 				"name": "vue/valid-v-else-if",
 				"url": "https://eslint.vuejs.org/rules/valid-v-else-if.html"
 			}
-		],
-		"flint": {
-			"name": "elseIfDirectiveValidity",
-			"plugin": "vue",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "emitsValidatorReturns",
+			"plugin": "vue",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "vue/return-in-emits-validator",
 				"url": "https://eslint.vuejs.org/rules/return-in-emits-validator.html"
 			}
 		],
-		"flint": {
-			"name": "emitsValidatorReturns",
-			"plugin": "vue",
-			"preset": "logical"
-		},
 		"oxlint": [
 			{
 				"name": "vue/return-in-emits-validator",
@@ -33412,95 +33412,95 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "emitValidators",
+			"plugin": "vue",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "vue/require-emit-validator",
 				"url": "https://eslint.vuejs.org/rules/require-emit-validator.html"
 			}
-		],
-		"flint": {
-			"name": "emitValidators",
-			"plugin": "vue",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "emptyComponentBlocks",
+			"plugin": "vue",
+			"preset": "stylistic"
+		},
 		"eslint": [
 			{
 				"name": "vue/no-empty-component-block",
 				"url": "https://eslint.vuejs.org/rules/no-empty-component-block.html"
 			}
-		],
-		"flint": {
-			"name": "emptyComponentBlocks",
-			"plugin": "vue",
-			"preset": "stylistic"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "emptyPatterns",
+			"plugin": "vue",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "vue/no-empty-pattern",
 				"url": "https://eslint.vuejs.org/rules/no-empty-pattern.html"
 			}
-		],
-		"flint": {
-			"name": "emptyPatterns",
-			"plugin": "vue",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "endTagPresence",
+			"plugin": "vue",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "vue/html-end-tags",
 				"url": "https://eslint.vuejs.org/rules/html-end-tags.html"
 			}
-		],
-		"flint": {
-			"name": "endTagPresence",
-			"plugin": "vue",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "eventTriggerExplicitEmits",
+			"plugin": "vue",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "vue/require-explicit-emits",
 				"url": "https://eslint.vuejs.org/rules/require-explicit-emits.html"
 			}
-		],
-		"flint": {
-			"name": "eventTriggerExplicitEmits",
-			"plugin": "vue",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "explicitSlots",
+			"plugin": "vue",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "vue/require-explicit-slots",
 				"url": "https://eslint.vuejs.org/rules/require-explicit-slots.html"
 			}
-		],
-		"flint": {
-			"name": "explicitSlots",
-			"plugin": "vue",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "exposeAfterAwaits",
+			"plugin": "vue",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "vue/no-expose-after-await",
 				"url": "https://eslint.vuejs.org/rules/no-expose-after-await.html"
 			}
 		],
-		"flint": {
-			"name": "exposeAfterAwaits",
-			"plugin": "vue",
-			"preset": "logical"
-		},
 		"oxlint": [
 			{
 				"name": "vue/no-expose-after-await",
@@ -33509,19 +33509,24 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "exposeMacros",
+			"plugin": "vue",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "vue/require-expose",
 				"url": "https://eslint.vuejs.org/rules/require-expose.html"
 			}
-		],
-		"flint": {
-			"name": "exposeMacros",
-			"plugin": "vue",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "forBindKeys",
+			"plugin": "vue",
+			"preset": "logical"
+		},
 		"biome": [
 			{
 				"name": "useVueVForKey",
@@ -33533,27 +33538,27 @@
 				"name": "vue/require-v-for-key",
 				"url": "https://eslint.vuejs.org/rules/require-v-for-key.html"
 			}
-		],
-		"flint": {
-			"name": "forBindKeys",
-			"plugin": "vue",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "forDelimiterStyles",
+			"plugin": "vue",
+			"preset": "stylistic"
+		},
 		"eslint": [
 			{
 				"name": "vue/v-for-delimiter-style",
 				"url": "https://eslint.vuejs.org/rules/v-for-delimiter-style.html"
 			}
-		],
-		"flint": {
-			"name": "forDelimiterStyles",
-			"plugin": "vue",
-			"preset": "stylistic"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "forDirectiveValidity",
+			"plugin": "vue",
+			"preset": "logical"
+		},
 		"biome": [
 			{
 				"name": "useVueValidVFor",
@@ -33565,28 +33570,28 @@
 				"name": "vue/valid-v-for",
 				"url": "https://eslint.vuejs.org/rules/valid-v-for.html"
 			}
-		],
-		"flint": {
-			"name": "forDirectiveValidity",
-			"plugin": "vue",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "functionCallSpaces",
+			"plugin": "vue",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "vue/func-call-spacing",
 				"url": "https://eslint.vuejs.org/rules/func-call-spacing.html"
 			}
 		],
-		"flint": {
-			"name": "functionCallSpaces",
-			"plugin": "vue",
-			"status": "skipped"
-		},
 		"notes": "Formatting rule."
 	},
 	{
+		"flint": {
+			"name": "htmlDirectiveValidity",
+			"plugin": "vue",
+			"preset": "logical"
+		},
 		"biome": [
 			{
 				"name": "useVueValidVHtml",
@@ -33598,42 +33603,42 @@
 				"name": "vue/valid-v-html",
 				"url": "https://eslint.vuejs.org/rules/valid-v-html.html"
 			}
-		],
-		"flint": {
-			"name": "htmlDirectiveValidity",
-			"plugin": "vue",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "htmlQuotes",
+			"plugin": "vue",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "vue/html-quotes",
 				"url": "https://eslint.vuejs.org/rules/html-quotes.html"
 			}
 		],
-		"flint": {
-			"name": "htmlQuotes",
-			"plugin": "vue",
-			"status": "skipped"
-		},
 		"notes": "Formatting rule."
 	},
 	{
+		"flint": {
+			"name": "htmlTagsSelfClosing",
+			"plugin": "vue",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "vue/html-self-closing",
 				"url": "https://eslint.vuejs.org/rules/html-self-closing.html"
 			}
 		],
-		"flint": {
-			"name": "htmlTagsSelfClosing",
-			"plugin": "vue",
-			"status": "skipped"
-		},
 		"notes": "Formatting rule."
 	},
 	{
+		"flint": {
+			"name": "ifDirectiveValidity",
+			"plugin": "vue",
+			"preset": "logical"
+		},
 		"biome": [
 			{
 				"name": "useVueValidVIf",
@@ -33645,108 +33650,108 @@
 				"name": "vue/valid-v-if",
 				"url": "https://eslint.vuejs.org/rules/valid-v-if.html"
 			}
-		],
-		"flint": {
-			"name": "ifDirectiveValidity",
-			"plugin": "vue",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "ifElseKeys",
+			"plugin": "vue",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "vue/v-if-else-key",
 				"url": "https://eslint.vuejs.org/rules/v-if-else-key.html"
 			}
-		],
-		"flint": {
-			"name": "ifElseKeys",
-			"plugin": "vue",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "implicitCoercions",
+			"plugin": "vue",
+			"preset": "stylistic"
+		},
 		"eslint": [
 			{
 				"name": "vue/no-implicit-coercion",
 				"url": "https://eslint.vuejs.org/rules/no-implicit-coercion.html"
 			}
-		],
-		"flint": {
-			"name": "implicitCoercions",
-			"plugin": "vue",
-			"preset": "stylistic"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "indents",
+			"plugin": "vue",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "vue/html-indent",
 				"url": "https://eslint.vuejs.org/rules/html-indent.html"
 			}
 		],
-		"flint": {
-			"name": "indents",
-			"plugin": "vue",
-			"status": "skipped"
-		},
 		"notes": "Formatting rule."
 	},
 	{
+		"flint": {
+			"name": "infixOperatorSpaces",
+			"plugin": "vue",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "vue/space-infix-ops",
 				"url": "https://eslint.vuejs.org/rules/space-infix-ops.html"
 			}
 		],
-		"flint": {
-			"name": "infixOperatorSpaces",
-			"plugin": "vue",
-			"status": "skipped"
-		},
 		"notes": "Formatting rule."
 	},
 	{
+		"flint": {
+			"name": "irregularWhitespace",
+			"plugin": "vue",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "vue/no-irregular-whitespace",
 				"url": "https://eslint.vuejs.org/rules/no-irregular-whitespace.html"
 			}
 		],
-		"flint": {
-			"name": "irregularWhitespace",
-			"plugin": "vue",
-			"status": "skipped"
-		},
 		"notes": "Formatting rule."
 	},
 	{
+		"flint": {
+			"name": "isDirectiveValidity",
+			"plugin": "vue",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "vue/valid-v-is",
 				"url": "https://eslint.vuejs.org/rules/valid-v-is.html"
 			}
-		],
-		"flint": {
-			"name": "isDirectiveValidity",
-			"plugin": "vue",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "jsxVariableUses",
+			"plugin": "vue",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "vue/jsx-uses-vars",
 				"url": "https://eslint.vuejs.org/rules/jsx-uses-vars.html"
 			}
-		],
-		"flint": {
-			"name": "jsxVariableUses",
-			"plugin": "vue",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "keyDuplicates",
+			"plugin": "vue",
+			"preset": "logical"
+		},
 		"biome": [
 			{
 				"name": "noVueDuplicateKeys",
@@ -33758,41 +33763,41 @@
 				"name": "vue/no-dupe-keys",
 				"url": "https://eslint.vuejs.org/rules/no-dupe-keys.html"
 			}
-		],
-		"flint": {
-			"name": "keyDuplicates",
-			"plugin": "vue",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "keysOrder",
+			"plugin": "vue",
+			"preset": "sorting"
+		},
 		"eslint": [
 			{
 				"name": "vue/sort-keys",
 				"url": "https://eslint.vuejs.org/rules/sort-keys.html"
 			}
-		],
-		"flint": {
-			"name": "keysOrder",
-			"plugin": "vue",
-			"preset": "sorting"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "keySpaces",
+			"plugin": "vue",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "vue/key-spacing",
 				"url": "https://eslint.vuejs.org/rules/key-spacing.html"
 			}
 		],
-		"flint": {
-			"name": "keySpaces",
-			"plugin": "vue",
-			"status": "skipped"
-		},
 		"notes": "Formatting rule."
 	},
 	{
+		"flint": {
+			"name": "keyValidity",
+			"plugin": "vue",
+			"preset": "logical"
+		},
 		"biome": [
 			{
 				"name": "noVueReservedKeys",
@@ -33805,11 +33810,6 @@
 				"url": "https://eslint.vuejs.org/rules/no-reserved-keys.html"
 			}
 		],
-		"flint": {
-			"name": "keyValidity",
-			"plugin": "vue",
-			"preset": "logical"
-		},
 		"oxlint": [
 			{
 				"name": "vue/no-reserved-keys",
@@ -33818,31 +33818,31 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "keywordSpaces",
+			"plugin": "vue",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "vue/keyword-spacing",
 				"url": "https://eslint.vuejs.org/rules/keyword-spacing.html"
 			}
 		],
-		"flint": {
-			"name": "keywordSpaces",
-			"plugin": "vue",
-			"status": "skipped"
-		},
 		"notes": "Formatting rule."
 	},
 	{
+		"flint": {
+			"name": "lifecyclesAfterAwaits",
+			"plugin": "vue",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "vue/no-lifecycle-after-await",
 				"url": "https://eslint.vuejs.org/rules/no-lifecycle-after-await.html"
 			}
 		],
-		"flint": {
-			"name": "lifecyclesAfterAwaits",
-			"plugin": "vue",
-			"preset": "logical"
-		},
 		"oxlint": [
 			{
 				"name": "vue/no-lifecycle-after-await",
@@ -33851,221 +33851,226 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "lineLengths",
+			"plugin": "vue",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "vue/max-len",
 				"url": "https://eslint.vuejs.org/rules/max-len.html"
 			}
 		],
-		"flint": {
-			"name": "lineLengths",
-			"plugin": "vue",
-			"status": "skipped"
-		},
 		"notes": "Formatting rule."
 	},
 	{
-		"eslint": [
-			{
-				"name": "vue/no-lone-template",
-				"url": "https://eslint.vuejs.org/rules/no-lone-template.html"
-			}
-		],
 		"flint": {
 			"name": "loneTemplates",
 			"plugin": "vue",
 			"preset": "logical",
 			"strictness": "strict"
-		}
+		},
+		"eslint": [
+			{
+				"name": "vue/no-lone-template",
+				"url": "https://eslint.vuejs.org/rules/no-lone-template.html"
+			}
+		]
 	},
 	{
+		"flint": {
+			"name": "macroVariableNames",
+			"plugin": "vue",
+			"preset": "stylistic"
+		},
 		"eslint": [
 			{
 				"name": "vue/require-macro-variable-name",
 				"url": "https://eslint.vuejs.org/rules/require-macro-variable-name.html"
 			}
-		],
-		"flint": {
-			"name": "macroVariableNames",
-			"plugin": "vue",
-			"preset": "stylistic"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "maximumComponentsPerFile",
+			"plugin": "vue",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "vue/one-component-per-file",
 				"url": "https://eslint.vuejs.org/rules/one-component-per-file.html"
 			}
 		],
-		"flint": {
-			"name": "maximumComponentsPerFile",
-			"plugin": "vue",
-			"status": "skipped"
-		},
 		"notes": "Overly opinionated."
 	},
 	{
+		"flint": {
+			"name": "memoDirectiveValidity",
+			"plugin": "vue",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "vue/valid-v-memo",
 				"url": "https://eslint.vuejs.org/rules/valid-v-memo.html"
 			}
-		],
-		"flint": {
-			"name": "memoDirectiveValidity",
-			"plugin": "vue",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "modelDefinitionValidity",
+			"plugin": "vue",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "vue/valid-model-definition",
 				"url": "https://eslint.vuejs.org/rules/valid-model-definition.html"
 			}
-		],
-		"flint": {
-			"name": "modelDefinitionValidity",
-			"plugin": "vue",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "modelDirectiveArguments",
+			"plugin": "vue",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "vue/no-v-model-argument",
 				"url": "https://eslint.vuejs.org/rules/no-v-model-argument.html"
 			}
-		],
-		"flint": {
-			"name": "modelDirectiveArguments",
-			"plugin": "vue",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "modelDirectives",
+			"plugin": "vue",
+			"preset": "stylistic"
+		},
 		"eslint": [
 			{
 				"name": "vue/prefer-v-model",
 				"url": "https://eslint.vuejs.org/rules/prefer-v-model.html"
 			}
-		],
-		"flint": {
-			"name": "modelDirectives",
-			"plugin": "vue",
-			"preset": "stylistic"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "modelDirectiveValidity",
+			"plugin": "vue",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "vue/valid-v-model",
 				"url": "https://eslint.vuejs.org/rules/valid-v-model.html"
 			}
-		],
-		"flint": {
-			"name": "modelDirectiveValidity",
-			"plugin": "vue",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "multilineElementContentNewlines",
+			"plugin": "vue",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "vue/multiline-html-element-content-newline",
 				"url": "https://eslint.vuejs.org/rules/multiline-html-element-content-newline.html"
 			}
 		],
-		"flint": {
-			"name": "multilineElementContentNewlines",
-			"plugin": "vue",
-			"status": "skipped"
-		},
 		"notes": "Formatting rule."
 	},
 	{
+		"flint": {
+			"name": "multilinePropertyNewlines",
+			"plugin": "vue",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "vue/new-line-between-multi-line-property",
 				"url": "https://eslint.vuejs.org/rules/new-line-between-multi-line-property.html"
 			}
 		],
-		"flint": {
-			"name": "multilinePropertyNewlines",
-			"plugin": "vue",
-			"status": "skipped"
-		},
 		"notes": "Formatting rule."
 	},
 	{
+		"flint": {
+			"name": "multilineTernaries",
+			"plugin": "vue",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "vue/multiline-ternary",
 				"url": "https://eslint.vuejs.org/rules/multiline-ternary.html"
 			}
 		],
-		"flint": {
-			"name": "multilineTernaries",
-			"plugin": "vue",
-			"status": "skipped"
-		},
 		"notes": "Formatting rule."
 	},
 	{
+		"flint": {
+			"name": "mustacheInterpolationSpaces",
+			"plugin": "vue",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "vue/mustache-interpolation-spacing",
 				"url": "https://eslint.vuejs.org/rules/mustache-interpolation-spacing.html"
 			}
 		],
-		"flint": {
-			"name": "mustacheInterpolationSpaces",
-			"plugin": "vue",
-			"status": "skipped"
-		},
 		"notes": "Formatting rule."
 	},
 	{
+		"flint": {
+			"name": "nameProperties",
+			"plugin": "vue",
+			"preset": "stylistic"
+		},
 		"eslint": [
 			{
 				"name": "vue/require-name-property",
 				"url": "https://eslint.vuejs.org/rules/require-name-property.html"
 			}
-		],
-		"flint": {
-			"name": "nameProperties",
-			"plugin": "vue",
-			"preset": "stylistic"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "negatedConditions",
+			"plugin": "vue",
+			"preset": "stylistic"
+		},
 		"eslint": [
 			{
 				"name": "vue/no-negated-condition",
 				"url": "https://eslint.vuejs.org/rules/no-negated-condition.html"
 			}
-		],
-		"flint": {
-			"name": "negatedConditions",
-			"plugin": "vue",
-			"preset": "stylistic"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "negatedIfConditions",
+			"plugin": "vue",
+			"preset": "stylistic"
+		},
 		"eslint": [
 			{
 				"name": "vue/no-negated-v-if-condition",
 				"url": "https://eslint.vuejs.org/rules/no-negated-v-if-condition.html"
 			}
-		],
-		"flint": {
-			"name": "negatedIfConditions",
-			"plugin": "vue",
-			"preset": "stylistic"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "nextTickStyles",
+			"plugin": "vue",
+			"preset": "stylistic"
+		},
 		"biome": [
 			{
 				"name": "useVueNextTickPromise",
@@ -34078,11 +34083,6 @@
 				"url": "https://eslint.vuejs.org/rules/next-tick-style.html"
 			}
 		],
-		"flint": {
-			"name": "nextTickStyles",
-			"plugin": "vue",
-			"preset": "stylistic"
-		},
 		"oxlint": [
 			{
 				"name": "vue/next-tick-style",
@@ -34091,17 +34091,17 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "nextTickValidity",
+			"plugin": "vue",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "vue/valid-next-tick",
 				"url": "https://eslint.vuejs.org/rules/valid-next-tick.html"
 			}
 		],
-		"flint": {
-			"name": "nextTickValidity",
-			"plugin": "vue",
-			"preset": "logical"
-		},
 		"oxlint": [
 			{
 				"name": "vue/valid-next-tick",
@@ -34110,61 +34110,66 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "objectCurlyNewlines",
+			"plugin": "vue",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "vue/object-curly-newline",
 				"url": "https://eslint.vuejs.org/rules/object-curly-newline.html"
 			}
 		],
-		"flint": {
-			"name": "objectCurlyNewlines",
-			"plugin": "vue",
-			"status": "skipped"
-		},
 		"notes": "Formatting rule."
 	},
 	{
+		"flint": {
+			"name": "objectCurlySpaces",
+			"plugin": "vue",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "vue/object-curly-spacing",
 				"url": "https://eslint.vuejs.org/rules/object-curly-spacing.html"
 			}
 		],
-		"flint": {
-			"name": "objectCurlySpaces",
-			"plugin": "vue",
-			"status": "skipped"
-		},
 		"notes": "Formatting rule."
 	},
 	{
+		"flint": {
+			"name": "objectPropertyNewlines",
+			"plugin": "vue",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "vue/object-property-newline",
 				"url": "https://eslint.vuejs.org/rules/object-property-newline.html"
 			}
 		],
-		"flint": {
-			"name": "objectPropertyNewlines",
-			"plugin": "vue",
-			"status": "skipped"
-		},
 		"notes": "Formatting rule."
 	},
 	{
+		"flint": {
+			"name": "objectShorthands",
+			"plugin": "vue",
+			"preset": "stylistic"
+		},
 		"eslint": [
 			{
 				"name": "vue/object-shorthand",
 				"url": "https://eslint.vuejs.org/rules/object-shorthand.html"
 			}
-		],
-		"flint": {
-			"name": "objectShorthands",
-			"plugin": "vue",
-			"preset": "stylistic"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "onceDirectiveValidity",
+			"plugin": "vue",
+			"preset": "logical"
+		},
 		"biome": [
 			{
 				"name": "useVueValidVOnce",
@@ -34176,14 +34181,14 @@
 				"name": "vue/valid-v-once",
 				"url": "https://eslint.vuejs.org/rules/valid-v-once.html"
 			}
-		],
-		"flint": {
-			"name": "onceDirectiveValidity",
-			"plugin": "vue",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "onDirectiveValidity",
+			"plugin": "vue",
+			"preset": "logical"
+		},
 		"biome": [
 			{
 				"name": "useVueValidVOn",
@@ -34195,27 +34200,27 @@
 				"name": "vue/valid-v-on",
 				"url": "https://eslint.vuejs.org/rules/valid-v-on.html"
 			}
-		],
-		"flint": {
-			"name": "onDirectiveValidity",
-			"plugin": "vue",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "onEventHyphens",
+			"plugin": "vue",
+			"preset": "stylistic"
+		},
 		"eslint": [
 			{
 				"name": "vue/v-on-event-hyphenation",
 				"url": "https://eslint.vuejs.org/rules/v-on-event-hyphenation.html"
 			}
-		],
-		"flint": {
-			"name": "onEventHyphens",
-			"plugin": "vue",
-			"preset": "stylistic"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "onEventStyles",
+			"plugin": "vue",
+			"preset": "stylistic"
+		},
 		"biome": [
 			{
 				"name": "useVueConsistentVOnStyle",
@@ -34227,122 +34232,122 @@
 				"name": "vue/v-on-style",
 				"url": "https://eslint.vuejs.org/rules/v-on-style.html"
 			}
-		],
-		"flint": {
-			"name": "onEventStyles",
-			"plugin": "vue",
-			"preset": "stylistic"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "onExactModifiers",
+			"plugin": "vue",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "vue/use-v-on-exact",
 				"url": "https://eslint.vuejs.org/rules/use-v-on-exact.html"
 			}
-		],
-		"flint": {
-			"name": "onExactModifiers",
-			"plugin": "vue",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "onHandlerStyles",
+			"plugin": "vue",
+			"preset": "stylistic"
+		},
 		"eslint": [
 			{
 				"name": "vue/v-on-handler-style",
 				"url": "https://eslint.vuejs.org/rules/v-on-handler-style.html"
 			}
-		],
-		"flint": {
-			"name": "onHandlerStyles",
-			"plugin": "vue",
-			"preset": "stylistic"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "operatorLinebreaks",
+			"plugin": "vue",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "vue/operator-linebreak",
 				"url": "https://eslint.vuejs.org/rules/operator-linebreak.html"
 			}
 		],
-		"flint": {
-			"name": "operatorLinebreaks",
-			"plugin": "vue",
-			"status": "skipped"
-		},
 		"notes": "Formatting rule."
 	},
 	{
+		"flint": {
+			"name": "optionalPropDefaults",
+			"plugin": "vue",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "vue/require-default-prop",
 				"url": "https://eslint.vuejs.org/rules/require-default-prop.html"
 			}
-		],
-		"flint": {
-			"name": "optionalPropDefaults",
-			"plugin": "vue",
-			"preset": "logical"
-		}
+		]
 	},
 	{
-		"biome": [
-			{
-				"name": "noVueOptionsApi",
-				"url": "https://biomejs.dev/linter/rules/no-vue-options-api"
-			}
-		],
 		"flint": {
 			"name": "optionsApi",
 			"plugin": "vue",
 			"preset": "stylistic",
 			"strictness": "strict"
-		}
+		},
+		"biome": [
+			{
+				"name": "noVueOptionsApi",
+				"url": "https://biomejs.dev/linter/rules/no-vue-options-api"
+			}
+		]
 	},
 	{
+		"flint": {
+			"name": "parenthesisSpaces",
+			"plugin": "vue",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "vue/space-in-parens",
 				"url": "https://eslint.vuejs.org/rules/space-in-parens.html"
 			}
 		],
-		"flint": {
-			"name": "parenthesisSpaces",
-			"plugin": "vue",
-			"status": "skipped"
-		},
 		"notes": "Formatting rule."
 	},
 	{
+		"flint": {
+			"name": "parsingErrors",
+			"plugin": "vue",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "vue/no-parsing-error",
 				"url": "https://eslint.vuejs.org/rules/no-parsing-error.html"
 			}
 		],
-		"flint": {
-			"name": "parsingErrors",
-			"plugin": "vue",
-			"status": "skipped"
-		},
 		"notes": "Generally handled by parsers."
 	},
 	{
+		"flint": {
+			"name": "precisionLoss",
+			"plugin": "vue",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "vue/no-loss-of-precision",
 				"url": "https://eslint.vuejs.org/rules/no-loss-of-precision.html"
 			}
-		],
-		"flint": {
-			"name": "precisionLoss",
-			"plugin": "vue",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "preDirectiveValidity",
+			"plugin": "vue",
+			"preset": "logical"
+		},
 		"biome": [
 			{
 				"name": "useVueValidVPre",
@@ -34354,52 +34359,47 @@
 				"name": "vue/valid-v-pre",
 				"url": "https://eslint.vuejs.org/rules/valid-v-pre.html"
 			}
-		],
-		"flint": {
-			"name": "preDirectiveValidity",
-			"plugin": "vue",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "propComments",
+			"plugin": "vue",
+			"preset": "stylistic"
+		},
 		"eslint": [
 			{
 				"name": "vue/require-prop-comment",
 				"url": "https://eslint.vuejs.org/rules/require-prop-comment.html"
 			}
-		],
-		"flint": {
-			"name": "propComments",
-			"plugin": "vue",
-			"preset": "stylistic"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "propertyQuotes",
+			"plugin": "vue",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "vue/quote-props",
 				"url": "https://eslint.vuejs.org/rules/quote-props.html"
 			}
 		],
-		"flint": {
-			"name": "propertyQuotes",
-			"plugin": "vue",
-			"status": "skipped"
-		},
 		"notes": "Formatting rule."
 	},
 	{
+		"flint": {
+			"name": "propLimits",
+			"plugin": "vue",
+			"preset": "stylistic"
+		},
 		"eslint": [
 			{
 				"name": "vue/max-props",
 				"url": "https://eslint.vuejs.org/rules/max-props.html"
 			}
 		],
-		"flint": {
-			"name": "propLimits",
-			"plugin": "vue",
-			"preset": "stylistic"
-		},
 		"oxlint": [
 			{
 				"name": "vue/max-props",
@@ -34408,17 +34408,17 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "propNameCasing",
+			"plugin": "vue",
+			"preset": "stylistic"
+		},
 		"eslint": [
 			{
 				"name": "vue/prop-name-casing",
 				"url": "https://eslint.vuejs.org/rules/prop-name-casing.html"
 			}
 		],
-		"flint": {
-			"name": "propNameCasing",
-			"plugin": "vue",
-			"preset": "stylistic"
-		},
 		"oxlint": [
 			{
 				"name": "vue/prop-name-casing",
@@ -34427,6 +34427,11 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "propNameValidity",
+			"plugin": "vue",
+			"preset": "logical"
+		},
 		"biome": [
 			{
 				"name": "noVueReservedProps",
@@ -34439,11 +34444,6 @@
 				"url": "https://eslint.vuejs.org/rules/no-reserved-props.html"
 			}
 		],
-		"flint": {
-			"name": "propNameValidity",
-			"plugin": "vue",
-			"preset": "logical"
-		},
 		"oxlint": [
 			{
 				"name": "vue/no-reserved-props",
@@ -34452,18 +34452,18 @@
 		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "vue/no-required-prop-with-default",
-				"url": "https://eslint.vuejs.org/rules/no-required-prop-with-default.html"
-			}
-		],
 		"flint": {
 			"name": "propRequiredAndDefaults",
 			"plugin": "vue",
 			"preset": "logical",
 			"strictness": "strict"
 		},
+		"eslint": [
+			{
+				"name": "vue/no-required-prop-with-default",
+				"url": "https://eslint.vuejs.org/rules/no-required-prop-with-default.html"
+			}
+		],
 		"oxlint": [
 			{
 				"name": "vue/no-required-prop-with-default",
@@ -34472,17 +34472,17 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "propTypeConstructors",
+			"plugin": "vue",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "vue/require-prop-type-constructor",
 				"url": "https://eslint.vuejs.org/rules/require-prop-type-constructor.html"
 			}
 		],
-		"flint": {
-			"name": "propTypeConstructors",
-			"plugin": "vue",
-			"preset": "logical"
-		},
 		"oxlint": [
 			{
 				"name": "vue/require-prop-type-constructor",
@@ -34491,17 +34491,17 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "propTypes",
+			"plugin": "vue",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "vue/require-prop-types",
 				"url": "https://eslint.vuejs.org/rules/require-prop-types.html"
 			}
 		],
-		"flint": {
-			"name": "propTypes",
-			"plugin": "vue",
-			"preset": "logical"
-		},
 		"oxlint": [
 			{
 				"name": "vue/require-prop-types",
@@ -34510,19 +34510,24 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "refObjectReactivityLoss",
+			"plugin": "vue",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "vue/no-ref-object-reactivity-loss",
 				"url": "https://eslint.vuejs.org/rules/no-ref-object-reactivity-loss.html"
 			}
-		],
-		"flint": {
-			"name": "refObjectReactivityLoss",
-			"plugin": "vue",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "refOperands",
+			"plugin": "vue",
+			"preset": "logical"
+		},
 		"biome": [
 			{
 				"name": "noVueRefAsOperand",
@@ -34534,25 +34539,20 @@
 				"name": "vue/no-ref-as-operand",
 				"url": "https://eslint.vuejs.org/rules/no-ref-as-operand.html"
 			}
-		],
-		"flint": {
-			"name": "refOperands",
-			"plugin": "vue",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "renderReturns",
+			"plugin": "vue",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "vue/require-render-return",
 				"url": "https://eslint.vuejs.org/rules/require-render-return.html"
 			}
 		],
-		"flint": {
-			"name": "renderReturns",
-			"plugin": "vue",
-			"preset": "logical"
-		},
 		"oxlint": [
 			{
 				"name": "vue/require-render-return",
@@ -34561,213 +34561,213 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "restrictedBindDirectives",
+			"plugin": "vue",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "vue/no-restricted-v-bind",
 				"url": "https://eslint.vuejs.org/rules/no-restricted-v-bind.html"
 			}
-		],
-		"flint": {
-			"name": "restrictedBindDirectives",
-			"plugin": "vue",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "restrictedBlocks",
+			"plugin": "vue",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "vue/no-restricted-block",
 				"url": "https://eslint.vuejs.org/rules/no-restricted-block.html"
 			}
-		],
-		"flint": {
-			"name": "restrictedBlocks",
-			"plugin": "vue",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "restrictedCallsAfterAwaits",
+			"plugin": "vue",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "vue/no-restricted-call-after-await",
 				"url": "https://eslint.vuejs.org/rules/no-restricted-call-after-await.html"
 			}
-		],
-		"flint": {
-			"name": "restrictedCallsAfterAwaits",
-			"plugin": "vue",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "restrictedClasses",
+			"plugin": "vue",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "vue/no-restricted-class",
 				"url": "https://eslint.vuejs.org/rules/no-restricted-class.html"
 			}
-		],
-		"flint": {
-			"name": "restrictedClasses",
-			"plugin": "vue",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "restrictedComponentNames",
+			"plugin": "vue",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "vue/no-restricted-component-names",
 				"url": "https://eslint.vuejs.org/rules/no-restricted-component-names.html"
 			}
-		],
-		"flint": {
-			"name": "restrictedComponentNames",
-			"plugin": "vue",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "restrictedComponentNamesLegacy",
+			"plugin": "vue",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "vue/restricted-component-names",
 				"url": "https://eslint.vuejs.org/rules/restricted-component-names.html"
 			}
-		],
-		"flint": {
-			"name": "restrictedComponentNamesLegacy",
-			"plugin": "vue",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "restrictedComponentOptions",
+			"plugin": "vue",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "vue/no-restricted-component-options",
 				"url": "https://eslint.vuejs.org/rules/no-restricted-component-options.html"
 			}
-		],
-		"flint": {
-			"name": "restrictedComponentOptions",
-			"plugin": "vue",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "restrictedCustomEvents",
+			"plugin": "vue",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "vue/no-restricted-custom-event",
 				"url": "https://eslint.vuejs.org/rules/no-restricted-custom-event.html"
 			}
-		],
-		"flint": {
-			"name": "restrictedCustomEvents",
-			"plugin": "vue",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "restrictedHtmlElements",
+			"plugin": "vue",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "vue/no-restricted-html-elements",
 				"url": "https://eslint.vuejs.org/rules/no-restricted-html-elements.html"
 			}
-		],
-		"flint": {
-			"name": "restrictedHtmlElements",
-			"plugin": "vue",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "restrictedOnDirectives",
+			"plugin": "vue",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "vue/no-restricted-v-on",
 				"url": "https://eslint.vuejs.org/rules/no-restricted-v-on.html"
 			}
-		],
-		"flint": {
-			"name": "restrictedOnDirectives",
-			"plugin": "vue",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "restrictedProps",
+			"plugin": "vue",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "vue/no-restricted-props",
 				"url": "https://eslint.vuejs.org/rules/no-restricted-props.html"
 			}
-		],
-		"flint": {
-			"name": "restrictedProps",
-			"plugin": "vue",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "restrictedStaticAttributes",
+			"plugin": "vue",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "vue/no-restricted-static-attribute",
 				"url": "https://eslint.vuejs.org/rules/no-restricted-static-attribute.html"
 			}
-		],
-		"flint": {
-			"name": "restrictedStaticAttributes",
-			"plugin": "vue",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "restrictedSyntaxes",
+			"plugin": "vue",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "vue/no-restricted-syntax",
 				"url": "https://eslint.vuejs.org/rules/no-restricted-syntax.html"
 			}
-		],
-		"flint": {
-			"name": "restrictedSyntaxes",
-			"plugin": "vue",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "rootIfDirectives",
+			"plugin": "vue",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "vue/no-root-v-if",
 				"url": "https://eslint.vuejs.org/rules/no-root-v-if.html"
 			}
-		],
-		"flint": {
-			"name": "rootIfDirectives",
-			"plugin": "vue",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "scriptIndentation",
+			"plugin": "vue",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "vue/script-indent",
 				"url": "https://eslint.vuejs.org/rules/script-indent.html"
 			}
 		],
-		"flint": {
-			"name": "scriptIndentation",
-			"plugin": "vue",
-			"status": "skipped"
-		},
 		"notes": "Formatting rule."
 	},
 	{
+		"flint": {
+			"name": "scriptSetupExports",
+			"plugin": "vue",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "vue/no-export-in-script-setup",
 				"url": "https://eslint.vuejs.org/rules/no-export-in-script-setup.html"
 			}
 		],
-		"flint": {
-			"name": "scriptSetupExports",
-			"plugin": "vue",
-			"preset": "logical"
-		},
 		"oxlint": [
 			{
 				"name": "vue/no-export-in-script-setup",
@@ -34776,19 +34776,24 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "separateStaticClasses",
+			"plugin": "vue",
+			"preset": "stylistic"
+		},
 		"eslint": [
 			{
 				"name": "vue/prefer-separate-static-class",
 				"url": "https://eslint.vuejs.org/rules/prefer-separate-static-class.html"
 			}
-		],
-		"flint": {
-			"name": "separateStaticClasses",
-			"plugin": "vue",
-			"preset": "stylistic"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "setupPropsReactivityLoss",
+			"plugin": "vue",
+			"preset": "logical"
+		},
 		"biome": [
 			{
 				"name": "noVueSetupPropsReactivityLoss",
@@ -34800,66 +34805,61 @@
 				"name": "vue/no-setup-props-reactivity-loss",
 				"url": "https://eslint.vuejs.org/rules/no-setup-props-reactivity-loss.html"
 			}
-		],
-		"flint": {
-			"name": "setupPropsReactivityLoss",
-			"plugin": "vue",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "showDirectiveValidity",
+			"plugin": "vue",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "vue/valid-v-show",
 				"url": "https://eslint.vuejs.org/rules/valid-v-show.html"
 			}
-		],
-		"flint": {
-			"name": "showDirectiveValidity",
-			"plugin": "vue",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "singleEventPayloads",
+			"plugin": "vue",
+			"preset": "stylistic"
+		},
 		"eslint": [
 			{
 				"name": "vue/prefer-single-event-payload",
 				"url": "https://eslint.vuejs.org/rules/prefer-single-event-payload.html"
 			}
-		],
-		"flint": {
-			"name": "singleEventPayloads",
-			"plugin": "vue",
-			"preset": "stylistic"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "singleLineElementContentNewlines",
+			"plugin": "vue",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "vue/singleline-html-element-content-newline",
 				"url": "https://eslint.vuejs.org/rules/singleline-html-element-content-newline.html"
 			}
 		],
-		"flint": {
-			"name": "singleLineElementContentNewlines",
-			"plugin": "vue",
-			"status": "skipped"
-		},
 		"notes": "Formatting rule."
 	},
 	{
-		"eslint": [
-			{
-				"name": "vue/no-multiple-slot-args",
-				"url": "https://eslint.vuejs.org/rules/no-multiple-slot-args.html"
-			}
-		],
 		"flint": {
 			"name": "slotArguments",
 			"plugin": "vue",
 			"preset": "logical",
 			"strictness": "strict"
 		},
+		"eslint": [
+			{
+				"name": "vue/no-multiple-slot-args",
+				"url": "https://eslint.vuejs.org/rules/no-multiple-slot-args.html"
+			}
+		],
 		"oxlint": [
 			{
 				"name": "vue/no-multiple-slot-args",
@@ -34868,43 +34868,43 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "slotDirectiveValidity",
+			"plugin": "vue",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "vue/valid-v-slot",
 				"url": "https://eslint.vuejs.org/rules/valid-v-slot.html"
 			}
-		],
-		"flint": {
-			"name": "slotDirectiveValidity",
-			"plugin": "vue",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "slotNameCasing",
+			"plugin": "vue",
+			"preset": "stylistic"
+		},
 		"eslint": [
 			{
 				"name": "vue/slot-name-casing",
 				"url": "https://eslint.vuejs.org/rules/slot-name-casing.html"
 			}
-		],
-		"flint": {
-			"name": "slotNameCasing",
-			"plugin": "vue",
-			"preset": "stylistic"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "slotsAsFunctions",
+			"plugin": "vue",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "vue/require-slots-as-functions",
 				"url": "https://eslint.vuejs.org/rules/require-slots-as-functions.html"
 			}
 		],
-		"flint": {
-			"name": "slotsAsFunctions",
-			"plugin": "vue",
-			"preset": "logical"
-		},
 		"oxlint": [
 			{
 				"name": "vue/require-slots-as-functions",
@@ -34913,59 +34913,64 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "slotStyles",
+			"plugin": "vue",
+			"preset": "stylistic"
+		},
 		"eslint": [
 			{
 				"name": "vue/v-slot-style",
 				"url": "https://eslint.vuejs.org/rules/v-slot-style.html"
 			}
-		],
-		"flint": {
-			"name": "slotStyles",
-			"plugin": "vue",
-			"preset": "stylistic"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "spaces",
+			"plugin": "vue",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "vue/no-multi-spaces",
 				"url": "https://eslint.vuejs.org/rules/no-multi-spaces.html"
 			}
 		],
-		"flint": {
-			"name": "spaces",
-			"plugin": "vue",
-			"status": "skipped"
-		},
 		"notes": "Formatting rule."
 	},
 	{
+		"flint": {
+			"name": "sparseArrays",
+			"plugin": "vue",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "vue/no-sparse-arrays",
 				"url": "https://eslint.vuejs.org/rules/no-sparse-arrays.html"
 			}
-		],
-		"flint": {
-			"name": "sparseArrays",
-			"plugin": "vue",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "staticClassNamesOrder",
+			"plugin": "vue",
+			"preset": "sorting"
+		},
 		"eslint": [
 			{
 				"name": "vue/static-class-names-order",
 				"url": "https://eslint.vuejs.org/rules/static-class-names-order.html"
 			}
-		],
-		"flint": {
-			"name": "staticClassNamesOrder",
-			"plugin": "vue",
-			"preset": "sorting"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "staticInlineStyles",
+			"plugin": "vue",
+			"preset": "stylistic"
+		},
 		"biome": [
 			{
 				"name": "noInlineStyles",
@@ -34977,27 +34982,27 @@
 				"name": "vue/no-static-inline-styles",
 				"url": "https://eslint.vuejs.org/rules/no-static-inline-styles.html"
 			}
-		],
-		"flint": {
-			"name": "staticInlineStyles",
-			"plugin": "vue",
-			"preset": "stylistic"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "strictEqualityOperators",
+			"plugin": "vue",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "vue/eqeqeq",
 				"url": "https://eslint.vuejs.org/rules/eqeqeq.html"
 			}
-		],
-		"flint": {
-			"name": "strictEqualityOperators",
-			"plugin": "vue",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "styleAttributes",
+			"plugin": "vue",
+			"preset": "logical"
+		},
 		"biome": [
 			{
 				"name": "useScopedStyles",
@@ -35009,133 +35014,133 @@
 				"name": "vue/enforce-style-attribute",
 				"url": "https://eslint.vuejs.org/rules/enforce-style-attribute.html"
 			}
-		],
-		"flint": {
-			"name": "styleAttributes",
-			"plugin": "vue",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "tagPaddingLines",
+			"plugin": "vue",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "vue/padding-line-between-tags",
 				"url": "https://eslint.vuejs.org/rules/padding-line-between-tags.html"
 			}
 		],
-		"flint": {
-			"name": "tagPaddingLines",
-			"plugin": "vue",
-			"status": "skipped"
-		},
 		"notes": "Formatting rule."
 	},
 	{
+		"flint": {
+			"name": "templateBareStrings",
+			"plugin": "vue",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "vue/no-bare-strings-in-template",
 				"url": "https://eslint.vuejs.org/rules/no-bare-strings-in-template.html"
 			}
-		],
-		"flint": {
-			"name": "templateBareStrings",
-			"plugin": "vue",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "templateCurlySpaces",
+			"plugin": "vue",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "vue/template-curly-spacing",
 				"url": "https://eslint.vuejs.org/rules/template-curly-spacing.html"
 			}
 		],
-		"flint": {
-			"name": "templateCurlySpaces",
-			"plugin": "vue",
-			"status": "skipped"
-		},
 		"notes": "Formatting rule."
 	},
 	{
+		"flint": {
+			"name": "templateDepthLimits",
+			"plugin": "vue",
+			"preset": "stylistic"
+		},
 		"eslint": [
 			{
 				"name": "vue/max-template-depth",
 				"url": "https://eslint.vuejs.org/rules/max-template-depth.html"
 			}
-		],
-		"flint": {
-			"name": "templateDepthLimits",
-			"plugin": "vue",
-			"preset": "stylistic"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "templateForKeys",
+			"plugin": "vue",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "vue/no-v-for-template-key",
 				"url": "https://eslint.vuejs.org/rules/no-v-for-template-key.html"
 			}
-		],
-		"flint": {
-			"name": "templateForKeys",
-			"plugin": "vue",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "templateKeys",
+			"plugin": "vue",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "vue/no-template-key",
 				"url": "https://eslint.vuejs.org/rules/no-template-key.html"
 			}
-		],
-		"flint": {
-			"name": "templateKeys",
-			"plugin": "vue",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "templateLiterals",
+			"plugin": "vue",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "vue/no-literals-in-template",
 				"url": "https://eslint.vuejs.org/rules/no-literals-in-template.html"
 			}
-		],
-		"flint": {
-			"name": "templateLiterals",
-			"plugin": "vue",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "templateRefs",
+			"plugin": "vue",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "vue/prefer-use-template-ref",
 				"url": "https://eslint.vuejs.org/rules/prefer-use-template-ref.html"
 			}
-		],
-		"flint": {
-			"name": "templateRefs",
-			"plugin": "vue",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "templateRootMultiplicity",
+			"plugin": "vue",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "vue/no-multiple-template-root",
 				"url": "https://eslint.vuejs.org/rules/no-multiple-template-root.html"
 			}
-		],
-		"flint": {
-			"name": "templateRootMultiplicity",
-			"plugin": "vue",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "templateRootValidity",
+			"plugin": "vue",
+			"preset": "logical"
+		},
 		"biome": [
 			{
 				"name": "useVueValidTemplateRoot",
@@ -35147,93 +35152,93 @@
 				"name": "vue/valid-template-root",
 				"url": "https://eslint.vuejs.org/rules/valid-template-root.html"
 			}
-		],
-		"flint": {
-			"name": "templateRootValidity",
-			"plugin": "vue",
-			"preset": "logical"
-		}
+		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "vue/no-template-shadow",
-				"url": "https://eslint.vuejs.org/rules/no-template-shadow.html"
-			}
-		],
 		"flint": {
 			"name": "templateShadows",
 			"plugin": "vue",
 			"preset": "logical",
 			"strictness": "strict"
-		}
+		},
+		"eslint": [
+			{
+				"name": "vue/no-template-shadow",
+				"url": "https://eslint.vuejs.org/rules/no-template-shadow.html"
+			}
+		]
 	},
 	{
+		"flint": {
+			"name": "templateStrings",
+			"plugin": "vue",
+			"preset": "stylistic"
+		},
 		"eslint": [
 			{
 				"name": "vue/prefer-template",
 				"url": "https://eslint.vuejs.org/rules/prefer-template.html"
 			}
-		],
-		"flint": {
-			"name": "templateStrings",
-			"plugin": "vue",
-			"preset": "stylistic"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "templateTargetBlanks",
+			"plugin": "vue",
+			"preset": "security"
+		},
 		"eslint": [
 			{
 				"name": "vue/no-template-target-blank",
 				"url": "https://eslint.vuejs.org/rules/no-template-target-blank.html"
 			}
-		],
-		"flint": {
-			"name": "templateTargetBlanks",
-			"plugin": "vue",
-			"preset": "security"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "templateVForOnChildren",
+			"plugin": "vue",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "vue/no-v-for-template-key-on-child",
 				"url": "https://eslint.vuejs.org/rules/no-v-for-template-key-on-child.html"
 			}
-		],
-		"flint": {
-			"name": "templateVForOnChildren",
-			"plugin": "vue",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "textareaMustacheChildren",
+			"plugin": "vue",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "vue/no-textarea-mustache",
 				"url": "https://eslint.vuejs.org/rules/no-textarea-mustache.html"
 			}
-		],
-		"flint": {
-			"name": "textareaMustacheChildren",
-			"plugin": "vue",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "textDirectives",
+			"plugin": "vue",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "vue/no-v-text",
 				"url": "https://eslint.vuejs.org/rules/no-v-text.html"
 			}
-		],
-		"flint": {
-			"name": "textDirectives",
-			"plugin": "vue",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "textDirectiveValidity",
+			"plugin": "vue",
+			"preset": "logical"
+		},
 		"biome": [
 			{
 				"name": "useVueValidVText",
@@ -35245,92 +35250,87 @@
 				"name": "vue/valid-v-text",
 				"url": "https://eslint.vuejs.org/rules/valid-v-text.html"
 			}
-		],
-		"flint": {
-			"name": "textDirectiveValidity",
-			"plugin": "vue",
-			"preset": "logical"
-		}
+		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "vue/this-in-template",
-				"url": "https://eslint.vuejs.org/rules/this-in-template.html"
-			}
-		],
 		"flint": {
 			"name": "thisInTemplates",
 			"plugin": "vue",
 			"preset": "logical",
 			"strictness": "strict"
-		}
+		},
+		"eslint": [
+			{
+				"name": "vue/this-in-template",
+				"url": "https://eslint.vuejs.org/rules/this-in-template.html"
+			}
+		]
 	},
 	{
+		"flint": {
+			"name": "trailingCommas",
+			"plugin": "vue",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "vue/comma-dangle",
 				"url": "https://eslint.vuejs.org/rules/comma-dangle.html"
 			}
 		],
-		"flint": {
-			"name": "trailingCommas",
-			"plugin": "vue",
-			"status": "skipped"
-		},
 		"notes": "Formatting rule."
 	},
 	{
+		"flint": {
+			"name": "transitionToggles",
+			"plugin": "vue",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "vue/require-toggle-inside-transition",
 				"url": "https://eslint.vuejs.org/rules/require-toggle-inside-transition.html"
 			}
-		],
-		"flint": {
-			"name": "transitionToggles",
-			"plugin": "vue",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "trueAttributeShorthands",
+			"plugin": "vue",
+			"preset": "stylistic"
+		},
 		"eslint": [
 			{
 				"name": "vue/prefer-true-attribute-shorthand",
 				"url": "https://eslint.vuejs.org/rules/prefer-true-attribute-shorthand.html"
 			}
-		],
-		"flint": {
-			"name": "trueAttributeShorthands",
-			"plugin": "vue",
-			"preset": "stylistic"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "typedObjectProps",
+			"plugin": "vue",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "vue/require-typed-object-prop",
 				"url": "https://eslint.vuejs.org/rules/require-typed-object-prop.html"
 			}
-		],
-		"flint": {
-			"name": "typedObjectProps",
-			"plugin": "vue",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "typedRefs",
+			"plugin": "vue",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "vue/require-typed-ref",
 				"url": "https://eslint.vuejs.org/rules/require-typed-ref.html"
 			}
 		],
-		"flint": {
-			"name": "typedRefs",
-			"plugin": "vue",
-			"preset": "logical"
-		},
 		"oxlint": [
 			{
 				"name": "vue/require-typed-ref",
@@ -35339,230 +35339,235 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "unaryOperatorSpaces",
+			"plugin": "vue",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "vue/space-unary-ops",
 				"url": "https://eslint.vuejs.org/rules/space-unary-ops.html"
 			}
 		],
-		"flint": {
-			"name": "unaryOperatorSpaces",
-			"plugin": "vue",
-			"status": "skipped"
-		},
 		"notes": "Formatting rule."
 	},
 	{
+		"flint": {
+			"name": "undefinedComponents",
+			"plugin": "vue",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "vue/no-undef-components",
 				"url": "https://eslint.vuejs.org/rules/no-undef-components.html"
 			}
-		],
-		"flint": {
-			"name": "undefinedComponents",
-			"plugin": "vue",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "undefinedDirectives",
+			"plugin": "vue",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "vue/no-undef-directives",
 				"url": "https://eslint.vuejs.org/rules/no-undef-directives.html"
 			}
-		],
-		"flint": {
-			"name": "undefinedDirectives",
-			"plugin": "vue",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "undefinedProperties",
+			"plugin": "vue",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "vue/no-undef-properties",
 				"url": "https://eslint.vuejs.org/rules/no-undef-properties.html"
 			}
-		],
-		"flint": {
-			"name": "undefinedProperties",
-			"plugin": "vue",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "unnecessaryBindDirectives",
+			"plugin": "vue",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "vue/no-useless-v-bind",
 				"url": "https://eslint.vuejs.org/rules/no-useless-v-bind.html"
 			}
-		],
-		"flint": {
-			"name": "unnecessaryBindDirectives",
-			"plugin": "vue",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "unnecessaryConcatenations",
+			"plugin": "vue",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "vue/no-useless-concat",
 				"url": "https://eslint.vuejs.org/rules/no-useless-concat.html"
 			}
-		],
-		"flint": {
-			"name": "unnecessaryConcatenations",
-			"plugin": "vue",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "unnecessaryMustaches",
+			"plugin": "vue",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "vue/no-useless-mustaches",
 				"url": "https://eslint.vuejs.org/rules/no-useless-mustaches.html"
 			}
-		],
-		"flint": {
-			"name": "unnecessaryMustaches",
-			"plugin": "vue",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "unnecessaryParentheses",
+			"plugin": "vue",
+			"preset": "stylistic"
+		},
 		"eslint": [
 			{
 				"name": "vue/no-extra-parens",
 				"url": "https://eslint.vuejs.org/rules/no-extra-parens.html"
 			}
-		],
-		"flint": {
-			"name": "unnecessaryParentheses",
-			"plugin": "vue",
-			"preset": "stylistic"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "unnecessaryTemplateAttributes",
+			"plugin": "vue",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "vue/no-useless-template-attributes",
 				"url": "https://eslint.vuejs.org/rules/no-useless-template-attributes.html"
 			}
-		],
-		"flint": {
-			"name": "unnecessaryTemplateAttributes",
-			"plugin": "vue",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "unsupportedFeatures",
+			"plugin": "vue",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "vue/no-unsupported-features",
 				"url": "https://eslint.vuejs.org/rules/no-unsupported-features.html"
 			}
-		],
-		"flint": {
-			"name": "unsupportedFeatures",
-			"plugin": "vue",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "unusedComponents",
+			"plugin": "vue",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "vue/no-unused-components",
 				"url": "https://eslint.vuejs.org/rules/no-unused-components.html"
 			}
-		],
-		"flint": {
-			"name": "unusedComponents",
-			"plugin": "vue",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "unusedEmitDeclarations",
+			"plugin": "vue",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "vue/no-unused-emit-declarations",
 				"url": "https://eslint.vuejs.org/rules/no-unused-emit-declarations.html"
 			}
-		],
-		"flint": {
-			"name": "unusedEmitDeclarations",
-			"plugin": "vue",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "unusedProperties",
+			"plugin": "vue",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "vue/no-unused-properties",
 				"url": "https://eslint.vuejs.org/rules/no-unused-properties.html"
 			}
-		],
-		"flint": {
-			"name": "unusedProperties",
-			"plugin": "vue",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "unusedRefs",
+			"plugin": "vue",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "vue/no-unused-refs",
 				"url": "https://eslint.vuejs.org/rules/no-unused-refs.html"
 			}
-		],
-		"flint": {
-			"name": "unusedRefs",
-			"plugin": "vue",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "unusedVariables",
+			"plugin": "vue",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "vue/no-unused-vars",
 				"url": "https://eslint.vuejs.org/rules/no-unused-vars.html"
 			}
-		],
-		"flint": {
-			"name": "unusedVariables",
-			"plugin": "vue",
-			"preset": "logical"
-		}
+		]
 	},
 	{
-		"biome": [
-			{
-				"name": "useVueVapor",
-				"url": "https://biomejs.dev/linter/rules/use-vue-vapor"
-			}
-		],
 		"flint": {
 			"name": "vapor",
 			"plugin": "vue",
 			"preset": "stylistic",
 			"strictness": "strict"
-		}
+		},
+		"biome": [
+			{
+				"name": "useVueVapor",
+				"url": "https://biomejs.dev/linter/rules/use-vue-vapor"
+			}
+		]
 	},
 	{
-		"eslint": [
-			{
-				"name": "vue/no-v-html",
-				"url": "https://eslint.vuejs.org/rules/no-v-html.html"
-			}
-		],
 		"flint": {
 			"name": "vHtmlDirectives",
 			"plugin": "vue",
 			"preset": "logical",
 			"strictness": "strict"
-		}
+		},
+		"eslint": [
+			{
+				"name": "vue/no-v-html",
+				"url": "https://eslint.vuejs.org/rules/no-v-html.html"
+			}
+		]
 	},
 	{
+		"flint": {
+			"name": "vIfsWithVFors",
+			"plugin": "vue",
+			"preset": "logical"
+		},
 		"biome": [
 			{
 				"name": "noVueVIfWithVFor",
@@ -35574,25 +35579,20 @@
 				"name": "vue/no-use-v-if-with-v-for",
 				"url": "https://eslint.vuejs.org/rules/no-use-v-if-with-v-for.html"
 			}
-		],
-		"flint": {
-			"name": "vIfsWithVFors",
-			"plugin": "vue",
-			"preset": "logical"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "vuePackageImports",
+			"plugin": "vue",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "vue/prefer-import-from-vue",
 				"url": "https://eslint.vuejs.org/rules/prefer-import-from-vue.html"
 			}
 		],
-		"flint": {
-			"name": "vuePackageImports",
-			"plugin": "vue",
-			"preset": "logical"
-		},
 		"oxlint": [
 			{
 				"name": "vue/prefer-import-from-vue",
@@ -35601,17 +35601,17 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "watchAfterAwaits",
+			"plugin": "vue",
+			"preset": "logical"
+		},
 		"eslint": [
 			{
 				"name": "vue/no-watch-after-await",
 				"url": "https://eslint.vuejs.org/rules/no-watch-after-await.html"
 			}
 		],
-		"flint": {
-			"name": "watchAfterAwaits",
-			"plugin": "vue",
-			"preset": "logical"
-		},
 		"oxlint": [
 			{
 				"name": "vue/no-watch-after-await",
@@ -35620,6 +35620,11 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "watchArrowFunctions",
+			"plugin": "vue",
+			"preset": "logical"
+		},
 		"biome": [
 			{
 				"name": "noVueArrowFuncInWatch",
@@ -35632,11 +35637,6 @@
 				"url": "https://eslint.vuejs.org/rules/no-arrow-functions-in-watch.html"
 			}
 		],
-		"flint": {
-			"name": "watchArrowFunctions",
-			"plugin": "vue",
-			"preset": "logical"
-		},
 		"oxlint": [
 			{
 				"name": "vue/no-arrow-functions-in-watch",
@@ -35645,390 +35645,390 @@
 		]
 	},
 	{
+		"flint": {
+			"name": "blockMappingColonIndicatorNewlines",
+			"plugin": "yaml",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "yml/block-mapping-colon-indicator-newline",
 				"url": "https://ota-meshi.github.io/eslint-plugin-yml/rules/block-mapping-colon-indicator-newline.html"
 			}
 		],
-		"flint": {
-			"name": "blockMappingColonIndicatorNewlines",
-			"plugin": "yaml",
-			"status": "skipped"
-		},
 		"notes": "Formatting rule."
 	},
 	{
+		"flint": {
+			"name": "blockMappingQuestionIndicatorNewlines",
+			"plugin": "yaml",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "yml/block-mapping-question-indicator-newline",
 				"url": "https://ota-meshi.github.io/eslint-plugin-yml/rules/block-mapping-question-indicator-newline.html"
 			}
 		],
-		"flint": {
-			"name": "blockMappingQuestionIndicatorNewlines",
-			"plugin": "yaml",
-			"status": "skipped"
-		},
 		"notes": "Formatting rule."
 	},
 	{
-		"eslint": [
-			{
-				"name": "yml/block-mapping",
-				"url": "https://ota-meshi.github.io/eslint-plugin-yml/rules/block-mapping.html"
-			}
-		],
 		"flint": {
 			"name": "blockMappings",
 			"plugin": "yaml",
 			"preset": "stylistic",
 			"status": "implemented"
-		}
+		},
+		"eslint": [
+			{
+				"name": "yml/block-mapping",
+				"url": "https://ota-meshi.github.io/eslint-plugin-yml/rules/block-mapping.html"
+			}
+		]
 	},
 	{
+		"flint": {
+			"name": "blockSequenceHyphenIndicatorNewlines",
+			"plugin": "yaml",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "yml/block-sequence-hyphen-indicator-newline",
 				"url": "https://ota-meshi.github.io/eslint-plugin-yml/rules/block-sequence-hyphen-indicator-newline.html"
 			}
 		],
-		"flint": {
-			"name": "blockSequenceHyphenIndicatorNewlines",
-			"plugin": "yaml",
-			"status": "skipped"
-		},
 		"notes": "Formatting rule."
 	},
 	{
-		"eslint": [
-			{
-				"name": "yml/block-sequence",
-				"url": "https://ota-meshi.github.io/eslint-plugin-yml/rules/block-sequence.html"
-			}
-		],
 		"flint": {
 			"name": "blockSequences",
 			"plugin": "yaml",
 			"preset": "stylistic",
 			"status": "implemented"
-		}
-	},
-	{
+		},
 		"eslint": [
 			{
-				"name": "yml/no-empty-document",
-				"url": "https://ota-meshi.github.io/eslint-plugin-yml/rules/no-empty-document.html"
+				"name": "yml/block-sequence",
+				"url": "https://ota-meshi.github.io/eslint-plugin-yml/rules/block-sequence.html"
 			}
-		],
+		]
+	},
+	{
 		"flint": {
 			"name": "emptyDocuments",
 			"plugin": "yaml",
 			"preset": "logical",
 			"status": "implemented"
-		}
-	},
-	{
+		},
 		"eslint": [
 			{
-				"name": "yml/no-empty-key",
-				"url": "https://ota-meshi.github.io/eslint-plugin-yml/rules/no-empty-key.html"
+				"name": "yml/no-empty-document",
+				"url": "https://ota-meshi.github.io/eslint-plugin-yml/rules/no-empty-document.html"
 			}
-		],
+		]
+	},
+	{
 		"flint": {
 			"name": "emptyMappingKeys",
 			"plugin": "yaml",
 			"preset": "logical",
 			"status": "implemented"
-		}
-	},
-	{
+		},
 		"eslint": [
 			{
-				"name": "yml/no-empty-mapping-value",
-				"url": "https://ota-meshi.github.io/eslint-plugin-yml/rules/no-empty-mapping-value.html"
+				"name": "yml/no-empty-key",
+				"url": "https://ota-meshi.github.io/eslint-plugin-yml/rules/no-empty-key.html"
 			}
-		],
+		]
+	},
+	{
 		"flint": {
 			"name": "emptyMappingValues",
 			"plugin": "yaml",
 			"preset": "logical",
 			"status": "implemented"
-		}
-	},
-	{
+		},
 		"eslint": [
 			{
-				"name": "yml/no-empty-sequence-entry",
-				"url": "https://ota-meshi.github.io/eslint-plugin-yml/rules/no-empty-sequence-entry.html"
+				"name": "yml/no-empty-mapping-value",
+				"url": "https://ota-meshi.github.io/eslint-plugin-yml/rules/no-empty-mapping-value.html"
 			}
-		],
+		]
+	},
+	{
 		"flint": {
 			"name": "emptySequenceEntries",
 			"plugin": "yaml",
 			"preset": "logical",
 			"status": "implemented"
-		}
-	},
-	{
+		},
 		"eslint": [
 			{
-				"name": "yml/file-extension",
-				"url": "https://ota-meshi.github.io/eslint-plugin-yml/rules/file-extension.html"
+				"name": "yml/no-empty-sequence-entry",
+				"url": "https://ota-meshi.github.io/eslint-plugin-yml/rules/no-empty-sequence-entry.html"
 			}
-		],
+		]
+	},
+	{
 		"flint": {
 			"name": "fileExtensions",
 			"plugin": "yaml",
 			"preset": "stylistic",
 			"status": "implemented",
 			"strictness": "strict"
-		}
+		},
+		"eslint": [
+			{
+				"name": "yml/file-extension",
+				"url": "https://ota-meshi.github.io/eslint-plugin-yml/rules/file-extension.html"
+			}
+		]
 	},
 	{
+		"flint": {
+			"name": "flowMappingCurlyNewlines",
+			"plugin": "yaml",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "yml/flow-mapping-curly-newline",
 				"url": "https://ota-meshi.github.io/eslint-plugin-yml/rules/flow-mapping-curly-newline.html"
 			}
 		],
-		"flint": {
-			"name": "flowMappingCurlyNewlines",
-			"plugin": "yaml",
-			"status": "skipped"
-		},
 		"notes": "Formatting rule."
 	},
 	{
+		"flint": {
+			"name": "flowMappingCurlySpacing",
+			"plugin": "yaml",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "yml/flow-mapping-curly-spacing",
 				"url": "https://ota-meshi.github.io/eslint-plugin-yml/rules/flow-mapping-curly-spacing.html"
 			}
 		],
-		"flint": {
-			"name": "flowMappingCurlySpacing",
-			"plugin": "yaml",
-			"status": "skipped"
-		},
 		"notes": "Formatting rule."
 	},
 	{
+		"flint": {
+			"name": "flowSequenceBracketNewlines",
+			"plugin": "yaml",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "yml/flow-sequence-bracket-newline",
 				"url": "https://ota-meshi.github.io/eslint-plugin-yml/rules/flow-sequence-bracket-newline.html"
 			}
 		],
-		"flint": {
-			"name": "flowSequenceBracketNewlines",
-			"plugin": "yaml",
-			"status": "skipped"
-		},
 		"notes": "Formatting rule."
 	},
 	{
+		"flint": {
+			"name": "flowSequenceBracketSpacing",
+			"plugin": "yaml",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "yml/flow-sequence-bracket-spacing",
 				"url": "https://ota-meshi.github.io/eslint-plugin-yml/rules/flow-sequence-bracket-spacing.html"
 			}
 		],
-		"flint": {
-			"name": "flowSequenceBracketSpacing",
-			"plugin": "yaml",
-			"status": "skipped"
-		},
 		"notes": "Formatting rule."
 	},
 	{
+		"flint": {
+			"name": "indentation",
+			"plugin": "yaml",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "yml/indent",
 				"url": "https://ota-meshi.github.io/eslint-plugin-yml/rules/indent.html"
 			}
 		],
-		"flint": {
-			"name": "indentation",
-			"plugin": "yaml",
-			"status": "skipped"
-		},
 		"notes": "Formatting rule."
 	},
 	{
+		"flint": {
+			"name": "irregularWhitespace",
+			"plugin": "yaml",
+			"preset": "stylistic"
+		},
 		"eslint": [
 			{
 				"name": "yml/no-irregular-whitespace",
 				"url": "https://ota-meshi.github.io/eslint-plugin-yml/rules/no-irregular-whitespace.html"
 			}
-		],
-		"flint": {
-			"name": "irregularWhitespace",
-			"plugin": "yaml",
-			"preset": "stylistic"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "keySpacing",
+			"plugin": "yaml",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "yml/key-spacing",
 				"url": "https://ota-meshi.github.io/eslint-plugin-yml/rules/key-spacing.html"
 			}
 		],
-		"flint": {
-			"name": "keySpacing",
-			"plugin": "yaml",
-			"status": "skipped"
-		},
 		"notes": "Formatting rule."
 	},
 	{
+		"flint": {
+			"name": "mappingKeyCasing",
+			"plugin": "yaml",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "yml/key-name-casing",
 				"url": "https://ota-meshi.github.io/eslint-plugin-yml/rules/key-name-casing.html"
 			}
-		],
-		"flint": {
-			"name": "mappingKeyCasing",
-			"plugin": "yaml",
-			"status": "skipped"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "multipleEmptyLines",
+			"plugin": "yaml"
+		},
 		"eslint": [
 			{
 				"name": "yml/no-multiple-empty-lines",
 				"url": "https://ota-meshi.github.io/eslint-plugin-yml/rules/no-multiple-empty-lines.html"
 			}
 		],
-		"flint": {
-			"name": "multipleEmptyLines",
-			"plugin": "yaml"
-		},
 		"notes": "Formatting rule."
 	},
 	{
-		"eslint": [
-			{
-				"name": "yml/no-trailing-zeros",
-				"url": "https://ota-meshi.github.io/eslint-plugin-yml/rules/no-trailing-zeros.html"
-			}
-		],
 		"flint": {
 			"name": "numericTrailingZeros",
 			"plugin": "yaml",
 			"preset": "stylistic",
 			"status": "implemented",
 			"strictness": "strict"
-		}
-	},
-	{
+		},
 		"eslint": [
 			{
-				"name": "yml/plain-scalar",
-				"url": "https://ota-meshi.github.io/eslint-plugin-yml/rules/plain-scalar.html"
+				"name": "yml/no-trailing-zeros",
+				"url": "https://ota-meshi.github.io/eslint-plugin-yml/rules/no-trailing-zeros.html"
 			}
-		],
+		]
+	},
+	{
 		"flint": {
 			"name": "plainScalars",
 			"plugin": "yaml",
 			"preset": "stylistic",
 			"status": "implemented",
 			"strictness": "strict"
-		}
+		},
+		"eslint": [
+			{
+				"name": "yml/plain-scalar",
+				"url": "https://ota-meshi.github.io/eslint-plugin-yml/rules/plain-scalar.html"
+			}
+		]
 	},
 	{
+		"flint": {
+			"name": "quotes",
+			"plugin": "yaml"
+		},
 		"eslint": [
 			{
 				"name": "yml/quotes",
 				"url": "https://ota-meshi.github.io/eslint-plugin-yml/rules/quotes.html"
 			}
 		],
-		"flint": {
-			"name": "quotes",
-			"plugin": "yaml"
-		},
 		"notes": "Formatting rule."
 	},
 	{
+		"flint": {
+			"name": "spacedComments",
+			"plugin": "yaml",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "yml/spaced-comment",
 				"url": "https://ota-meshi.github.io/eslint-plugin-yml/rules/spaced-comment.html"
 			}
 		],
-		"flint": {
-			"name": "spacedComments",
-			"plugin": "yaml",
-			"status": "skipped"
-		},
 		"notes": "Formatting rule."
 	},
 	{
-		"eslint": [
-			{
-				"name": "yml/require-string-key",
-				"url": "https://ota-meshi.github.io/eslint-plugin-yml/rules/require-string-key.html"
-			}
-		],
 		"flint": {
 			"name": "stringMappingKeys",
 			"plugin": "yaml",
 			"preset": "logical",
 			"status": "implemented",
 			"strictness": "strict"
-		}
+		},
+		"eslint": [
+			{
+				"name": "yml/require-string-key",
+				"url": "https://ota-meshi.github.io/eslint-plugin-yml/rules/require-string-key.html"
+			}
+		]
 	},
 	{
+		"flint": {
+			"name": "tabIndents",
+			"plugin": "yaml",
+			"status": "skipped"
+		},
 		"eslint": [
 			{
 				"name": "yml/no-tab-indent",
 				"url": "https://ota-meshi.github.io/eslint-plugin-yml/rules/no-tab-indent.html"
 			}
 		],
-		"flint": {
-			"name": "tabIndents",
-			"plugin": "yaml",
-			"status": "skipped"
-		},
 		"notes": "Formatting rule."
 	},
 	{
+		"flint": {
+			"name": "vueCustomBlockParsingErrors",
+			"plugin": "yaml"
+		},
 		"eslint": [
 			{
 				"name": "yml/vue-custom-block/no-parsing-error",
 				"url": "https://ota-meshi.github.io/eslint-plugin-yml/rules/vue-custom-block/no-parsing-error.html"
 			}
-		],
-		"flint": {
-			"name": "vueCustomBlockParsingErrors",
-			"plugin": "yaml"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "yamlKeysOrder",
+			"plugin": "yaml"
+		},
 		"eslint": [
 			{
 				"name": "yml/sort-keys",
 				"url": "https://ota-meshi.github.io/eslint-plugin-yml/rules/sort-keys.html"
 			}
-		],
-		"flint": {
-			"name": "yamlKeysOrder",
-			"plugin": "yaml"
-		}
+		]
 	},
 	{
+		"flint": {
+			"name": "yamlSequenceValuesOrder",
+			"plugin": "yaml",
+			"preset": "sorting"
+		},
 		"eslint": [
 			{
 				"name": "yml/sort-sequence-values",
 				"url": "https://ota-meshi.github.io/eslint-plugin-yml/rules/sort-sequence-values.html"
 			}
-		],
-		"flint": {
-			"name": "yamlSequenceValuesOrder",
-			"plugin": "yaml",
-			"preset": "sorting"
-		}
+		]
 	}
 ]

--- a/packages/comparisons/src/data.schema.json
+++ b/packages/comparisons/src/data.schema.json
@@ -10,7 +10,7 @@
 		"properties": {
 			"flint": {
 				"type": "object",
-				"required": ["name"],
+				"required": ["name", "plugin"],
 				"additionalProperties": false,
 				"properties": {
 					"name": {

--- a/packages/comparisons/src/index.ts
+++ b/packages/comparisons/src/index.ts
@@ -1,4 +1,9 @@
-export * from "./comparisons.ts";
-export * from "./getRuleForPlugin.ts";
+export {
+	comparisons,
+	getComparisonId,
+	type LinterName,
+	linterNames,
+} from "./comparisons.ts";
+export { getRuleForPlugin, getRuleForPluginSafe } from "./getRuleForPlugin.ts";
 
-export type { Comparison, FlintRuleReference, LinterName } from "./schemas.ts";
+export type { Comparison, FlintRuleReference } from "./schemas.ts";

--- a/packages/comparisons/src/index.ts
+++ b/packages/comparisons/src/index.ts
@@ -6,4 +6,8 @@ export {
 } from "./comparisons.ts";
 export { getRuleForPlugin, getRuleForPluginSafe } from "./getRuleForPlugin.ts";
 
-export type { Comparison, FlintRuleReference } from "./schemas.ts";
+export {
+	type Comparison,
+	comparisonsDataSchema,
+	type FlintRuleReference,
+} from "./schemas.ts";

--- a/packages/comparisons/src/schemas.ts
+++ b/packages/comparisons/src/schemas.ts
@@ -1,47 +1,86 @@
 import { z } from "zod/v4";
 
-const linterNameSchema = z.union([
-	z.literal("biome"),
-	z.literal("deno"),
-	z.literal("eslint"),
-	z.literal("markdownlint"),
-	z.literal("oxlint"),
-	z.literal("stylelint"),
+const flintRulePluginSchema = z.union([
+	z.literal("astro"),
+	z.literal("browser"),
+	z.literal("css"),
+	z.literal("drizzle"),
+	z.literal("flint"),
+	z.literal("graphql"),
+	z.literal("json"),
+	z.literal("jest"),
+	z.literal("jsx"),
+	z.literal("md"),
+	z.literal("next"),
+	z.literal("node"),
+	z.literal("nuxt"),
+	z.literal("package-json"),
+	z.literal("performance"),
+	z.literal("playwright"),
+	z.literal("qwik"),
+	z.literal("react"),
+	z.literal("react-native"),
+	z.literal("security"),
+	z.literal("solid"),
+	z.literal("spelling"),
+	z.literal("svelte"),
+	z.literal("ts"),
+	z.literal("vitest"),
+	z.literal("vue"),
+	z.literal("yaml"),
 ]);
 
-export type LinterName = z.infer<typeof linterNameSchema>;
-
-const flintRuleStatusSchema = z.union([
-	z.literal("implemented"),
-	z.literal("skipped"),
+const flintRulePresetSchema = z.union([
+	z.literal("config"),
+	z.literal("javascript"),
+	z.literal("logical"),
+	z.literal("none"),
+	z.literal("security"),
+	z.literal("sorting"),
+	z.literal("stylistic"),
 ]);
 
-const flintRuleReferenceSchema = z.object({
-	name: linterNameSchema,
-	plugin: z.string(),
-	preset: z.string(),
-	status: flintRuleStatusSchema.optional(),
-	strictness: z.string().optional(),
-});
+const flintRuleReferenceSchema = z.union([
+	z
+		.object({
+			name: z.string().min(1),
+			plugin: flintRulePluginSchema,
+			status: z.literal("skipped"),
+		})
+		.strict(),
+	z
+		.object({
+			name: z.string().min(1),
+			plugin: flintRulePluginSchema,
+			preset: flintRulePresetSchema.optional(),
+			status: z.literal(["implemented"]).optional(),
+			strictness: z.literal("strict").optional(),
+		})
+		.strict(),
+]);
 
 export type FlintRuleReference = z.infer<typeof flintRuleReferenceSchema>;
 
-const linterRuleReferenceSchema = z.object({
-	name: z.string(),
-	url: z.string(),
-});
-
-const comparisonSchema = z.object({
-	biome: z.array(linterRuleReferenceSchema).optional(),
-	deno: z.array(linterRuleReferenceSchema).optional(),
-	eslint: z.array(linterRuleReferenceSchema).optional(),
-	flint: flintRuleReferenceSchema,
-	markdownlint: z.array(linterRuleReferenceSchema).optional(),
-	notes: z.string().optional(),
-	oxlint: z.array(linterRuleReferenceSchema).optional(),
-	stylelint: z.array(linterRuleReferenceSchema).optional(),
-});
+const linterRuleReferenceSchema = z
+	.object({
+		name: z.string(),
+		url: z.url(),
+	})
+	.strict();
 
 export type Comparison = z.infer<typeof comparisonSchema>;
+
+const comparisonSchema = z
+	.object({
+		biome: z.array(linterRuleReferenceSchema).optional(),
+		deno: z.array(linterRuleReferenceSchema).optional(),
+		eslint: z.array(linterRuleReferenceSchema).optional(),
+		flint: flintRuleReferenceSchema,
+		markdownlint: z.array(linterRuleReferenceSchema).optional(),
+		notes: z.string().optional(),
+		oxlint: z.array(linterRuleReferenceSchema).optional(),
+		stylelint: z.array(linterRuleReferenceSchema).optional(),
+	})
+	.strict();
 
 export const comparisonsDataSchema = z.array(comparisonSchema);

--- a/packages/comparisons/src/schemas.ts
+++ b/packages/comparisons/src/schemas.ts
@@ -1,3 +1,17 @@
+/* eslint perfectionist/sort-objects: ["error", {
+	customGroups: [
+		{
+			groupName: "flint",
+			elementNamePattern: "^flint$",
+		},
+		{
+			groupName: "notes",
+			elementNamePattern: "^notes$",
+		},
+	],
+	groups: ["flint", "unknown", "notes"],
+}] */
+
 import { z } from "zod/v4";
 
 const flintRulePluginSchema = z.union([
@@ -72,14 +86,14 @@ export type Comparison = z.infer<typeof comparisonSchema>;
 
 const comparisonSchema = z
 	.object({
+		flint: flintRuleReferenceSchema,
 		biome: z.array(linterRuleReferenceSchema).optional(),
 		deno: z.array(linterRuleReferenceSchema).optional(),
 		eslint: z.array(linterRuleReferenceSchema).optional(),
-		flint: flintRuleReferenceSchema,
 		markdownlint: z.array(linterRuleReferenceSchema).optional(),
-		notes: z.string().optional(),
 		oxlint: z.array(linterRuleReferenceSchema).optional(),
 		stylelint: z.array(linterRuleReferenceSchema).optional(),
+		notes: z.string().optional(),
 	})
 	.strict();
 

--- a/packages/comparisons/src/sort-data.ts
+++ b/packages/comparisons/src/sort-data.ts
@@ -1,13 +1,24 @@
 import fs from "node:fs/promises";
 import path from "node:path";
-import { isDeepStrictEqual } from "node:util";
-
-import prettier from "prettier";
+import process from "node:process";
+import { isDeepStrictEqual, parseArgs } from "node:util";
 
 import dataOriginal from "./data.json" with { type: "json" };
 import { comparisonsDataSchema } from "./schemas.ts";
 
 const dataFilePath = path.join(import.meta.dirname, "data.json");
+
+const {
+	values: { check },
+} = parseArgs({
+	options: {
+		check: {
+			default: false,
+			short: "c",
+			type: "boolean",
+		},
+	},
+});
 
 const dataSorted = comparisonsDataSchema
 	.parse(dataOriginal)
@@ -17,13 +28,20 @@ const dataSorted = comparisonsDataSchema
 			: a.flint.plugin.localeCompare(b.flint.plugin),
 	);
 
-if (!isDeepStrictEqual(dataOriginal, dataSorted)) {
-	console.log("Writing to:", dataFilePath);
-	await fs.writeFile(
-		dataFilePath,
-		await prettier.format(JSON.stringify(dataSorted, null, 2), {
-			parser: "json",
-			...(await prettier.resolveConfig(dataFilePath)),
-		}),
-	);
+const dirty = !isDeepStrictEqual(dataOriginal, dataSorted);
+
+if (dirty) {
+	if (check) {
+		console.log(`File unsorted: ${dataFilePath}`);
+
+		process.exitCode = 1;
+	} else {
+		console.log(`Writing to: ${dataFilePath}`);
+		await fs.writeFile(
+			dataFilePath,
+			JSON.stringify(dataSorted, null, "	") + "\n",
+		);
+	}
+} else {
+	console.log(`File sorted correctly: ${dataFilePath}`);
 }

--- a/packages/comparisons/tsconfig.json
+++ b/packages/comparisons/tsconfig.json
@@ -1,21 +1,8 @@
 {
 	"extends": "@flint.fyi/build/tsconfig.base.json",
-	"compilerOptions": {
-		"tsBuildInfoFile": "node_modules/.cache/tsbuild/info.json",
-		"rootDir": "src/",
-		"outDir": "lib/",
-		"types": ["node"]
-	},
-	"include": ["src", "src/data.json"],
+	"include": [],
 	"references": [
-		{ "path": "../astro" },
-		{ "path": "../browser" },
-		{ "path": "../flint" },
-		{ "path": "../jsx" },
-		{ "path": "../node" },
-		{ "path": "../performance" },
-		{ "path": "../plugin-flint" },
-		{ "path": "../spelling" },
-		{ "path": "../vitest" }
+		{ "path": "./tsconfig.src.json" },
+		{ "path": "./tsconfig.test.json" }
 	]
 }

--- a/packages/comparisons/tsconfig.src.json
+++ b/packages/comparisons/tsconfig.src.json
@@ -1,0 +1,22 @@
+{
+	"compilerOptions": {
+		"tsBuildInfoFile": "node_modules/.cache/tsbuild/info.json",
+		"rootDir": "src/",
+		"outDir": "lib/",
+		"types": ["node"]
+	},
+	"extends": "@flint.fyi/build/tsconfig.base.json",
+	"include": ["src", "src/data.json"],
+	"exclude": ["src/**/*.test.ts"],
+	"references": [
+		{ "path": "../astro" },
+		{ "path": "../browser" },
+		{ "path": "../flint" },
+		{ "path": "../jsx" },
+		{ "path": "../node" },
+		{ "path": "../performance" },
+		{ "path": "../plugin-flint" },
+		{ "path": "../spelling" },
+		{ "path": "../vitest" }
+	]
+}

--- a/packages/comparisons/tsconfig.test.json
+++ b/packages/comparisons/tsconfig.test.json
@@ -1,0 +1,11 @@
+{
+	"compilerOptions": {
+		"tsBuildInfoFile": "node_modules/.cache/tsbuild/info.test.json",
+		"rootDir": "src/",
+		"outDir": "node_modules/.cache/tsbuild/test",
+		"types": ["node"]
+	},
+	"extends": "@flint.fyi/build/tsconfig.base.json",
+	"include": ["src/**/*.test.ts"],
+	"references": [{ "path": "./tsconfig.src.json" }]
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -147,6 +147,7 @@ export type {
 } from "./types/shapes.ts";
 export type { WithExitKeys } from "./types/visitors.ts";
 export { binarySearch } from "./utils/arrays.ts";
+export { jsonCodec } from "./utils/codecs.ts";
 export {
 	getColumnAndLineOfPosition,
 	getPositionOfColumnAndLine,

--- a/packages/site/src/components/RulesTable.tsx
+++ b/packages/site/src/components/RulesTable.tsx
@@ -35,7 +35,7 @@ function renderFlintPlugin(flint: FlintRuleReference) {
 }
 
 function renderFlintPreset(flint: FlintRuleReference) {
-	if (!flint.preset) {
+	if (flint.status === "skipped" || !flint.preset) {
 		return <td className={styles.noneCell}>(none)</td>;
 	}
 

--- a/packages/site/src/components/createRuleComparator.ts
+++ b/packages/site/src/components/createRuleComparator.ts
@@ -10,15 +10,15 @@ export function createRuleComparator(sortBy?: RuleSortBy): RuleComparator {
 	}
 
 	return (a, b) => {
+		if (a.flint.status === "skipped" || !a.flint.preset) {
+			return 1;
+		}
+
+		if (b.flint.status === "skipped" || !b.flint.preset) {
+			return -1;
+		}
+
 		if (a.flint.preset !== b.flint.preset) {
-			if (!a.flint.preset) {
-				return 1;
-			}
-
-			if (!b.flint.preset) {
-				return -1;
-			}
-
 			return a.flint.preset.localeCompare(b.flint.preset);
 		}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -825,8 +825,8 @@ importers:
         specifier: 3.17.1
         version: 3.17.1(eslint@10.7.0)(svelte@5.56.2)
       eslint-plugin-unicorn:
-        specifier: 64.0.0
-        version: 64.0.0(eslint@10.7.0)
+        specifier: 72.0.0
+        version: 72.0.0(eslint@10.7.0)
       eslint-plugin-vue:
         specifier: 10.9.1
         version: 10.9.1(@typescript-eslint/parser@8.64.0)(eslint@10.7.0)(vue-eslint-parser@10.4.1)
@@ -2845,6 +2845,10 @@ packages:
     resolution: {integrity: sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
+  '@eslint/css-tree@4.0.5':
+    resolution: {integrity: sha512-iPmijIAq4hlIJB86PYmY/fcZORHtjphSqICDbwuw32A/JmkhZQ/K/6TjHE03zqf3n5yABpVcbRAMG8Mi9ojy8g==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
   '@eslint/eslintrc@3.3.5':
     resolution: {integrity: sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -4411,10 +4415,6 @@ packages:
   cjs-module-lexer@1.4.3:
     resolution: {integrity: sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==}
 
-  clean-regexp@1.0.0:
-    resolution: {integrity: sha512-GfisEZEJvzKrmGWkvfhgzcz/BllN1USeqD2V6tg14OAOgaCD2Z/PUEuxnAZ/nPvmaHRG7a8y77p1T/IRQ4D1Hw==}
-    engines: {node: '>=4'}
-
   cli-cursor@5.0.0:
     resolution: {integrity: sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==}
     engines: {node: '>=18'}
@@ -4470,6 +4470,10 @@ packages:
   console-fail-test@0.6.1:
     resolution: {integrity: sha512-KxgTskG1eCVCKB6f3XuM3lkzuM+0ASGCPVLIJU8r6Lv6lzCCk4FEoYkHJubEnUKzqHAQNVl1lw5UOyufTTILjg==}
     engines: {node: '>=20.19.0'}
+
+  convert-hrtime@5.0.0:
+    resolution: {integrity: sha512-lOETlkIeYSJWcbbcvjRKGxVMXJR+8+OQb/mTPbA4ObPMytYIsUbuOE0Jzy60hjARYszq1id0j8KgVhC+WGZVTg==}
+    engines: {node: '>=12'}
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
@@ -4810,10 +4814,6 @@ packages:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
 
-  escape-string-regexp@1.0.5:
-    resolution: {integrity: sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==}
-    engines: {node: '>=0.8.0'}
-
   escape-string-regexp@4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
@@ -4995,11 +4995,11 @@ packages:
       svelte:
         optional: true
 
-  eslint-plugin-unicorn@64.0.0:
-    resolution: {integrity: sha512-rNZwalHh8i0UfPlhNwg5BTUO1CMdKNmjqe+TgzOTZnpKoi8VBgsW7u9qCHIdpxEzZ1uwrJrPF0uRb7l//K38gA==}
-    engines: {node: ^20.10.0 || >=21.0.0}
+  eslint-plugin-unicorn@72.0.0:
+    resolution: {integrity: sha512-hqO6ksoOHO+ZhdseTuKRVQbx9U7PRO/cv8qAR1mctwzdVO2hYud8uS9luAhp43RJgziYgHAph8eHyipT8GL0ng==}
+    engines: {node: '>=22'}
     peerDependencies:
-      eslint: '>=9.38.0'
+      eslint: '>=10.4'
 
   eslint-plugin-vue@10.9.1:
     resolution: {integrity: sha512-cHB0Tf4Duvzwecwd/AqWzZvF/QszE13BhjVUpVXWCy9AeMR5GjkAjP3i85vqgLgOuTmkHR1OJ5oMeqLHtuw8zg==}
@@ -5284,6 +5284,10 @@ packages:
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
 
+  function-timeout@1.0.2:
+    resolution: {integrity: sha512-939eZS4gJ3htTHAldmyyuzlrD58P03fHG49v2JfFXbV6OhvZKRC9j2yAtdHw/zrp2zXHuv05zMIy40F0ge7spA==}
+    engines: {node: '>=18'}
+
   function.prototype.name@1.1.8:
     resolution: {integrity: sha512-e5iwyodOHhbMr/yNrc7fDYG4qlbIvI5gajyzPnb5TCwyhjApznQh1BMFou9b30SevY43gCJKXycoCBjMbsuW0Q==}
     engines: {node: '>= 0.4'}
@@ -5544,6 +5548,10 @@ packages:
     resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
     engines: {node: '>=0.10.0'}
 
+  identifier-regex@1.1.0:
+    resolution: {integrity: sha512-SLX4H/vtcYlYnL7XqnuJKHU7Z8517TgsW9nmQiGOgMCjQ8V/deLYu6bEmbGoXe7WMMhc9+EUGyFFneHja8KabA==}
+    engines: {node: '>=18'}
+
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
     engines: {node: '>= 4'}
@@ -5682,6 +5690,10 @@ packages:
   is-html@2.0.0:
     resolution: {integrity: sha512-S+OpgB5i7wzIue/YSE5hg0e5ZYfG3hhpNh9KGl6ayJ38p7ED6wxQLd1TV91xHpcTvw90KMJ9EwN3F/iNflHBVg==}
     engines: {node: '>=8'}
+
+  is-identifier@1.1.0:
+    resolution: {integrity: sha512-NhOds0mDx9lJu+1lBRO0xbwFo5nobA7GCk/0e5xjr6+6XugX985+0OyGX35BNrTkPAsdLcIKg02HUQJOK8D8kw==}
+    engines: {node: '>=18'}
 
   is-inside-container@1.0.0:
     resolution: {integrity: sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==}
@@ -6046,6 +6058,10 @@ packages:
   magicast@0.5.2:
     resolution: {integrity: sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==}
 
+  make-asynchronous@1.1.0:
+    resolution: {integrity: sha512-ayF7iT+44LXdxJLTrTd3TLQpFDDvPCBxXxbv+pMUSuHA5Q8zyAfwkRP6aHHwNVFBUFWtxAHqwNJxF8vMZLAbVg==}
+    engines: {node: '>=18'}
+
   make-dir@4.0.0:
     resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
     engines: {node: '>=10'}
@@ -6137,6 +6153,9 @@ packages:
 
   mdn-data@2.27.1:
     resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
+
+  mdn-data@2.29.0:
+    resolution: {integrity: sha512-pVxQFCcaYUEAH853+v7yoI/qzhxXSq1bTb9obMYGYAN1c3Hen+XDCEvr296XhstrwlSTNgOR7mCSD4JPjbJe5A==}
 
   mdurl@2.0.0:
     resolution: {integrity: sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==}
@@ -6445,6 +6464,10 @@ packages:
       vite-plus:
         optional: true
 
+  p-event@6.0.1:
+    resolution: {integrity: sha512-Q6Bekk5wpzW5qIyUP4gdMEujObYstZl6DMMOSenwBvV0BlE5LkDwkjs5yHbZmdCEq2o4RJx4tE1vwxFVf2FG1w==}
+    engines: {node: '>=16.17'}
+
   p-filter@2.1.0:
     resolution: {integrity: sha512-ZBxxZ5sL2HghephhpGAQdoskxplTwr7ICaehZwLIlfL6acuVgZPm8yBNuRAFBGEqtD/hmUeq9eqLg2ys9Xr/yw==}
     engines: {node: '>=8'}
@@ -6476,6 +6499,10 @@ packages:
   p-queue@9.1.2:
     resolution: {integrity: sha512-ktsDOALzTYTWWF1PbkNVg2rOt+HaOaMWJMUnt7T3qf5tvZ1L8dBW3tObzprBcXNMKkwj+yFSLqHso0x+UFcJXw==}
     engines: {node: '>=20'}
+
+  p-timeout@6.1.4:
+    resolution: {integrity: sha512-MyIV3ZA/PmyBN/ud8vV9XzwTrNtR4jFrObymZYnZqMmW0zA8Z17vnT0rBgFE/TlohB+YCHqXMgZzb3Csp49vqg==}
+    engines: {node: '>=14.16'}
 
   p-timeout@7.0.1:
     resolution: {integrity: sha512-AxTM2wDGORHGEkPCt8yqxOTMgpfbEHqF51f/5fJCmwFC3C/zNcGT63SymH2ttOAaiIws2zVg4+izQCjrakcwHg==}
@@ -6705,6 +6732,10 @@ packages:
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
 
+  quote-js-string@0.1.0:
+    resolution: {integrity: sha512-Y3NoRtprEEZQD8RfxMCfS0ZTqc4e+i18OrXEXAvpM6TfC/3y+0L5rNbZiSnbBBEkDfFzbpd8o+cE8q3/anjMGA==}
+    engines: {node: '>=22'}
+
   radix3@1.1.2:
     resolution: {integrity: sha512-b484I/7b8rDEdSDKckSSBA8knMpcdsXudlE/LNL639wFoHKwLbEkQFZHWEYwDC0wa0FKUcCY+GAF73Z7wxNVFA==}
 
@@ -6778,10 +6809,6 @@ packages:
   regexp-ast-analysis@0.7.1:
     resolution: {integrity: sha512-sZuz1dYW/ZsfG17WSAG7eS85r5a0dDsvg+7BiiYR5o6lKCAtUrEwdmRmaGF6rwVj3LcmAeYkOWKEPlbPzN3Y3A==}
     engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
-
-  regexp-tree@0.1.27:
-    resolution: {integrity: sha512-iETxpjK6YoRWJG5o6hXLwvjYAoW+FEZn9os0PD/b6AP6xQwsa/Y7lCVgIixBbUPMfhu+i2LtdeAqVTgGlQarfA==}
-    hasBin: true
 
   regexp.prototype.flags@1.5.4:
     resolution: {integrity: sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==}
@@ -7229,6 +7256,10 @@ packages:
   suf-log@2.5.3:
     resolution: {integrity: sha512-KvC8OPjzdNOe+xQ4XWJV2whQA0aM1kGVczMQ8+dStAO6KfEB140JEVQ9dE76ONZ0/Ylf67ni4tILPJB41U0eow==}
 
+  super-regex@1.1.0:
+    resolution: {integrity: sha512-WHkws2ZflZe41zj6AolvvmaTrWds/VuyeYr9iPVv/oQeaIoVxMKaushfFWpOGDT+GuBrM/sVqF8KUCYQlSSTdQ==}
+    engines: {node: '>=18'}
+
   supports-color@10.2.2:
     resolution: {integrity: sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==}
     engines: {node: '>=18'}
@@ -7292,6 +7323,10 @@ packages:
   text-table-fast@0.1.0:
     resolution: {integrity: sha512-Oq4da1awNnp6yoj4lgfDrIvXPE3vqjwwK7NudaV0Ei+Y51cvAEZ66Ef64CqPayJjn55NshAtSoQ9elX7QroiaA==}
     engines: {node: '>=18'}
+
+  time-span@5.1.0:
+    resolution: {integrity: sha512-75voc/9G4rDIJleOo4jPvN4/YC4GRZrY8yy1uU4lwrB3XEQbWve8zXoO5No4eFrGcTAMYyoY67p8jRQdtA1HbA==}
+    engines: {node: '>=12'}
 
   tiny-inflate@1.0.3:
     resolution: {integrity: sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==}
@@ -7814,6 +7849,9 @@ packages:
 
   web-namespaces@2.0.1:
     resolution: {integrity: sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==}
+
+  web-worker@1.5.0:
+    resolution: {integrity: sha512-RiMReJrTAiA+mBjGONMnjVDP2u3p9R1vkcGz6gDIrOMT3oGuYwX2WRMYI9ipkphSuE5XKEhydbhNEJh4NY9mlw==}
 
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
@@ -9063,6 +9101,11 @@ snapshots:
   '@eslint/core@1.2.1':
     dependencies:
       '@types/json-schema': 7.0.15
+
+  '@eslint/css-tree@4.0.5':
+    dependencies:
+      mdn-data: 2.29.0
+      source-map-js: 1.2.1
 
   '@eslint/eslintrc@3.3.5':
     dependencies:
@@ -10605,10 +10648,6 @@ snapshots:
 
   cjs-module-lexer@1.4.3: {}
 
-  clean-regexp@1.0.0:
-    dependencies:
-      escape-string-regexp: 1.0.5
-
   cli-cursor@5.0.0:
     dependencies:
       restore-cursor: 5.1.0
@@ -10652,6 +10691,8 @@ snapshots:
   concat-map@0.0.1: {}
 
   console-fail-test@0.6.1: {}
+
+  convert-hrtime@5.0.0: {}
 
   convert-source-map@2.0.0: {}
 
@@ -11084,8 +11125,6 @@ snapshots:
 
   escalade@3.2.0: {}
 
-  escape-string-regexp@1.0.5: {}
-
   escape-string-regexp@4.0.0: {}
 
   escape-string-regexp@5.0.0: {}
@@ -11364,25 +11403,29 @@ snapshots:
     transitivePeerDependencies:
       - ts-node
 
-  eslint-plugin-unicorn@64.0.0(eslint@10.7.0):
+  eslint-plugin-unicorn@72.0.0(eslint@10.7.0):
     dependencies:
-      '@babel/helper-validator-identifier': 7.29.7
       '@eslint-community/eslint-utils': 4.9.1(eslint@10.7.0)
+      '@eslint/css-tree': 4.0.5
+      browserslist: 4.28.5
       change-case: 5.4.4
       ci-info: 4.4.0
-      clean-regexp: 1.0.0
       core-js-compat: 3.49.0
+      detect-indent: 7.0.2
+      entities: 4.5.0
       eslint: 10.7.0(jiti@2.7.0)
       find-up-simple: 1.0.1
       globals: 17.7.0
       indent-string: 5.0.0
       is-builtin-module: 5.0.0
-      jsesc: 3.1.0
+      is-identifier: 1.1.0
       pluralize: 8.0.0
-      regexp-tree: 0.1.27
+      quote-js-string: 0.1.0
       regjsparser: 0.13.2
+      reserved-identifiers: 1.2.0
       semver: 7.8.5
       strip-indent: 4.1.1
+      yaml: 2.9.0
 
   eslint-plugin-vue@10.9.1(@typescript-eslint/parser@8.64.0)(eslint@10.7.0)(vue-eslint-parser@10.4.1):
     dependencies:
@@ -11756,6 +11799,8 @@ snapshots:
 
   function-bind@1.1.2: {}
 
+  function-timeout@1.0.2: {}
+
   function.prototype.name@1.1.8:
     dependencies:
       call-bind: 1.0.9
@@ -12127,6 +12172,10 @@ snapshots:
     dependencies:
       safer-buffer: 2.1.2
 
+  identifier-regex@1.1.0:
+    dependencies:
+      reserved-identifiers: 1.2.0
+
   ignore@5.3.2: {}
 
   ignore@7.0.5: {}
@@ -12248,6 +12297,11 @@ snapshots:
   is-html@2.0.0:
     dependencies:
       html-tags: 3.3.1
+
+  is-identifier@1.1.0:
+    dependencies:
+      identifier-regex: 1.1.0
+      super-regex: 1.1.0
 
   is-inside-container@1.0.0:
     dependencies:
@@ -12581,6 +12635,12 @@ snapshots:
       '@babel/types': 7.29.0
       source-map-js: 1.2.1
 
+  make-asynchronous@1.1.0:
+    dependencies:
+      p-event: 6.0.1
+      type-fest: 4.41.0
+      web-worker: 1.5.0
+
   make-dir@4.0.0:
     dependencies:
       semver: 7.8.5
@@ -12825,6 +12885,8 @@ snapshots:
   mdn-data@2.0.28: {}
 
   mdn-data@2.27.1: {}
+
+  mdn-data@2.29.0: {}
 
   mdurl@2.0.0: {}
 
@@ -13359,6 +13421,10 @@ snapshots:
       '@oxlint/binding-win32-ia32-msvc': 1.69.0
       '@oxlint/binding-win32-x64-msvc': 1.69.0
 
+  p-event@6.0.1:
+    dependencies:
+      p-timeout: 6.1.4
+
   p-filter@2.1.0:
     dependencies:
       p-map: 2.1.0
@@ -13389,6 +13455,8 @@ snapshots:
     dependencies:
       eventemitter3: 5.0.4
       p-timeout: 7.0.1
+
+  p-timeout@6.1.4: {}
 
   p-timeout@7.0.1: {}
 
@@ -13585,6 +13653,8 @@ snapshots:
 
   queue-microtask@1.2.3: {}
 
+  quote-js-string@0.1.0: {}
+
   radix3@1.1.2: {}
 
   react-dom@19.2.4(react@19.2.4):
@@ -13681,8 +13751,6 @@ snapshots:
     dependencies:
       '@eslint-community/regexpp': 4.12.2
       refa: 0.12.1
-
-  regexp-tree@0.1.27: {}
 
   regexp.prototype.flags@1.5.4:
     dependencies:
@@ -14331,6 +14399,12 @@ snapshots:
     dependencies:
       s.color: 0.0.15
 
+  super-regex@1.1.0:
+    dependencies:
+      function-timeout: 1.0.2
+      make-asynchronous: 1.1.0
+      time-span: 5.1.0
+
   supports-color@10.2.2: {}
 
   supports-color@7.2.0:
@@ -14410,6 +14484,10 @@ snapshots:
       supports-hyperlinks: 4.4.0
 
   text-table-fast@0.1.0: {}
+
+  time-span@5.1.0:
+    dependencies:
+      convert-hrtime: 5.0.0
 
   tiny-inflate@1.0.3: {}
 
@@ -14881,6 +14959,8 @@ snapshots:
   walk-up-path@4.0.0: {}
 
   web-namespaces@2.0.1: {}
+
+  web-worker@1.5.0: {}
 
   webidl-conversions@3.0.1: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -739,9 +739,6 @@ importers:
       '@flint.fyi/yaml':
         specifier: workspace:^
         version: link:../yaml
-      prettier:
-        specifier: 3.8.1
-        version: 3.8.1
       zod:
         specifier: ^4.3.6
         version: 4.4.1

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,7 @@
 	"include": [
 		"./@types/*/*.ts",
 		"./*.ts",
+		"./packages/*/scripts/*.ts",
 		"./packages/*/tsdown.config.ts",
 		"./scripts/*.ts"
 	],


### PR DESCRIPTION
## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [`status: accepting prs`](https://github.com/flint-fyi/flint/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [ ] Steps in [CONTRIBUTING.md](https://github.com/flint-fyi/flint/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Update eslint-plugin-unicorn to v72 and add comparison coverage for every rule it exports.

This adds 193 Unicorn rule references, merging 38 semantic duplicates into existing Flint concepts and adding 155 standalone concepts.
Of those standalone concepts, 142 are planned for implementation and 13 convention, formatting, or threshold rules are skipped.
It also replaces the renamed `unicorn/no-array-for-each` reference, bringing comparison coverage to 341 of 341 exported rules.

Closes #3108.

---

<sub>Stacked on #3130.</sub>