### PR TITLE
feat: add restrictedProperties rule

### DIFF
--- a/.changeset/quiet-properties-rule.md
+++ b/.changeset/quiet-properties-rule.md
@@ -1,0 +1,5 @@
+---
+"@flint.fyi/ts": patch
+---
+
+Add the configuration-only, type-aware `restrictedProperties` rule.

--- a/packages/e2e/tests/typescript/fixtures/src/with-issues.ts
+++ b/packages/e2e/tests/typescript/fixtures/src/with-issues.ts
@@ -4,5 +4,7 @@ export function debug(value: unknown): void {
 }
 
 export function calculate(a: number, b: number): number {
+	JSON.stringify({ a, b });
+	JSON.parse("{}");
 	return a + b;
 }

--- a/packages/e2e/tests/typescript/flint.config.ts
+++ b/packages/e2e/tests/typescript/flint.config.ts
@@ -5,7 +5,19 @@ export default defineConfig({
 	use: [
 		{
 			files: "fixtures/**/*.ts",
-			rules: ts.presets.logical,
+			rules: [
+				ts.presets.logical,
+				ts.rules({
+					restrictedProperties: {
+						restrictions: [
+							{
+								object: { from: "lib", name: "JSON" },
+								property: "parse",
+							},
+						],
+					},
+				}),
+			],
 		},
 	],
 });

--- a/packages/e2e/tests/typescript/typescript.test.ts
+++ b/packages/e2e/tests/typescript/typescript.test.ts
@@ -13,11 +13,12 @@ describe("typescript", () => {
 			"<dim>Linting with <cyan><bold>flint.config.ts</bold></fg><dim>...</fg>
 
 			<underline><cwd>/fixtures/src/with-issues.ts</underline>
-			<dim>  2:2</fg>  Debugger statements should not be used in production code.  <yellow>ts/debuggerStatements</fg>
+			<dim>  2:2</fg>  Debugger statements should not be used in production code.           <yellow>ts/debuggerStatements</fg>
+			<dim>  8:7</fg>  Accessing the 'parse' property on this type or value is restricted.  <yellow>ts/restrictedProperties</fg>
 
-			<red>✖ Found <bold>1 report</bold> across <bold>1 file</bold>.</fg>
+			<red>✖ Found <bold>2 reports</bold> across <bold>1 file</bold>.</fg>
 			<red></fg>
-			<dim>Finished in <time> on 2 files with 138 rules.</fg>
+			<dim>Finished in <time> on 2 files with 139 rules.</fg>
 			<dim></fg>"
 		`);
 	});

--- a/packages/rule-data/src/data.json
+++ b/packages/rule-data/src/data.json
@@ -26717,7 +26717,8 @@
 		],
 		"flint": {
 			"name": "restrictedProperties",
-			"plugin": "ts"
+			"plugin": "ts",
+			"status": "implemented"
 		},
 		"oxlint": [
 			{

--- a/packages/site/src/content/docs/rules/ts/restrictedProperties.mdx
+++ b/packages/site/src/content/docs/rules/ts/restrictedProperties.mdx
@@ -85,4 +85,4 @@ For deprecation diagnostics, use TypeScript deprecations or Flint's dedicated de
 
 ## Equivalents in Other Linters
 
-<RuleEquivalents plugin="ts" rule="restrictedProperties" />
+<RuleEquivalents pluginId="ts" ruleId="restrictedProperties" />

--- a/packages/site/src/content/docs/rules/ts/restrictedProperties.mdx
+++ b/packages/site/src/content/docs/rules/ts/restrictedProperties.mdx
@@ -1,0 +1,88 @@
+---
+description: "Disallows accessing specified properties on configured types or values."
+title: "restrictedProperties"
+topic: "rules"
+---
+
+import { TabItem, Tabs } from "@astrojs/starlight/components";
+import { RuleEquivalents } from "~/components/RuleEquivalents";
+import RuleSummary from "~/components/RuleSummary.astro";
+
+<RuleSummary plugin="ts" rule="restrictedProperties" />
+
+This rule restricts statically known properties on values and nominal types identified by a `TypeOrValueSpecifier`.
+Unlike spelling-based checks, it follows imported and immutable aliases while distinguishing shadowed values and structurally identical types.
+It checks property reads, calls, writes, optional accesses, and object destructuring declarations and assignments.
+
+## Examples
+
+<Tabs>
+<TabItem label="❌ Incorrect">
+
+```ts
+JSON.parse(input);
+```
+
+```ts
+const { parse } = JSON;
+```
+
+</TabItem>
+<TabItem label="✅ Correct">
+
+```ts
+JSON.stringify(value);
+```
+
+```ts
+const JSON = { parse: customParse };
+JSON.parse(input);
+```
+
+</TabItem>
+</Tabs>
+
+## Options
+
+### `restrictions`
+
+- Type: `Array<Restriction>`
+- Default: `[]`
+
+Each entry requires an `object` TypeOrValueSpecifier and exact `property` string, and may include a custom `message`.
+
+```jsonc
+{
+	"restrictions": [
+		{
+			"message": "Use the validated parser.",
+			"object": { "from": "lib", "name": "JSON" },
+			"property": "parse",
+		},
+	],
+}
+```
+
+An object specifier may use `{ "from": "lib", "name": "..." }`, `{ "from": "file", "path": "...", "name": "..." }`, or `{ "from": "package", "package": "...", "name": "..." }`.
+The optional `name` may also be an array.
+The rule matches values through import aliases, namespace-qualified exports, and immutable `const` alias chains.
+It also matches nominal types through type aliases, base classes and interfaces, generic constraints, and intersections.
+All non-nullish members of a union must match the restriction, which avoids reporting accesses that may occur on an unrelated value.
+The rule recognizes literal and statically evaluated string, number, and bigint keys, but skips dynamic keys, symbols, `any`, `unknown`, and unions containing unrelated receivers.
+It reports property names without a fix because replacing an access can alter evaluation order, accessors, assignment behavior, or `this` binding.
+
+## When Not To Use It
+
+Projects without property-specific API policies do not need to configure this rule.
+The rule is also unsuitable when restrictions depend on dynamic keys or runtime value flow that TypeScript cannot resolve.
+For deprecation diagnostics, use TypeScript deprecations or Flint's dedicated deprecation rules instead.
+
+## Further Reading
+
+- [TypeScript: Symbols](https://www.typescriptlang.org/docs/handbook/symbols.html)
+- [MDN: Destructuring](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring)
+- [MDN: Property accessors](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Property_accessors)
+
+## Equivalents in Other Linters
+
+<RuleEquivalents plugin="ts" rule="restrictedProperties" />

--- a/packages/ts/src/plugin.ts
+++ b/packages/ts/src/plugin.ts
@@ -252,6 +252,7 @@ import requireImports from "./rules/requireImports.ts";
 import responseJsonMethods from "./rules/responseJsonMethods.ts";
 import restrictedIdentifiers from "./rules/restrictedIdentifiers.ts";
 import restrictedImports from "./rules/restrictedImports.ts";
+import restrictedProperties from "./rules/restrictedProperties.ts";
 import returnAssignments from "./rules/returnAssignments.ts";
 import returnThisTypes from "./rules/returnThisTypes.ts";
 import selfAssignments from "./rules/selfAssignments.ts";
@@ -566,6 +567,7 @@ export const ts = createPlugin({
 		responseJsonMethods,
 		restrictedIdentifiers,
 		restrictedImports,
+		restrictedProperties,
 		returnAssignments,
 		returnThisTypes,
 		selfAssignments,

--- a/packages/ts/src/rules/restrictedProperties.test.ts
+++ b/packages/ts/src/rules/restrictedProperties.test.ts
@@ -1,0 +1,451 @@
+import rule from "./restrictedProperties.ts";
+import { ruleTester } from "./ruleTester.ts";
+
+const jsonParseRestriction = {
+	object: { from: "lib" as const, name: "JSON" },
+	property: "parse",
+};
+
+const serviceDeclarations = `
+export interface Service {
+    blocked(): void;
+    nested: Service;
+}
+export interface DerivedService extends Service {}
+export declare const service: { blocked(): void };
+`;
+
+const serviceRestriction = {
+	object: {
+		from: "file" as const,
+		name: ["Service", "service"],
+		path: "./service.ts",
+	},
+	property: "blocked",
+};
+
+ruleTester.describe(rule, {
+	invalid: [
+		{
+			code: `
+JSON.parse("{}");
+`,
+			options: { restrictions: [jsonParseRestriction] },
+			snapshot: `
+JSON.parse("{}");
+     ~~~~~
+     Accessing the 'parse' property on this type or value is restricted.
+`,
+		},
+		{
+			code: `
+const parse = JSON["parse"];
+`,
+			options: {
+				restrictions: [
+					{ ...jsonParseRestriction, message: "Use the validated parser." },
+				],
+			},
+			snapshot: `
+const parse = JSON["parse"];
+                   ~~~~~~~
+                   Accessing the 'parse' property on this type or value is restricted. Use the validated parser.
+`,
+		},
+		{
+			code: `
+JSON.parse("{}");
+`,
+			options: {
+				restrictions: [
+					jsonParseRestriction,
+					{ ...jsonParseRestriction, message: "This message must not win." },
+				],
+			},
+			snapshot: `
+JSON.parse("{}");
+     ~~~~~
+     Accessing the 'parse' property on this type or value is restricted.
+`,
+		},
+		{
+			code: `
+const key = "parse" as const;
+JSON[key];
+JSON[\`parse\`];
+JSON?.[key];
+`,
+			options: { restrictions: [jsonParseRestriction] },
+			snapshot: `
+const key = "parse" as const;
+JSON[key];
+     ~~~
+     Accessing the 'parse' property on this type or value is restricted.
+JSON[\`parse\`];
+     ~~~~~~~
+     Accessing the 'parse' property on this type or value is restricted.
+JSON?.[key];
+       ~~~
+       Accessing the 'parse' property on this type or value is restricted.
+`,
+		},
+		{
+			code: `
+(JSON as typeof JSON).parse;
+(JSON satisfies typeof JSON).parse;
+JSON!.parse;
+`,
+			options: { restrictions: [jsonParseRestriction] },
+			snapshot: `
+(JSON as typeof JSON).parse;
+                      ~~~~~
+                      Accessing the 'parse' property on this type or value is restricted.
+(JSON satisfies typeof JSON).parse;
+                             ~~~~~
+                             Accessing the 'parse' property on this type or value is restricted.
+JSON!.parse;
+      ~~~~~
+      Accessing the 'parse' property on this type or value is restricted.
+`,
+		},
+		{
+			code: `
+JSON.parse = () => undefined;
+JSON.parse++;
+delete JSON.parse;
+new JSON.parse();
+JSON.parse\`value\`;
+`,
+			options: { restrictions: [jsonParseRestriction] },
+			snapshot: `
+JSON.parse = () => undefined;
+     ~~~~~
+     Accessing the 'parse' property on this type or value is restricted.
+JSON.parse++;
+     ~~~~~
+     Accessing the 'parse' property on this type or value is restricted.
+delete JSON.parse;
+            ~~~~~
+            Accessing the 'parse' property on this type or value is restricted.
+new JSON.parse();
+         ~~~~~
+         Accessing the 'parse' property on this type or value is restricted.
+JSON.parse\`value\`;
+     ~~~~~
+     Accessing the 'parse' property on this type or value is restricted.
+`,
+		},
+		{
+			code: `
+const JSONAlias = JSON;
+const secondAlias = JSONAlias;
+secondAlias?.parse("{}");
+`,
+			options: { restrictions: [jsonParseRestriction] },
+			snapshot: `
+const JSONAlias = JSON;
+const secondAlias = JSONAlias;
+secondAlias?.parse("{}");
+             ~~~~~
+             Accessing the 'parse' property on this type or value is restricted.
+`,
+		},
+		{
+			code: `
+const { parse, parse: parser, ["parse"]: computedParser, ...rest } = JSON;
+`,
+			options: { restrictions: [jsonParseRestriction] },
+			snapshot: `
+const { parse, parse: parser, ["parse"]: computedParser, ...rest } = JSON;
+        ~~~~~
+        Accessing the 'parse' property on this type or value is restricted.
+               ~~~~~
+               Accessing the 'parse' property on this type or value is restricted.
+                               ~~~~~~~
+                               Accessing the 'parse' property on this type or value is restricted.
+`,
+		},
+		{
+			code: `
+JSON[0];
+JSON[1n];
+const key = 2 as const;
+JSON[key];
+JSON[""];
+`,
+			options: {
+				restrictions: [
+					{ object: jsonParseRestriction.object, property: "0" },
+					{ object: jsonParseRestriction.object, property: "1" },
+					{ object: jsonParseRestriction.object, property: "2" },
+					{ object: jsonParseRestriction.object, property: "" },
+				],
+			},
+			snapshot: `
+JSON[0];
+     ~
+     Accessing the '0' property on this type or value is restricted.
+JSON[1n];
+     ~~
+     Accessing the '1' property on this type or value is restricted.
+const key = 2 as const;
+JSON[key];
+     ~~~
+     Accessing the '2' property on this type or value is restricted.
+JSON[""];
+     ~~
+     Accessing the '' property on this type or value is restricted.
+`,
+		},
+		{
+			code: `
+const { parse: parser, ["parse"]: computedParser, ...rest } = JSON;
+`,
+			options: { restrictions: [jsonParseRestriction] },
+			snapshot: `
+const { parse: parser, ["parse"]: computedParser, ...rest } = JSON;
+        ~~~~~
+        Accessing the 'parse' property on this type or value is restricted.
+                        ~~~~~~~
+                        Accessing the 'parse' property on this type or value is restricted.
+`,
+		},
+		{
+			code: `
+let parse: typeof JSON.parse;
+let parser: typeof JSON.parse;
+({ parse, ["parse"]: parser } = JSON);
+`,
+			options: { restrictions: [jsonParseRestriction] },
+			snapshot: `
+let parse: typeof JSON.parse;
+let parser: typeof JSON.parse;
+({ parse, ["parse"]: parser } = JSON);
+   ~~~~~
+   Accessing the 'parse' property on this type or value is restricted.
+           ~~~~~~~
+           Accessing the 'parse' property on this type or value is restricted.
+`,
+		},
+		{
+			code: `
+import { service as renamedService } from "./service";
+renamedService.blocked();
+`,
+			files: { "service.ts": serviceDeclarations },
+			options: { restrictions: [serviceRestriction] },
+			snapshot: `
+import { service as renamedService } from "./service";
+renamedService.blocked();
+               ~~~~~~~
+               Accessing the 'blocked' property on this type or value is restricted.
+`,
+		},
+		{
+			code: `
+import type { DerivedService, Service } from "./service";
+declare const derived: DerivedService;
+declare const intersection: Service & { extra: true };
+declare const nullable: Service | undefined;
+derived.blocked();
+intersection.blocked();
+nullable?.blocked();
+`,
+			files: { "service.ts": serviceDeclarations },
+			options: { restrictions: [serviceRestriction] },
+			snapshot: `
+import type { DerivedService, Service } from "./service";
+declare const derived: DerivedService;
+declare const intersection: Service & { extra: true };
+declare const nullable: Service | undefined;
+derived.blocked();
+        ~~~~~~~
+        Accessing the 'blocked' property on this type or value is restricted.
+intersection.blocked();
+             ~~~~~~~
+             Accessing the 'blocked' property on this type or value is restricted.
+nullable?.blocked();
+          ~~~~~~~
+          Accessing the 'blocked' property on this type or value is restricted.
+`,
+		},
+		{
+			code: `
+import type { DerivedService, Service } from "./service";
+declare const first: Service;
+declare const second: DerivedService;
+declare const union: typeof first | typeof second;
+function access<T extends Service>(value: T) {
+    value.blocked();
+}
+union.blocked();
+`,
+			files: { "service.ts": serviceDeclarations },
+			options: { restrictions: [serviceRestriction] },
+			snapshot: `
+import type { DerivedService, Service } from "./service";
+declare const first: Service;
+declare const second: DerivedService;
+declare const union: typeof first | typeof second;
+function access<T extends Service>(value: T) {
+    value.blocked();
+          ~~~~~~~
+          Accessing the 'blocked' property on this type or value is restricted.
+}
+union.blocked();
+      ~~~~~~~
+      Accessing the 'blocked' property on this type or value is restricted.
+`,
+		},
+		{
+			code: `
+import type { Service } from "./service";
+function consume({ blocked: operation, ["blocked"]: computed }: Service) {}
+`,
+			files: { "service.ts": serviceDeclarations },
+			options: { restrictions: [serviceRestriction] },
+			snapshot: `
+import type { Service } from "./service";
+function consume({ blocked: operation, ["blocked"]: computed }: Service) {}
+                   ~~~~~~~
+                   Accessing the 'blocked' property on this type or value is restricted.
+                                        ~~~~~~~~~
+                                        Accessing the 'blocked' property on this type or value is restricted.
+`,
+		},
+		{
+			code: `
+import type { Service } from "./service";
+declare const source: { nested: Service };
+const { nested: { blocked } } = source;
+`,
+			files: { "service.ts": serviceDeclarations },
+			options: { restrictions: [serviceRestriction] },
+			snapshot: `
+import type { Service } from "./service";
+declare const source: { nested: Service };
+const { nested: { blocked } } = source;
+                  ~~~~~~~
+                  Accessing the 'blocked' property on this type or value is restricted.
+`,
+		},
+		{
+			code: `
+import type { Service } from "./service";
+declare const source: { nested: { nested: Service } };
+let blocked: Service["blocked"];
+({ nested: { nested: { blocked } } } = source);
+`,
+			files: { "service.ts": serviceDeclarations },
+			options: { restrictions: [serviceRestriction] },
+			snapshot: `
+import type { Service } from "./service";
+declare const source: { nested: { nested: Service } };
+let blocked: Service["blocked"];
+({ nested: { nested: { blocked } } } = source);
+                       ~~~~~~~
+                       Accessing the 'blocked' property on this type or value is restricted.
+`,
+		},
+		{
+			code: `
+import { service } from "test-package";
+service.blocked();
+`,
+			files: {
+				"test-package.d.ts": `declare module "test-package" { export const service: { blocked(): void }; }`,
+			},
+			options: {
+				restrictions: [
+					{
+						object: {
+							from: "package",
+							name: "service",
+							package: "test-package",
+						},
+						property: "blocked",
+					},
+				],
+			},
+			snapshot: `
+import { service } from "test-package";
+service.blocked();
+        ~~~~~~~
+        Accessing the 'blocked' property on this type or value is restricted.
+`,
+		},
+	],
+	valid: [
+		`JSON.parse("{}");`,
+		{
+			code: `export {}; const JSON = { parse() {}, stringify() {} }; JSON.parse();`,
+			options: { restrictions: [jsonParseRestriction] },
+		},
+		{
+			code: `const key: string = "parse"; JSON[key]; JSON["parse" + ""];`,
+			options: { restrictions: [jsonParseRestriction] },
+		},
+		{
+			code: `JSON.stringify({}); JSON[true];`,
+			options: {
+				restrictions: [
+					jsonParseRestriction,
+					{ ...jsonParseRestriction, message: "This must not win." },
+				],
+			},
+		},
+		{
+			code: `({ parse: () => {} }); JSON.parse && ({ ...JSON });`,
+			options: { restrictions: [] },
+		},
+		{
+			code: `
+import type { Service } from "./service";
+interface Similar { blocked(): void }
+declare const mixed: Service | Similar;
+declare const similar: Similar;
+declare const anything: any;
+declare const uncertain: unknown;
+mixed.blocked();
+similar.blocked();
+anything.blocked();
+uncertain;
+`,
+			files: { "service.ts": serviceDeclarations },
+			options: { restrictions: [serviceRestriction] },
+		},
+		{
+			code: `
+import { service } from "./service";
+let mutable = service;
+mutable = { blocked() {} };
+mutable.blocked();
+`,
+			files: { "service.ts": serviceDeclarations },
+			options: { restrictions: [serviceRestriction] },
+		},
+		{
+			code: `
+import type { Service } from "./service";
+declare const source: Service;
+const { ...rest } = source;
+let blocked: Service["blocked"];
+({ ...rest } = source);
+[blocked] = [];
+`,
+			files: { "service.ts": serviceDeclarations },
+			options: { restrictions: [serviceRestriction] },
+		},
+		{
+			code: `
+import type { Service } from "./service";
+declare const source: Record<string, Service>;
+declare const dynamic: string;
+let blocked: Service["blocked"];
+({ [dynamic]: { blocked } } = source);
+`,
+			files: { "service.ts": serviceDeclarations },
+			options: { restrictions: [serviceRestriction] },
+		},
+	],
+});

--- a/packages/ts/src/rules/restrictedProperties.ts
+++ b/packages/ts/src/rules/restrictedProperties.ts
@@ -1,0 +1,356 @@
+import ts, { NodeFlags, SyntaxKind } from "typescript";
+import { z } from "zod/v4";
+
+import {
+	getStaticValue,
+	typescriptLanguage,
+	type AST,
+	type Checker,
+	type TypeScriptFileServices,
+} from "@flint.fyi/typescript-language";
+import { nullThrows } from "@flint.fyi/utils";
+
+import { matchesSpecifier } from "../type-utils/matchesSpecifier.ts";
+import { typeOrValueSpecifierSchema } from "../type-utils/schemas.ts";
+import { ruleCreator } from "./ruleCreator.ts";
+
+const restrictionSchema = z.object({
+	message: z
+		.string()
+		.optional()
+		.describe("A custom message to display when the restriction is triggered."),
+	object: typeOrValueSpecifierSchema.describe(
+		"A TypeOrValueSpecifier identifying the restricted receiver.",
+	),
+	property: z.string().describe("The property name to restrict."),
+});
+
+type Receiver =
+	| { expression: ts.Expression; type?: never }
+	| { expression?: never; type: ts.Type };
+
+type Restriction = z.infer<typeof restrictionSchema>;
+
+function getDeclarations(symbol: ts.Symbol, checker: Checker) {
+	const resolved =
+		symbol.flags & ts.SymbolFlags.Alias
+			? checker.getAliasedSymbol(symbol)
+			: symbol;
+	return {
+		declarations: nullThrows(
+			resolved.getDeclarations(),
+			"Resolved symbols must have declarations.",
+		),
+		name: resolved.getName(),
+	};
+}
+
+function getPropertyName(
+	node: AST.Expression | AST.PrivateIdentifier,
+	checker: Checker,
+	allowIdentifier: boolean,
+) {
+	if (
+		ts.isPrivateIdentifier(node) ||
+		(allowIdentifier && ts.isIdentifier(node))
+	) {
+		return node.text;
+	}
+
+	const staticValue = getStaticValue(node)?.value;
+	if (
+		typeof staticValue === "string" ||
+		typeof staticValue === "number" ||
+		typeof staticValue === "bigint"
+	) {
+		return String(staticValue);
+	}
+
+	const type = checker.getTypeAtLocation(node);
+	if (type.isStringLiteral() || type.isNumberLiteral()) {
+		return String(type.value);
+	}
+
+	return undefined;
+}
+
+function symbolMatches(
+	symbol: ts.Symbol | undefined,
+	restriction: Restriction,
+	checker: Checker,
+	program: ts.Program,
+) {
+	if (!symbol) {
+		return false;
+	}
+
+	const { declarations, name } = getDeclarations(symbol, checker);
+	return matchesSpecifier(name, declarations, restriction.object, program);
+}
+
+function typeMatches(
+	type: ts.Type,
+	restriction: Restriction,
+	checker: Checker,
+	program: ts.Program,
+): boolean {
+	if (type.flags & (ts.TypeFlags.Any | ts.TypeFlags.Unknown)) {
+		return false;
+	}
+
+	if (type.isUnion()) {
+		const viable = type.types.filter(
+			(constituent) =>
+				!(constituent.flags & (ts.TypeFlags.Null | ts.TypeFlags.Undefined)),
+		);
+		return viable.every((constituent) =>
+			typeMatches(constituent, restriction, checker, program),
+		);
+	}
+
+	if (type.isIntersection()) {
+		return type.types.some((constituent) =>
+			typeMatches(constituent, restriction, checker, program),
+		);
+	}
+
+	if (
+		symbolMatches(type.aliasSymbol, restriction, checker, program) ||
+		symbolMatches(type.getSymbol(), restriction, checker, program)
+	) {
+		return true;
+	}
+
+	const constraint = checker.getBaseConstraintOfType(type);
+	if (constraint && typeMatches(constraint, restriction, checker, program)) {
+		return true;
+	}
+
+	return (
+		type.isClassOrInterface() &&
+		nullThrows(
+			type.getBaseTypes(),
+			"Class and interface types must provide base types.",
+		).some((base) => typeMatches(base, restriction, checker, program))
+	);
+}
+
+function valueMatches(
+	expression: ts.Expression,
+	restriction: Restriction,
+	checker: Checker,
+	program: ts.Program,
+	seen = new Set<ts.Symbol>(),
+): boolean {
+	const symbol = checker.getSymbolAtLocation(expression);
+	if (symbolMatches(symbol, restriction, checker, program)) {
+		return true;
+	}
+
+	if (symbol && !seen.has(symbol)) {
+		seen.add(symbol);
+		const declaration = symbol.valueDeclaration;
+		if (
+			declaration &&
+			ts.isVariableDeclaration(declaration) &&
+			declaration.initializer &&
+			(declaration.parent.flags & NodeFlags.Const) !== 0 &&
+			valueMatches(declaration.initializer, restriction, checker, program, seen)
+		) {
+			return true;
+		}
+	}
+
+	return typeMatches(
+		checker.getTypeAtLocation(expression),
+		restriction,
+		checker,
+		program,
+	);
+}
+
+export default ruleCreator.createRule(typescriptLanguage, {
+	about: {
+		description:
+			"Disallows accessing specified properties on configured types or values.",
+		id: "restrictedProperties",
+	},
+	messages: {
+		restricted: {
+			primary:
+				"Accessing the '{{ property }}' property on this type or value is restricted.",
+			secondary: [
+				"This property has been restricted by project configuration.",
+			],
+			suggestions: ["Use an allowed property or value instead."],
+		},
+		restrictedWithMessage: {
+			primary:
+				"Accessing the '{{ property }}' property on this type or value is restricted. {{ customMessage }}",
+			secondary: [
+				"This property has been restricted by project configuration.",
+			],
+			suggestions: ["Use an allowed property or value instead."],
+		},
+	},
+	options: {
+		restrictions: z
+			.array(restrictionSchema)
+			.default([])
+			.describe("Restrictions on properties of specified types or values."),
+	},
+	setup(context) {
+		function check(
+			key: AST.Expression | AST.PrivateIdentifier,
+			receiver: Receiver,
+			services: TypeScriptFileServices & {
+				options: { restrictions: Restriction[] };
+			},
+			allowIdentifier = true,
+		) {
+			const property = getPropertyName(
+				key,
+				services.typeChecker,
+				allowIdentifier,
+			);
+			if (property === undefined) {
+				return;
+			}
+
+			for (const restriction of services.options.restrictions) {
+				if (restriction.property !== property) {
+					continue;
+				}
+
+				const matches = receiver.expression
+					? valueMatches(
+							receiver.expression,
+							restriction,
+							services.typeChecker,
+							services.program,
+						)
+					: typeMatches(
+							receiver.type,
+							restriction,
+							services.typeChecker,
+							services.program,
+						);
+				if (!matches) {
+					continue;
+				}
+
+				context.report({
+					data: { customMessage: restriction.message ?? "", property },
+					message: restriction.message ? "restrictedWithMessage" : "restricted",
+					range: {
+						begin: key.getStart(services.sourceFile),
+						end: key.getEnd(),
+					},
+				});
+				return;
+			}
+		}
+
+		function checkBindingPattern(
+			pattern: AST.ObjectBindingPattern,
+			services: Parameters<typeof check>[2],
+		) {
+			const receiver = {
+				type: services.typeChecker.getTypeAtLocation(pattern),
+			};
+			for (const element of pattern.elements) {
+				if (element.dotDotDotToken) {
+					continue;
+				}
+				const key = element.propertyName ?? (element.name as AST.Identifier);
+				if (ts.isComputedPropertyName(key)) {
+					check(key.expression, receiver, services, false);
+				} else {
+					check(key, receiver, services);
+				}
+			}
+		}
+
+		function checkAssignmentPattern(
+			pattern: AST.ObjectLiteralExpression,
+			receiver: Receiver,
+			services: Parameters<typeof check>[2],
+		) {
+			for (const property of pattern.properties) {
+				if (ts.isShorthandPropertyAssignment(property)) {
+					check(property.name, receiver, services);
+					continue;
+				}
+
+				if (!ts.isPropertyAssignment(property)) {
+					continue;
+				}
+
+				const isComputed = ts.isComputedPropertyName(property.name);
+				const key = isComputed ? property.name.expression : property.name;
+				check(key, receiver, services, !isComputed);
+
+				const nestedPattern = ts.isObjectLiteralExpression(property.initializer)
+					? property.initializer
+					: undefined;
+				if (!nestedPattern) {
+					continue;
+				}
+
+				const propertyName = getPropertyName(
+					key,
+					services.typeChecker,
+					!isComputed,
+				);
+				if (propertyName === undefined) {
+					continue;
+				}
+
+				const receiverType = receiver.expression
+					? services.typeChecker.getTypeAtLocation(receiver.expression)
+					: receiver.type;
+				const propertyType = services.typeChecker.getTypeOfPropertyOfType(
+					receiverType,
+					propertyName,
+				);
+				if (propertyType) {
+					checkAssignmentPattern(
+						nestedPattern,
+						{ type: propertyType },
+						services,
+					);
+				}
+			}
+		}
+
+		return {
+			visitors: {
+				BinaryExpression: (node, services) => {
+					if (
+						node.operatorToken.kind !== SyntaxKind.EqualsToken ||
+						!ts.isObjectLiteralExpression(node.left)
+					) {
+						return;
+					}
+					checkAssignmentPattern(
+						node.left,
+						{ expression: node.right },
+						services,
+					);
+				},
+				ElementAccessExpression: (node, services) => {
+					check(
+						node.argumentExpression,
+						{ expression: node.expression },
+						services,
+						false,
+					);
+				},
+				ObjectBindingPattern: checkBindingPattern,
+				PropertyAccessExpression: (node, services) => {
+					check(node.name, { expression: node.expression }, services);
+				},
+			},
+		};
+	},
+});


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #2000
- [x] That issue was marked as [`status: accepting prs`](https://github.com/flint-fyi/flint/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/flint-fyi/flint/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Adds the configuration-only `ts/restrictedProperties` rule with an empty default restriction list.

Restrictions identify receiver types or values with `TypeOrValueSpecifier` and match property accesses semantically through TypeScript declarations, aliases, nominal types, inheritance, generic constraints, and conservative union handling. The rule covers direct and computed accesses plus object binding and assignment destructuring, reports precise property ranges, and avoids fixes that could alter runtime semantics.

The TypeScript plugin registration, rule data, documentation, patch changeset, focused coverage, and TypeScript E2E fixture are included.

❤️‍🔥