### PR TITLE
feat(ts): add restrictedTypes rule

### DIFF
--- a/.changeset/fuzzy-tools-restrict.md
+++ b/.changeset/fuzzy-tools-restrict.md
@@ -1,0 +1,5 @@
+---
+"@flint.fyi/ts": minor
+---
+
+Add the source-aware `restrictedTypes` rule for restricting declarations referenced in type positions.

--- a/packages/e2e/tests/typescript/fixtures/src/with-issues.ts
+++ b/packages/e2e/tests/typescript/fixtures/src/with-issues.ts
@@ -6,3 +6,5 @@ export function debug(value: unknown): void {
 export function calculate(a: number, b: number): number {
 	return a + b;
 }
+
+export type Timestamp = Date;

--- a/packages/e2e/tests/typescript/flint.config.ts
+++ b/packages/e2e/tests/typescript/flint.config.ts
@@ -5,7 +5,14 @@ export default defineConfig({
 	use: [
 		{
 			files: "fixtures/**/*.ts",
-			rules: ts.presets.logical,
+			rules: [
+				ts.presets.logical,
+				ts.rules({
+					restrictedTypes: {
+						restrictions: [{ specifier: { from: "lib", name: "Date" } }],
+					},
+				}),
+			],
 		},
 	],
 });

--- a/packages/e2e/tests/typescript/typescript.test.ts
+++ b/packages/e2e/tests/typescript/typescript.test.ts
@@ -13,11 +13,12 @@ describe("typescript", () => {
 			"<dim>Linting with <cyan><bold>flint.config.ts</bold></fg><dim>...</fg>
 
 			<underline><cwd>/fixtures/src/with-issues.ts</underline>
-			<dim>  2:2</fg>  Debugger statements should not be used in production code.  <yellow>ts/debuggerStatements</fg>
+			<dim>  2:2</fg>    Debugger statements should not be used in production code.   <yellow>ts/debuggerStatements</fg>
+			<dim>  10:25</fg>  Type reference 'Date' resolves to a restricted declaration.  <yellow>ts/restrictedTypes</fg>
 
-			<red>✖ Found <bold>1 report</bold> across <bold>1 file</bold>.</fg>
+			<red>✖ Found <bold>2 reports</bold> across <bold>1 file</bold>.</fg>
 			<red></fg>
-			<dim>Finished in <time> on 2 files with 138 rules.</fg>
+			<dim>Finished in <time> on 2 files with 139 rules.</fg>
 			<dim></fg>"
 		`);
 	});

--- a/packages/rule-data/src/data.json
+++ b/packages/rule-data/src/data.json
@@ -26757,7 +26757,8 @@
 		],
 		"flint": {
 			"name": "restrictedTypes",
-			"plugin": "ts"
+			"plugin": "ts",
+			"status": "implemented"
 		},
 		"oxlint": [
 			{

--- a/packages/site/src/content/docs/rules/ts/restrictedTypes.mdx
+++ b/packages/site/src/content/docs/rules/ts/restrictedTypes.mdx
@@ -1,0 +1,145 @@
+---
+description: "Disallows references to specified types and values in type positions."
+title: "restrictedTypes"
+topic: "rules"
+---
+
+import { TabItem, Tabs } from "@astrojs/starlight/components";
+import { RuleEquivalents } from "~/components/RuleEquivalents";
+import RuleSummary from "~/components/RuleSummary.astro";
+
+<RuleSummary plugin="ts" rule="restrictedTypes" />
+
+Some projects need to prevent type-level dependencies on particular declarations.
+This rule resolves references with TypeScript and restricts them by their final declaration name and source.
+Imported names, re-exported names, namespace-qualified references, import types, heritage clauses, and `typeof` type queries are supported.
+
+## Examples
+
+<Tabs>
+<TabItem label="❌ Incorrect">
+
+```ts
+// With restrictions: [{ specifier: { from: "lib", name: "Date" } }]
+type Timestamp = Date;
+```
+
+```ts
+// With restrictions: [{ specifier: { from: "package", name: "Legacy", package: "models" } }]
+import type { Legacy as LocalModel } from "models";
+
+type Model = LocalModel;
+```
+
+```ts
+// With restrictions: [{ specifier: { from: "file", path: "./internal.ts" } }]
+type InternalModule = import("./internal");
+```
+
+```ts
+// With restrictions: [{ specifier: { from: "package", name: "legacyValue", package: "models" } }]
+import { legacyValue as localValue } from "models";
+
+type Model = typeof localValue;
+```
+
+</TabItem>
+<TabItem label="✅ Correct">
+
+```ts
+// A primitive keyword is not a declaration reference.
+type Identifier = string;
+```
+
+```ts
+// With restrictions: [{ specifier: { from: "package", name: "Legacy", package: "models" } }]
+import type { Legacy } from "modern-models";
+
+type PublicModel = Legacy;
+```
+
+```ts
+// Structural similarity does not transfer declaration identity.
+interface PublicModel {
+	id: string;
+}
+```
+
+```ts
+// Runtime uses are not type-position references.
+// With restrictions: [{ specifier: { from: "package", name: "LegacyModel", package: "models" } }]
+import { LegacyModel } from "models";
+
+export const model = new LegacyModel();
+```
+
+</TabItem>
+</Tabs>
+
+## Options
+
+### `restrictions`
+
+- Type: `Array<Restriction>`
+- Default: `[]`
+
+Each entry has an optional `message` string and a required `specifier`.
+Entries are checked in array order, and only the first match controls the message for a reference.
+
+| Field       | Type                   | Description                                      |
+| ----------- | ---------------------- | ------------------------------------------------ |
+| `message`   | `string?`              | Adds project-specific context to the diagnostic. |
+| `specifier` | `TypeOrValueSpecifier` | Identifies the declaration and its provenance.   |
+
+`TypeOrValueSpecifier` supports these variants:
+
+| Variant   | Fields                     | Description                                                |
+| --------- | -------------------------- | ---------------------------------------------------------- |
+| `file`    | `from`, `name?`, `path?`   | Matches declarations from a file or all matching files.    |
+| `lib`     | `from`, `name?`            | Matches declarations supplied by TypeScript library files. |
+| `package` | `from`, `name?`, `package` | Matches declarations supplied by an npm package.           |
+
+The optional `name` may be a string or an array of strings.
+When present, it matches the final declaration name rather than an imported local alias.
+When omitted, the restriction matches every declaration from the selected source.
+
+```jsonc
+{
+	"restrictions": [
+		{
+			"message": "Use Temporal.Instant for new timestamps.",
+			"specifier": { "from": "lib", "name": "Date" },
+		},
+		{
+			"specifier": {
+				"from": "package",
+				"name": ["LegacyRequest", "LegacyResponse"],
+				"package": "legacy-api",
+			},
+		},
+		{
+			"specifier": { "from": "file", "path": "./src/internal.ts" },
+		},
+	],
+}
+```
+
+The rule reports direct references and does not rewrite code because choosing a replacement requires project-specific type semantics.
+It does not match primitive keywords, `{}`, `[]`, generic-instantiation text patterns, structural equivalents, or later uses of a local type alias.
+
+## When Not To Use It
+
+Do not use this rule when declaration provenance is not available to TypeScript or when a project intentionally permits interchangeable declarations regardless of their source.
+Use a syntax-oriented rule instead when restrictions need to target primitive keywords or structural spellings such as `{}` and `[]`.
+Projects without restricted type dependencies can leave the rule disabled instead of maintaining an empty configuration.
+
+## Further Reading
+
+- [Everyday Types](https://www.typescriptlang.org/docs/handbook/2/everyday-types.html)
+- [The `typeof` Type Operator](https://www.typescriptlang.org/docs/handbook/2/typeof-types.html)
+- [Modules](https://www.typescriptlang.org/docs/handbook/2/modules.html)
+- [Declaration Merging](https://www.typescriptlang.org/docs/handbook/declaration-merging.html)
+
+## Equivalents in Other Linters
+
+<RuleEquivalents pluginId="ts" ruleId="restrictedTypes" />

--- a/packages/ts/src/plugin.ts
+++ b/packages/ts/src/plugin.ts
@@ -252,6 +252,7 @@ import requireImports from "./rules/requireImports.ts";
 import responseJsonMethods from "./rules/responseJsonMethods.ts";
 import restrictedIdentifiers from "./rules/restrictedIdentifiers.ts";
 import restrictedImports from "./rules/restrictedImports.ts";
+import restrictedTypes from "./rules/restrictedTypes.ts";
 import returnAssignments from "./rules/returnAssignments.ts";
 import returnThisTypes from "./rules/returnThisTypes.ts";
 import selfAssignments from "./rules/selfAssignments.ts";
@@ -566,6 +567,7 @@ export const ts = createPlugin({
 		responseJsonMethods,
 		restrictedIdentifiers,
 		restrictedImports,
+		restrictedTypes,
 		returnAssignments,
 		returnThisTypes,
 		selfAssignments,

--- a/packages/ts/src/rules/restrictedTypes.test.ts
+++ b/packages/ts/src/rules/restrictedTypes.test.ts
@@ -1,0 +1,351 @@
+import rule from "./restrictedTypes.ts";
+import { ruleTester } from "./ruleTester.ts";
+
+const restrictedFile = {
+	restrictions: [
+		{
+			specifier: {
+				from: "file" as const,
+				name: "Restricted",
+				path: "./restricted.ts",
+			},
+		},
+	],
+};
+
+const restrictedFiles = {
+	"restricted.ts": `
+export interface Restricted {}
+export class RestrictedBase {}
+export const restrictedValue = 1;
+export namespace Space { export interface Restricted {} }
+`,
+};
+
+const restrictedPackageFiles = {
+	"legacy-package.d.ts": `
+declare module "legacy-package" {
+    export interface Dangerous {}
+    export const dangerousValue: number;
+}
+`,
+};
+
+ruleTester.describe(rule, {
+	invalid: [
+		{
+			code: `
+import type { Restricted } from "./restricted";
+type Result = Restricted;
+`,
+			files: restrictedFiles,
+			options: restrictedFile,
+			snapshot: `
+import type { Restricted } from "./restricted";
+type Result = Restricted;
+              ~~~~~~~~~~
+              Type reference 'Restricted' resolves to a restricted declaration.
+`,
+		},
+		{
+			code: `
+import type { Restricted as Local } from "./restricted";
+type Result = Local;
+`,
+			files: restrictedFiles,
+			options: restrictedFile,
+			snapshot: `
+import type { Restricted as Local } from "./restricted";
+type Result = Local;
+              ~~~~~
+              Type reference 'Local' resolves to a restricted declaration.
+`,
+		},
+		{
+			code: `
+import type * as Types from "./restricted";
+type Result = Types.Restricted;
+`,
+			files: restrictedFiles,
+			options: restrictedFile,
+			snapshot: `
+import type * as Types from "./restricted";
+type Result = Types.Restricted;
+              ~~~~~~~~~~~~~~~~
+              Type reference 'Types.Restricted' resolves to a restricted declaration.
+`,
+		},
+		{
+			code: `
+import type { Restricted } from "./restricted";
+type Result = Restricted<Array<Restricted>>;
+`,
+			files: restrictedFiles,
+			options: restrictedFile,
+			snapshot: `
+import type { Restricted } from "./restricted";
+type Result = Restricted<Array<Restricted>>;
+              ~~~~~~~~~~
+              Type reference 'Restricted' resolves to a restricted declaration.
+                               ~~~~~~~~~~
+                               Type reference 'Restricted' resolves to a restricted declaration.
+`,
+		},
+		{
+			code: `
+import { RestrictedBase } from "./restricted";
+import type { Restricted } from "./restricted";
+class Derived extends RestrictedBase implements Restricted {}
+interface Extended extends RestrictedBase {}
+`,
+			files: restrictedFiles,
+			options: {
+				restrictions: [
+					{ specifier: { from: "file", path: "./restricted.ts" } },
+				],
+			},
+			snapshot: `
+import { RestrictedBase } from "./restricted";
+import type { Restricted } from "./restricted";
+class Derived extends RestrictedBase implements Restricted {}
+                      ~~~~~~~~~~~~~~
+                      Type reference 'RestrictedBase' resolves to a restricted declaration.
+                                                ~~~~~~~~~~
+                                                Type reference 'Restricted' resolves to a restricted declaration.
+interface Extended extends RestrictedBase {}
+                           ~~~~~~~~~~~~~~
+                           Type reference 'RestrictedBase' resolves to a restricted declaration.
+`,
+		},
+		{
+			code: `
+import type { Dangerous as LocalType } from "legacy-package";
+type Result = LocalType;
+`,
+			files: restrictedPackageFiles,
+			options: {
+				restrictions: [
+					{
+						specifier: {
+							from: "package",
+							name: ["Dangerous", "OtherType"],
+							package: "legacy-package",
+						},
+					},
+				],
+			},
+			snapshot: `
+import type { Dangerous as LocalType } from "legacy-package";
+type Result = LocalType;
+              ~~~~~~~~~
+              Type reference 'LocalType' resolves to a restricted declaration.
+`,
+		},
+		{
+			code: `
+import type { PublicType as LocalType } from "./barrel";
+type Result = LocalType;
+`,
+			files: {
+				...restrictedPackageFiles,
+				"barrel.ts": `export type { Dangerous as PublicType } from "legacy-package";`,
+			},
+			options: {
+				restrictions: [
+					{
+						specifier: {
+							from: "package",
+							name: "Dangerous",
+							package: "legacy-package",
+						},
+					},
+				],
+			},
+			snapshot: `
+import type { PublicType as LocalType } from "./barrel";
+type Result = LocalType;
+              ~~~~~~~~~
+              Type reference 'LocalType' resolves to a restricted declaration.
+`,
+		},
+		{
+			code: `
+type Module = import("./restricted");
+`,
+			files: restrictedFiles,
+			options: {
+				restrictions: [
+					{ specifier: { from: "file", path: "./restricted.ts" } },
+				],
+			},
+			snapshot: `
+type Module = import("./restricted");
+              ~~~~~~~~~~~~~~~~~~~~~~
+              Type reference 'import("./restricted")' resolves to a restricted declaration.
+`,
+		},
+		{
+			code: `
+type Result = import("./restricted").Space.Restricted;
+`,
+			files: restrictedFiles,
+			options: restrictedFile,
+			snapshot: `
+type Result = import("./restricted").Space.Restricted;
+                                     ~~~~~~~~~~~~~~~~
+                                     Type reference 'Space.Restricted' resolves to a restricted declaration.
+`,
+		},
+		{
+			code: `
+type Module = typeof import("legacy-package");
+`,
+			files: restrictedPackageFiles,
+			options: {
+				restrictions: [
+					{
+						specifier: { from: "package", package: "legacy-package" },
+					},
+				],
+			},
+			snapshot: `
+type Module = typeof import("legacy-package");
+              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+              Type reference 'typeof import("legacy-package")' resolves to a restricted declaration.
+`,
+		},
+		{
+			code: `
+import * as Values from "./restricted";
+type Result = typeof Values.restrictedValue;
+`,
+			files: restrictedFiles,
+			options: {
+				restrictions: [
+					{
+						message: "Choose the public value.",
+						specifier: {
+							from: "file",
+							name: "restrictedValue",
+							path: "./restricted.ts",
+						},
+					},
+					{ specifier: { from: "file", path: "./restricted.ts" } },
+				],
+			},
+			snapshot: `
+import * as Values from "./restricted";
+type Result = typeof Values.restrictedValue;
+                     ~~~~~~~~~~~~~~~~~~~~~~
+                     Type reference 'Values.restrictedValue' resolves to a restricted declaration. Choose the public value.
+`,
+		},
+		{
+			code: `
+type Result = Date;
+type Qualified = globalThis.Date;
+`,
+			options: {
+				restrictions: [{ specifier: { from: "lib", name: ["Date", "Other"] } }],
+			},
+			snapshot: `
+type Result = Date;
+              ~~~~
+              Type reference 'Date' resolves to a restricted declaration.
+type Qualified = globalThis.Date;
+                 ~~~~~~~~~~~~~~~
+                 Type reference 'globalThis.Date' resolves to a restricted declaration.
+`,
+		},
+		{
+			code: `
+interface Merged { value: string }
+namespace Merged { export const value = ""; }
+type Result = Merged;
+`,
+			options: {
+				restrictions: [{ specifier: { from: "file", name: "Merged" } }],
+			},
+			snapshot: `
+interface Merged { value: string }
+namespace Merged { export const value = ""; }
+type Result = Merged;
+              ~~~~~~
+              Type reference 'Merged' resolves to a restricted declaration.
+`,
+		},
+		{
+			code: `
+import type { Restricted } from "./restricted";
+type Alias = Restricted;
+type Result = Alias;
+`,
+			files: restrictedFiles,
+			options: restrictedFile,
+			snapshot: `
+import type { Restricted } from "./restricted";
+type Alias = Restricted;
+             ~~~~~~~~~~
+             Type reference 'Restricted' resolves to a restricted declaration.
+type Result = Alias;
+`,
+		},
+	],
+	valid: [
+		`type Result = Date;`,
+		{ code: `type Result = Date;`, options: { restrictions: [] } },
+		{
+			code: `interface Restricted {}; type Result = Restricted;`,
+			options: restrictedFile,
+		},
+		{
+			code: `import type { Restricted } from "./restricted";`,
+			files: restrictedFiles,
+			options: restrictedFile,
+		},
+		{
+			code: `import { restrictedValue } from "./restricted"; console.log(restrictedValue);`,
+			files: restrictedFiles,
+			options: {
+				restrictions: [
+					{ specifier: { from: "file", path: "./restricted.ts" } },
+				],
+			},
+		},
+		{
+			code: `import type { Dangerous } from "allowed-package"; type Result = Dangerous;`,
+			files: {
+				...restrictedPackageFiles,
+				"allowed-package.d.ts": `declare module "allowed-package" { export interface Dangerous {} }`,
+			},
+			options: {
+				restrictions: [
+					{
+						specifier: {
+							from: "package",
+							name: "Dangerous",
+							package: "legacy-package",
+						},
+					},
+				],
+			},
+		},
+		{
+			code: `type Values = string | number | {} | [];`,
+			options: {
+				restrictions: [{ specifier: { from: "lib" } }],
+			},
+		},
+		{
+			code: `type Missing = Unknown; type Module = import("./missing"); type InvalidModule = import(Unknown); class Derived extends unknownCall() {}`,
+			options: {
+				restrictions: [{ specifier: { from: "file" } }],
+			},
+		},
+		{
+			code: `type Module = import("./restricted");`,
+			files: restrictedFiles,
+			options: restrictedFile,
+		},
+	],
+});

--- a/packages/ts/src/rules/restrictedTypes.ts
+++ b/packages/ts/src/rules/restrictedTypes.ts
@@ -1,0 +1,136 @@
+import ts from "typescript";
+import { z } from "zod/v4";
+
+import {
+	getTSNodeRange,
+	typescriptLanguage,
+	type TypeScriptFileServices,
+} from "@flint.fyi/typescript-language";
+
+import { matchesSpecifier } from "../type-utils/matchesSpecifier.ts";
+import { typeOrValueSpecifierSchema } from "../type-utils/schemas.ts";
+import { ruleCreator } from "./ruleCreator.ts";
+
+const restrictionSchema = z.object({
+	message: z
+		.string()
+		.optional()
+		.describe("A custom message to display when the restriction is triggered."),
+	specifier: typeOrValueSpecifierSchema.describe(
+		"A TypeOrValueSpecifier identifying the restricted declaration.",
+	),
+});
+
+interface Options {
+	restrictions: z.infer<typeof restrictionSchema>[];
+}
+
+interface VisitorServices extends TypeScriptFileServices {
+	options: Options;
+}
+
+export default ruleCreator.createRule(typescriptLanguage, {
+	about: {
+		description:
+			"Disallows references to specified types and values in type positions.",
+		id: "restrictedTypes",
+	},
+	messages: {
+		restricted: {
+			primary:
+				"Type reference '{{ source }}' resolves to a restricted declaration.",
+			secondary: [
+				"Restrictions match the final declaration identity rather than the local spelling.",
+			],
+			suggestions: ["Use an allowed type instead."],
+		},
+		restrictedWithMessage: {
+			primary:
+				"Type reference '{{ source }}' resolves to a restricted declaration. {{ customMessage }}",
+			secondary: [
+				"Restrictions match the final declaration identity rather than the local spelling.",
+			],
+			suggestions: ["Use an allowed type instead."],
+		},
+	},
+	options: {
+		restrictions: z
+			.array(restrictionSchema)
+			.default([])
+			.describe("Declarations that are restricted in type positions."),
+	},
+	setup(context) {
+		return {
+			visitors: {
+				ExpressionWithTypeArguments: (node, services) => {
+					checkNode(node.expression, services);
+				},
+				ImportType: (node, services) => {
+					if (node.qualifier) {
+						checkNode(node.qualifier, services);
+					} else {
+						checkNode(
+							ts.isLiteralTypeNode(node.argument)
+								? node.argument.literal
+								: node.argument,
+							services,
+							node,
+							true,
+						);
+					}
+				},
+				TypeQuery: (node, services) => {
+					checkNode(node.exprName, services);
+				},
+				TypeReference: (node, services) => {
+					checkNode(node.typeName, services);
+				},
+			},
+		};
+
+		function checkNode(
+			symbolNode: ts.Node,
+			{ options, program, sourceFile, typeChecker }: VisitorServices,
+			reportNode: ts.Node = symbolNode,
+			omitName = false,
+		) {
+			if (!options.restrictions.length) {
+				return;
+			}
+
+			let symbol = typeChecker.getSymbolAtLocation(symbolNode);
+			if (!symbol) {
+				return;
+			}
+
+			if (symbol.flags & ts.SymbolFlags.Alias) {
+				symbol = typeChecker.getAliasedSymbol(symbol);
+			}
+
+			symbol = typeChecker.getMergedSymbol(symbol);
+			const declarations = symbol.getDeclarations();
+			if (!declarations?.length) {
+				return;
+			}
+
+			const name = omitName ? undefined : symbol.getName();
+			for (const restriction of options.restrictions) {
+				if (
+					!matchesSpecifier(name, declarations, restriction.specifier, program)
+				) {
+					continue;
+				}
+
+				context.report({
+					data: {
+						customMessage: restriction.message ?? "",
+						source: reportNode.getText(sourceFile),
+					},
+					message: restriction.message ? "restrictedWithMessage" : "restricted",
+					range: getTSNodeRange(reportNode, sourceFile),
+				});
+				return;
+			}
+		}
+	},
+});


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #2001
- [x] That issue was marked as [`status: accepting prs`](https://github.com/flint-fyi/flint/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/flint-fyi/flint/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Adds the TypeScript `restrictedTypes` rule with source-aware restrictions using `TypeOrValueSpecifier`.

The rule resolves direct references in type positions through imports and re-exports, then matches their final declarations by file, package, or TypeScript library provenance. It supports named and qualified references, generic references, heritage clauses, import types, and `typeof` type queries while avoiding same-name false positives from unrelated declarations.

The rule intentionally does not propagate restrictions through local aliases or computed structural equivalence, and it does not inspect runtime expressions, primitive keywords, `{}`, or `[]`.

Includes rule documentation, full semantic unit coverage, TypeScript CLI integration coverage, rule-data registration, and a release changeset.

❤️‍🔥