### PR TITLE
feat(ts): add unnecessary computed keys rule

### DIFF
--- a/.changeset/tidy-keys-appear.md
+++ b/.changeset/tidy-keys-appear.md
@@ -1,0 +1,5 @@
+---
+"@flint.fyi/ts": patch
+---
+
+Added the type-aware `unnecessaryComputedKeys` rule to report computed keys with safely removable literal-valued expressions.

--- a/packages/rule-data/src/data.json
+++ b/packages/rule-data/src/data.json
@@ -28711,7 +28711,8 @@
 		"flint": {
 			"name": "unnecessaryComputedKeys",
 			"plugin": "ts",
-			"preset": "stylistic"
+			"preset": "stylistic",
+			"status": "implemented"
 		},
 		"oxlint": [
 			{

--- a/packages/site/src/content/docs/rules/ts/unnecessaryComputedKeys.mdx
+++ b/packages/site/src/content/docs/rules/ts/unnecessaryComputedKeys.mdx
@@ -1,0 +1,79 @@
+---
+description: "Reports computed property keys that can be written as literal property names."
+title: "unnecessaryComputedKeys"
+topic: "rules"
+---
+
+import { TabItem, Tabs } from "@astrojs/starlight/components";
+import { RuleEquivalents } from "~/components/RuleEquivalents";
+import RuleSummary from "~/components/RuleSummary.astro";
+
+<RuleSummary plugin="ts" rule="unnecessaryComputedKeys" />
+
+Computed property syntax is useful when evaluating an expression determines a property name.
+It adds unnecessary punctuation when TypeScript knows that a safe expression has one string or number value.
+
+This rule uses TypeScript's type information, so it recognizes literal-valued constants and type-preserving wrappers in addition to literal syntax.
+It does not report expressions whose evaluation could have side effects, even when their return type is a single literal.
+
+## Examples
+
+<Tabs>
+<TabItem label="❌ Incorrect">
+
+```ts
+const settings = { ["theme"]: "dark" };
+```
+
+```ts
+const statusKey = "status" as const;
+const record = { [statusKey]: "ready" };
+```
+
+```ts
+class Registry {
+	["lookup"]() {}
+}
+```
+
+</TabItem>
+<TabItem label="✅ Correct">
+
+```ts
+const settings = { theme: "dark" };
+```
+
+```ts
+const statusKey = "status" as const;
+const record = { status: "ready" };
+```
+
+```ts
+declare function getKey(): "dynamic";
+const record = { [getKey()]: true };
+```
+
+```ts
+const object = { ["__proto__"]: prototype };
+```
+
+</TabItem>
+</Tabs>
+
+The last two examples preserve computed syntax because removing a function call can remove observable evaluation and because an object initializer's literal `__proto__` data property has special prototype-setting semantics.
+The rule also preserves class keys where literal `constructor` or `prototype` syntax would change or invalidate the class member.
+
+## When Not To Use It
+
+Do not use this rule when a project intentionally keeps computed syntax to emphasize that keys originate from shared constants, even when those constants currently have singleton literal types.
+It may also be unsuitable during a large migration where changing property spelling would create excessive formatting churn.
+
+## Further Reading
+
+- [MDN: Object initializer](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Object_initializer)
+- [MDN: Public class fields](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes/Public_class_fields)
+- [MDN: Classes](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes)
+
+## Equivalents in Other Linters
+
+<RuleEquivalents pluginId="ts" ruleId="unnecessaryComputedKeys" />

--- a/packages/ts/src/plugin.ts
+++ b/packages/ts/src/plugin.ts
@@ -289,6 +289,7 @@ import unnecessaryBlocks from "./rules/unnecessaryBlocks.ts";
 import unnecessaryBooleanCasts from "./rules/unnecessaryBooleanCasts.ts";
 import unnecessaryCatches from "./rules/unnecessaryCatches.ts";
 import unnecessaryComparisons from "./rules/unnecessaryComparisons.ts";
+import unnecessaryComputedKeys from "./rules/unnecessaryComputedKeys.ts";
 import unnecessaryConcatenation from "./rules/unnecessaryConcatenation.ts";
 import unnecessaryEscapes from "./rules/unnecessaryEscapes.ts";
 import unnecessaryMathClamps from "./rules/unnecessaryMathClamps.ts";
@@ -603,6 +604,7 @@ export const ts = createPlugin({
 		unnecessaryBooleanCasts,
 		unnecessaryCatches,
 		unnecessaryComparisons,
+		unnecessaryComputedKeys,
 		unnecessaryConcatenation,
 		unnecessaryEscapes,
 		unnecessaryMathClamps,

--- a/packages/ts/src/rules/unnecessaryComputedKeys.test.ts
+++ b/packages/ts/src/rules/unnecessaryComputedKeys.test.ts
@@ -1,0 +1,261 @@
+/* eslint-disable no-useless-escape */
+import { ruleTester } from "./ruleTester.ts";
+import rule from "./unnecessaryComputedKeys.ts";
+
+ruleTester.describe(rule, {
+	invalid: [
+		{
+			code: `
+const text = {
+    ["name"]: 1,
+    [("parenthesized")]: 2,
+    [\`template\`]: 3,
+    [\`\`]: 4,
+    [12]: 5,
+    [-1]: 6,
+    [-0]: 7,
+    [1e999]: 8,
+};
+`,
+			output: `
+const text = {
+    "name": 1,
+    "parenthesized": 2,
+    "template": 3,
+    "": 4,
+    12: 5,
+    "-1": 6,
+    0: 7,
+    "Infinity": 8,
+};
+`,
+			snapshot: `
+const text = {
+    ["name"]: 1,
+    ~~~~~~~~
+    This computed key has the single literal value "name".
+    [("parenthesized")]: 2,
+    ~~~~~~~~~~~~~~~~~~~
+    This computed key has the single literal value "parenthesized".
+    [\`template\`]: 3,
+    ~~~~~~~~~~~~
+    This computed key has the single literal value "template".
+    [\`\`]: 4,
+    ~~~~
+    This computed key has the single literal value "".
+    [12]: 5,
+    ~~~~
+    This computed key has the single literal value 12.
+    [-1]: 6,
+    ~~~~
+    This computed key has the single literal value "-1".
+    [-0]: 7,
+    ~~~~
+    This computed key has the single literal value 0.
+    [1e999]: 8,
+    ~~~~~~~
+    This computed key has the single literal value "Infinity".
+};
+`,
+		},
+		{
+			code: `
+const stringKey = "quoted\\\"\\\\\\n\\u2028\\u2029" as const;
+const numberKey = 42 as const;
+const values = {
+    [stringKey]: 1,
+    [numberKey!]: 2,
+    [("asserted" as const) satisfies string]: 3,
+    [<"angled">"angled"]: 4,
+};
+`,
+			output: `
+const stringKey = "quoted\\\"\\\\\\n\\u2028\\u2029" as const;
+const numberKey = 42 as const;
+const values = {
+    "quoted\\\"\\\\\\n\\u2028\\u2029": 1,
+    42: 2,
+    "asserted": 3,
+    "angled": 4,
+};
+`,
+			snapshot: `
+const stringKey = "quoted\\\"\\\\\\n\\u2028\\u2029" as const;
+const numberKey = 42 as const;
+const values = {
+    [stringKey]: 1,
+    ~~~~~~~~~~~
+    This computed key has the single literal value "quoted\\\"\\\\\\n\\u2028\\u2029".
+    [numberKey!]: 2,
+    ~~~~~~~~~~~~
+    This computed key has the single literal value 42.
+    [("asserted" as const) satisfies string]: 3,
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    This computed key has the single literal value "asserted".
+    [<"angled">"angled"]: 4,
+    ~~~~~~~~~~~~~~~~~~~~
+    This computed key has the single literal value "angled".
+};
+`,
+		},
+		{
+			code: `
+const object = {
+    ["method"]() {},
+    async ["async"]() {},
+    *["generator"]() {},
+    get ["getter"]() { return 1; },
+    set ["setter"](value: number) {},
+};
+const { ["binding"]: binding } = object;
+({ ["__proto__"]: binding } = object);
+({ nested: [{ ["__proto__"]: binding }] } = object);
+for ({ ["iterated"]: binding } of objects) {}
+for ({ ["enumerated"]: binding } in object) {}
+`,
+			output: `
+const object = {
+    "method"() {},
+    async "async"() {},
+    *"generator"() {},
+    get "getter"() { return 1; },
+    set "setter"(value: number) {},
+};
+const { "binding": binding } = object;
+({ "__proto__": binding } = object);
+({ nested: [{ "__proto__": binding }] } = object);
+for ({ "iterated": binding } of objects) {}
+for ({ "enumerated": binding } in object) {}
+`,
+			snapshot: `
+const object = {
+    ["method"]() {},
+    ~~~~~~~~~~
+    This computed key has the single literal value "method".
+    async ["async"]() {},
+          ~~~~~~~~~
+          This computed key has the single literal value "async".
+    *["generator"]() {},
+     ~~~~~~~~~~~~~
+     This computed key has the single literal value "generator".
+    get ["getter"]() { return 1; },
+        ~~~~~~~~~~
+        This computed key has the single literal value "getter".
+    set ["setter"](value: number) {},
+        ~~~~~~~~~~
+        This computed key has the single literal value "setter".
+};
+const { ["binding"]: binding } = object;
+        ~~~~~~~~~~~
+        This computed key has the single literal value "binding".
+({ ["__proto__"]: binding } = object);
+   ~~~~~~~~~~~~~
+   This computed key has the single literal value "__proto__".
+({ nested: [{ ["__proto__"]: binding }] } = object);
+              ~~~~~~~~~~~~~
+              This computed key has the single literal value "__proto__".
+for ({ ["iterated"]: binding } of objects) {}
+       ~~~~~~~~~~~~
+       This computed key has the single literal value "iterated".
+for ({ ["enumerated"]: binding } in object) {}
+       ~~~~~~~~~~~~~~
+       This computed key has the single literal value "enumerated".
+`,
+		},
+		{
+			code: `
+class Container {
+    static ["constructor"]() {}
+    ["prototype"]() {}
+    get ["constructor"]() { return 1; }
+    set ["prototype"](value: number) {}
+    static get ["constructor"]() { return 1; }
+    static set ["constructor"](value: number) {}
+    ["prototype"] = 1;
+}
+interface Shape {
+    ["property"]: string;
+    ["method"](): void;
+}
+`,
+			output: `
+class Container {
+    static "constructor"() {}
+    "prototype"() {}
+    get "constructor"() { return 1; }
+    set "prototype"(value: number) {}
+    static get "constructor"() { return 1; }
+    static set "constructor"(value: number) {}
+    "prototype" = 1;
+}
+interface Shape {
+    "property": string;
+    "method"(): void;
+}
+`,
+			snapshot: `
+class Container {
+    static ["constructor"]() {}
+           ~~~~~~~~~~~~~~~
+           This computed key has the single literal value "constructor".
+    ["prototype"]() {}
+    ~~~~~~~~~~~~~
+    This computed key has the single literal value "prototype".
+    get ["constructor"]() { return 1; }
+        ~~~~~~~~~~~~~~~
+        This computed key has the single literal value "constructor".
+    set ["prototype"](value: number) {}
+        ~~~~~~~~~~~~~
+        This computed key has the single literal value "prototype".
+    static get ["constructor"]() { return 1; }
+               ~~~~~~~~~~~~~~~
+               This computed key has the single literal value "constructor".
+    static set ["constructor"](value: number) {}
+               ~~~~~~~~~~~~~~~
+               This computed key has the single literal value "constructor".
+    ["prototype"] = 1;
+    ~~~~~~~~~~~~~
+    This computed key has the single literal value "prototype".
+}
+interface Shape {
+    ["property"]: string;
+    ~~~~~~~~~~~~
+    This computed key has the single literal value "property".
+    ["method"](): void;
+    ~~~~~~~~~~
+    This computed key has the single literal value "method".
+}
+`,
+		},
+		{
+			code: `
+const comments = { [/* keep */ "block"]: 1, [// keep
+"line"]: 2 };
+`,
+			snapshot: `
+const comments = { [/* keep */ "block"]: 1, [// keep
+                   ~~~~~~~~~~~~~~~~~~~~
+                   This computed key has the single literal value "block".
+                                            ~~~~~~~~
+                                            This computed key has the single literal value "line".
+"line"]: 2 };
+~~~~~~~
+`,
+		},
+	],
+	valid: [
+		`const key: string = "wide"; const value = { [key]: 1 };`,
+		`const key: "first" | "second" = condition ? "first" : "second"; const value = { [key]: 1 };`,
+		`const values = { [true]: 1, [null]: 2, [1n]: 3 };`,
+		`declare const key: symbol; const value = { [key]: 1 };`,
+		`declare function key(): "called"; const value = { [key()]: 1 };`,
+		`declare const source: { key: "accessed" }; const value = { [source.key]: 1 };`,
+		`const value = { [(sideEffect(), "result")]: 1, [condition ? "a" : "a"]: 2 };`,
+		`const value = { [!0]: 1, [await key]: 2 };`,
+		`const value = { ["__proto__"]: prototype };`,
+		`class Value { ["constructor"]() {} ["constructor"] = 1; static ["constructor"] = 1; static ["prototype"]() {} static ["prototype"] = 1; static get ["prototype"]() { return 1; } static set ["prototype"](value: number) {} }`,
+		`const value = ({ ["__proto__"]: 1 }) + other;`,
+		`for (const key in { ["__proto__"]: 1 }) { consume(key); }`,
+		`enum Values { ["member"] = 1 }`,
+	],
+});

--- a/packages/ts/src/rules/unnecessaryComputedKeys.ts
+++ b/packages/ts/src/rules/unnecessaryComputedKeys.ts
@@ -1,0 +1,201 @@
+import ts, { SyntaxKind } from "typescript";
+
+import {
+	getTSNodeRange,
+	typescriptLanguage,
+	type AST,
+} from "@flint.fyi/typescript-language";
+
+import { ruleCreator } from "./ruleCreator.ts";
+import { countCommentsInRange } from "./utils/countCommentsInRange.ts";
+
+function formatKey(key: number | string) {
+	if (typeof key === "string") {
+		return JSON.stringify(key)
+			.replaceAll("\u2028", "\\u2028")
+			.replaceAll("\u2029", "\\u2029");
+	}
+
+	if (Number.isFinite(key) && key >= 0) {
+		return String(key);
+	}
+
+	return JSON.stringify(String(key));
+}
+
+function hasStaticModifier(node: ts.Node) {
+	return (
+		ts.canHaveModifiers(node) &&
+		ts
+			.getModifiers(node)
+			?.some((modifier) => modifier.kind === SyntaxKind.StaticKeyword)
+	);
+}
+
+function isAssignmentPattern(objectLiteral: AST.ObjectLiteralExpression) {
+	let current: ts.Node = objectLiteral;
+
+	while (true) {
+		const parent = current.parent;
+		if (ts.isBinaryExpression(parent)) {
+			return (
+				parent.operatorToken.kind === SyntaxKind.EqualsToken &&
+				parent.left === current
+			);
+		}
+
+		if (ts.isForInStatement(parent) || ts.isForOfStatement(parent)) {
+			return parent.initializer === current;
+		}
+
+		switch (parent.kind) {
+			case SyntaxKind.ArrayLiteralExpression:
+				current = parent;
+				break;
+
+			case SyntaxKind.ObjectLiteralExpression:
+				current = parent;
+				break;
+
+			case SyntaxKind.PropertyAssignment:
+				current = parent;
+				break;
+
+			default:
+				return false;
+		}
+	}
+}
+
+function isEvaluationSafe(node: AST.Expression): boolean {
+	switch (node.kind) {
+		case SyntaxKind.AsExpression:
+		case SyntaxKind.NonNullExpression:
+		case SyntaxKind.ParenthesizedExpression:
+		case SyntaxKind.SatisfiesExpression:
+			return isEvaluationSafe(node.expression);
+
+		case SyntaxKind.Identifier:
+		case SyntaxKind.NoSubstitutionTemplateLiteral:
+		case SyntaxKind.NumericLiteral:
+		case SyntaxKind.StringLiteral:
+			return true;
+		case SyntaxKind.PrefixUnaryExpression:
+			return (
+				(node.operator === SyntaxKind.MinusToken ||
+					node.operator === SyntaxKind.PlusToken) &&
+				isEvaluationSafe(node.operand)
+			);
+
+		case SyntaxKind.TypeAssertionExpression:
+			return isEvaluationSafe(node.expression);
+
+		default:
+			return false;
+	}
+}
+
+function isSupportedParent(node: AST.ComputedPropertyName) {
+	switch (node.parent.kind) {
+		case SyntaxKind.BindingElement:
+			return node.parent.propertyName === node;
+
+		case SyntaxKind.GetAccessor:
+		case SyntaxKind.MethodDeclaration:
+		case SyntaxKind.MethodSignature:
+		case SyntaxKind.PropertyAssignment:
+		case SyntaxKind.PropertyDeclaration:
+		case SyntaxKind.PropertySignature:
+		case SyntaxKind.SetAccessor:
+			return node.parent.name === node;
+		default:
+			return false;
+	}
+}
+
+function preservesSemantics(
+	node: AST.ComputedPropertyName,
+	key: number | string,
+) {
+	const parent = node.parent;
+	if (parent.kind === SyntaxKind.PropertyAssignment && key === "__proto__") {
+		return !isAssignmentPattern(parent.parent);
+	}
+
+	if (
+		parent.kind !== SyntaxKind.GetAccessor &&
+		parent.kind !== SyntaxKind.MethodDeclaration &&
+		parent.kind !== SyntaxKind.PropertyDeclaration &&
+		parent.kind !== SyntaxKind.SetAccessor
+	) {
+		return false;
+	}
+
+	if (
+		parent.parent.kind !== SyntaxKind.ClassDeclaration &&
+		parent.parent.kind !== SyntaxKind.ClassExpression
+	) {
+		return false;
+	}
+
+	const isStatic = !!hasStaticModifier(parent);
+	if (key === "prototype" && isStatic) {
+		return true;
+	}
+
+	return (
+		key === "constructor" &&
+		(parent.kind === SyntaxKind.PropertyDeclaration ||
+			(parent.kind === SyntaxKind.MethodDeclaration && !isStatic))
+	);
+}
+
+export default ruleCreator.createRule(typescriptLanguage, {
+	about: {
+		description:
+			"Reports computed property keys that can be written as literal property names.",
+		id: "unnecessaryComputedKeys",
+		presets: ["stylistic"],
+	},
+	messages: {
+		unnecessaryComputedKey: {
+			primary: "This computed key has the single literal value {{ key }}.",
+			secondary: [
+				"Literal property names express the same key without computed-name syntax.",
+			],
+			suggestions: ["Write the key as the literal property name {{ key }}."],
+		},
+	},
+	setup(context) {
+		return {
+			visitors: {
+				ComputedPropertyName: (node, { sourceFile, typeChecker }) => {
+					if (!isSupportedParent(node) || !isEvaluationSafe(node.expression)) {
+						return;
+					}
+
+					const type = typeChecker.getTypeAtLocation(node.expression);
+					const key = type.isStringLiteral()
+						? type.value
+						: type.isNumberLiteral()
+							? type.value
+							: undefined;
+					if (key === undefined || preservesSemantics(node, key)) {
+						return;
+					}
+
+					const range = getTSNodeRange(node, sourceFile);
+					const replacement = formatKey(key);
+					context.report({
+						data: { key: replacement },
+						fix: countCommentsInRange(sourceFile.text, range)
+							? undefined
+							: { range, text: replacement },
+						message: "unnecessaryComputedKey",
+						range,
+					});
+				},
+			},
+		};
+	},
+});


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #2223
- [x] That issue was marked as [`status: accepting prs`](https://github.com/flint-fyi/flint/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/flint-fyi/flint/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Adds the type-aware `ts/unnecessaryComputedKeys` rule to report safely removable computed property keys with singleton string or number values.

The rule preserves computed syntax when evaluating the key might have side effects or when literal syntax would change `__proto__`, `constructor`, or static `prototype` semantics. It includes safe fixes, focused tests, documentation, plugin registration, rule-data integration, and a patch changeset.

❤️‍🔥