### PR TITLE
feat(ts): add restricted globals rule

### DIFF
--- a/.changeset/calm-globals-report.md
+++ b/.changeset/calm-globals-report.md
@@ -1,0 +1,6 @@
+---
+"@flint.fyi/rule-data": patch
+"@flint.fyi/ts": patch
+---
+
+Add the checker-backed `ts/restrictedGlobals` rule.

--- a/packages/e2e/tests/typescript/fixtures/src/with-issues.ts
+++ b/packages/e2e/tests/typescript/fixtures/src/with-issues.ts
@@ -4,5 +4,6 @@ export function debug(value: unknown): void {
 }
 
 export function calculate(a: number, b: number): number {
+	Array.from([]);
 	return a + b;
 }

--- a/packages/e2e/tests/typescript/flint.config.ts
+++ b/packages/e2e/tests/typescript/flint.config.ts
@@ -5,7 +5,10 @@ export default defineConfig({
 	use: [
 		{
 			files: "fixtures/**/*.ts",
-			rules: ts.presets.logical,
+			rules: [
+				ts.presets.logical,
+				ts.rules({ restrictedGlobals: { deny: ["Array"] } }),
+			],
 		},
 	],
 });

--- a/packages/e2e/tests/typescript/typescript.test.ts
+++ b/packages/e2e/tests/typescript/typescript.test.ts
@@ -14,10 +14,11 @@ describe("typescript", () => {
 
 			<underline><cwd>/fixtures/src/with-issues.ts</underline>
 			<dim>  2:2</fg>  Debugger statements should not be used in production code.  <yellow>ts/debuggerStatements</fg>
+			<dim>  7:2</fg>  Global variable 'Array' is restricted.                      <yellow>ts/restrictedGlobals</fg>
 
-			<red>✖ Found <bold>1 report</bold> across <bold>1 file</bold>.</fg>
+			<red>✖ Found <bold>2 reports</bold> across <bold>1 file</bold>.</fg>
 			<red></fg>
-			<dim>Finished in <time> on 2 files with 138 rules.</fg>
+			<dim>Finished in <time> on 2 files with 139 rules.</fg>
 			<dim></fg>"
 		`);
 	});

--- a/packages/rule-data/src/data.json
+++ b/packages/rule-data/src/data.json
@@ -26632,7 +26632,8 @@
 		],
 		"flint": {
 			"name": "restrictedGlobals",
-			"plugin": "ts"
+			"plugin": "ts",
+			"status": "implemented"
 		},
 		"oxlint": [
 			{

--- a/packages/site/src/content/docs/rules/ts/restrictedGlobals.mdx
+++ b/packages/site/src/content/docs/rules/ts/restrictedGlobals.mdx
@@ -1,0 +1,77 @@
+---
+description: "Disallows references to specified global variables."
+title: "restrictedGlobals"
+topic: "rules"
+---
+
+import { TabItem, Tabs } from "@astrojs/starlight/components";
+import { RuleEquivalents } from "~/components/RuleEquivalents";
+import RuleSummary from "~/components/RuleSummary.astro";
+
+<RuleSummary plugin="ts" rule="restrictedGlobals" />
+
+Global variables can expose APIs that a project does not intend to use.
+This rule uses the TypeScript checker to report configured names only when they resolve to global runtime values from the project's active typings.
+Local and imported bindings, unresolved names, and references used only as types are not reported.
+
+Access through a global object, such as `globalThis.Array` or `window.event`, is not checked because the configured restriction applies to direct identifier references.
+
+## Options
+
+### `deny`
+
+> Type: `string[]`
+> Default: `[]`
+
+Global variable names whose resolved runtime references are disallowed.
+
+```ts
+ts.rules({
+	restrictedGlobals: {
+		deny: ["Array", "event"],
+	},
+});
+```
+
+<Tabs>
+<TabItem label="❌ Incorrect">
+
+```ts
+const values = Array.from(new Set([1, 2, 3]));
+```
+
+```ts
+function handle() {
+	event.preventDefault();
+}
+```
+
+</TabItem>
+<TabItem label="✅ Correct">
+
+```ts
+function collect(Array: ArrayConstructor) {
+	return Array.from(new Set([1, 2, 3]));
+}
+```
+
+```ts
+const values = globalThis.Array.from(new Set([1, 2, 3]));
+```
+
+</TabItem>
+</Tabs>
+
+## When Not To Use It
+
+Do not use this rule when the project permits every global supplied by its configured TypeScript libraries, or when another tool enforces the same restrictions before linting.
+
+## Further Reading
+
+- [MDN: Global object](https://developer.mozilla.org/en-US/docs/Glossary/Global_object)
+- [TypeScript: `lib` TSConfig option](https://www.typescriptlang.org/tsconfig/lib.html)
+- [MDN: `Window.event`](https://developer.mozilla.org/en-US/docs/Web/API/Window/event)
+
+## Equivalents in Other Linters
+
+<RuleEquivalents pluginId="ts" ruleId="restrictedGlobals" />

--- a/packages/ts/src/plugin.ts
+++ b/packages/ts/src/plugin.ts
@@ -250,6 +250,7 @@ import regexWordMatchers from "./rules/regexWordMatchers.ts";
 import regexZeroQuantifiers from "./rules/regexZeroQuantifiers.ts";
 import requireImports from "./rules/requireImports.ts";
 import responseJsonMethods from "./rules/responseJsonMethods.ts";
+import restrictedGlobals from "./rules/restrictedGlobals.ts";
 import restrictedIdentifiers from "./rules/restrictedIdentifiers.ts";
 import restrictedImports from "./rules/restrictedImports.ts";
 import returnAssignments from "./rules/returnAssignments.ts";
@@ -564,6 +565,7 @@ export const ts = createPlugin({
 		requireImports,
 		requireImports,
 		responseJsonMethods,
+		restrictedGlobals,
 		restrictedIdentifiers,
 		restrictedImports,
 		returnAssignments,

--- a/packages/ts/src/rules/restrictedGlobals.test.ts
+++ b/packages/ts/src/rules/restrictedGlobals.test.ts
@@ -1,0 +1,220 @@
+import rule from "./restrictedGlobals.ts";
+import { domLibRuleTester, ruleTester } from "./ruleTester.ts";
+
+ruleTester.describe(rule, {
+	invalid: [
+		{
+			code: `
+Array();
+const values = new Array();
+const nested = { Array };
+const property = { values: Array };
+Array = values;
+Array += values;
+++Array;
+Array++;
+typeof Array;
+class Collection extends Array {}
+export default Array;
+`,
+			options: { deny: ["Array"] },
+			snapshot: `
+Array();
+~~~~~
+Global variable 'Array' is restricted.
+const values = new Array();
+                   ~~~~~
+                   Global variable 'Array' is restricted.
+const nested = { Array };
+                 ~~~~~
+                 Global variable 'Array' is restricted.
+const property = { values: Array };
+                           ~~~~~
+                           Global variable 'Array' is restricted.
+Array = values;
+~~~~~
+Global variable 'Array' is restricted.
+Array += values;
+~~~~~
+Global variable 'Array' is restricted.
+++Array;
+  ~~~~~
+  Global variable 'Array' is restricted.
+Array++;
+~~~~~
+Global variable 'Array' is restricted.
+typeof Array;
+       ~~~~~
+       Global variable 'Array' is restricted.
+class Collection extends Array {}
+                         ~~~~~
+                         Global variable 'Array' is restricted.
+export default Array;
+               ~~~~~
+               Global variable 'Array' is restricted.
+`,
+		},
+		{
+			code: `
+[Array] = values;
+`,
+			options: { deny: ["Array"] },
+			snapshot: `
+[Array] = values;
+ ~~~~~
+ Global variable 'Array' is restricted.
+`,
+		},
+		{
+			code: `
+Array.Array;
+`,
+			options: { deny: ["Array"] },
+			snapshot: `
+Array.Array;
+~~~~~
+Global variable 'Array' is restricted.
+`,
+		},
+		{
+			code: `
+projectGlobal;
+`,
+			files: {
+				"globals.d.ts": `declare const projectGlobal: string;`,
+			},
+			options: { deny: ["projectGlobal"] },
+			snapshot: `
+projectGlobal;
+~~~~~~~~~~~~~
+Global variable 'projectGlobal' is restricted.
+`,
+		},
+		{
+			code: `
+const element = <Array />;
+`,
+			fileName: "file.tsx",
+			options: { deny: ["Array"] },
+			snapshot: `
+const element = <Array />;
+                 ~~~~~
+                 Global variable 'Array' is restricted.
+`,
+		},
+	],
+	valid: [
+		"Array.from([]);",
+		{ code: "Array.from([]);", options: { deny: [] } },
+		{ code: "Array.from([]);", options: { deny: ["Error"] } },
+		{
+			code: "function collect() { const Array = {}; Array.from([]); }",
+			options: { deny: ["Array"] },
+		},
+		{
+			code: "function collect() { let Array; Array = {}; }",
+			options: { deny: ["Array"] },
+		},
+		{ code: "function Array() {}", options: { deny: ["Array"] } },
+		{ code: "class Array {}", options: { deny: ["Array"] } },
+		{
+			code: "function collect(Array: unknown) { return Array; }",
+			options: { deny: ["Array"] },
+		},
+		{ code: "try {} catch (Array) { Array; }", options: { deny: ["Array"] } },
+		{ code: "{ const Array = {}; Array; }", options: { deny: ["Array"] } },
+		{
+			code: "import { Array } from 'values'; Array;",
+			options: { deny: ["Array"] },
+		},
+		{
+			code: "import Array from 'values'; Array;",
+			options: { deny: ["Array"] },
+		},
+		{
+			code: "import * as Array from 'values'; Array;",
+			options: { deny: ["Array"] },
+		},
+		{
+			code: "const object = { Array: 1 }; object.Array;",
+			options: { deny: ["Array"] },
+		},
+		{ code: "const { Array: value } = object;", options: { deny: ["Array"] } },
+		{
+			code: "class Value { Array() {} } interface Shape { Array: string }",
+			options: { deny: ["Array"] },
+		},
+		{
+			code: "Array: while (true) { break Array; }",
+			options: { deny: ["Array"] },
+		},
+		{ code: "type Value = Array<string>;", options: { deny: ["Array"] } },
+		{
+			code: "type Value = Array.Iterator<string>;",
+			options: { deny: ["Array"] },
+		},
+		{
+			code: "interface Value extends Array<string> {}",
+			options: { deny: ["Array"] },
+		},
+		{
+			code: "class Value implements Array<string> {}",
+			options: { deny: ["Array"] },
+		},
+		{ code: "type Value = typeof Array;", options: { deny: ["Array"] } },
+		{ code: "type Value = typeof Array.from;", options: { deny: ["Array"] } },
+		{
+			code: "interface Value { [Array.iterator]: string }",
+			options: { deny: ["Array"] },
+		},
+		{ code: "export { Array };", options: { deny: ["Array"] } },
+		{ code: "export type { Array };", options: { deny: ["Array"] } },
+		{ code: "MissingGlobal;", options: { deny: ["MissingGlobal"] } },
+		{
+			code: "const value = { MissingGlobal };",
+			options: { deny: ["MissingGlobal"] },
+		},
+		{
+			code: "globalThis.Array; window.Array; self.Array; global.Array;",
+			options: { deny: ["Array"] },
+		},
+	],
+});
+
+domLibRuleTester.describe(rule, {
+	invalid: [
+		{
+			code: `
+event;
+`,
+			options: { deny: ["event"] },
+			snapshot: `
+event;
+~~~~~
+Global variable 'event' is restricted.
+`,
+		},
+		{
+			code: `
+window.addEventListener("load", () => {});
+`,
+			options: { deny: ["window"] },
+			snapshot: `
+window.addEventListener("load", () => {});
+~~~~~~
+Global variable 'window' is restricted.
+`,
+		},
+	],
+	valid: [
+		{
+			code: "function open() { const window = {}; window; }",
+			options: { deny: ["window"] },
+		},
+		{
+			code: "function handle(event: Event) { return event; }",
+			options: { deny: ["event"] },
+		},
+		{ code: "window.event; globalThis.event;", options: { deny: ["event"] } },
+	],
+});

--- a/packages/ts/src/rules/restrictedGlobals.ts
+++ b/packages/ts/src/rules/restrictedGlobals.ts
@@ -1,0 +1,128 @@
+import ts, { SymbolFlags, SyntaxKind } from "typescript";
+import z from "zod/v4";
+
+import {
+	getTSNodeRange,
+	typescriptLanguage,
+	type AST,
+	type Checker,
+} from "@flint.fyi/typescript-language";
+
+import { ruleCreator } from "./ruleCreator.ts";
+
+function isGlobalReference(node: AST.Identifier, typeChecker: Checker) {
+	const symbol = ts.isShorthandPropertyAssignment(node.parent)
+		? typeChecker.getShorthandAssignmentValueSymbol(node.parent)
+		: typeChecker.getSymbolAtLocation(node);
+	if (
+		!symbol ||
+		typeChecker.resolveName(node.text, node, SymbolFlags.Value, true)
+	) {
+		return false;
+	}
+
+	return (
+		typeChecker.resolveName(node.text, node, SymbolFlags.Value, false) ===
+		symbol
+	);
+}
+
+function isNonReferenceName(node: AST.Identifier) {
+	const parent = node.parent;
+	if (ts.isPropertyAccessExpression(parent)) {
+		return parent.expression !== node;
+	}
+
+	return (
+		(ts.isPropertyAssignment(parent) && parent.name === node) ||
+		(ts.isBindingElement(parent) && parent.propertyName === node) ||
+		(ts.isLabeledStatement(parent) && parent.label === node) ||
+		((ts.isBreakStatement(parent) || ts.isContinueStatement(parent)) &&
+			parent.label === node) ||
+		ts.isImportSpecifier(parent) ||
+		ts.isExportSpecifier(parent) ||
+		ts.isImportClause(parent) ||
+		ts.isNamespaceImport(parent)
+	);
+}
+
+function isOnlyTypeReference(node: AST.Identifier) {
+	let parent: ts.Node = node.parent;
+	for (;;) {
+		if (ts.isTypeElement(parent)) {
+			return true;
+		}
+
+		if (ts.isHeritageClause(parent)) {
+			return (
+				parent.token === SyntaxKind.ImplementsKeyword ||
+				ts.isInterfaceDeclaration(parent.parent)
+			);
+		}
+
+		if (ts.isTypeQueryNode(parent)) {
+			return true;
+		}
+
+		if (ts.isTypeNode(parent) && !ts.isExpressionWithTypeArguments(parent)) {
+			return true;
+		}
+
+		if (ts.isSourceFile(parent)) {
+			return false;
+		}
+
+		parent = parent.parent;
+	}
+}
+
+export default ruleCreator.createRule(typescriptLanguage, {
+	about: {
+		description: "Disallows references to specified global variables.",
+		id: "restrictedGlobals",
+	},
+	messages: {
+		restricted: {
+			primary: "Global variable '{{ name }}' is restricted.",
+			secondary: [
+				"This global variable has been disallowed by project configuration.",
+			],
+			suggestions: ["Use an allowed alternative or introduce a local binding."],
+		},
+	},
+	options: {
+		deny: z
+			.array(z.string())
+			.default([])
+			.describe(
+				"Global variable names whose resolved runtime references are disallowed.",
+			),
+	},
+	setup(context) {
+		let deniedNames: Set<string> | undefined;
+		return {
+			visitors: {
+				Identifier: (node, { options, sourceFile, typeChecker }) => {
+					deniedNames ??= new Set(options.deny);
+					if (
+						!deniedNames.has(node.text) ||
+						isNonReferenceName(node) ||
+						isOnlyTypeReference(node)
+					) {
+						return;
+					}
+
+					if (!isGlobalReference(node, typeChecker)) {
+						return;
+					}
+
+					context.report({
+						data: { name: node.text },
+						message: "restricted",
+						range: getTSNodeRange(node, sourceFile),
+					});
+				},
+			},
+		};
+	},
+});


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #1997
- [x] That issue was marked as [`status: accepting prs`](https://github.com/flint-fyi/flint/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/flint-fyi/flint/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Adds the `ts/restrictedGlobals` rule with a configurable `deny` list.

The rule uses TypeScript symbol resolution to report direct runtime references to configured globals while allowing local and imported bindings, unresolved names, property names, and type-only references.
It includes rule tests, documentation, plugin and rule-data registration, an end-to-end case, and a patch changeset.

❤️‍🔥
