### PR TITLE
feat(ts): add returnAwaitPromises rule

### DIFF
--- a/.changeset/tidy-promises-await.md
+++ b/.changeset/tidy-promises-await.md
@@ -1,0 +1,5 @@
+---
+"@flint.fyi/ts": patch
+---
+
+Add the logical `returnAwaitPromises` rule to preserve rejection handling and resource disposal around returned promises.

--- a/packages/e2e/tests/directives/directives.test.ts
+++ b/packages/e2e/tests/directives/directives.test.ts
@@ -25,7 +25,7 @@ describe("directives", () => {
 
 			<red>✖ Found <bold>4 reports</bold> across <bold>3 files</bold>.</fg>
 			<red></fg>
-			<dim>Finished in <time> on 4 files with 139 rules.</fg>
+			<dim>Finished in <time> on 4 files with 140 rules.</fg>
 			<dim></fg>"
 		`);
 		// cspell:enable

--- a/packages/e2e/tests/typescript/fixtures/src/with-issues.ts
+++ b/packages/e2e/tests/typescript/fixtures/src/with-issues.ts
@@ -6,3 +6,11 @@ export function debug(value: unknown): void {
 export function calculate(a: number, b: number): number {
 	return a + b;
 }
+
+export async function loadSomething() {
+	try {
+		return Promise.resolve("loaded");
+	} catch {
+		return "fallback";
+	}
+}

--- a/packages/e2e/tests/typescript/typescript.test.ts
+++ b/packages/e2e/tests/typescript/typescript.test.ts
@@ -13,11 +13,12 @@ describe("typescript", () => {
 			"<dim>Linting with <cyan><bold>flint.config.ts</bold></fg><dim>...</fg>
 
 			<underline><cwd>/fixtures/src/with-issues.ts</underline>
-			<dim>  2:2</fg>  Debugger statements should not be used in production code.  <yellow>ts/debuggerStatements</fg>
+			<dim>  2:2</fg>    Debugger statements should not be used in production code.                                                                     <yellow>ts/debuggerStatements</fg>
+			<dim>  12:10</fg>  Await this returned promise so its rejection is handled before the surrounding error handling or resource disposal completes.  <yellow>ts/returnAwaitPromises</fg>
 
-			<red>✖ Found <bold>1 report</bold> across <bold>1 file</bold>.</fg>
+			<red>✖ Found <bold>2 reports</bold> across <bold>1 file</bold>.</fg>
 			<red></fg>
-			<dim>Finished in <time> on 2 files with 138 rules.</fg>
+			<dim>Finished in <time> on 2 files with 139 rules.</fg>
 			<dim></fg>"
 		`);
 	});

--- a/packages/rule-data/src/data.json
+++ b/packages/rule-data/src/data.json
@@ -26815,7 +26815,8 @@
 		"flint": {
 			"name": "returnAwaitPromises",
 			"plugin": "ts",
-			"preset": "logical"
+			"preset": "logical",
+			"status": "implemented"
 		},
 		"oxlint": [
 			{

--- a/packages/site/src/content/docs/rules/ts/returnAwaitPromises.mdx
+++ b/packages/site/src/content/docs/rules/ts/returnAwaitPromises.mdx
@@ -1,0 +1,80 @@
+---
+description: "Reports missing awaits that affect returned-promise handling and unnecessary awaits on non-thenable return values."
+title: "returnAwaitPromises"
+topic: "rules"
+---
+
+import { TabItem, Tabs } from "@astrojs/starlight/components";
+import { RuleEquivalents } from "~/components/RuleEquivalents";
+import RuleSummary from "~/components/RuleSummary.astro";
+
+<RuleSummary plugin="ts" rule="returnAwaitPromises" />
+
+An async function normally adopts a returned promise after its surrounding `try` statement or active `using` resources have completed.
+Awaiting the promise first lets a rejection reach the active `catch` or `finally` and keeps resources alive until settlement.
+This rule requires that await only when the returned value is definitely thenable and reports awaits of definitely non-thenable return values.
+It preserves ordinary promise returns, ordinary `return await`, and uncertain types such as `any`, `unknown`, open generic constraints, and mixed unions.
+Async generators are excluded because their return completion already awaits its value.
+
+## Examples
+
+<Tabs>
+<TabItem label="❌ Incorrect">
+
+```ts
+async function read() {
+	try {
+		return fetch("/data");
+	} catch (error) {
+		console.error(error);
+	}
+}
+```
+
+```ts
+async function count() {
+	return await 1;
+}
+```
+
+</TabItem>
+<TabItem label="✅ Correct">
+
+```ts
+async function read() {
+	try {
+		return await fetch("/data");
+	} catch (error) {
+		console.error(error);
+	}
+}
+```
+
+```ts
+async function read() {
+	return fetch("/data");
+}
+```
+
+</TabItem>
+</Tabs>
+
+## Options
+
+This rule is not configurable.
+
+## When Not To Use It
+
+You might not want to use this rule if your code intentionally allows returned promise rejections to bypass surrounding `catch` blocks.
+You might also avoid it while migrating code that depends on the existing microtask timing of `return await` on non-thenable values.
+
+## Further Reading
+
+- [MDN: await](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/await)
+- [MDN: async function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/async_function)
+- [MDN: try...catch](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/try...catch)
+- [TypeScript: `using` declarations](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-5-2.html)
+
+## Equivalents in Other Linters
+
+<RuleEquivalents pluginId="ts" ruleId="returnAwaitPromises" />

--- a/packages/ts/src/plugin.ts
+++ b/packages/ts/src/plugin.ts
@@ -253,6 +253,7 @@ import responseJsonMethods from "./rules/responseJsonMethods.ts";
 import restrictedIdentifiers from "./rules/restrictedIdentifiers.ts";
 import restrictedImports from "./rules/restrictedImports.ts";
 import returnAssignments from "./rules/returnAssignments.ts";
+import returnAwaitPromises from "./rules/returnAwaitPromises.ts";
 import returnThisTypes from "./rules/returnThisTypes.ts";
 import selfAssignments from "./rules/selfAssignments.ts";
 import sequences from "./rules/sequences.ts";
@@ -567,6 +568,7 @@ export const ts = createPlugin({
 		restrictedIdentifiers,
 		restrictedImports,
 		returnAssignments,
+		returnAwaitPromises,
 		returnThisTypes,
 		selfAssignments,
 		sequences,

--- a/packages/ts/src/rules/returnAwaitPromises.test.ts
+++ b/packages/ts/src/rules/returnAwaitPromises.test.ts
@@ -1,0 +1,580 @@
+import rule from "./returnAwaitPromises.ts";
+import { ruleTester } from "./ruleTester.ts";
+
+ruleTester.describe(rule, {
+	invalid: [
+		{
+			code: `
+async function load() {
+    try {
+        return Promise.resolve(1);
+    } catch {}
+}
+`,
+			snapshot: `
+async function load() {
+    try {
+        return Promise.resolve(1);
+               ~~~~~~~~~~~~~~~~~~
+               Await this returned promise so its rejection is handled before the surrounding error handling or resource disposal completes.
+    } catch {}
+}
+`,
+			suggestions: [
+				{
+					id: "addAwait",
+					updated: `
+async function load() {
+    try {
+        return await Promise.resolve(1);
+    } catch {}
+}
+`,
+				},
+			],
+		},
+		{
+			code: `
+const load = async () => await 1;
+`,
+			snapshot: `
+const load = async () => await 1;
+                         ~~~~~
+                         This returned value is not thenable, so awaiting it only changes completion timing.
+`,
+			suggestions: [
+				{
+					id: "removeAwait",
+					updated: `
+const load = async () => 1;
+`,
+				},
+			],
+		},
+		{
+			code: `
+async function choose(flag: boolean) {
+    try {
+        return flag ? Promise.resolve(1) : 1;
+    } finally {}
+}
+`,
+			snapshot: `
+async function choose(flag: boolean) {
+    try {
+        return flag ? Promise.resolve(1) : 1;
+                      ~~~~~~~~~~~~~~~~~~
+                      Await this returned promise so its rejection is handled before the surrounding error handling or resource disposal completes.
+    } finally {}
+}
+`,
+			suggestions: [
+				{
+					id: "addAwait",
+					updated: `
+async function choose(flag: boolean) {
+    try {
+        return flag ? await Promise.resolve(1) : 1;
+    } finally {}
+}
+`,
+				},
+			],
+		},
+		{
+			code: `
+async function dispose() {
+    using resource = createResource();
+    return Promise.resolve(1);
+}
+`,
+			snapshot: `
+async function dispose() {
+    using resource = createResource();
+    return Promise.resolve(1);
+           ~~~~~~~~~~~~~~~~~~
+           Await this returned promise so its rejection is handled before the surrounding error handling or resource disposal completes.
+}
+`,
+			suggestions: [
+				{
+					id: "addAwait",
+					updated: `
+async function dispose() {
+    using resource = createResource();
+    return await Promise.resolve(1);
+}
+`,
+				},
+			],
+		},
+		{
+			code: `
+async function load() {
+    return await {};
+}
+`,
+			snapshot: `
+async function load() {
+    return await {};
+           ~~~~~
+           This returned value is not thenable, so awaiting it only changes completion timing.
+}
+`,
+			suggestions: [
+				{
+					id: "removeAwait",
+					updated: `
+async function load() {
+    return {};
+}
+`,
+				},
+			],
+		},
+		{
+			code: `
+async function load(value: PromiseLike<number>) {
+    try {} catch {
+        return value;
+    } finally {}
+}
+`,
+			snapshot: `
+async function load(value: PromiseLike<number>) {
+    try {} catch {
+        return value;
+               ~~~~~
+               Await this returned promise so its rejection is handled before the surrounding error handling or resource disposal completes.
+    } finally {}
+}
+`,
+			suggestions: [
+				{
+					id: "addAwait",
+					updated: `
+async function load(value: PromiseLike<number>) {
+    try {} catch {
+        return await value;
+    } finally {}
+}
+`,
+				},
+			],
+		},
+		{
+			code: `
+async function load() {
+    try {
+        try {} finally {
+            return Promise.resolve(1);
+        }
+    } catch {}
+}
+`,
+			snapshot: `
+async function load() {
+    try {
+        try {} finally {
+            return Promise.resolve(1);
+                   ~~~~~~~~~~~~~~~~~~
+                   Await this returned promise so its rejection is handled before the surrounding error handling or resource disposal completes.
+        }
+    } catch {}
+}
+`,
+			suggestions: [
+				{
+					id: "addAwait",
+					updated: `
+async function load() {
+    try {
+        try {} finally {
+            return await Promise.resolve(1);
+        }
+    } catch {}
+}
+`,
+				},
+			],
+		},
+		{
+			code: `
+async function load(left: Promise<number>, right: Promise<string>) {
+    try {
+        return left || right;
+    } finally {}
+}
+`,
+			snapshot: `
+async function load(left: Promise<number>, right: Promise<string>) {
+    try {
+        return left || right;
+               ~~~~~~~~~~~~~
+               Await this returned promise so its rejection is handled before the surrounding error handling or resource disposal completes.
+    } finally {}
+}
+`,
+			suggestions: [
+				{
+					id: "addAwait",
+					updated: `
+async function load(left: Promise<number>, right: Promise<string>) {
+    try {
+        return await (left || right);
+    } finally {}
+}
+`,
+				},
+			],
+		},
+		{
+			code: `
+async function load(value: unknown) {
+    try {
+        return value as Promise<number>;
+    } finally {}
+}
+`,
+			snapshot: `
+async function load(value: unknown) {
+    try {
+        return value as Promise<number>;
+               ~~~~~~~~~~~~~~~~~~~~~~~~
+               Await this returned promise so its rejection is handled before the surrounding error handling or resource disposal completes.
+    } finally {}
+}
+`,
+			suggestions: [
+				{
+					id: "addAwait",
+					updated: `
+async function load(value: unknown) {
+    try {
+        return await (value as Promise<number>);
+    } finally {}
+}
+`,
+				},
+			],
+		},
+		{
+			code: `
+async function load(value: Promise<number>) {
+    try {
+        return (value satisfies PromiseLike<number>);
+    } finally {}
+}
+`,
+			snapshot: `
+async function load(value: Promise<number>) {
+    try {
+        return (value satisfies PromiseLike<number>);
+               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+               Await this returned promise so its rejection is handled before the surrounding error handling or resource disposal completes.
+    } finally {}
+}
+`,
+			suggestions: [
+				{
+					id: "addAwait",
+					updated: `
+async function load(value: Promise<number>) {
+    try {
+        return await (value satisfies PromiseLike<number>);
+    } finally {}
+}
+`,
+				},
+			],
+		},
+		{
+			code: `
+async function load() {
+    for (using resource = createResource(); condition; update()) {
+        return Promise.resolve(1);
+    }
+}
+`,
+			snapshot: `
+async function load() {
+    for (using resource = createResource(); condition; update()) {
+        return Promise.resolve(1);
+               ~~~~~~~~~~~~~~~~~~
+               Await this returned promise so its rejection is handled before the surrounding error handling or resource disposal completes.
+    }
+}
+`,
+			suggestions: [
+				{
+					id: "addAwait",
+					updated: `
+async function load() {
+    for (using resource = createResource(); condition; update()) {
+        return await Promise.resolve(1);
+    }
+}
+`,
+				},
+			],
+		},
+		{
+			code: `
+class Loader {
+    async load() {
+        for (using resource of resources) {
+            return Promise.resolve(1);
+        }
+    }
+}
+`,
+			snapshot: `
+class Loader {
+    async load() {
+        for (using resource of resources) {
+            return Promise.resolve(1);
+                   ~~~~~~~~~~~~~~~~~~
+                   Await this returned promise so its rejection is handled before the surrounding error handling or resource disposal completes.
+        }
+    }
+}
+`,
+			suggestions: [
+				{
+					id: "addAwait",
+					updated: `
+class Loader {
+    async load() {
+        for (using resource of resources) {
+            return await Promise.resolve(1);
+        }
+    }
+}
+`,
+				},
+			],
+		},
+		{
+			code: `
+async function load(flag: boolean) {
+    try {
+        return ((flag ? Promise.resolve(1) : 1));
+    } finally {}
+}
+`,
+			snapshot: `
+async function load(flag: boolean) {
+    try {
+        return ((flag ? Promise.resolve(1) : 1));
+                        ~~~~~~~~~~~~~~~~~~
+                        Await this returned promise so its rejection is handled before the surrounding error handling or resource disposal completes.
+    } finally {}
+}
+`,
+			suggestions: [
+				{
+					id: "addAwait",
+					updated: `
+async function load(flag: boolean) {
+    try {
+        return ((flag ? await Promise.resolve(1) : 1));
+    } finally {}
+}
+`,
+				},
+			],
+		},
+		{
+			code: `
+async function load() {
+    return await /* retain */ 1;
+}
+`,
+			snapshot: `
+async function load() {
+    return await /* retain */ 1;
+           ~~~~~
+           This returned value is not thenable, so awaiting it only changes completion timing.
+}
+`,
+			suggestions: [
+				{
+					id: "removeAwait",
+					updated: `
+async function load() {
+    return  /* retain */ 1;
+}
+`,
+				},
+			],
+		},
+		{
+			code: `
+const load = async function () {
+    try {
+        return <Promise<number>>Promise.resolve(1);
+    } finally {}
+};
+`,
+			snapshot: `
+const load = async function () {
+    try {
+        return <Promise<number>>Promise.resolve(1);
+               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+               Await this returned promise so its rejection is handled before the surrounding error handling or resource disposal completes.
+    } finally {}
+};
+`,
+			suggestions: [
+				{
+					id: "addAwait",
+					updated: `
+const load = async function () {
+    try {
+        return await (<Promise<number>>Promise.resolve(1));
+    } finally {}
+};
+`,
+				},
+			],
+		},
+		{
+			code: `
+async function load<T extends PromiseLike<number>>(value: T) {
+    try {
+        return value;
+    } finally {}
+}
+`,
+			snapshot: `
+async function load<T extends PromiseLike<number>>(value: T) {
+    try {
+        return value;
+               ~~~~~
+               Await this returned promise so its rejection is handled before the surrounding error handling or resource disposal completes.
+    } finally {}
+}
+`,
+			suggestions: [
+				{
+					id: "addAwait",
+					updated: `
+async function load<T extends PromiseLike<number>>(value: T) {
+    try {
+        return await value;
+    } finally {}
+}
+`,
+				},
+			],
+		},
+		{
+			code: `
+type NumberThen = (resolve: (value: number) => void) => void;
+type StringThen = (resolve: (value: string) => void) => void;
+async function load(value: { then: NumberThen | StringThen }) {
+    try {
+        return value;
+    } finally {}
+}
+`,
+			snapshot: `
+type NumberThen = (resolve: (value: number) => void) => void;
+type StringThen = (resolve: (value: string) => void) => void;
+async function load(value: { then: NumberThen | StringThen }) {
+    try {
+        return value;
+               ~~~~~
+               Await this returned promise so its rejection is handled before the surrounding error handling or resource disposal completes.
+    } finally {}
+}
+`,
+			suggestions: [
+				{
+					id: "addAwait",
+					updated: `
+type NumberThen = (resolve: (value: number) => void) => void;
+type StringThen = (resolve: (value: string) => void) => void;
+async function load(value: { then: NumberThen | StringThen }) {
+    try {
+        return await value;
+    } finally {}
+}
+`,
+				},
+			],
+		},
+	],
+	valid: [
+		`async function load() { return Promise.resolve(1); }`,
+		`async function load() { try {} catch { return Promise.resolve(1); } }`,
+		`async function load() { try {} finally { return Promise.resolve(1); } }`,
+		`async function* load() { try { return Promise.resolve(1); } finally {} }`,
+		`const load = async function* () { try { return await 1; } finally {} };`,
+		`class Loader { async *load() { try { return Promise.resolve(1); } finally {} } }`,
+		`function load() { try { return Promise.resolve(1); } finally {} }`,
+		`const load = () => { try { return Promise.resolve(1); } finally {} };`,
+		`class Loader { get value() { try { return Promise.resolve(1); } finally {} } }`,
+		`async function load(value: any) { try { return value; } finally {} }`,
+		`async function load(value: unknown) { try { return value; } finally {} }`,
+		`async function load(value: Promise<number> | number) { try { return value; } finally {} }`,
+		`async function load(value: Promise<number> | undefined) { try { return value; } finally {} }`,
+		`async function load(value: number | string) { try { return value; } finally {} }`,
+		`async function load<T extends object>(value: T) { try { return value; } finally {} }`,
+		`async function load<T extends { value: number }>(value: T) { try { return value; } finally {} }`,
+		`async function load<T extends number>(value: T) { try { return value; } finally {} }`,
+		`async function load<T>(value: T) { try { return value; } finally {} }`,
+		`async function load<T extends any>(value: T) { try { return value; } finally {} }`,
+		`async function load<T extends unknown>(value: T) { try { return value; } finally {} }`,
+		`async function load<T extends PromiseLike<number> | number>(value: T) { try { return value; } finally {} }`,
+		`async function load(value: never) { try { return value; } finally {} }`,
+		`async function load(value: null | undefined | void) { try { return value; } finally {} }`,
+		`async function load(value: bigint | boolean | number | string | symbol) { try { return value; } finally {} }`,
+		`async function load(value: { then?: (resolve: (value: number) => void) => void }) { try { return value; } finally {} }`,
+		`async function load(value: { then: ((resolve: (value: number) => void) => void) | undefined }) { try { return value; } finally {} }`,
+		`async function load(value: { then: any }) { try { return value; } finally {} }`,
+		`async function load(value: { then(): void }) { try { return value; } finally {} }`,
+		`async function load(value: { then(resolve: number): void }) { try { return value; } finally {} }`,
+		`async function load(value: { then(resolve: any): void }) { try { return value; } finally {} }`,
+		`async function load() { return await Promise.resolve(1); }`,
+		`async function load(value: Promise<number> | number) { return await value; }`,
+		`async function load(flag: boolean, value: Promise<number>) { try { return await (flag ? value : 1); } finally {} }`,
+		`async function load(flag: boolean, value: Promise<number>) { try { return flag && value; } finally {} }`,
+		`async function load() { return; }`,
+		`return Promise.resolve(1);`,
+		`
+async function load() {
+    return Promise.resolve(1);
+    using resource = createResource();
+}
+`,
+		`
+async function outer() {
+    using resource = createResource();
+    return async function inner() { return Promise.resolve(1); };
+}
+`,
+		`
+async function load(flag: boolean) {
+    if (flag) {
+        using resource = createResource();
+    }
+    return Promise.resolve(1);
+}
+`,
+		`
+async function load() {
+    {
+        using resource = createResource();
+    }
+    return Promise.resolve(1);
+}
+`,
+		`
+async function load() {
+    const value = 1;
+    return Promise.resolve(value);
+}
+`,
+	],
+});

--- a/packages/ts/src/rules/returnAwaitPromises.ts
+++ b/packages/ts/src/rules/returnAwaitPromises.ts
@@ -1,0 +1,379 @@
+import * as tsutils from "ts-api-utils";
+import ts, { NodeFlags, SyntaxKind, TypeFlags } from "typescript";
+
+import {
+	getTSNodeRange,
+	typescriptLanguage,
+	type AST,
+	type Checker,
+	type TypeScriptFileServices,
+} from "@flint.fyi/typescript-language";
+
+import { ruleCreator } from "./ruleCreator.ts";
+
+type Awaitability = "nonThenable" | "thenable" | "uncertain";
+type FunctionNode =
+	| AST.ArrowFunction
+	| AST.FunctionDeclaration
+	| AST.FunctionExpression
+	| AST.MethodDeclaration;
+
+export default ruleCreator.createRule(typescriptLanguage, {
+	about: {
+		description:
+			"Reports missing awaits that affect returned-promise handling and unnecessary awaits on non-thenable return values.",
+		id: "returnAwaitPromises",
+		presets: ["logical"],
+	},
+	messages: {
+		missingAwait: {
+			primary:
+				"Await this returned promise so its rejection is handled before the surrounding error handling or resource disposal completes.",
+			secondary: [],
+			suggestions: [],
+		},
+		unnecessaryAwait: {
+			primary:
+				"This returned value is not thenable, so awaiting it only changes completion timing.",
+			secondary: [],
+			suggestions: [],
+		},
+	},
+	setup(context) {
+		function checkExpression(
+			expression: AST.Expression,
+			owner: FunctionNode,
+			services: TypeScriptFileServices,
+		) {
+			if (expression.kind === SyntaxKind.AwaitExpression) {
+				if (
+					classifyType(
+						services.typeChecker.getTypeAtLocation(expression.expression),
+						services.typeChecker,
+						expression.expression,
+					) === "nonThenable"
+				) {
+					reportUnnecessaryAwait(expression, services.sourceFile);
+				}
+				return;
+			}
+
+			if (
+				!hasActiveErrorContext(expression, owner) &&
+				!hasActiveResource(expression, owner)
+			) {
+				return;
+			}
+
+			reportThenableExpressions(expression, services);
+		}
+
+		function reportThenableExpressions(
+			expression: AST.Expression,
+			{
+				sourceFile,
+				typeChecker,
+			}: Pick<TypeScriptFileServices, "sourceFile" | "typeChecker">,
+		) {
+			const awaitability = classifyType(
+				typeChecker.getTypeAtLocation(expression),
+				typeChecker,
+				expression,
+			);
+			if (awaitability === "thenable") {
+				const text = expression.getText(sourceFile);
+				context.report({
+					message: "missingAwait",
+					range: getTSNodeRange(expression, sourceFile),
+					suggestions: [
+						{
+							id: "addAwait",
+							range: getTSNodeRange(expression, sourceFile),
+							text: needsParentheses(expression)
+								? `await (${text})`
+								: `await ${text}`,
+						},
+					],
+				});
+				return;
+			}
+
+			const unwrapped = skipParentheses(expression);
+			if (
+				awaitability === "uncertain" &&
+				unwrapped.kind === SyntaxKind.ConditionalExpression
+			) {
+				reportThenableExpressions(unwrapped.whenTrue, {
+					sourceFile,
+					typeChecker,
+				});
+				reportThenableExpressions(unwrapped.whenFalse, {
+					sourceFile,
+					typeChecker,
+				});
+			}
+		}
+
+		function reportUnnecessaryAwait(
+			expression: AST.AwaitExpression,
+			sourceFile: AST.SourceFile,
+		) {
+			const keywordEnd = expression.getStart(sourceFile) + "await".length;
+			const operandStart = expression.expression.getStart(sourceFile);
+			const removableEnd = /^\s*$/.test(
+				sourceFile.text.slice(keywordEnd, operandStart),
+			)
+				? operandStart
+				: keywordEnd;
+			context.report({
+				message: "unnecessaryAwait",
+				range: {
+					begin: expression.getStart(sourceFile),
+					end: keywordEnd,
+				},
+				suggestions: [
+					{
+						id: "removeAwait",
+						range: {
+							begin: expression.getStart(sourceFile),
+							end: removableEnd,
+						},
+						text: "",
+					},
+				],
+			});
+		}
+
+		return {
+			visitors: {
+				ArrowFunction(node, services) {
+					if (node.body.kind !== SyntaxKind.Block && isSupportedOwner(node)) {
+						checkExpression(node.body, node, services);
+					}
+				},
+				ReturnStatement(node, services) {
+					if (!node.expression) {
+						return;
+					}
+
+					const owner = findOwner(node);
+					if (owner && isSupportedOwner(owner)) {
+						checkExpression(node.expression, owner, services);
+					}
+				},
+			},
+		};
+	},
+});
+
+function classifyThenType(
+	type: ts.Type,
+	typeChecker: Checker,
+	location: ts.Node,
+): Awaitability {
+	if (type.flags & (TypeFlags.Any | TypeFlags.Unknown)) {
+		return "uncertain";
+	}
+	if (tsutils.isUnionType(type)) {
+		const [first, ...rest] = type.types.map((constituent) =>
+			classifyThenType(constituent, typeChecker, location),
+		) as [Awaitability, ...Awaitability[]];
+		return rest.every((classification) => classification === first)
+			? first
+			: "uncertain";
+	}
+
+	const signatures = type.getCallSignatures();
+	if (!signatures.length) {
+		return "nonThenable";
+	}
+
+	let classification: Awaitability = "nonThenable";
+	for (const signature of signatures) {
+		const parameter = signature.getParameters()[0];
+		if (!parameter) {
+			continue;
+		}
+		const parameterType = typeChecker.getTypeOfSymbolAtLocation(
+			parameter,
+			location,
+		);
+		if (parameterType.flags & (TypeFlags.Any | TypeFlags.Unknown)) {
+			classification = "uncertain";
+			continue;
+		}
+		if (
+			typeChecker.getNonNullableType(parameterType).getCallSignatures().length
+		) {
+			return "thenable";
+		}
+	}
+	return classification;
+}
+
+function classifyType(
+	type: ts.Type,
+	typeChecker: Checker,
+	location: ts.Node,
+): Awaitability {
+	if (type.flags & TypeFlags.TypeParameter) {
+		const constraint = typeChecker.getBaseConstraintOfType(type);
+		if (!constraint) {
+			return "uncertain";
+		}
+
+		const classification = classifyType(constraint, typeChecker, location);
+		return classification === "nonThenable" &&
+			constraint.flags & TypeFlags.Object
+			? "uncertain"
+			: classification;
+	}
+
+	if (tsutils.isUnionType(type)) {
+		const [first, ...rest] = type.types.map((constituent) =>
+			classifyType(constituent, typeChecker, location),
+		) as [Awaitability, ...Awaitability[]];
+		return rest.every((classification) => classification === first)
+			? first
+			: "uncertain";
+	}
+
+	if (type.flags & (TypeFlags.Any | TypeFlags.Unknown)) {
+		return "uncertain";
+	}
+	if (
+		type.flags &
+		(TypeFlags.Never |
+			TypeFlags.Null |
+			TypeFlags.Undefined |
+			TypeFlags.StringLike |
+			TypeFlags.NumberLike |
+			TypeFlags.BigIntLike |
+			TypeFlags.BooleanLike |
+			TypeFlags.ESSymbolLike)
+	) {
+		return "nonThenable";
+	}
+
+	const apparentType = typeChecker.getApparentType(type);
+	const then = apparentType.getProperty("then");
+	if (!then) {
+		return "nonThenable";
+	}
+	if (then.flags & ts.SymbolFlags.Optional) {
+		return "uncertain";
+	}
+
+	const thenType = typeChecker.getTypeOfSymbolAtLocation(then, location);
+	return classifyThenType(thenType, typeChecker, location);
+}
+
+function findOwner(node: AST.AnyNode): FunctionNode | undefined {
+	for (
+		let current = node.parent;
+		current.kind !== SyntaxKind.SourceFile;
+		current = current.parent
+	) {
+		if (tsutils.isFunctionScopeBoundary(current)) {
+			return isFunctionNode(current) ? current : undefined;
+		}
+	}
+	return undefined;
+}
+
+function hasActiveErrorContext(node: AST.AnyNode, owner: FunctionNode) {
+	for (
+		let current: ts.Node = node;
+		current !== owner;
+		current = current.parent
+	) {
+		const parent = current.parent;
+		if (ts.isTryStatement(parent) && parent.tryBlock === current) {
+			return true;
+		}
+		if (
+			ts.isCatchClause(parent) &&
+			ts.isTryStatement(parent.parent) &&
+			parent.parent.finallyBlock
+		) {
+			return true;
+		}
+	}
+	return false;
+}
+
+function hasActiveResource(node: AST.AnyNode, owner: FunctionNode) {
+	for (
+		let current: ts.Node = node;
+		current !== owner;
+		current = current.parent
+	) {
+		const parent = current.parent;
+		if (ts.isBlock(parent) || ts.isSourceFile(parent)) {
+			for (const statement of parent.statements) {
+				if (
+					statement === current ||
+					statement.getStart(parent.getSourceFile()) >=
+						current.getStart(parent.getSourceFile())
+				) {
+					break;
+				}
+				if (isUsingStatement(statement)) {
+					return true;
+				}
+			}
+		}
+		if (
+			(ts.isForStatement(parent) || ts.isForOfStatement(parent)) &&
+			parent.statement === current &&
+			parent.initializer &&
+			ts.isVariableDeclarationList(parent.initializer) &&
+			tsutils.isNodeFlagSet(parent.initializer, NodeFlags.Using)
+		) {
+			return true;
+		}
+	}
+	return false;
+}
+
+function isFunctionNode(node: ts.Node): node is FunctionNode {
+	return (
+		ts.isArrowFunction(node) ||
+		ts.isFunctionDeclaration(node) ||
+		ts.isFunctionExpression(node) ||
+		ts.isMethodDeclaration(node)
+	);
+}
+
+function isSupportedOwner(node: FunctionNode) {
+	return (
+		!node.asteriskToken &&
+		!!node.modifiers?.some(
+			(modifier) => modifier.kind === SyntaxKind.AsyncKeyword,
+		)
+	);
+}
+
+function isUsingStatement(statement: ts.Statement) {
+	return (
+		ts.isVariableStatement(statement) &&
+		tsutils.isNodeFlagSet(statement.declarationList, NodeFlags.Using)
+	);
+}
+
+function needsParentheses(expression: AST.Expression) {
+	return (
+		expression.kind === SyntaxKind.AsExpression ||
+		expression.kind === SyntaxKind.BinaryExpression ||
+		expression.kind === SyntaxKind.ConditionalExpression ||
+		expression.kind === SyntaxKind.SatisfiesExpression ||
+		expression.kind === SyntaxKind.TypeAssertionExpression
+	);
+}
+
+function skipParentheses(expression: AST.Expression): AST.Expression {
+	while (expression.kind === SyntaxKind.ParenthesizedExpression) {
+		expression = expression.expression;
+	}
+	return expression;
+}


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #2002
- [x] That issue was marked as [`status: accepting prs`](https://github.com/flint-fyi/flint/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/flint-fyi/flint/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Adds the type-aware `ts/returnAwaitPromises` logical rule.

The rule requires `await` when a definitely thenable return would otherwise bypass active error handling or resource disposal, and reports unnecessary `await` expressions on definitely non-thenable return values.
It remains conservative for uncertain values and mixed unions, leaves ordinary promise-return style unchanged, and excludes async generators whose return completion already awaits its value.

Includes focused rule tests, documentation, plugin and rule-data registration, TypeScript end-to-end coverage, and a patch changeset.

❤️‍🔥
