### PR TITLE
feat(ts): add unnecessary conditions rule

### DIFF
--- a/.changeset/bright-conditions-report.md
+++ b/.changeset/bright-conditions-report.md
@@ -1,0 +1,6 @@
+---
+"@flint.fyi/rule-data": patch
+"@flint.fyi/ts": patch
+---
+
+Add the checker-backed `ts/unnecessaryConditions` rule to report conditions with statically known outcomes.

--- a/packages/e2e/tests/directives/directives.test.ts
+++ b/packages/e2e/tests/directives/directives.test.ts
@@ -25,7 +25,7 @@ describe("directives", () => {
 
 			<red>✖ Found <bold>4 reports</bold> across <bold>3 files</bold>.</fg>
 			<red></fg>
-			<dim>Finished in <time> on 4 files with 139 rules.</fg>
+			<dim>Finished in <time> on 4 files with 140 rules.</fg>
 			<dim></fg>"
 		`);
 		// cspell:enable

--- a/packages/e2e/tests/typescript/fixtures/src/with-issues.ts
+++ b/packages/e2e/tests/typescript/fixtures/src/with-issues.ts
@@ -6,3 +6,7 @@ export function debug(value: unknown): void {
 export function calculate(a: number, b: number): number {
 	return a + b;
 }
+
+if (true) {
+	console.log("known condition");
+}

--- a/packages/e2e/tests/typescript/typescript.test.ts
+++ b/packages/e2e/tests/typescript/typescript.test.ts
@@ -13,11 +13,12 @@ describe("typescript", () => {
 			"<dim>Linting with <cyan><bold>flint.config.ts</bold></fg><dim>...</fg>
 
 			<underline><cwd>/fixtures/src/with-issues.ts</underline>
-			<dim>  2:2</fg>  Debugger statements should not be used in production code.  <yellow>ts/debuggerStatements</fg>
+			<dim>  2:2</fg>   Debugger statements should not be used in production code.  <yellow>ts/debuggerStatements</fg>
+			<dim>  10:5</fg>  This condition is always truthy.                            <yellow>ts/unnecessaryConditions</fg>
 
-			<red>✖ Found <bold>1 report</bold> across <bold>1 file</bold>.</fg>
+			<red>✖ Found <bold>2 reports</bold> across <bold>1 file</bold>.</fg>
 			<red></fg>
-			<dim>Finished in <time> on 2 files with 138 rules.</fg>
+			<dim>Finished in <time> on 2 files with 139 rules.</fg>
 			<dim></fg>"
 		`);
 	});

--- a/packages/rule-data/src/data.json
+++ b/packages/rule-data/src/data.json
@@ -28762,7 +28762,8 @@
 		"flint": {
 			"name": "unnecessaryConditions",
 			"plugin": "ts",
-			"preset": "logical"
+			"preset": "logical",
+			"status": "implemented"
 		},
 		"oxlint": [
 			{

--- a/packages/site/src/content/docs/rules/ts/unnecessaryConditions.mdx
+++ b/packages/site/src/content/docs/rules/ts/unnecessaryConditions.mdx
@@ -1,0 +1,75 @@
+---
+description: "Reports conditions whose outcomes are statically known."
+title: "unnecessaryConditions"
+topic: "rules"
+---
+
+import { TabItem, Tabs } from "@astrojs/starlight/components";
+import { RuleEquivalents } from "~/components/RuleEquivalents";
+import RuleSummary from "~/components/RuleSummary.astro";
+
+<RuleSummary plugin="ts" rule="unnecessaryConditions" />
+
+This checker-backed rule uses TypeScript's flow-narrowed types to find truthiness, nullability, comparisons, switch cases, optional chains, logical assignments, and built-in Array predicate callbacks whose results are known.
+It requires `strictNullChecks` so that the checker can distinguish nullish values from other values.
+
+## Examples
+
+<Tabs>
+<TabItem label="❌ Incorrect">
+
+```ts
+declare const label: string;
+
+if (label) {
+	console.log(label);
+}
+```
+
+```ts
+const settings = { theme: "dark" };
+const theme = settings?.theme;
+```
+
+</TabItem>
+<TabItem label="✅ Correct">
+
+```ts
+declare const label: string | undefined;
+
+if (label) {
+	console.log(label);
+}
+```
+
+```ts
+declare const settings: { theme: string } | undefined;
+const theme = settings?.theme;
+```
+
+</TabItem>
+</Tabs>
+
+Optional-chain diagnostics offer a suggestion that removes only the unnecessary `?.` token.
+The rule does not apply an unconditional fix because preserving evaluation and control-flow intent can require a larger edit.
+
+## Options
+
+This rule has no options.
+
+## When Not To Use It
+
+Do not use this rule in projects that cannot enable `strictNullChecks` or whose generated declarations do not accurately describe runtime nullability.
+The rule intentionally does not inspect arbitrary assertion calls or user-defined type-predicate calls, and it does not infer that unrelated object interfaces can never overlap.
+When `noUncheckedIndexedAccess` is disabled, it conservatively retains checks on array elements, dynamic tuple indexes, and index-signature accesses because those reads can produce `undefined` at runtime.
+
+## Rule Equivalents
+
+<RuleEquivalents plugin="ts" rule="unnecessaryConditions" />
+
+## Further Reading
+
+- [MDN: Truthy](https://developer.mozilla.org/en-US/docs/Glossary/Truthy)
+- [MDN: Falsy](https://developer.mozilla.org/en-US/docs/Glossary/Falsy)
+- [MDN: Optional chaining](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining)
+- [TypeScript: Narrowing](https://www.typescriptlang.org/docs/handbook/2/narrowing.html)

--- a/packages/site/src/content/docs/rules/ts/unnecessaryConditions.mdx
+++ b/packages/site/src/content/docs/rules/ts/unnecessaryConditions.mdx
@@ -65,7 +65,7 @@ When `noUncheckedIndexedAccess` is disabled, it conservatively retains checks on
 
 ## Rule Equivalents
 
-<RuleEquivalents plugin="ts" rule="unnecessaryConditions" />
+<RuleEquivalents pluginId="ts" ruleId="unnecessaryConditions" />
 
 ## Further Reading
 

--- a/packages/ts/src/plugin.ts
+++ b/packages/ts/src/plugin.ts
@@ -290,6 +290,7 @@ import unnecessaryBooleanCasts from "./rules/unnecessaryBooleanCasts.ts";
 import unnecessaryCatches from "./rules/unnecessaryCatches.ts";
 import unnecessaryComparisons from "./rules/unnecessaryComparisons.ts";
 import unnecessaryConcatenation from "./rules/unnecessaryConcatenation.ts";
+import unnecessaryConditions from "./rules/unnecessaryConditions.ts";
 import unnecessaryEscapes from "./rules/unnecessaryEscapes.ts";
 import unnecessaryMathClamps from "./rules/unnecessaryMathClamps.ts";
 import unnecessaryNumericFractions from "./rules/unnecessaryNumericFractions.ts";
@@ -604,6 +605,7 @@ export const ts = createPlugin({
 		unnecessaryCatches,
 		unnecessaryComparisons,
 		unnecessaryConcatenation,
+		unnecessaryConditions,
 		unnecessaryEscapes,
 		unnecessaryMathClamps,
 		unnecessaryNumericFractions,

--- a/packages/ts/src/rules/unnecessaryConditions.test.ts
+++ b/packages/ts/src/rules/unnecessaryConditions.test.ts
@@ -1,0 +1,565 @@
+// flint-disable-file flint/testCaseDuplicates
+// flint-disable-file flint/testCaseNonStaticCode
+
+import { createRuleTesterTSConfig } from "@flint.fyi/typescript-language";
+
+import { ruleTester } from "./ruleTester.ts";
+import rule from "./unnecessaryConditions.ts";
+
+function invalid(
+	line: string,
+	highlight: string,
+	message: string,
+	occurrence = 0,
+) {
+	let begin = -1;
+	for (let index = 0; index <= occurrence; index += 1) {
+		begin = line.indexOf(highlight, begin + 1);
+	}
+	return {
+		code: `
+${line}
+`,
+		snapshot: `
+${line}
+${" ".repeat(begin)}${"~".repeat(highlight.length)}
+${" ".repeat(begin)}${message}
+`,
+	};
+}
+
+const alwaysFalsy = "This condition is always falsy.";
+const alwaysTruthy = "This condition is always truthy.";
+const alwaysNullish = "This expression is always nullish.";
+const neverNullish = "This expression is never nullish.";
+
+ruleTester.describe(rule, {
+	invalid: [
+		invalid(`if (true) console.log("reachable");`, "true", alwaysTruthy),
+		invalid(`if (false) console.log("unreachable");`, "false", alwaysFalsy),
+		invalid(`const value = true ? 1 : 2;`, "true", alwaysTruthy),
+		invalid(`while (true) break;`, "true", alwaysTruthy),
+		invalid(`do {} while (false);`, "false", alwaysFalsy),
+		invalid(`for (; true;) break;`, "true", alwaysTruthy),
+		invalid(`if (!true) console.log("unreachable");`, "!true", alwaysFalsy),
+		invalid(`if (!false) console.log("reachable");`, "!false", alwaysTruthy),
+		invalid(`if (!!true) console.log("reachable");`, "!!true", alwaysTruthy),
+		invalid(`if ((true)) console.log("reachable");`, "(true)", alwaysTruthy),
+		invalid(
+			`if ("present") console.log("reachable");`,
+			`"present"`,
+			alwaysTruthy,
+		),
+		invalid(`if (0) console.log("unreachable");`, "0", alwaysFalsy),
+		invalid(`if (1n) console.log("reachable");`, "1n", alwaysTruthy),
+		invalid(
+			`declare function fail(): never; if (fail()) console.log("unreachable");`,
+			"fail()",
+			"This expression has type `never`.",
+			1,
+		),
+		invalid(`true && console.log("reachable");`, "true", alwaysTruthy),
+		invalid(`false || console.log("reachable");`, "false", alwaysFalsy),
+		invalid(`let object = {}; object &&= {};`, "object", alwaysTruthy, 1),
+		invalid(`let object = {}; object ||= {};`, "object", alwaysTruthy, 1),
+		invalid(`const value = null ?? "fallback";`, "null", alwaysNullish),
+		invalid(
+			`const value = undefined ?? "fallback";`,
+			"undefined",
+			alwaysNullish,
+		),
+		invalid(`const value = void 0 ?? "fallback";`, "void 0", alwaysNullish),
+		invalid(`const value = {} ?? "fallback";`, "{}", neverNullish),
+		invalid(
+			`declare function fail(): never; const value = fail() ?? "fallback";`,
+			"fail()",
+			"This expression has type `never`.",
+			1,
+		),
+		invalid(`let value: object = {}; value ??= {};`, "value", neverNullish, 1),
+		invalid(`let value: null = null; value ??= {};`, "value", alwaysNullish, 1),
+		invalid(
+			`const value = 1 === 2;`,
+			"1 === 2",
+			"This comparison is always false.",
+		),
+		invalid(
+			`const value = 2 !== 1;`,
+			"2 !== 1",
+			"This comparison is always true.",
+		),
+		invalid(
+			`const value = 1 == "1";`,
+			`1 == "1"`,
+			"This comparison is always true.",
+		),
+		invalid(
+			`const value = 1 != "1";`,
+			`1 != "1"`,
+			"This comparison is always false.",
+		),
+		invalid(
+			`const value = null == undefined;`,
+			"null == undefined",
+			"This comparison is always true.",
+		),
+		invalid(
+			`const value = null == 1;`,
+			"null == 1",
+			"This comparison is always false.",
+		),
+		invalid(
+			`const value = 1 == null;`,
+			"1 == null",
+			"This comparison is always false.",
+		),
+		invalid(
+			`const value = 1 == 1;`,
+			"1 == 1",
+			"This comparison is always true.",
+		),
+		invalid(
+			`const value = 1 == 2;`,
+			"1 == 2",
+			"This comparison is always false.",
+		),
+		invalid(
+			`const value = true == 1;`,
+			"true == 1",
+			"This comparison is always true.",
+		),
+		invalid(
+			`const value = 1 == true;`,
+			"1 == true",
+			"This comparison is always true.",
+		),
+		invalid(
+			`const value = "2" == 2;`,
+			`"2" == 2`,
+			"This comparison is always true.",
+		),
+		invalid(
+			`const value = 2 == "3";`,
+			`2 == "3"`,
+			"This comparison is always false.",
+		),
+		invalid(
+			`const value = 2n == "2";`,
+			`2n == "2"`,
+			"This comparison is always true.",
+		),
+		invalid(
+			`const value = "2" == 2n;`,
+			`"2" == 2n`,
+			"This comparison is always true.",
+		),
+		invalid(
+			`const value = "invalid" == 2n;`,
+			`"invalid" == 2n`,
+			"This comparison is always false.",
+		),
+		invalid(
+			`const value = 2n == 2;`,
+			"2n == 2",
+			"This comparison is always true.",
+		),
+		invalid(
+			`const value = 2n == 2.5;`,
+			"2n == 2.5",
+			"This comparison is always false.",
+		),
+		invalid(
+			`const value = 2 == 2n;`,
+			"2 == 2n",
+			"This comparison is always true.",
+		),
+		invalid(
+			`const value = 2.5 == 2n;`,
+			"2.5 == 2n",
+			"This comparison is always false.",
+		),
+		invalid(`const value = 2 > 1;`, "2 > 1", "This comparison is always true."),
+		invalid(
+			`const value = 2 >= 2;`,
+			"2 >= 2",
+			"This comparison is always true.",
+		),
+		invalid(
+			`const value = -2 < -1;`,
+			"-2 < -1",
+			"This comparison is always true.",
+		),
+		invalid(
+			`const value = 1 <= 0;`,
+			"1 <= 0",
+			"This comparison is always false.",
+		),
+		invalid(
+			`const value = 2n > 1n;`,
+			"2n > 1n",
+			"This comparison is always true.",
+		),
+		invalid(
+			`const value = 1n <= 1n;`,
+			"1n <= 1n",
+			"This comparison is always true.",
+		),
+		invalid(
+			`const value = 1n < 2n;`,
+			"1n < 2n",
+			"This comparison is always true.",
+		),
+		invalid(
+			`const value = "a" <= "a";`,
+			`"a" <= "a"`,
+			"This comparison is always true.",
+		),
+		invalid(
+			`const value = "a" < "b";`,
+			`"a" < "b"`,
+			"This comparison is always true.",
+		),
+		invalid(
+			`const value = "b" < "a";`,
+			`"b" < "a"`,
+			"This comparison is always false.",
+		),
+		invalid(
+			`const value = null === null;`,
+			"null === null",
+			"This comparison is always true.",
+		),
+		invalid(
+			`const value = undefined === undefined;`,
+			"undefined === undefined",
+			"This comparison is always true.",
+		),
+		invalid(
+			`const value = true === false;`,
+			"true === false",
+			"This comparison is always false.",
+		),
+		invalid(
+			`declare const value: string; const result = value === 1;`,
+			"value === 1",
+			"This comparison is always false.",
+		),
+		invalid(
+			`declare const value: string; const result = value !== 1;`,
+			"value !== 1",
+			"This comparison is always true.",
+		),
+		invalid(
+			`declare const value: "a" | "b"; const result = value === "c";`,
+			`value === "c"`,
+			"This comparison is always false.",
+		),
+		invalid(
+			`declare const value: bigint; const result = value === "1";`,
+			`value === "1"`,
+			"This comparison is always false.",
+		),
+		invalid(
+			`declare const value: boolean; const result = value === 1;`,
+			"value === 1",
+			"This comparison is always false.",
+		),
+		invalid(
+			`declare const value: null; const result = value === undefined;`,
+			"value === undefined",
+			"This comparison is always false.",
+		),
+		invalid(
+			`declare const value: (string | null); const result = value === 1;`,
+			"value === 1",
+			"This comparison is always false.",
+		),
+		invalid(
+			`declare const value: (string | undefined); const result = value === 1;`,
+			"value === 1",
+			"This comparison is always false.",
+		),
+		invalid(
+			`type BrandedBoolean = boolean & { readonly brand: unique symbol }; declare const value: BrandedBoolean; const result = value === 1;`,
+			"value === 1",
+			"This comparison is always false.",
+		),
+		invalid(
+			`declare function run(): void; const result = run() === 1;`,
+			"run() === 1",
+			"This comparison is always false.",
+		),
+		invalid(
+			`declare const values: "a"[]; declare const index: number; const result = values[index] === "b";`,
+			`values[index] === "b"`,
+			"This comparison is always false.",
+		),
+		invalid(
+			`declare const tuple: [object]; if (tuple[0]) console.log("reachable");`,
+			"tuple[0]",
+			alwaysTruthy,
+		),
+		invalid(
+			`declare const record: { value: object }; if (record.value) console.log("reachable");`,
+			"record.value",
+			alwaysTruthy,
+		),
+		invalid(
+			`declare const record: { value: object }; if (record["value"]) console.log("reachable");`,
+			`record["value"]`,
+			alwaysTruthy,
+		),
+		invalid(
+			`switch ("a" as "a" | "b") { case "c": break; }`,
+			`"c"`,
+			"This switch case can never match the switch expression.",
+		),
+		invalid(
+			`[1].every(() => true);`,
+			"true",
+			"This array predicate callback always returns a truthy value.",
+		),
+		invalid(
+			`[1].filter(() => false);`,
+			"false",
+			"This array predicate callback always returns a falsy value.",
+		),
+		invalid(
+			`[1].find(() => ({}));`,
+			"({})",
+			"This array predicate callback always returns a truthy value.",
+		),
+		invalid(
+			`[1].findIndex(function () { return 0; });`,
+			"0",
+			"This array predicate callback always returns a falsy value.",
+		),
+		invalid(
+			`[1].findLast(() => "yes");`,
+			`"yes"`,
+			"This array predicate callback always returns a truthy value.",
+		),
+		invalid(
+			`[1].findLastIndex(() => 0n);`,
+			"0n",
+			"This array predicate callback always returns a falsy value.",
+		),
+		invalid(
+			`[1].some(() => Promise.resolve(false));`,
+			"Promise.resolve(false)",
+			"This array predicate callback always returns a truthy value.",
+		),
+		invalid(
+			`[1]["some"](() => true);`,
+			"true",
+			"This array predicate callback always returns a truthy value.",
+		),
+		invalid(
+			`const method = "some" as const; [1][method](() => false);`,
+			"false",
+			"This array predicate callback always returns a falsy value.",
+		),
+		invalid(
+			`const callback = (): object => ({}); [1].some(callback);`,
+			"callback",
+			"This array predicate callback always returns a truthy value.",
+			1,
+		),
+		invalid(
+			`const callback = (): undefined => undefined; [1].some(callback);`,
+			"callback",
+			"This array predicate callback always returns a falsy value.",
+			1,
+		),
+		{
+			code: `
+if (false || true) console.log("reachable");
+`,
+			snapshot: `
+if (false || true) console.log("reachable");
+    ~~~~~
+    This condition is always falsy.
+             ~~~~
+             This condition is always truthy.
+`,
+		},
+		{
+			code: `
+const record = { value: 1 };
+record?.value;
+`,
+			snapshot: `
+const record = { value: 1 };
+record?.value;
+      ~~
+      This optional chain is unnecessary because the value is never nullish.
+`,
+			suggestions: [
+				{
+					id: "removeOptionalChain",
+					updated: `
+const record = { value: 1 };
+record.value;
+`,
+				},
+			],
+		},
+		{
+			code: `
+const record = { value: 1 };
+record?.["value"];
+`,
+			snapshot: `
+const record = { value: 1 };
+record?.["value"];
+      ~~
+      This optional chain is unnecessary because the value is never nullish.
+`,
+			suggestions: [
+				{
+					id: "removeOptionalChain",
+					updated: `
+const record = { value: 1 };
+record["value"];
+`,
+				},
+			],
+		},
+		{
+			code: `
+const callback = () => 1;
+callback?.();
+`,
+			snapshot: `
+const callback = () => 1;
+callback?.();
+        ~~
+        This optional chain is unnecessary because the value is never nullish.
+`,
+			suggestions: [
+				{
+					id: "removeOptionalChain",
+					updated: `
+const callback = () => 1;
+callback();
+`,
+				},
+			],
+		},
+		{
+			code: `
+declare const record: { value: { nested: number } } | undefined;
+record?.value?.nested;
+`,
+			snapshot: `
+declare const record: { value: { nested: number } } | undefined;
+record?.value?.nested;
+             ~~
+             This optional chain is unnecessary because the value is never nullish.
+`,
+			suggestions: [
+				{
+					id: "removeOptionalChain",
+					updated: `
+declare const record: { value: { nested: number } } | undefined;
+record?.value.nested;
+`,
+				},
+			],
+		},
+		{
+			code: `
+declare const factory: (() => () => number) | undefined;
+factory?.()?.();
+`,
+			snapshot: `
+declare const factory: (() => () => number) | undefined;
+factory?.()?.();
+           ~~
+           This optional chain is unnecessary because the value is never nullish.
+`,
+			suggestions: [
+				{
+					id: "removeOptionalChain",
+					updated: `
+declare const factory: (() => () => number) | undefined;
+factory?.()();
+`,
+				},
+			],
+		},
+		{
+			code: `
+if (true) console.log("reachable");
+`,
+			files: createRuleTesterTSConfig({ strictNullChecks: false }),
+			snapshot: `
+if (true) console.log("reachable");
+
+This rule requires the \`strictNullChecks\` compiler option.
+`,
+		},
+		{
+			code: `
+null ?? 1;
+({})?.value;
+[1].some(() => true);
+switch ("a") { case "b": break; }
+`,
+			files: createRuleTesterTSConfig({ strictNullChecks: false }),
+			snapshot: `
+null ?? 1;
+
+This rule requires the \`strictNullChecks\` compiler option.
+({})?.value;
+[1].some(() => true);
+switch ("a") { case "b": break; }
+`,
+		},
+	],
+	valid: [
+		`declare const value: string | undefined; if (value) console.log(value);`,
+		`declare const value: boolean; if (value) console.log(value);`,
+		`declare const value: any; if (value) console.log(value);`,
+		`declare const value: unknown; if (value) console.log(value);`,
+		`function check<T>(value: T) { if (value) console.log(value); }`,
+		`function check<T extends string>(value: T) { if (value) console.log(value); }`,
+		`for (;;) break;`,
+		`declare const value: boolean | undefined; const result = value ?? true;`,
+		`declare const value: any; const result = value ?? true;`,
+		`declare function run(): void; const value = run() ?? 1;`,
+		`declare const values: object[]; declare const index: number; if (values[index]) console.log(index);`,
+		`declare const values: object[]; declare const index: number; values[index]?.toString();`,
+		`declare const values: object[]; values[0]?.toString();`,
+		`declare const tuple: [object, object]; declare const index: number; if (tuple[index]) console.log(index);`,
+		`declare const record: Record<string, object>; declare const key: string; if (record[key]) console.log(key);`,
+		`declare const optional: { value?: object }; optional.value ?? {};`,
+		`declare const optional: { value?: object }; if (optional.value) console.log(optional.value);`,
+		`declare const record: { [key: string]: object }; if (record.missing) console.log(record.missing);`,
+		`declare const record: { [key: number]: object }; declare const index: number; if (record[index]) console.log(index);`,
+		`declare const nullable: { value: number } | undefined; nullable?.value;`,
+		`declare const callback: (() => number) | undefined; callback?.();`,
+		`declare const factory: (() => (() => number) | undefined) | undefined; factory?.()?.();`,
+		`declare const left: string; declare const right: string; left === right;`,
+		`declare const left: string; declare const right: number; left == right;`,
+		`declare const value: any; value === 1;`,
+		`declare const value: unknown; value === 1;`,
+		`function compare<T>(value: T) { return value === 1; }`,
+		`declare const value: object; value === {};`,
+		`declare const custom: { some(callback: () => object): void }; custom.some(() => ({}));`,
+		`class CustomArray extends Array<number> { override some(predicate: (value: number) => unknown): boolean { return predicate(0) as boolean; } } new CustomArray().some(() => true);`,
+		`export {}; declare global { interface Array<T> { some(predicate: (value: T) => unknown, marker?: "custom"): boolean; } } [1].some(() => true);`,
+		`[1].some(() => Math.random() > 0.5);`,
+		`[1].some(function () { if (Math.random()) return true; return false; });`,
+		`declare const callback: () => any; [1].some(callback);`,
+		`declare const callback: () => never; [1].some(callback);`,
+		`[1].some();`,
+		`const method = Math.random() ? "some" : "map"; [1][method](() => true);`,
+		`const object = { value: true }; object.value;`,
+		`switch (Math.random() ? "a" : "b") { case "a": break; default: break; }`,
+		{
+			code: `declare const values: object[]; declare const index: number; if (values[index]) console.log(index);`,
+			files: createRuleTesterTSConfig({ noUncheckedIndexedAccess: true }),
+		},
+	],
+});

--- a/packages/ts/src/rules/unnecessaryConditions.ts
+++ b/packages/ts/src/rules/unnecessaryConditions.ts
@@ -1,0 +1,897 @@
+import * as tsutils from "ts-api-utils";
+import {
+	IndexKind,
+	SyntaxKind,
+	TypeFlags,
+	type BigIntLiteralType,
+	type Declaration,
+	type NumberLiteralType,
+	type StringLiteralType,
+	type Type,
+} from "typescript";
+
+import {
+	getTSNodeRange,
+	typescriptLanguage,
+	type AST,
+	type Checker,
+	type TypeScriptFileServices,
+} from "@flint.fyi/typescript-language";
+
+import { ruleCreator } from "./ruleCreator.ts";
+import { getConstrainedTypeAtLocation } from "./utils/getConstrainedType.ts";
+
+type ComparisonKind =
+	| SyntaxKind.EqualsEqualsEqualsToken
+	| SyntaxKind.EqualsEqualsToken
+	| SyntaxKind.ExclamationEqualsEqualsToken
+	| SyntaxKind.ExclamationEqualsToken
+	| SyntaxKind.GreaterThanEqualsToken
+	| SyntaxKind.GreaterThanToken
+	| SyntaxKind.LessThanEqualsToken
+	| SyntaxKind.LessThanToken;
+type KnownValue = bigint | boolean | null | number | string | undefined;
+type Outcome =
+	| "alwaysFalsy"
+	| "alwaysNullish"
+	| "alwaysTruthy"
+	| "never"
+	| "neverNullish";
+
+const comparisonKinds = new Set<SyntaxKind>([
+	SyntaxKind.EqualsEqualsEqualsToken,
+	SyntaxKind.EqualsEqualsToken,
+	SyntaxKind.ExclamationEqualsEqualsToken,
+	SyntaxKind.ExclamationEqualsToken,
+	SyntaxKind.GreaterThanEqualsToken,
+	SyntaxKind.GreaterThanToken,
+	SyntaxKind.LessThanEqualsToken,
+	SyntaxKind.LessThanToken,
+]);
+const predicateMethods = new Set([
+	"every",
+	"filter",
+	"find",
+	"findIndex",
+	"findLast",
+	"findLastIndex",
+	"some",
+]);
+const unknownValue = Symbol("unknown value");
+
+function chainContainsPotentiallyAbsentAccess(
+	node: AST.Expression,
+	services: TypeScriptFileServices,
+): boolean {
+	const unwrapped = unwrapExpression(node);
+	if (isChainAccessExpression(unwrapped)) {
+		return (
+			isPotentiallyAbsentAccess(unwrapped, services) ||
+			chainContainsPotentiallyAbsentAccess(unwrapped.expression, services)
+		);
+	}
+	return isPotentiallyAbsentAccess(unwrapped, services);
+}
+
+function compare(left: KnownValue, right: KnownValue, kind: ComparisonKind) {
+	switch (kind) {
+		case SyntaxKind.EqualsEqualsEqualsToken:
+			return left === right;
+		case SyntaxKind.EqualsEqualsToken:
+			return looselyEqual(left, right);
+		case SyntaxKind.ExclamationEqualsEqualsToken:
+			return left !== right;
+		case SyntaxKind.ExclamationEqualsToken:
+			return !looselyEqual(left, right);
+		case SyntaxKind.GreaterThanEqualsToken:
+			return compareRelational(left, right) >= 0;
+		case SyntaxKind.GreaterThanToken:
+			return compareRelational(left, right) > 0;
+		case SyntaxKind.LessThanEqualsToken:
+			return compareRelational(left, right) <= 0;
+		case SyntaxKind.LessThanToken:
+			return compareRelational(left, right) < 0;
+	}
+}
+
+function compareRelational(left: KnownValue, right: KnownValue) {
+	if (typeof left === "string" && typeof right === "string") {
+		return left === right ? 0 : left < right ? -1 : 1;
+	}
+	if (typeof left === "bigint" && typeof right === "bigint") {
+		return left === right ? 0 : left < right ? -1 : 1;
+	}
+	const leftNumber = Number(left);
+	const rightNumber = Number(right);
+	return leftNumber === rightNumber ? 0 : leftNumber < rightNumber ? -1 : 1;
+}
+
+function getConstituents(type: Type) {
+	return tsutils.unionConstituents(type);
+}
+
+function getIntrinsicName(type: Type) {
+	return (type as { intrinsicName?: string }).intrinsicName;
+}
+
+function getKnownValue(type: Type): KnownValue | typeof unknownValue {
+	if (tsutils.isTypeFlagSet(type, TypeFlags.Null)) {
+		return null;
+	}
+	if (tsutils.isTypeFlagSet(type, TypeFlags.Undefined)) {
+		return undefined;
+	}
+	if (tsutils.isTypeFlagSet(type, TypeFlags.BooleanLiteral)) {
+		return getIntrinsicName(type) === "true";
+	}
+	if (tsutils.isTypeFlagSet(type, TypeFlags.StringLiteral)) {
+		return (type as StringLiteralType).value;
+	}
+	if (tsutils.isTypeFlagSet(type, TypeFlags.NumberLiteral)) {
+		return (type as NumberLiteralType).value;
+	}
+	if (tsutils.isTypeFlagSet(type, TypeFlags.BigIntLiteral)) {
+		return BigInt((type as BigIntLiteralType).value.base10Value);
+	}
+	return unknownValue;
+}
+
+function getKnownValues(type: Type, implicitlyUndefined: boolean) {
+	const values = getConstituents(type).map(getKnownValue);
+	if (values.includes(unknownValue)) {
+		return undefined;
+	}
+	if (implicitlyUndefined && !values.includes(undefined)) {
+		values.push(undefined);
+	}
+	return values as KnownValue[];
+}
+
+function getNullishness(type: Type, implicitlyUndefined: boolean) {
+	if (isIndeterminate(type)) {
+		return undefined;
+	}
+	if (tsutils.isTypeFlagSet(type, TypeFlags.Never)) {
+		return "never" as const;
+	}
+	const constituents = getConstituents(type);
+	const possiblyNullish =
+		implicitlyUndefined ||
+		constituents.some((constituent) =>
+			tsutils.isTypeFlagSet(
+				constituent,
+				TypeFlags.Null | TypeFlags.Undefined | TypeFlags.Void,
+			),
+		);
+	const possiblyNonNullish = constituents.some(
+		(constituent) =>
+			!tsutils.isTypeFlagSet(
+				constituent,
+				TypeFlags.Null | TypeFlags.Undefined | TypeFlags.Void,
+			),
+	);
+	if (
+		!possiblyNonNullish &&
+		constituents.every((constituent) =>
+			tsutils.isTypeFlagSet(constituent, TypeFlags.Null | TypeFlags.Undefined),
+		)
+	) {
+		return "alwaysNullish" as const;
+	}
+	if (!possiblyNullish) {
+		return "neverNullish" as const;
+	}
+	return undefined;
+}
+
+function getOwnOptionalChainNullishness(
+	node: AST.Expression,
+	services: TypeScriptFileServices,
+) {
+	if (
+		node.kind === SyntaxKind.PropertyAccessExpression &&
+		node.questionDotToken
+	) {
+		const receiverType = services.typeChecker.getNonNullableType(
+			services.typeChecker.getTypeAtLocation(node.expression),
+		);
+		const propertyType = services.typeChecker.getTypeOfPropertyOfType(
+			receiverType,
+			node.name.text,
+		);
+		return propertyType && getNullishness(propertyType, false);
+	}
+	if (node.kind === SyntaxKind.CallExpression && node.questionDotToken) {
+		const returnTypes = tsutils
+			.getCallSignaturesOfType(
+				services.typeChecker.getNonNullableType(
+					services.typeChecker.getTypeAtLocation(node.expression),
+				),
+			)
+			.map((signature) => getNullishness(signature.getReturnType(), false));
+		return returnTypes.length &&
+			returnTypes.every((outcome) => outcome === "neverNullish")
+			? "neverNullish"
+			: undefined;
+	}
+	return undefined;
+}
+
+function getPredicateInfo(node: AST.CallExpression, typeChecker: Checker) {
+	if (node.expression.kind === SyntaxKind.PropertyAccessExpression) {
+		return {
+			method: node.expression.name.text,
+			receiver: node.expression.expression,
+		};
+	}
+	if (node.expression.kind === SyntaxKind.ElementAccessExpression) {
+		return {
+			method: getStaticPropertyName(
+				node.expression.argumentExpression,
+				typeChecker,
+			),
+			receiver: node.expression.expression,
+		};
+	}
+	return undefined;
+}
+
+function getPrimitiveDomains(type: Type): Set<string> | undefined {
+	if (isIndeterminate(type)) {
+		return undefined;
+	}
+	const domains = new Set<string>();
+	for (const constituent of getConstituents(type)) {
+		const parts = tsutils.intersectionConstituents(constituent);
+		if (
+			parts.some((part) => tsutils.isTypeFlagSet(part, TypeFlags.StringLike))
+		) {
+			domains.add("string");
+		} else if (
+			parts.some((part) => tsutils.isTypeFlagSet(part, TypeFlags.NumberLike))
+		) {
+			domains.add("number");
+		} else if (
+			parts.some((part) => tsutils.isTypeFlagSet(part, TypeFlags.BigIntLike))
+		) {
+			domains.add("bigint");
+		} else if (
+			parts.some((part) => tsutils.isTypeFlagSet(part, TypeFlags.BooleanLike))
+		) {
+			domains.add("boolean");
+		} else if (tsutils.isTypeFlagSet(constituent, TypeFlags.Null)) {
+			domains.add("null");
+		} else if (
+			tsutils.isTypeFlagSet(constituent, TypeFlags.Undefined | TypeFlags.Void)
+		) {
+			domains.add("undefined");
+		} else {
+			return undefined;
+		}
+	}
+	return domains;
+}
+
+function getStaticPropertyName(node: AST.Expression, typeChecker: Checker) {
+	const value = getKnownValue(getConstrainedTypeAtLocation(node, typeChecker));
+	return typeof value === "string" || typeof value === "number"
+		? String(value)
+		: undefined;
+}
+
+function getTruthiness(
+	type: Type,
+	implicitlyUndefined: boolean,
+): Outcome | undefined {
+	if (isIndeterminate(type)) {
+		return undefined;
+	}
+	if (tsutils.isTypeFlagSet(type, TypeFlags.Never)) {
+		return "never";
+	}
+	const constituents = getConstituents(type);
+	const possiblyFalsy =
+		implicitlyUndefined ||
+		constituents.some(
+			(constituent) =>
+				!isTruthyLiteral(constituent) &&
+				tsutils.isTypeFlagSet(constituent, TypeFlags.PossiblyFalsy),
+		);
+	const possiblyTruthy = constituents.some((constituent) =>
+		tsutils
+			.intersectionConstituents(constituent)
+			.every((part) => !tsutils.isFalsyType(part)),
+	);
+	if (!possiblyTruthy) {
+		return "alwaysFalsy";
+	}
+	if (!possiblyFalsy) {
+		return "alwaysTruthy";
+	}
+	return undefined;
+}
+
+function hasDisjointStrictDomains(left: Type, right: Type) {
+	const leftDomains = getPrimitiveDomains(left);
+	const rightDomains = getPrimitiveDomains(right);
+	return !!(
+		leftDomains &&
+		rightDomains &&
+		![...leftDomains].some((domain) => rightDomains.has(domain))
+	);
+}
+
+function isChainAccessExpression(
+	node: AST.Expression,
+): node is
+	| AST.CallExpression
+	| AST.ElementAccessExpression
+	| AST.PropertyAccessExpression {
+	return (
+		node.kind === SyntaxKind.CallExpression ||
+		node.kind === SyntaxKind.ElementAccessExpression ||
+		node.kind === SyntaxKind.PropertyAccessExpression
+	);
+}
+
+function isIndeterminate(type: Type) {
+	return getConstituents(type).some((constituent) =>
+		tsutils.isTypeFlagSet(
+			constituent,
+			TypeFlags.Any | TypeFlags.TypeParameter | TypeFlags.Unknown,
+		),
+	);
+}
+
+function isPotentiallyAbsentAccess(
+	node: AST.Expression,
+	services: TypeScriptFileServices,
+) {
+	if (services.program.getCompilerOptions().noUncheckedIndexedAccess) {
+		return false;
+	}
+	const unwrapped = unwrapExpression(node);
+	if (
+		unwrapped.kind !== SyntaxKind.ElementAccessExpression &&
+		unwrapped.kind !== SyntaxKind.PropertyAccessExpression
+	) {
+		return false;
+	}
+	const receiverType = services.typeChecker.getTypeAtLocation(
+		unwrapped.expression,
+	);
+	const propertyName =
+		unwrapped.kind === SyntaxKind.PropertyAccessExpression
+			? unwrapped.name.text
+			: getStaticPropertyName(
+					unwrapped.argumentExpression,
+					services.typeChecker,
+				);
+	const resolvedSymbol =
+		propertyName === undefined
+			? undefined
+			: services.typeChecker.getPropertyOfType(receiverType, propertyName);
+	const symbol = resolvedSymbol?.declarations?.length
+		? resolvedSymbol
+		: undefined;
+	const receivers = getConstituents(receiverType);
+	if (unwrapped.kind === SyntaxKind.PropertyAccessExpression) {
+		return (
+			!symbol &&
+			receivers.some((receiver) =>
+				services.typeChecker.getIndexTypeOfType(receiver, IndexKind.String),
+			)
+		);
+	}
+	return receivers.some((receiver) => {
+		if (symbol) {
+			return false;
+		}
+		if (services.typeChecker.isTupleType(receiver)) {
+			const index = getStaticPropertyName(
+				unwrapped.argumentExpression,
+				services.typeChecker,
+			);
+			return (
+				index === undefined ||
+				Number(index) >= services.typeChecker.getTypeArguments(receiver).length
+			);
+		}
+		return true;
+	});
+}
+
+function isTruthyLiteral(type: Type) {
+	if (tsutils.isTypeFlagSet(type, TypeFlags.BooleanLiteral)) {
+		return getIntrinsicName(type) === "true";
+	}
+	if (tsutils.isTypeFlagSet(type, TypeFlags.StringLiteral)) {
+		return !!(type as StringLiteralType).value;
+	}
+	if (tsutils.isTypeFlagSet(type, TypeFlags.NumberLiteral)) {
+		return !!(type as NumberLiteralType).value;
+	}
+	if (tsutils.isTypeFlagSet(type, TypeFlags.BigIntLiteral)) {
+		return (type as BigIntLiteralType).value.base10Value !== "0";
+	}
+	return false;
+}
+
+function looselyEqual(left: KnownValue, right: KnownValue): boolean {
+	if (left === null || left === undefined) {
+		return right === null || right === undefined;
+	}
+	if (right === null || right === undefined) {
+		return false;
+	}
+	if (typeof left === typeof right) {
+		return left === right;
+	}
+	if (typeof left === "boolean") {
+		return looselyEqual(Number(left), right);
+	}
+	if (typeof right === "boolean") {
+		return looselyEqual(left, Number(right));
+	}
+	if (
+		(typeof left === "string" && typeof right === "number") ||
+		(typeof left === "number" && typeof right === "string")
+	) {
+		return Number(left) === Number(right);
+	}
+	if (
+		(typeof left === "bigint" && typeof right === "string") ||
+		(typeof left === "string" && typeof right === "bigint")
+	) {
+		try {
+			return BigInt(left) === BigInt(right);
+		} catch {
+			return false;
+		}
+	}
+	if (typeof left === "bigint" && typeof right === "number") {
+		return Number.isInteger(right) && left === BigInt(right);
+	}
+	return (
+		typeof left === "number" &&
+		typeof right === "bigint" &&
+		Number.isInteger(left) &&
+		BigInt(left) === right
+	);
+}
+
+function unwrapExpression(node: AST.Expression): AST.Expression {
+	return node.kind === SyntaxKind.ParenthesizedExpression
+		? unwrapExpression(node.expression)
+		: node;
+}
+
+export default ruleCreator.createRule(typescriptLanguage, {
+	about: {
+		description: "Reports conditions whose outcomes are statically known.",
+		id: "unnecessaryConditions",
+		presets: ["logical"],
+	},
+	messages: {
+		alwaysFalsy: {
+			primary: "This condition is always falsy.",
+			secondary: [],
+			suggestions: [],
+		},
+		alwaysFalsyPredicate: {
+			primary: "This array predicate callback always returns a falsy value.",
+			secondary: [],
+			suggestions: [],
+		},
+		alwaysNullish: {
+			primary: "This expression is always nullish.",
+			secondary: [],
+			suggestions: [],
+		},
+		alwaysTruthy: {
+			primary: "This condition is always truthy.",
+			secondary: [],
+			suggestions: [],
+		},
+		alwaysTruthyPredicate: {
+			primary: "This array predicate callback always returns a truthy value.",
+			secondary: [],
+			suggestions: [],
+		},
+		comparison: {
+			primary: "This comparison is always {{ outcome }}.",
+			secondary: [],
+			suggestions: [],
+		},
+		impossibleCase: {
+			primary: "This switch case can never match the switch expression.",
+			secondary: [],
+			suggestions: [],
+		},
+		never: {
+			primary: "This expression has type `never`.",
+			secondary: [],
+			suggestions: [],
+		},
+		neverNullish: {
+			primary: "This expression is never nullish.",
+			secondary: [],
+			suggestions: [],
+		},
+		requiresStrictNullChecks: {
+			primary: "This rule requires the `strictNullChecks` compiler option.",
+			secondary: [],
+			suggestions: [],
+		},
+		unnecessaryOptionalChain: {
+			primary:
+				"This optional chain is unnecessary because the value is never nullish.",
+			secondary: [],
+			suggestions: ["Remove the unnecessary optional chain."],
+		},
+	},
+	setup(context) {
+		let enabled = true;
+
+		function reportOutcome(
+			node: AST.Expression,
+			outcome: Outcome,
+			services: TypeScriptFileServices,
+		) {
+			context.report({
+				message: outcome,
+				range: getTSNodeRange(node, services.sourceFile),
+			});
+		}
+
+		function checkCondition(
+			node: AST.Expression,
+			services: TypeScriptFileServices,
+			inverted = false,
+			reportNode = node,
+		): void {
+			if (!enabled) {
+				return;
+			}
+			const unwrapped = unwrapExpression(node);
+			if (
+				unwrapped.kind === SyntaxKind.PrefixUnaryExpression &&
+				unwrapped.operator === SyntaxKind.ExclamationToken
+			) {
+				checkCondition(unwrapped.operand, services, !inverted, reportNode);
+				return;
+			}
+			if (
+				unwrapped.kind === SyntaxKind.BinaryExpression &&
+				(unwrapped.operatorToken.kind === SyntaxKind.AmpersandAmpersandToken ||
+					unwrapped.operatorToken.kind === SyntaxKind.BarBarToken)
+			) {
+				checkCondition(unwrapped.right, services);
+				return;
+			}
+			const outcome = getTruthiness(
+				getConstrainedTypeAtLocation(unwrapped, services.typeChecker),
+				isPotentiallyAbsentAccess(unwrapped, services),
+			);
+			if (!outcome) {
+				return;
+			}
+			const reportedOutcome =
+				inverted && outcome !== "never"
+					? outcome === "alwaysTruthy"
+						? "alwaysFalsy"
+						: "alwaysTruthy"
+					: outcome;
+			reportOutcome(reportNode, reportedOutcome, services);
+		}
+
+		function getComparisonOutcome(
+			leftNode: AST.Expression,
+			rightNode: AST.Expression,
+			kind: ComparisonKind,
+			services: TypeScriptFileServices,
+		) {
+			const leftType = getConstrainedTypeAtLocation(
+				leftNode,
+				services.typeChecker,
+			);
+			const rightType = getConstrainedTypeAtLocation(
+				rightNode,
+				services.typeChecker,
+			);
+			const leftValues = getKnownValues(
+				leftType,
+				isPotentiallyAbsentAccess(leftNode, services),
+			);
+			const rightValues = getKnownValues(
+				rightType,
+				isPotentiallyAbsentAccess(rightNode, services),
+			);
+			if (leftValues && rightValues) {
+				const outcomes = leftValues.flatMap((left) =>
+					rightValues.map((right) => compare(left, right, kind)),
+				);
+				if (outcomes.every(Boolean)) {
+					return true;
+				}
+				if (outcomes.every((outcome) => !outcome)) {
+					return false;
+				}
+				return undefined;
+			}
+			if (
+				(kind === SyntaxKind.EqualsEqualsEqualsToken ||
+					kind === SyntaxKind.ExclamationEqualsEqualsToken) &&
+				hasDisjointStrictDomains(leftType, rightType)
+			) {
+				return kind === SyntaxKind.ExclamationEqualsEqualsToken;
+			}
+			return undefined;
+		}
+
+		function checkComparison(
+			node: AST.BinaryExpression,
+			services: TypeScriptFileServices,
+		) {
+			if (!enabled || !comparisonKinds.has(node.operatorToken.kind)) {
+				return;
+			}
+			const outcome = getComparisonOutcome(
+				node.left,
+				node.right,
+				node.operatorToken.kind as ComparisonKind,
+				services,
+			);
+			if (outcome === undefined) {
+				return;
+			}
+			context.report({
+				data: { outcome: String(outcome) },
+				message: "comparison",
+				range: getTSNodeRange(node, services.sourceFile),
+			});
+		}
+
+		function checkOptional(
+			node:
+				| AST.CallExpression
+				| AST.ElementAccessExpression
+				| AST.PropertyAccessExpression,
+			services: TypeScriptFileServices,
+		) {
+			if (!enabled || !node.questionDotToken) {
+				return;
+			}
+			const expression = unwrapExpression(node.expression);
+			if (
+				chainContainsPotentiallyAbsentAccess(expression, services) ||
+				(getOwnOptionalChainNullishness(expression, services) ??
+					getNullishness(
+						getConstrainedTypeAtLocation(expression, services.typeChecker),
+						false,
+					)) !== "neverNullish"
+			) {
+				return;
+			}
+			const range = getTSNodeRange(node.questionDotToken, services.sourceFile);
+			context.report({
+				message: "unnecessaryOptionalChain",
+				range,
+				suggestions: [
+					{
+						id: "removeOptionalChain",
+						range,
+						text: node.kind === SyntaxKind.PropertyAccessExpression ? "." : "",
+					},
+				],
+			});
+		}
+
+		function reportPredicate(
+			node: AST.Expression,
+			outcome: Outcome | undefined,
+			services: TypeScriptFileServices,
+		) {
+			if (outcome !== "alwaysFalsy" && outcome !== "alwaysTruthy") {
+				return;
+			}
+			context.report({
+				message:
+					outcome === "alwaysTruthy"
+						? "alwaysTruthyPredicate"
+						: "alwaysFalsyPredicate",
+				range: getTSNodeRange(node, services.sourceFile),
+			});
+		}
+
+		function checkPredicate(
+			node: AST.CallExpression,
+			services: TypeScriptFileServices,
+		) {
+			if (!enabled) {
+				return;
+			}
+			const predicate = getPredicateInfo(node, services.typeChecker);
+			const method = predicate?.method;
+			if (!method || !predicateMethods.has(method)) {
+				return;
+			}
+			const receiverTypes = getConstituents(
+				services.typeChecker.getTypeAtLocation(predicate.receiver),
+			);
+			if (
+				!receiverTypes.every(
+					(type) =>
+						services.typeChecker.isArrayType(type) ||
+						services.typeChecker.isTupleType(type),
+				)
+			) {
+				return;
+			}
+			if (
+				!receiverTypes.every((type) => {
+					const methodSymbol = services.typeChecker.getPropertyOfType(
+						type,
+						method,
+					) as { getDeclarations(): Declaration[] };
+					return methodSymbol
+						.getDeclarations()
+						.every((declaration) =>
+							services.program.isSourceFileDefaultLibrary(
+								declaration.getSourceFile(),
+							),
+						);
+				})
+			) {
+				return;
+			}
+			const callback = node.arguments[0];
+			if (!callback) {
+				return;
+			}
+			if (
+				callback.kind === SyntaxKind.ArrowFunction ||
+				callback.kind === SyntaxKind.FunctionExpression
+			) {
+				const expressionBody =
+					callback.body.kind !== SyntaxKind.Block
+						? callback.body
+						: callback.body.statements.length === 1 &&
+							  callback.body.statements[0]?.kind === SyntaxKind.ReturnStatement
+							? callback.body.statements[0].expression
+							: undefined;
+				if (expressionBody) {
+					reportPredicate(
+						expressionBody,
+						getTruthiness(
+							getConstrainedTypeAtLocation(
+								expressionBody,
+								services.typeChecker,
+							),
+							false,
+						),
+						services,
+					);
+					return;
+				}
+			}
+			let possiblyFalsy = false;
+			let possiblyTruthy = false;
+			for (const signature of tsutils.getCallSignaturesOfType(
+				getConstrainedTypeAtLocation(callback, services.typeChecker),
+			)) {
+				const returnType =
+					services.typeChecker.getBaseConstraintOfType(
+						signature.getReturnType(),
+					) ?? signature.getReturnType();
+				if (isIndeterminate(returnType)) {
+					return;
+				}
+				const outcome = getTruthiness(returnType, false);
+				if (outcome === "never") {
+					continue;
+				}
+				possiblyFalsy ||= outcome !== "alwaysTruthy";
+				possiblyTruthy ||= outcome !== "alwaysFalsy";
+				if (possiblyFalsy && possiblyTruthy) {
+					return;
+				}
+			}
+			reportPredicate(
+				callback,
+				possiblyTruthy
+					? "alwaysTruthy"
+					: possiblyFalsy
+						? "alwaysFalsy"
+						: undefined,
+				services,
+			);
+		}
+
+		return {
+			visitors: {
+				BinaryExpression: (node, services) => {
+					checkComparison(node, services);
+					const kind = node.operatorToken.kind;
+					if (
+						kind === SyntaxKind.QuestionQuestionToken ||
+						kind === SyntaxKind.QuestionQuestionEqualsToken
+					) {
+						if (!enabled) {
+							return;
+						}
+						const outcome = getNullishness(
+							getConstrainedTypeAtLocation(node.left, services.typeChecker),
+							isPotentiallyAbsentAccess(node.left, services),
+						);
+						if (outcome) {
+							reportOutcome(node.left, outcome, services);
+						}
+					} else if (
+						kind === SyntaxKind.AmpersandAmpersandToken ||
+						kind === SyntaxKind.BarBarToken ||
+						kind === SyntaxKind.AmpersandAmpersandEqualsToken ||
+						kind === SyntaxKind.BarBarEqualsToken
+					) {
+						checkCondition(node.left, services);
+					}
+				},
+				CallExpression: (node, services) => {
+					checkOptional(node, services);
+					checkPredicate(node, services);
+				},
+				CaseClause: (node, services) => {
+					if (!enabled) {
+						return;
+					}
+					const outcome = getComparisonOutcome(
+						node.parent.parent.expression,
+						node.expression,
+						SyntaxKind.EqualsEqualsEqualsToken,
+						services,
+					);
+					if (outcome === false) {
+						context.report({
+							message: "impossibleCase",
+							range: getTSNodeRange(node.expression, services.sourceFile),
+						});
+					}
+				},
+				ConditionalExpression: (node, services) => {
+					checkCondition(node.condition, services);
+				},
+				DoStatement: (node, services) => {
+					checkCondition(node.expression, services);
+				},
+				ElementAccessExpression: checkOptional,
+				ForStatement: (node, services) => {
+					if (node.condition) {
+						checkCondition(node.condition, services);
+					}
+				},
+				IfStatement: (node, services) => {
+					checkCondition(node.expression, services);
+				},
+				PropertyAccessExpression: checkOptional,
+				SourceFile: (node, services) => {
+					enabled = tsutils.isStrictCompilerOptionEnabled(
+						services.program.getCompilerOptions(),
+						"strictNullChecks",
+					);
+					if (!enabled) {
+						context.report({
+							message: "requiresStrictNullChecks",
+							range: {
+								begin: node.getStart(services.sourceFile),
+								end: node.getStart(services.sourceFile),
+							},
+						});
+					}
+				},
+				WhileStatement: (node, services) => {
+					checkCondition(node.expression, services);
+				},
+			},
+		};
+	},
+});


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #2225
- [x] That issue was marked as [`status: accepting prs`](https://github.com/flint-fyi/flint/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/flint-fyi/flint/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Adds the checker-backed `ts/unnecessaryConditions` rule for statically known truthiness, nullishness, comparisons, switch cases, optional chains, logical expressions, and built-in Array predicates.

Registers the rule in the logical preset, documents its semantic behavior and conservative exclusions, updates comparison data and end-to-end snapshots, and adds a patch changeset.

❤️‍🔥