### PR TITLE
feat(ts): add typeExports rule

### DIFF
--- a/.changeset/fuzzy-types-export.md
+++ b/.changeset/fuzzy-types-export.md
@@ -1,0 +1,5 @@
+---
+"@flint.fyi/ts": minor
+---
+
+Add the `ts/typeExports` rule to require type-only syntax for exports of types.

--- a/packages/e2e/tests/typescript/fixtures/src/type-exports.ts
+++ b/packages/e2e/tests/typescript/fixtures/src/type-exports.ts
@@ -1,0 +1,6 @@
+interface Account {
+	name: string;
+}
+
+// @ts-expect-error -- Verifies the lint rule independently of the matching compiler error.
+export { Account };

--- a/packages/e2e/tests/typescript/flint.config.ts
+++ b/packages/e2e/tests/typescript/flint.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
 	use: [
 		{
 			files: "fixtures/**/*.ts",
-			rules: ts.presets.logical,
+			rules: [ts.presets.logical, ts.rules({ typeExports: true })],
 		},
 	],
 });

--- a/packages/e2e/tests/typescript/typescript.test.ts
+++ b/packages/e2e/tests/typescript/typescript.test.ts
@@ -12,12 +12,15 @@ describe("typescript", () => {
 		expect(normalizeOutput(stdout, cwd)).toMatchInlineSnapshot(`
 			"<dim>Linting with <cyan><bold>flint.config.ts</bold></fg><dim>...</fg>
 
+			<underline><cwd>/fixtures/src/type-exports.ts</underline>
+			<dim>  6:1</fg>  All exports in this declaration are types. Use \`export type\`.  <yellow>ts/typeExports</fg>
+
 			<underline><cwd>/fixtures/src/with-issues.ts</underline>
 			<dim>  2:2</fg>  Debugger statements should not be used in production code.  <yellow>ts/debuggerStatements</fg>
 
-			<red>✖ Found <bold>1 report</bold> across <bold>1 file</bold>.</fg>
+			<red>✖ Found <bold>2 reports</bold> across <bold>2 files</bold> (<bold>1 fixable with --fix</bold>).</fg>
 			<red></fg>
-			<dim>Finished in <time> on 2 files with 138 rules.</fg>
+			<dim>Finished in <time> on 3 files with 139 rules.</fg>
 			<dim></fg>"
 		`);
 	});

--- a/packages/rule-data/src/data.json
+++ b/packages/rule-data/src/data.json
@@ -28222,7 +28222,8 @@
 		"flint": {
 			"name": "typeExports",
 			"plugin": "ts",
-			"preset": "stylistic"
+			"preset": "stylistic",
+			"status": "implemented"
 		},
 		"oxlint": [
 			{

--- a/packages/site/src/content/docs/rules/ts/typeExports.mdx
+++ b/packages/site/src/content/docs/rules/ts/typeExports.mdx
@@ -172,4 +172,4 @@ You may also avoid it when deliberately preserving runtime star-export loading o
 - [TypeScript: Declaration Merging](https://www.typescriptlang.org/docs/handbook/declaration-merging.html)
 - [TypeScript: `verbatimModuleSyntax`](https://www.typescriptlang.org/tsconfig/#verbatimModuleSyntax)
 
-<RuleEquivalents plugin="ts" rule="typeExports" />
+<RuleEquivalents pluginId="ts" ruleId="typeExports" />

--- a/packages/site/src/content/docs/rules/ts/typeExports.mdx
+++ b/packages/site/src/content/docs/rules/ts/typeExports.mdx
@@ -1,0 +1,175 @@
+---
+description: "Reports exports of types that do not use type-only export syntax."
+title: "typeExports"
+topic: "rules"
+---
+
+import { TabItem, Tabs } from "@astrojs/starlight/components";
+import { RuleEquivalents } from "~/components/RuleEquivalents";
+import RuleSummary from "~/components/RuleSummary.astro";
+
+<RuleSummary plugin="ts" rule="typeExports" />
+
+TypeScript's type-only export syntax documents which exports are erased from emitted JavaScript.
+This rule uses TypeScript's checker to resolve local declarations, imports, renamed and remote re-exports, and alias chains.
+It conservatively skips unresolved or cyclic symbols.
+
+## Examples
+
+### Named exports
+
+<Tabs>
+<TabItem label="❌ Incorrect">
+
+```ts
+interface Account {
+	name: string;
+}
+
+export { Account };
+```
+
+</TabItem>
+<TabItem label="✅ Correct">
+
+```ts
+interface Account {
+	name: string;
+}
+
+export type { Account };
+```
+
+</TabItem>
+</Tabs>
+
+### Mixed exports
+
+<Tabs>
+<TabItem label="❌ Incorrect">
+
+```ts
+interface Account {
+	name: string;
+}
+const createAccount = (): Account => ({ name: "" });
+
+export { Account, createAccount };
+```
+
+</TabItem>
+<TabItem label="✅ Correct">
+
+```ts
+interface Account {
+	name: string;
+}
+const createAccount = (): Account => ({ name: "" });
+
+export { type Account, createAccount };
+```
+
+</TabItem>
+</Tabs>
+
+The fixer inserts inline modifiers without reconstructing the declaration, preserving comments and other trivia.
+Symbols produced by merged type and value declarations remain value-capable and are not reported.
+Explicit type exports of value-capable symbols are also accepted.
+
+### Re-exports
+
+The checker follows imported and re-exported aliases, including renamed and default exports.
+
+<Tabs>
+<TabItem label="❌ Incorrect">
+
+```ts
+export { Account as Customer } from "./models";
+```
+
+</TabItem>
+<TabItem label="✅ Correct">
+
+```ts
+export type { Account as Customer } from "./models";
+```
+
+</TabItem>
+</Tabs>
+
+### Star exports
+
+Type-only star and namespace-star syntax is required when the resolved module's effective export closure contains only types.
+The checker follows transitive barrels, including type-only star chains, while empty and unresolved modules are skipped.
+Star exports containing any runtime value are not reported because changing them could alter runtime behavior or side effects.
+
+<Tabs>
+<TabItem label="❌ Incorrect">
+
+```ts
+export * from "./models";
+```
+
+```ts
+export * as Models from "./models";
+```
+
+</TabItem>
+<TabItem label="✅ Correct">
+
+```ts
+export type * from "./models";
+```
+
+```ts
+export type * as Models from "./models";
+```
+
+</TabItem>
+</Tabs>
+
+### Type and value symbols
+
+Classes, enums, functions, and namespaces with runtime members can also be used as types.
+The rule allows their ordinary exports because those symbols have runtime values.
+
+```ts
+interface Account {
+	name: string;
+}
+
+class Account {
+	name = "";
+}
+
+export { Account };
+```
+
+An explicit type-only export can select the type side of a value-capable symbol.
+
+```ts
+class Account {
+	name = "";
+}
+
+export type { Account };
+```
+
+The rule analyzes declaration files, where ambient classes, functions, enums, and variables still represent value-capable exports.
+It does not analyze JavaScript or JSX files, ordinary default exports, export assignments, or `export as namespace` declarations.
+Named re-exports of a default type remain in scope.
+The rule has no options.
+
+## When Not To Use It
+
+Do not use this rule when generated barrels must retain a fixed output format or while incrementally migrating a project under a different export-style policy.
+You may also avoid it when deliberately preserving runtime star-export loading or side effects, even when the current target exposes only types.
+
+## Further Reading
+
+- [TypeScript 3.8: Type-Only Imports and Exports](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-8.html#type-only-imports-and-export)
+- [TypeScript Modules Reference](https://www.typescriptlang.org/docs/handbook/modules/reference.html)
+- [TypeScript: Declaration Merging](https://www.typescriptlang.org/docs/handbook/declaration-merging.html)
+- [TypeScript: `verbatimModuleSyntax`](https://www.typescriptlang.org/tsconfig/#verbatimModuleSyntax)
+
+<RuleEquivalents plugin="ts" rule="typeExports" />

--- a/packages/ts/src/plugin.ts
+++ b/packages/ts/src/plugin.ts
@@ -278,6 +278,7 @@ import tripleSlashReferenceValidity from "./rules/tripleSlashReferenceValidity.t
 import tsComments from "./rules/tsComments.ts";
 import tslintComments from "./rules/tslintComments.ts";
 import typeAssertionStyles from "./rules/typeAssertionStyles.ts";
+import typeExports from "./rules/typeExports.ts";
 import typeImports from "./rules/typeImports.ts";
 import typeofComparisons from "./rules/typeofComparisons.ts";
 import unassignedVariables from "./rules/unassignedVariables.ts";
@@ -592,6 +593,7 @@ export const ts = createPlugin({
 		tsComments,
 		tslintComments,
 		typeAssertionStyles,
+		typeExports,
 		typeImports,
 		typeofComparisons,
 		unassignedVariables,

--- a/packages/ts/src/rules/typeExports.test.ts
+++ b/packages/ts/src/rules/typeExports.test.ts
@@ -1,0 +1,376 @@
+import { ruleTester } from "./ruleTester.ts";
+import rule from "./typeExports.ts";
+
+ruleTester.describe(rule, {
+	invalid: [
+		{
+			code: `
+interface Account { name: string }
+export { Account };
+`,
+			output: `
+interface Account { name: string }
+export type { Account };
+`,
+			snapshot: `
+interface Account { name: string }
+export { Account };
+~~~~~~~~~~~~~~~~~~~
+All exports in this declaration are types. Use \`export type\`.
+`,
+		},
+		{
+			code: `
+type Account = { name: string };
+const account = { name: "" };
+export { Account, account };
+`,
+			output: `
+type Account = { name: string };
+const account = { name: "" };
+export { type Account, account };
+`,
+			snapshot: `
+type Account = { name: string };
+const account = { name: "" };
+export { Account, account };
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Exports “Account” are types. Use inline \`type\` modifiers for them.
+`,
+		},
+		{
+			code: `
+type Account = { name: string };
+interface Permission { level: number }
+const createAccount = () => ({ name: "" });
+export { Account as "customer", Permission, createAccount };
+`,
+			output: `
+type Account = { name: string };
+interface Permission { level: number }
+const createAccount = () => ({ name: "" });
+export { type Account as "customer", type Permission, createAccount };
+`,
+			snapshot: `
+type Account = { name: string };
+interface Permission { level: number }
+const createAccount = () => ({ name: "" });
+export { Account as "customer", Permission, createAccount };
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Exports “customer” and “Permission” are types. Use inline \`type\` modifiers for them.
+`,
+		},
+		{
+			code: `
+type Account = { name: string };
+interface Permission { level: number }
+export /* declaration */ { type/* account */ Account, Permission /* permission */ };
+`,
+			output: `
+type Account = { name: string };
+interface Permission { level: number }
+export type /* declaration */ { /* account */ Account, Permission /* permission */ };
+`,
+			snapshot: `
+type Account = { name: string };
+interface Permission { level: number }
+export /* declaration */ { type/* account */ Account, Permission /* permission */ };
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+All exports in this declaration are types. Use \`export type\`.
+`,
+		},
+		{
+			code: `
+type Account = { name: string };
+interface Permission { level: number }
+export { type Account, Permission };
+`,
+			output: `
+type Account = { name: string };
+interface Permission { level: number }
+export type { Account, Permission };
+`,
+			snapshot: `
+type Account = { name: string };
+interface Permission { level: number }
+export { type Account, Permission };
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+All exports in this declaration are types. Use \`export type\`.
+`,
+		},
+		{
+			code: `
+import { Account as Customer } from "./models";
+export { Customer };
+`,
+			files: {
+				"models.ts": "export interface Account { name: string }",
+			},
+			output: `
+import { Account as Customer } from "./models";
+export type { Customer };
+`,
+			snapshot: `
+import { Account as Customer } from "./models";
+export { Customer };
+~~~~~~~~~~~~~~~~~~~~
+All exports in this declaration are types. Use \`export type\`.
+`,
+		},
+		{
+			code: `
+import type { Account } from "./models";
+export { Account };
+`,
+			files: {
+				"models.ts": "export class Account {}",
+			},
+			output: `
+import type { Account } from "./models";
+export type { Account };
+`,
+			snapshot: `
+import type { Account } from "./models";
+export { Account };
+~~~~~~~~~~~~~~~~~~~
+All exports in this declaration are types. Use \`export type\`.
+`,
+		},
+		{
+			code: `
+export { Account as Customer } from "./barrel";
+`,
+			files: {
+				"barrel.ts": 'export { Account } from "./models";',
+				"models.ts":
+					"export default interface DefaultAccount {}\nexport interface Account {}",
+			},
+			output: `
+export type { Account as Customer } from "./barrel";
+`,
+			snapshot: `
+export { Account as Customer } from "./barrel";
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+All exports in this declaration are types. Use \`export type\`.
+`,
+		},
+		{
+			code: `
+export { default as Account } from "./models";
+`,
+			files: {
+				"models.ts": "export default interface Account {}",
+			},
+			output: `
+export type { default as Account } from "./models";
+`,
+			snapshot: `
+export { default as Account } from "./models";
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+All exports in this declaration are types. Use \`export type\`.
+`,
+		},
+		{
+			code: `
+export /* before star */ * from "./models";
+export * as Models from "./models";
+`,
+			files: {
+				"models.ts": "export interface Account {}",
+			},
+			output: `
+export type /* before star */ * from "./models";
+export type * as Models from "./models";
+`,
+			snapshot: `
+export /* before star */ * from "./models";
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+This module exports only types. Use \`export type\`.
+export * as Models from "./models";
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+This module exports only types. Use \`export type\`.
+`,
+		},
+		{
+			code: `
+export * from "./barrel";
+`,
+			files: {
+				"barrel.ts": 'export type * from "./models";',
+				"models.ts": "export interface Account {}\nexport const account = {};",
+			},
+			output: `
+export type * from "./barrel";
+`,
+			snapshot: `
+export * from "./barrel";
+~~~~~~~~~~~~~~~~~~~~~~~~~
+This module exports only types. Use \`export type\`.
+`,
+		},
+		{
+			code: `
+export * from "./models";
+`,
+			files: {
+				"models.ts":
+					"export default class RuntimeAccount {}\nexport interface Account {}",
+			},
+			output: `
+export type * from "./models";
+`,
+			snapshot: `
+export * from "./models";
+~~~~~~~~~~~~~~~~~~~~~~~~~
+This module exports only types. Use \`export type\`.
+`,
+		},
+		{
+			code: `
+export * from "./first";
+`,
+			files: {
+				"first.ts": 'export interface Account {}\nexport * from "./second";',
+				"second.ts": 'export interface Permission {}\nexport * from "./first";',
+			},
+			output: `
+export type * from "./first";
+`,
+			snapshot: `
+export * from "./first";
+~~~~~~~~~~~~~~~~~~~~~~~~
+This module exports only types. Use \`export type\`.
+`,
+		},
+		{
+			code: `
+interface Account {}
+export { Account } from "./models" with { type: "json" };
+`,
+			files: {
+				"models.ts": "export interface Account {}",
+			},
+			snapshot: `
+interface Account {}
+export { Account } from "./models" with { type: "json" };
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+All exports in this declaration are types. Use \`export type\`.
+`,
+		},
+		{
+			code: `
+export * from "./models" with { type: "json" };
+`,
+			files: {
+				"models.ts": "export interface Account {}",
+			},
+			snapshot: `
+export * from "./models" with { type: "json" };
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+This module exports only types. Use \`export type\`.
+`,
+		},
+		{
+			code: `
+interface Account {}
+export { Account };
+`,
+			fileName: "models.d.ts",
+			output: `
+interface Account {}
+export type { Account };
+`,
+			snapshot: `
+interface Account {}
+export { Account };
+~~~~~~~~~~~~~~~~~~~
+All exports in this declaration are types. Use \`export type\`.
+`,
+		},
+	],
+	valid: [
+		"export type { Account } from './models';",
+		"export type * from './models';",
+		"export type * as Models from './models';",
+		"class Account {} export { type Account };",
+		"class Account {} export { Account };",
+		"enum Permission {} export { Permission };",
+		"function createAccount() {} export { createAccount };",
+		"const account = {}; export { account };",
+		"namespace Accounts { export const count = 1; } export { Accounts };",
+		"namespace Accounts { export interface Account {} } export { type Accounts };",
+		"interface Account {} class Account {} export { Account };",
+		"type Account = {}; const Account = {}; export { Account };",
+		"declare class Account {} export { Account };",
+		"declare function createAccount(): void; export { createAccount };",
+		"declare enum Permission {} export { Permission };",
+		"declare const account: {}; export { account };",
+		"export default interface Account { name: string }",
+		"export default class Account {}",
+		"export default function createAccount() {}",
+		"const account = {}; export default account;",
+		"const account = {}; export = account;",
+		"export as namespace Accounts;",
+		"export { Account } from './missing';",
+		"export * from './missing';",
+		{
+			code: "export * from './empty';",
+			files: { "empty.ts": "export {};" },
+		},
+		{
+			code: "export * from './values';\nexport * from './values';",
+			files: {
+				"values.ts": "export interface Account {}\nexport const account = {};",
+			},
+		},
+		{
+			code: "export * from './barrel';",
+			files: {
+				"barrel.ts": 'export * from "./values";',
+				"values.ts": "export const account = {};",
+			},
+		},
+		{
+			code: "export * from './barrel';",
+			files: {
+				"barrel.ts":
+					'export interface Account {}\nexport {};\nexport * from "./generated";',
+			},
+		},
+		{
+			code: "export * from './models';",
+			files: { "models.ts": "export default interface Account {}" },
+		},
+		{
+			code: "export * as Models from './models';",
+			files: {
+				"models.ts":
+					"export default class RuntimeAccount {}\nexport interface Account {}",
+			},
+		},
+		{
+			code: `
+import type { Account } from "./models";
+const Account = {};
+export { Account };
+`,
+			files: { "models.ts": "export interface Account {}" },
+		},
+		{
+			code: `
+import type { Accounts } from "./models";
+namespace Accounts { export const count = 1; }
+export { Accounts };
+`,
+			files: { "models.ts": "export namespace Accounts {}" },
+		},
+		{
+			code: "interface Account {} export { Account };",
+			fileName: "file.js",
+		},
+		{
+			code: "declare class Account {} export { Account };",
+			fileName: "models.d.ts",
+		},
+	],
+});

--- a/packages/ts/src/rules/typeExports.ts
+++ b/packages/ts/src/rules/typeExports.ts
@@ -1,0 +1,287 @@
+import ts, {
+	NodeFlags,
+	SymbolFlags,
+	SyntaxKind,
+	type Symbol as TypeScriptSymbol,
+} from "typescript";
+
+import {
+	getTSNodeRange,
+	typescriptLanguage,
+	type AST,
+	type Checker,
+} from "@flint.fyi/typescript-language";
+
+import { ruleCreator } from "./ruleCreator.ts";
+
+type StarKind = "bare" | "namespace";
+type SymbolKind = "type" | "value" | undefined;
+
+function classifySymbol(
+	symbol: TypeScriptSymbol | undefined,
+	typeChecker: Checker,
+	seen = new Set<TypeScriptSymbol>(),
+): SymbolKind {
+	if (!symbol || typeChecker.isUnknownSymbol(symbol) || seen.has(symbol)) {
+		return undefined;
+	}
+
+	seen.add(symbol);
+	if (symbol.flags & SymbolFlags.Value) {
+		return "value";
+	}
+
+	if (
+		symbol.declarations?.some((declaration) =>
+			ts.isTypeOnlyImportOrExportDeclaration(declaration),
+		)
+	) {
+		return "type";
+	}
+
+	if (symbol.flags & SymbolFlags.Alias) {
+		return classifySymbol(
+			typeChecker.getImmediateAliasedSymbol(symbol),
+			typeChecker,
+			seen,
+		);
+	}
+
+	return "type";
+}
+
+function formatWordList(words: string[]) {
+	if (words.length < 2) {
+		return words.join("");
+	}
+
+	return `${words.slice(0, -1).join(", ")} and ${words.at(-1)}`;
+}
+
+function getTypeKeywordRange(
+	specifier: AST.ExportSpecifier,
+	sourceFile: AST.SourceFile,
+) {
+	const begin = specifier.getStart(sourceFile);
+	const end = begin + "type".length;
+	return {
+		begin,
+		end: end + (sourceFile.text[end] === " " ? 1 : 0),
+	};
+}
+
+function hasUnresolvedStarExport(
+	symbol: TypeScriptSymbol,
+	typeChecker: Checker,
+	seen = new Set<TypeScriptSymbol>(),
+) {
+	if (seen.has(symbol)) {
+		return false;
+	}
+
+	seen.add(symbol);
+	// eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- Resolved module symbols always have declarations.
+	for (const declaration of symbol.getDeclarations()!) {
+		for (const statement of declaration.getSourceFile().statements) {
+			if (!ts.isExportDeclaration(statement)) {
+				continue;
+			}
+
+			const nestedSymbol = statement.moduleSpecifier
+				? typeChecker.getSymbolAtLocation(statement.moduleSpecifier)
+				: undefined;
+			if (statement.isTypeOnly || statement.exportClause) {
+				continue;
+			}
+
+			if (
+				!nestedSymbol ||
+				typeChecker.isUnknownSymbol(nestedSymbol) ||
+				hasUnresolvedStarExport(nestedSymbol, typeChecker, seen)
+			) {
+				return true;
+			}
+		}
+	}
+
+	return false;
+}
+
+export default ruleCreator.createRule(typescriptLanguage, {
+	about: {
+		description:
+			"Reports exports of types that do not use type-only export syntax.",
+		id: "typeExports",
+		presets: ["stylistic"],
+	},
+	messages: {
+		allTypes: {
+			primary: "All exports in this declaration are types. Use `export type`.",
+			secondary: ["Type-only exports are erased from emitted JavaScript."],
+			suggestions: ["Add the `type` modifier to this export declaration."],
+		},
+		mixedTypes: {
+			primary:
+				"Exports {{ names }} are types. Use inline `type` modifiers for them.",
+			secondary: [
+				"Inline modifiers distinguish erased exports from runtime exports.",
+			],
+			suggestions: ["Add inline `type` modifiers to the type exports."],
+		},
+		starTypes: {
+			primary: "This module exports only types. Use `export type`.",
+			secondary: ["Type-only star exports are erased from emitted JavaScript."],
+			suggestions: ["Add the `type` modifier to this star export."],
+		},
+	},
+	setup(context) {
+		const bareModuleKinds = new Map<
+			TypeScriptSymbol,
+			Exclude<SymbolKind, undefined>
+		>();
+		const namespaceModuleKinds = new Map<
+			TypeScriptSymbol,
+			Exclude<SymbolKind, undefined>
+		>();
+
+		function classifyModule(
+			symbol: TypeScriptSymbol | undefined,
+			typeChecker: Checker,
+			starKind: StarKind,
+		) {
+			if (!symbol || typeChecker.isUnknownSymbol(symbol)) {
+				return undefined;
+			}
+
+			const moduleKinds =
+				starKind === "bare" ? bareModuleKinds : namespaceModuleKinds;
+			const cached = moduleKinds.get(symbol);
+			if (cached !== undefined) {
+				return cached;
+			}
+
+			if (hasUnresolvedStarExport(symbol, typeChecker)) {
+				return undefined;
+			}
+
+			const exports = typeChecker
+				.getExportsOfModule(symbol)
+				.filter(
+					(exported) => starKind === "namespace" || exported.name !== "default",
+				);
+			if (!exports.length) {
+				return undefined;
+			}
+
+			const moduleType = typeChecker.getTypeOfSymbol(symbol);
+			const kind = typeChecker
+				.getPropertiesOfType(moduleType)
+				.some(
+					(property) =>
+						(starKind === "namespace" || property.name !== "default") &&
+						typeChecker.getPropertyOfType(moduleType, property.name) !==
+							undefined,
+				)
+				? "value"
+				: "type";
+			moduleKinds.set(symbol, kind);
+			return kind;
+		}
+
+		return {
+			visitors: {
+				ExportDeclaration: (node, { sourceFile, typeChecker }) => {
+					if (sourceFile.flags & NodeFlags.JavaScriptFile || node.isTypeOnly) {
+						return;
+					}
+
+					const range = getTSNodeRange(node, sourceFile);
+					const exportKeywordEnd = node.getStart(sourceFile) + "export".length;
+					const moduleSymbol = node.moduleSpecifier
+						? typeChecker.getSymbolAtLocation(node.moduleSpecifier)
+						: undefined;
+					if (node.exportClause?.kind === SyntaxKind.NamedExports) {
+						const typeSpecifiers = node.exportClause.elements.filter(
+							(specifier) =>
+								!specifier.isTypeOnly &&
+								classifySymbol(
+									typeChecker.getSymbolAtLocation(specifier.name),
+									typeChecker,
+								) === "type",
+						);
+						if (!typeSpecifiers.length) {
+							return;
+						}
+
+						const allTypes = node.exportClause.elements.every(
+							(specifier) =>
+								specifier.isTypeOnly || typeSpecifiers.includes(specifier),
+						);
+						if (allTypes) {
+							const inlineRanges = node.exportClause.elements
+								.filter((specifier) => specifier.isTypeOnly)
+								.map((specifier) => getTypeKeywordRange(specifier, sourceFile));
+							context.report({
+								fix: !node.attributes
+									? [
+											{
+												range: {
+													begin: exportKeywordEnd,
+													end: exportKeywordEnd,
+												},
+												text: " type",
+											},
+											...inlineRanges.map((inlineRange) => ({
+												range: inlineRange,
+												text: "",
+											})),
+										]
+									: undefined,
+								message: "allTypes",
+								range,
+							});
+							return;
+						}
+
+						context.report({
+							data: {
+								names: formatWordList(
+									typeSpecifiers.map((specifier) => `“${specifier.name.text}”`),
+								),
+							},
+							fix: typeSpecifiers.map((specifier) => {
+								const start = specifier.getStart(sourceFile);
+								return { range: { begin: start, end: start }, text: "type " };
+							}),
+							message: "mixedTypes",
+							range,
+						});
+						return;
+					}
+
+					if (
+						classifyModule(
+							moduleSymbol,
+							typeChecker,
+							node.exportClause ? "namespace" : "bare",
+						) === "type"
+					) {
+						context.report({
+							fix: !node.attributes
+								? {
+										range: {
+											begin: exportKeywordEnd,
+											end: exportKeywordEnd,
+										},
+										text: " type",
+									}
+								: undefined,
+							message: "starTypes",
+							range,
+						});
+					}
+				},
+			},
+		};
+	},
+});


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #2077
- [x] That issue was marked as [`status: accepting prs`](https://github.com/flint-fyi/flint/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/flint-fyi/flint/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Adds the type-aware `ts/typeExports` rule and its stylistic preset registration.

The rule resolves local, imported, and re-exported symbols; distinguishes merged type/value declarations; and analyzes direct and transitive star exports while conservatively skipping unresolved module edges.
Its fixes use type-only export syntax without reconstructing declarations, preserving comments and formatting.

Includes focused rule coverage, documentation, rule comparison data, an end-to-end fixture, and a package changeset.

❤️‍🔥