### PR TITLE
perf(core): validate out-of-lint-set cache dependencies by timestamp

### DIFF
--- a/.changeset/sweet-lions-sit.md
+++ b/.changeset/sweet-lions-sit.md
@@ -1,0 +1,5 @@
+---
+"flint": patch
+---
+
+Validate out-of-lint-set cache dependencies by timestamp.

--- a/packages/core/src/cache/readFromCache.test.ts
+++ b/packages/core/src/cache/readFromCache.test.ts
@@ -1,0 +1,144 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { createVFSLinterHost } from "../host/createVFSLinterHost.ts";
+import type { CacheStorage } from "../types/cache.ts";
+import type { VFSLinterHost } from "../types/host.ts";
+import { readFromCache } from "./readFromCache.ts";
+
+const cacheFilePath = "/root/cache.json";
+const configFilePath = "/root/flint.config.ts";
+const dependencyPath = "/root/tsconfig.json";
+const filePath = "/root/src/index.ts";
+
+const cacheWriteTime = 3000;
+
+function createHostWithCache(
+	files: Record<string, number>,
+	cachedFiles: CacheStorage["files"],
+) {
+	const host = createVFSLinterHost({ caseSensitive: true, cwd: "/root" });
+
+	for (const [path, touchTime] of Object.entries(files)) {
+		vi.setSystemTime(touchTime);
+		host.vfsUpsertFile(path, "");
+	}
+
+	const storage: CacheStorage = {
+		configs: {
+			[configFilePath]: cacheWriteTime,
+			"package.json": cacheWriteTime,
+		},
+		files: cachedFiles,
+		globalInvalidations: [],
+	};
+
+	host.vfsUpsertFile(cacheFilePath, JSON.stringify(storage));
+
+	return host;
+}
+
+function read(host: VFSLinterHost, allFilePaths: string[]) {
+	return readFromCache(
+		host,
+		new Set(allFilePaths),
+		configFilePath,
+		cacheFilePath,
+	);
+}
+
+describe(readFromCache, () => {
+	vi.useFakeTimers();
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it("keeps a file cached when a dependency outside the lint set was not touched after the cache was written", async () => {
+		const host = createHostWithCache(
+			{
+				[configFilePath]: 1000,
+				[dependencyPath]: 1000,
+				[filePath]: 2000,
+				"package.json": 1000,
+			},
+			{
+				[filePath]: {
+					dependencies: [dependencyPath],
+					timestamp: cacheWriteTime,
+				},
+			},
+		);
+
+		const cached = await read(host, [filePath]);
+
+		expect(cached && Array.from(cached.keys())).toEqual([filePath]);
+	});
+
+	it("invalidates a file when a dependency outside the lint set was touched after the cache was written", async () => {
+		const host = createHostWithCache(
+			{
+				[configFilePath]: 1000,
+				[dependencyPath]: 4000,
+				[filePath]: 2000,
+				"package.json": 1000,
+			},
+			{
+				[filePath]: {
+					dependencies: [dependencyPath],
+					timestamp: cacheWriteTime,
+				},
+			},
+		);
+
+		const cached = await read(host, [filePath]);
+
+		expect(cached && Array.from(cached.keys())).toEqual([]);
+	});
+
+	it("invalidates a file when a dependency outside the lint set no longer exists", async () => {
+		const host = createHostWithCache(
+			{
+				[configFilePath]: 1000,
+				[filePath]: 2000,
+				"package.json": 1000,
+			},
+			{
+				[filePath]: {
+					dependencies: [dependencyPath],
+					timestamp: cacheWriteTime,
+				},
+			},
+		);
+
+		const cached = await read(host, [filePath]);
+
+		expect(cached && Array.from(cached.keys())).toEqual([]);
+	});
+
+	it("invalidates dependents when a dependency inside the lint set was touched after the cache was written", async () => {
+		const dependentPath = "/root/src/dependent.ts";
+		const host = createHostWithCache(
+			{
+				[configFilePath]: 1000,
+				[dependencyPath]: 1000,
+				[dependentPath]: 2000,
+				[filePath]: 4000,
+				"package.json": 1000,
+			},
+			{
+				[dependentPath]: {
+					dependencies: [dependencyPath, filePath],
+					timestamp: cacheWriteTime,
+				},
+				[filePath]: {
+					dependencies: [dependencyPath],
+					timestamp: cacheWriteTime,
+				},
+			},
+		);
+
+		const cached = await read(host, [dependentPath, filePath]);
+
+		expect(cached && Array.from(cached.keys())).toEqual([]);
+	});
+});

--- a/packages/core/src/cache/readFromCache.test.ts
+++ b/packages/core/src/cache/readFromCache.test.ts
@@ -53,6 +53,25 @@ describe(readFromCache, () => {
 		vi.useRealTimers();
 	});
 
+	it("keeps a file cached when it has no dependencies", async () => {
+		const host = createHostWithCache(
+			{
+				[configFilePath]: 1000,
+				[filePath]: 2000,
+				"package.json": 1000,
+			},
+			{
+				[filePath]: {
+					timestamp: cacheWriteTime,
+				},
+			},
+		);
+
+		const cached = await read(host, [filePath]);
+
+		expect(cached && Array.from(cached.keys())).toEqual([filePath]);
+	});
+
 	it("keeps a file cached when a dependency outside the lint set was not touched after the cache was written", async () => {
 		const host = createHostWithCache(
 			{

--- a/packages/core/src/cache/readFromCache.ts
+++ b/packages/core/src/cache/readFromCache.ts
@@ -70,6 +70,7 @@ export async function readFromCache(
 	}
 
 	const cached = new Map(Object.entries(cache.files));
+	const dependencyTouchTimes = new Map<string, number | undefined>();
 	const filePathsToLint = new Set<string>();
 
 	for (const {
@@ -99,18 +100,10 @@ export async function readFromCache(
 			continue;
 		}
 
-		if (fileCached.dependencies) {
-			for (const dependency of fileCached.dependencies) {
-				if (!allFilePathKeys.has(pathKey(dependency, caseSensitiveFS))) {
-					log(
-						"Directly invalidating cache for: %s due to dependency %s not being in linted files cache",
-						filePath,
-						dependency,
-					);
-					markAsUncached(filePath);
-					continue;
-				}
-			}
+		// flint-disable-next-line performance/loopAwaits
+		if (await hasOutdatedDependency(filePath, fileCached)) {
+			markAsUncached(filePath);
+			continue;
 		}
 
 		const timestampCached = fileCached.timestamp;
@@ -169,6 +162,44 @@ export async function readFromCache(
 		allFilePaths.size,
 	);
 	return cached;
+
+	async function getDependencyTouchTime(dependency: string) {
+		if (dependencyTouchTimes.has(dependency)) {
+			return dependencyTouchTimes.get(dependency);
+		}
+
+		const touchTime = await host.getFileTouchTime(dependency);
+		dependencyTouchTimes.set(dependency, touchTime);
+		return touchTime;
+	}
+
+	async function hasOutdatedDependency(
+		filePath: string,
+		fileCached: FileCacheStorage,
+	) {
+		for (const dependency of fileCached.dependencies ?? []) {
+			// Dependencies inside the lint set are validated by their own cache
+			// entries, then propagated here by the transitive invalidation pass.
+			if (allFilePathKeys.has(pathKey(dependency, caseSensitiveFS))) {
+				continue;
+			}
+
+			// flint-disable-next-line performance/loopAwaits
+			const timestampTouched = await getDependencyTouchTime(dependency);
+			if (timestampTouched == null || timestampTouched > fileCached.timestamp) {
+				log(
+					"Directly invalidating cache for: %s due to dependency %s touch timestamp %d after cache timestamp %d",
+					filePath,
+					dependency,
+					timestampTouched,
+					fileCached.timestamp,
+				);
+				return true;
+			}
+		}
+
+		return false;
+	}
 
 	function markAsUncached(filePath: string) {
 		cached.delete(filePath);

--- a/packages/core/src/cache/readFromCache.ts
+++ b/packages/core/src/cache/readFromCache.ts
@@ -178,8 +178,6 @@ export async function readFromCache(
 		fileCached: FileCacheStorage,
 	) {
 		for (const dependency of fileCached.dependencies ?? []) {
-			// Dependencies inside the lint set are validated by their own cache
-			// entries, then propagated here by the transitive invalidation pass.
 			if (allFilePathKeys.has(pathKey(dependency, caseSensitiveFS))) {
 				continue;
 			}

--- a/packages/core/src/host/createDiskBackedLinterHost.test.ts
+++ b/packages/core/src/host/createDiskBackedLinterHost.test.ts
@@ -78,14 +78,14 @@ describe("createDiskBackedLinterHost", () => {
 		const host = createDiskBackedLinterHost(integrationRoot);
 		const missingPath = path.join(integrationRoot, "missing.txt");
 
-		expect(await host.getFileTouchTime(missingPath)).toEqual(undefined);
+		expect(await host.getFileTouchTime(missingPath)).toBeUndefined();
 	});
 
 	it("returns undefined for a missing file touch time synchronously", () => {
 		const host = createDiskBackedLinterHost(integrationRoot);
 		const missingPath = path.join(integrationRoot, "missing.txt");
 
-		expect(host.getFileTouchTimeSync(missingPath)).toEqual(undefined);
+		expect(host.getFileTouchTimeSync(missingPath)).toBeUndefined();
 	});
 
 	it("finds the repository root from a nested file", () => {

--- a/packages/core/src/host/createDiskBackedLinterHost.test.ts
+++ b/packages/core/src/host/createDiskBackedLinterHost.test.ts
@@ -62,6 +62,32 @@ describe("createDiskBackedLinterHost", () => {
 		expect(host.fileTypeSync(missingPath)).toEqual(undefined);
 	});
 
+	it("returns file touch times", async () => {
+		const host = createDiskBackedLinterHost(integrationRoot);
+		const filePath = path.join(integrationRoot, "file.txt");
+		const touchTime = new Date("2025-01-02T03:04:05.000Z");
+
+		fs.writeFileSync(filePath, "hello");
+		fs.utimesSync(filePath, touchTime, touchTime);
+
+		expect(await host.getFileTouchTime(filePath)).toEqual(touchTime.getTime());
+		expect(host.getFileTouchTimeSync(filePath)).toEqual(touchTime.getTime());
+	});
+
+	it("returns undefined for a missing file touch time asynchronously", async () => {
+		const host = createDiskBackedLinterHost(integrationRoot);
+		const missingPath = path.join(integrationRoot, "missing.txt");
+
+		expect(await host.getFileTouchTime(missingPath)).toEqual(undefined);
+	});
+
+	it("returns undefined for a missing file touch time synchronously", () => {
+		const host = createDiskBackedLinterHost(integrationRoot);
+		const missingPath = path.join(integrationRoot, "missing.txt");
+
+		expect(host.getFileTouchTimeSync(missingPath)).toEqual(undefined);
+	});
+
 	it("finds the repository root from a nested file", () => {
 		const repositoryRoot = path.join(integrationRoot, "repo");
 		const packageDirectory = path.join(repositoryRoot, "packages/core");

--- a/packages/core/src/host/createDiskBackedLinterHost.ts
+++ b/packages/core/src/host/createDiskBackedLinterHost.ts
@@ -179,11 +179,18 @@ export function createDiskBackedLinterHost(cwd: string): LinterHost {
 			return cwd;
 		},
 		async getFileTouchTime(filePath) {
-			const stat = await fs.promises.stat(filePath);
-			return stat.mtimeMs;
+			try {
+				return (await fs.promises.stat(filePath)).mtimeMs;
+			} catch {
+				return undefined;
+			}
 		},
 		getFileTouchTimeSync(filePath) {
-			return fs.statSync(filePath).mtimeMs;
+			try {
+				return fs.statSync(filePath).mtimeMs;
+			} catch {
+				return undefined;
+			}
 		},
 		getRepositoryRoot() {
 			return repositoryRoot;


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #3248
- [x] That issue was marked as [`status: accepting prs`](https://github.com/flint-fyi/flint/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/flint-fyi/flint/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

For file paths outside the lint set, we now do a touch timestamp check on the file itself using `stat`. Touch times are cached so it's at most one per file.

Also two small fixes as a part of this:

- The `continue` inside the dependency loop continued the inner loop rather than moving to the next file, so `markAsUncached` could fire repeatedly for one file and the file's own timestamp check still ran after it had already been invalidated. The dependency scan is now a helper that returns a boolean, so the outer loop can `continue` properly.
- `createDiskBackedLinterHost`'s `getFileTouchTime`/`getFileTouchTimeSync` threw when a file did not exist, even though both are typed as returning `number | undefined` (the VFS host already returns `undefined`). They now return `undefined`, which is what lets a deleted dependency be treated as changed instead of crashing the run.

❤️‍🔥 