### PR TITLE
perf: load TypeScript through a single require path

### DIFF
--- a/packages/astro/src/rules/clientOnlyDirectiveValues.ts
+++ b/packages/astro/src/rules/clientOnlyDirectiveValues.ts
@@ -1,7 +1,10 @@
-import ts, { SyntaxKind } from "typescript";
+import type ts from "typescript";
 
 import { astroLanguage } from "@flint.fyi/astro-language";
 import { getTSNodeRange } from "@flint.fyi/typescript-language";
+import typescript, {
+	SyntaxKind,
+} from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 
@@ -11,7 +14,9 @@ function typeCanBeClientOnlyValue(
 ): boolean {
 	if (
 		type.flags &
-		(ts.TypeFlags.Any | ts.TypeFlags.StringLike | ts.TypeFlags.Unknown)
+		(typescript.TypeFlags.Any |
+			typescript.TypeFlags.StringLike |
+			typescript.TypeFlags.Unknown)
 	) {
 		return true;
 	}

--- a/packages/browser/src/rules/alerts.ts
+++ b/packages/browser/src/rules/alerts.ts
@@ -1,11 +1,10 @@
-import { SyntaxKind } from "typescript";
-
 import {
 	getTSNodeRange,
 	isGlobalDeclaration,
 	typescriptLanguage,
 	type AST,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/browser/src/rules/classListToggles.ts
+++ b/packages/browser/src/rules/classListToggles.ts
@@ -1,10 +1,9 @@
-import { SyntaxKind } from "typescript";
-
 import {
 	getTSNodeRange,
 	typescriptLanguage,
 	type AST,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 import { nullThrows } from "@flint.fyi/utils";
 
 import { ruleCreator } from "./ruleCreator.ts";

--- a/packages/browser/src/rules/documentCookies.ts
+++ b/packages/browser/src/rules/documentCookies.ts
@@ -1,10 +1,9 @@
-import { SyntaxKind } from "typescript";
-
 import {
 	getTSNodeRange,
 	isGlobalDeclaration,
 	typescriptLanguage,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/browser/src/rules/documentWrites.ts
+++ b/packages/browser/src/rules/documentWrites.ts
@@ -1,9 +1,8 @@
-import { SyntaxKind } from "typescript";
-
 import {
 	getTSNodeRange,
 	typescriptLanguage,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { isGlobalDocumentReference } from "./isGlobalDocumentReference.ts";
 import { ruleCreator } from "./ruleCreator.ts";

--- a/packages/browser/src/rules/eventListenerSubscriptions.ts
+++ b/packages/browser/src/rules/eventListenerSubscriptions.ts
@@ -1,10 +1,9 @@
-import { SyntaxKind } from "typescript";
-
 import {
 	getTSNodeRange,
 	isGlobalDeclaration,
 	typescriptLanguage,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/browser/src/rules/implicitGlobals.ts
+++ b/packages/browser/src/rules/implicitGlobals.ts
@@ -1,10 +1,11 @@
-import ts, { SyntaxKind } from "typescript";
-
 import {
 	getTSNodeRange,
 	typescriptLanguage,
 	type AST,
 } from "@flint.fyi/typescript-language";
+import typescript, {
+	SyntaxKind,
+} from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 
@@ -55,7 +56,7 @@ export default ruleCreator.createRule(typescriptLanguage, {
 				node.modifiers?.some(
 					(modifier) => modifier.kind === SyntaxKind.ExportKeyword,
 				) ||
-				node.declarationList.flags & ts.NodeFlags.BlockScoped
+				node.declarationList.flags & typescript.NodeFlags.BlockScoped
 			) {
 				return;
 			}

--- a/packages/browser/src/rules/isGlobalDocumentReference.ts
+++ b/packages/browser/src/rules/isGlobalDocumentReference.ts
@@ -1,10 +1,11 @@
-import { SyntaxKind, type Program } from "typescript";
+import type { Program } from "typescript";
 
 import {
 	isGlobalDeclaration,
 	type AST,
 	type Checker,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 // TODO: Use a util like getStaticValue
 // https://github.com/flint-fyi/flint/issues/1298

--- a/packages/browser/src/rules/keyboardEventKeys.ts
+++ b/packages/browser/src/rules/keyboardEventKeys.ts
@@ -1,4 +1,4 @@
-import { isInterfaceDeclaration, SyntaxKind, type Program } from "typescript";
+import type { Program } from "typescript";
 
 import {
 	getDeclarationsIfGlobal,
@@ -7,6 +7,10 @@ import {
 	type AST,
 	type Checker,
 } from "@flint.fyi/typescript-language";
+import {
+	isInterfaceDeclaration,
+	SyntaxKind,
+} from "@flint.fyi/typescript-language/typescript";
 import { nullThrows } from "@flint.fyi/utils";
 
 import { ruleCreator } from "./ruleCreator.ts";

--- a/packages/browser/src/rules/nodeAppendMethods.ts
+++ b/packages/browser/src/rules/nodeAppendMethods.ts
@@ -1,11 +1,10 @@
-import { SyntaxKind } from "typescript";
-
 import {
 	getTSNodeRange,
 	isGlobalDeclaration,
 	typescriptLanguage,
 	type AST,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 import { nullThrows } from "@flint.fyi/utils";
 
 import { ruleCreator } from "./ruleCreator.ts";

--- a/packages/browser/src/rules/nodeDatasetAttributes.ts
+++ b/packages/browser/src/rules/nodeDatasetAttributes.ts
@@ -1,5 +1,3 @@
-import { SyntaxKind } from "typescript";
-
 import {
 	getStaticStringValue,
 	getTSNodeRange,
@@ -7,6 +5,7 @@ import {
 	typescriptLanguage,
 	type AST,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 import { nullThrows } from "@flint.fyi/utils";
 
 import { ruleCreator } from "./ruleCreator.ts";

--- a/packages/browser/src/rules/nodeModificationMethods.ts
+++ b/packages/browser/src/rules/nodeModificationMethods.ts
@@ -1,10 +1,9 @@
-import { SyntaxKind } from "typescript";
-
 import {
 	getTSNodeRange,
 	typescriptLanguage,
 	type AST,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 import { nullThrows } from "@flint.fyi/utils";
 
 import { ruleCreator } from "./ruleCreator.ts";

--- a/packages/browser/src/rules/nodeQueryMethods.ts
+++ b/packages/browser/src/rules/nodeQueryMethods.ts
@@ -1,10 +1,9 @@
-import { SyntaxKind } from "typescript";
-
 import {
 	getTSNodeRange,
 	isGlobalDeclaration,
 	typescriptLanguage,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 import { nullThrows } from "@flint.fyi/utils";
 
 import { ruleCreator } from "./ruleCreator.ts";

--- a/packages/browser/src/rules/nodeRemoveMethods.ts
+++ b/packages/browser/src/rules/nodeRemoveMethods.ts
@@ -1,10 +1,9 @@
-import { SyntaxKind } from "typescript";
-
 import {
 	getTSNodeRange,
 	isGlobalDeclaration,
 	typescriptLanguage,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 import { nullThrows } from "@flint.fyi/utils";
 
 import { ruleCreator } from "./ruleCreator.ts";

--- a/packages/browser/src/rules/nodeTextContents.ts
+++ b/packages/browser/src/rules/nodeTextContents.ts
@@ -1,10 +1,9 @@
-import { SyntaxKind } from "typescript";
-
 import {
 	getTSNodeRange,
 	isGlobalDeclaration,
 	typescriptLanguage,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/browser/src/rules/removeEventListenerExpressions.ts
+++ b/packages/browser/src/rules/removeEventListenerExpressions.ts
@@ -1,10 +1,9 @@
-import { SyntaxKind } from "typescript";
-
 import {
 	getTSNodeRange,
 	isGlobalDeclaration,
 	typescriptLanguage,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 import { nullThrows } from "@flint.fyi/utils";
 
 import { ruleCreator } from "./ruleCreator.ts";

--- a/packages/browser/src/rules/scriptUrls.ts
+++ b/packages/browser/src/rules/scriptUrls.ts
@@ -1,10 +1,11 @@
-import { SyntaxKind, type Node } from "typescript";
+import type { Node } from "typescript";
 
 import {
 	getTSNodeRange,
 	typescriptLanguage,
 	type AST,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/browser/src/rules/windowMessagingTargetOrigin.ts
+++ b/packages/browser/src/rules/windowMessagingTargetOrigin.ts
@@ -1,4 +1,4 @@
-import { SyntaxKind, type Program } from "typescript";
+import type { Program } from "typescript";
 
 import {
 	getTSNodeRange,
@@ -7,6 +7,7 @@ import {
 	type AST,
 	type Checker,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/jsx/src/rules/accessKeys.ts
+++ b/packages/jsx/src/rules/accessKeys.ts
@@ -1,9 +1,8 @@
-import { SyntaxKind } from "typescript";
-
 import {
 	getTSNodeRange,
 	typescriptLanguage,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/jsx/src/rules/altTexts.ts
+++ b/packages/jsx/src/rules/altTexts.ts
@@ -1,11 +1,10 @@
-import { SyntaxKind } from "typescript";
-
 import {
 	getTSNodeRange,
 	typescriptLanguage,
 	type AST,
 	type TypeScriptFileServices,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/jsx/src/rules/anchorAmbiguousText.ts
+++ b/packages/jsx/src/rules/anchorAmbiguousText.ts
@@ -1,10 +1,9 @@
-import { SyntaxKind } from "typescript";
-
 import {
 	getTSNodeRange,
 	typescriptLanguage,
 	type AST,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/jsx/src/rules/anchorContent.ts
+++ b/packages/jsx/src/rules/anchorContent.ts
@@ -1,10 +1,9 @@
-import { SyntaxKind } from "typescript";
-
 import {
 	getTSNodeRange,
 	typescriptLanguage,
 	type AST,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/jsx/src/rules/anchorValidity.ts
+++ b/packages/jsx/src/rules/anchorValidity.ts
@@ -1,11 +1,10 @@
-import { SyntaxKind } from "typescript";
-
 import {
 	getTSNodeRange,
 	typescriptLanguage,
 	type AST,
 	type TypeScriptFileServices,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/jsx/src/rules/ariaActiveDescendantTabIndex.ts
+++ b/packages/jsx/src/rules/ariaActiveDescendantTabIndex.ts
@@ -1,11 +1,10 @@
-import { SyntaxKind } from "typescript";
-
 import {
 	getTSNodeRange,
 	typescriptLanguage,
 	type AST,
 	type TypeScriptFileServices,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/jsx/src/rules/ariaHiddenFocusables.ts
+++ b/packages/jsx/src/rules/ariaHiddenFocusables.ts
@@ -1,11 +1,10 @@
-import { SyntaxKind } from "typescript";
-
 import {
 	getTSNodeRange,
 	typescriptLanguage,
 	type AST,
 	type TypeScriptFileServices,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/jsx/src/rules/ariaPropTypes.ts
+++ b/packages/jsx/src/rules/ariaPropTypes.ts
@@ -1,11 +1,10 @@
-import { SyntaxKind } from "typescript";
-
 import {
 	getTSNodeRange,
 	typescriptLanguage,
 	type AST,
 	type TypeScriptFileServices,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/jsx/src/rules/ariaProps.ts
+++ b/packages/jsx/src/rules/ariaProps.ts
@@ -1,11 +1,10 @@
-import { SyntaxKind } from "typescript";
-
 import {
 	getTSNodeRange,
 	typescriptLanguage,
 	type AST,
 	type TypeScriptFileServices,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/jsx/src/rules/ariaRoleValidity.ts
+++ b/packages/jsx/src/rules/ariaRoleValidity.ts
@@ -1,11 +1,10 @@
-import { SyntaxKind } from "typescript";
-
 import {
 	getTSNodeRange,
 	typescriptLanguage,
 	type AST,
 	type TypeScriptFileServices,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/jsx/src/rules/ariaUnsupportedElements.ts
+++ b/packages/jsx/src/rules/ariaUnsupportedElements.ts
@@ -1,11 +1,10 @@
-import { SyntaxKind } from "typescript";
-
 import {
 	getTSNodeRange,
 	typescriptLanguage,
 	type AST,
 	type TypeScriptFileServices,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/jsx/src/rules/autoFocusProps.ts
+++ b/packages/jsx/src/rules/autoFocusProps.ts
@@ -1,11 +1,10 @@
-import { SyntaxKind } from "typescript";
-
 import {
 	getTSNodeRange,
 	typescriptLanguage,
 	type AST,
 	type TypeScriptFileServices,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/jsx/src/rules/autocomplete.ts
+++ b/packages/jsx/src/rules/autocomplete.ts
@@ -1,5 +1,3 @@
-import { SyntaxKind } from "typescript";
-
 import {
 	getStaticStringValue,
 	getTSNodeRange,
@@ -7,6 +5,7 @@ import {
 	type AST,
 	type TypeScriptFileServices,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 import { nullThrows } from "@flint.fyi/utils";
 
 import { ruleCreator } from "./ruleCreator.ts";

--- a/packages/jsx/src/rules/booleanValues.ts
+++ b/packages/jsx/src/rules/booleanValues.ts
@@ -1,11 +1,10 @@
-import { SyntaxKind } from "typescript";
-
 import {
 	getTSNodeRange,
 	typescriptLanguage,
 	type AST,
 	type TypeScriptFileServices,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/jsx/src/rules/bracedStatements.ts
+++ b/packages/jsx/src/rules/bracedStatements.ts
@@ -1,9 +1,8 @@
-import { SyntaxKind } from "typescript";
-
 import {
 	getTSNodeRange,
 	typescriptLanguage,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/jsx/src/rules/buttonTypes.ts
+++ b/packages/jsx/src/rules/buttonTypes.ts
@@ -1,5 +1,3 @@
-import { SyntaxKind } from "typescript";
-
 import {
 	getStaticStringValue,
 	getTSNodeRange,
@@ -7,6 +5,7 @@ import {
 	type AST,
 	type TypeScriptFileServices,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/jsx/src/rules/childrenProps.ts
+++ b/packages/jsx/src/rules/childrenProps.ts
@@ -1,11 +1,10 @@
-import { SyntaxKind } from "typescript";
-
 import {
 	getTSNodeRange,
 	typescriptLanguage,
 	type AST,
 	type TypeScriptFileServices,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/jsx/src/rules/clickEventKeyEvents.ts
+++ b/packages/jsx/src/rules/clickEventKeyEvents.ts
@@ -1,11 +1,10 @@
-import { SyntaxKind } from "typescript";
-
 import {
 	getTSNodeRange,
 	typescriptLanguage,
 	type AST,
 	type TypeScriptFileServices,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/jsx/src/rules/distractingElements.ts
+++ b/packages/jsx/src/rules/distractingElements.ts
@@ -1,11 +1,10 @@
-import { SyntaxKind } from "typescript";
-
 import {
 	getTSNodeRange,
 	typescriptLanguage,
 	type AST,
 	type TypeScriptFileServices,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/jsx/src/rules/elementChildrenValidity.ts
+++ b/packages/jsx/src/rules/elementChildrenValidity.ts
@@ -1,10 +1,9 @@
-import { SyntaxKind } from "typescript";
-
 import {
 	getTSNodeRange,
 	typescriptLanguage,
 	type TypeScriptFileServices,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/jsx/src/rules/headingContents.ts
+++ b/packages/jsx/src/rules/headingContents.ts
@@ -1,11 +1,10 @@
-import { SyntaxKind } from "typescript";
-
 import {
 	getTSNodeRange,
 	typescriptLanguage,
 	type AST,
 	type TypeScriptFileServices,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/jsx/src/rules/htmlLangs.ts
+++ b/packages/jsx/src/rules/htmlLangs.ts
@@ -1,9 +1,8 @@
-import { SyntaxKind } from "typescript";
-
 import {
 	getTSNodeRange,
 	typescriptLanguage,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/jsx/src/rules/iframeTitles.ts
+++ b/packages/jsx/src/rules/iframeTitles.ts
@@ -1,11 +1,10 @@
-import { SyntaxKind } from "typescript";
-
 import {
 	getTSNodeRange,
 	typescriptLanguage,
 	type AST,
 	type TypeScriptFileServices,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/jsx/src/rules/interactiveElementRoles.ts
+++ b/packages/jsx/src/rules/interactiveElementRoles.ts
@@ -1,11 +1,10 @@
-import { SyntaxKind } from "typescript";
-
 import {
 	getTSNodeRange,
 	typescriptLanguage,
 	type AST,
 	type TypeScriptFileServices,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/jsx/src/rules/interactiveElementsFocusable.ts
+++ b/packages/jsx/src/rules/interactiveElementsFocusable.ts
@@ -1,11 +1,10 @@
-import { SyntaxKind } from "typescript";
-
 import {
 	getTSNodeRange,
 	typescriptLanguage,
 	type AST,
 	type TypeScriptFileServices,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/jsx/src/rules/labelAssociatedControls.ts
+++ b/packages/jsx/src/rules/labelAssociatedControls.ts
@@ -1,4 +1,4 @@
-import { SyntaxKind, type NodeArray } from "typescript";
+import type { NodeArray } from "typescript";
 
 import {
 	getTSNodeRange,
@@ -6,6 +6,7 @@ import {
 	type AST,
 	type TypeScriptFileServices,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/jsx/src/rules/langValidity.ts
+++ b/packages/jsx/src/rules/langValidity.ts
@@ -1,5 +1,4 @@
 import languageTags from "language-tags";
-import { SyntaxKind } from "typescript";
 
 import {
 	getTSNodeRange,
@@ -7,6 +6,7 @@ import {
 	type AST,
 	type TypeScriptFileServices,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/jsx/src/rules/mediaCaptions.ts
+++ b/packages/jsx/src/rules/mediaCaptions.ts
@@ -1,11 +1,10 @@
-import { SyntaxKind } from "typescript";
-
 import {
 	getTSNodeRange,
 	typescriptLanguage,
 	type AST,
 	type TypeScriptFileServices,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/jsx/src/rules/mouseEventKeyEvents.ts
+++ b/packages/jsx/src/rules/mouseEventKeyEvents.ts
@@ -1,11 +1,10 @@
-import { SyntaxKind } from "typescript";
-
 import {
 	getTSNodeRange,
 	typescriptLanguage,
 	type AST,
 	type TypeScriptFileServices,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/jsx/src/rules/nonInteractiveElementInteractions.ts
+++ b/packages/jsx/src/rules/nonInteractiveElementInteractions.ts
@@ -1,11 +1,10 @@
-import { SyntaxKind } from "typescript";
-
 import {
 	getTSNodeRange,
 	typescriptLanguage,
 	type AST,
 	type TypeScriptFileServices,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/jsx/src/rules/nonInteractiveElementRoles.ts
+++ b/packages/jsx/src/rules/nonInteractiveElementRoles.ts
@@ -1,11 +1,10 @@
-import { SyntaxKind } from "typescript";
-
 import {
 	getTSNodeRange,
 	typescriptLanguage,
 	type AST,
 	type TypeScriptFileServices,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/jsx/src/rules/nonInteractiveElementTabIndexes.ts
+++ b/packages/jsx/src/rules/nonInteractiveElementTabIndexes.ts
@@ -1,11 +1,10 @@
-import { SyntaxKind } from "typescript";
-
 import {
 	getTSNodeRange,
 	typescriptLanguage,
 	type AST,
 	type TypeScriptFileServices,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/jsx/src/rules/roleRedundancies.ts
+++ b/packages/jsx/src/rules/roleRedundancies.ts
@@ -1,11 +1,10 @@
-import { SyntaxKind } from "typescript";
-
 import {
 	getTSNodeRange,
 	typescriptLanguage,
 	type AST,
 	type TypeScriptFileServices,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/jsx/src/rules/roleRequiredAriaProps.ts
+++ b/packages/jsx/src/rules/roleRequiredAriaProps.ts
@@ -1,11 +1,10 @@
-import { SyntaxKind } from "typescript";
-
 import {
 	getTSNodeRange,
 	typescriptLanguage,
 	type AST,
 	type TypeScriptFileServices,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/jsx/src/rules/roleSupportedAriaProps.ts
+++ b/packages/jsx/src/rules/roleSupportedAriaProps.ts
@@ -1,11 +1,10 @@
-import { SyntaxKind } from "typescript";
-
 import {
 	getTSNodeRange,
 	typescriptLanguage,
 	type AST,
 	type TypeScriptFileServices,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/jsx/src/rules/roleTags.ts
+++ b/packages/jsx/src/rules/roleTags.ts
@@ -1,11 +1,10 @@
-import { SyntaxKind } from "typescript";
-
 import {
 	getTSNodeRange,
 	typescriptLanguage,
 	type AST,
 	type TypeScriptFileServices,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/jsx/src/rules/scopeProps.ts
+++ b/packages/jsx/src/rules/scopeProps.ts
@@ -1,11 +1,10 @@
-import { SyntaxKind } from "typescript";
-
 import {
 	getTSNodeRange,
 	typescriptLanguage,
 	type AST,
 	type TypeScriptFileServices,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/jsx/src/rules/staticElementInteractions.ts
+++ b/packages/jsx/src/rules/staticElementInteractions.ts
@@ -1,11 +1,10 @@
-import { SyntaxKind } from "typescript";
-
 import {
 	getTSNodeRange,
 	typescriptLanguage,
 	type AST,
 	type TypeScriptFileServices,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/jsx/src/rules/svgTitles.ts
+++ b/packages/jsx/src/rules/svgTitles.ts
@@ -1,11 +1,10 @@
-import { SyntaxKind } from "typescript";
-
 import {
 	getTSNodeRange,
 	typescriptLanguage,
 	type AST,
 	type TypeScriptFileServices,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/jsx/src/rules/tabIndexPositiveValues.ts
+++ b/packages/jsx/src/rules/tabIndexPositiveValues.ts
@@ -1,10 +1,9 @@
-import { SyntaxKind } from "typescript";
-
 import {
 	getTSNodeRange,
 	typescriptLanguage,
 	type AST,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/jsx/src/rules/unnecessaryFragments.ts
+++ b/packages/jsx/src/rules/unnecessaryFragments.ts
@@ -1,7 +1,6 @@
-import { SyntaxKind } from "typescript";
-
 import type { CharacterReportRange } from "@flint.fyi/core";
 import { typescriptLanguage, type AST } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/node/src/rules/assertStrict.ts
+++ b/packages/node/src/rules/assertStrict.ts
@@ -1,10 +1,9 @@
-import { SyntaxKind } from "typescript";
-
 import {
 	getTSNodeRange,
 	typescriptLanguage,
 	type AST,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/node/src/rules/assertStyles.ts
+++ b/packages/node/src/rules/assertStyles.ts
@@ -1,9 +1,8 @@
-import { SyntaxKind } from "typescript";
-
 import {
 	getTSNodeRange,
 	typescriptLanguage,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/node/src/rules/blobReadingMethods.ts
+++ b/packages/node/src/rules/blobReadingMethods.ts
@@ -1,10 +1,9 @@
-import { SyntaxKind } from "typescript";
-
 import {
 	getTSNodeRange,
 	isGlobalDeclaration,
 	typescriptLanguage,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/node/src/rules/bufferAllocators.ts
+++ b/packages/node/src/rules/bufferAllocators.ts
@@ -1,9 +1,8 @@
-import { SyntaxKind } from "typescript";
-
 import {
 	getTSNodeRange,
 	typescriptLanguage,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/node/src/rules/consoleSpaces.ts
+++ b/packages/node/src/rules/consoleSpaces.ts
@@ -1,10 +1,9 @@
-import { SyntaxKind } from "typescript";
-
 import {
 	typescriptLanguage,
 	type AST,
 	type Checker,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 import { nullThrows } from "@flint.fyi/utils";
 
 import { ruleCreator } from "./ruleCreator.ts";

--- a/packages/node/src/rules/eventClasses.ts
+++ b/packages/node/src/rules/eventClasses.ts
@@ -1,5 +1,3 @@
-import { SyntaxKind } from "typescript";
-
 import {
 	getTSNodeRange,
 	typescriptLanguage,
@@ -7,6 +5,7 @@ import {
 	type Checker,
 	type TypeScriptFileServices,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/node/src/rules/exportsAssignments.ts
+++ b/packages/node/src/rules/exportsAssignments.ts
@@ -1,11 +1,10 @@
-import { SyntaxKind } from "typescript";
-
 import {
 	getTSNodeRange,
 	typescriptLanguage,
 	type AST,
 	type Checker,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/node/src/rules/filePathsFromImportMeta.ts
+++ b/packages/node/src/rules/filePathsFromImportMeta.ts
@@ -1,10 +1,9 @@
-import { SyntaxKind } from "typescript";
-
 import {
 	getTSNodeRange,
 	typescriptLanguage,
 	type AST,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 import { nullThrows } from "@flint.fyi/utils";
 
 import { ruleCreator } from "./ruleCreator.ts";

--- a/packages/node/src/rules/fileReadJSONBuffers.ts
+++ b/packages/node/src/rules/fileReadJSONBuffers.ts
@@ -1,10 +1,9 @@
-import { SyntaxKind } from "typescript";
-
 import {
 	getTSNodeRange,
 	typescriptLanguage,
 	type AST,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 import { nullThrows } from "@flint.fyi/utils";
 
 import { ruleCreator } from "./ruleCreator.ts";

--- a/packages/node/src/rules/nodeProtocols.ts
+++ b/packages/node/src/rules/nodeProtocols.ts
@@ -1,10 +1,9 @@
-import { SyntaxKind } from "typescript";
-
 import {
 	getTSNodeRange,
 	typescriptLanguage,
 	type AST,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 import { nullThrows } from "@flint.fyi/utils";
 
 import { ruleCreator } from "./ruleCreator.ts";

--- a/packages/node/src/rules/processExits.ts
+++ b/packages/node/src/rules/processExits.ts
@@ -1,9 +1,8 @@
-import { SyntaxKind } from "typescript";
-
 import {
 	getTSNodeRange,
 	typescriptLanguage,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 import { isDeclaredInNodeTypes } from "./utils/isDeclaredInNodeTypes.ts";

--- a/packages/performance/package.json
+++ b/packages/performance/package.json
@@ -27,7 +27,6 @@
 	"dependencies": {
 		"@flint.fyi/core": "workspace:^",
 		"@flint.fyi/typescript-language": "workspace:^",
-		"ts-api-utils": "^2.4.0",
 		"typescript": "^6.0.0"
 	},
 	"devDependencies": {

--- a/packages/performance/src/rules/importedNamespaceDynamicAccesses.ts
+++ b/packages/performance/src/rules/importedNamespaceDynamicAccesses.ts
@@ -1,4 +1,4 @@
-import { SyntaxKind, type Declaration } from "typescript";
+import type { Declaration } from "typescript";
 
 import {
 	getTSNodeRange,
@@ -6,6 +6,7 @@ import {
 	type AST,
 	type Checker,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "../ruleCreator.ts";
 

--- a/packages/performance/src/rules/loopAwaits.ts
+++ b/packages/performance/src/rules/loopAwaits.ts
@@ -1,11 +1,14 @@
-import * as tsutils from "ts-api-utils";
-import ts, { SyntaxKind } from "typescript";
+import type ts from "typescript";
 
 import {
 	typescriptLanguage,
 	type AST,
 	type TypeScriptFileServices,
 } from "@flint.fyi/typescript-language";
+import tsutils from "@flint.fyi/typescript-language/ts-api-utils";
+import typescript, {
+	SyntaxKind,
+} from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "../ruleCreator.ts";
 
@@ -57,7 +60,7 @@ export default ruleCreator.createRule(typescriptLanguage, {
 				return;
 			}
 
-			ts.forEachChild(node, (child) => {
+			typescript.forEachChild(node, (child) => {
 				checkForAwaitExpressions(child, loopNode, sourceFile);
 			});
 		}

--- a/packages/performance/src/rules/loopFunctions.ts
+++ b/packages/performance/src/rules/loopFunctions.ts
@@ -1,11 +1,14 @@
-import * as tsutils from "ts-api-utils";
-import ts, { SyntaxKind } from "typescript";
+import type ts from "typescript";
 
 import {
 	typescriptLanguage,
 	type AST,
 	type TypeScriptFileServices,
 } from "@flint.fyi/typescript-language";
+import tsutils from "@flint.fyi/typescript-language/ts-api-utils";
+import typescript, {
+	SyntaxKind,
+} from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "../ruleCreator.ts";
 
@@ -110,18 +113,18 @@ export default ruleCreator.createRule(typescriptLanguage, {
 			node: ts.Node,
 			loopVariables: Set<string>,
 		): boolean | undefined {
-			if (ts.isIdentifier(node) && loopVariables.has(node.text)) {
+			if (typescript.isIdentifier(node) && loopVariables.has(node.text)) {
 				return true;
 			}
 
-			return ts.forEachChild(node, (child) => {
+			return typescript.forEachChild(node, (child) => {
 				return (
 					!tsutils.isFunctionScopeBoundary(child) &&
-					!ts.isDoStatement(child) &&
-					!ts.isForInStatement(child) &&
-					!ts.isForOfStatement(child) &&
-					!ts.isForStatement(child) &&
-					!ts.isWhileStatement(child) &&
+					!typescript.isDoStatement(child) &&
+					!typescript.isForInStatement(child) &&
+					!typescript.isForOfStatement(child) &&
+					!typescript.isForStatement(child) &&
+					!typescript.isWhileStatement(child) &&
 					referencesLoopVariable(child, loopVariables)
 				);
 			});
@@ -143,11 +146,14 @@ export default ruleCreator.createRule(typescriptLanguage, {
 					const start = node.getStart(sourceFile);
 					let keyword = "function";
 
-					if (ts.isFunctionDeclaration(node) || ts.isFunctionExpression(node)) {
+					if (
+						typescript.isFunctionDeclaration(node) ||
+						typescript.isFunctionExpression(node)
+					) {
 						keyword = "function";
-					} else if (ts.isArrowFunction(node)) {
+					} else if (typescript.isArrowFunction(node)) {
 						const firstToken = node.getFirstToken(sourceFile);
-						if (firstToken && ts.isIdentifier(firstToken)) {
+						if (firstToken && typescript.isIdentifier(firstToken)) {
 							keyword = firstToken.text;
 						} else {
 							keyword = "(";
@@ -166,16 +172,16 @@ export default ruleCreator.createRule(typescriptLanguage, {
 			}
 
 			if (
-				ts.isDoStatement(node) ||
-				ts.isForInStatement(node) ||
-				ts.isForOfStatement(node) ||
-				ts.isForStatement(node) ||
-				ts.isWhileStatement(node)
+				typescript.isDoStatement(node) ||
+				typescript.isForInStatement(node) ||
+				typescript.isForOfStatement(node) ||
+				typescript.isForStatement(node) ||
+				typescript.isWhileStatement(node)
 			) {
 				return;
 			}
 
-			ts.forEachChild(node, (child) => {
+			typescript.forEachChild(node, (child) => {
 				checkFunctionInLoop(child, loopNode, loopVariables, sourceFile);
 			});
 		}

--- a/packages/performance/src/rules/spreadAccumulators.ts
+++ b/packages/performance/src/rules/spreadAccumulators.ts
@@ -1,11 +1,14 @@
-import * as tsutils from "ts-api-utils";
-import ts, { SyntaxKind } from "typescript";
+import type ts from "typescript";
 
 import {
 	typescriptLanguage,
 	type AST,
 	type TypeScriptFileServices,
 } from "@flint.fyi/typescript-language";
+import tsutils from "@flint.fyi/typescript-language/ts-api-utils";
+import typescript, {
+	SyntaxKind,
+} from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "../ruleCreator.ts";
 
@@ -32,7 +35,7 @@ export default ruleCreator.createRule(typescriptLanguage, {
 	},
 	setup(context) {
 		function getIdentifierName(node: ts.Node) {
-			return ts.isIdentifier(node) ? node.text : undefined;
+			return typescript.isIdentifier(node) ? node.text : undefined;
 		}
 
 		function hasSpreadOfIdentifier(
@@ -40,32 +43,33 @@ export default ruleCreator.createRule(typescriptLanguage, {
 			identifierName: string,
 		): boolean | undefined {
 			if (
-				(ts.isSpreadElement(node) || ts.isSpreadAssignment(node)) &&
+				(typescript.isSpreadElement(node) ||
+					typescript.isSpreadAssignment(node)) &&
 				identifierName === getIdentifierName(node.expression)
 			) {
 				return true;
 			}
 
-			return ts.forEachChild(node, (child) => {
+			return typescript.forEachChild(node, (child) => {
 				return hasSpreadOfIdentifier(child, identifierName);
 			});
 		}
 
 		function checkAssignmentInLoop(node: ts.Node, sourceFile: AST.SourceFile) {
 			if (
-				ts.isBinaryExpression(node) &&
+				typescript.isBinaryExpression(node) &&
 				node.operatorToken.kind === SyntaxKind.EqualsToken
 			) {
 				checkBinaryEqualsExpression(node, sourceFile);
 			}
 
-			ts.forEachChild(node, (child) => {
+			typescript.forEachChild(node, (child) => {
 				if (
-					ts.isDoStatement(child) ||
-					ts.isForInStatement(child) ||
-					ts.isForOfStatement(child) ||
-					ts.isForStatement(child) ||
-					ts.isWhileStatement(child) ||
+					typescript.isDoStatement(child) ||
+					typescript.isForInStatement(child) ||
+					typescript.isForOfStatement(child) ||
+					typescript.isForStatement(child) ||
+					typescript.isWhileStatement(child) ||
 					tsutils.isFunctionScopeBoundary(child)
 				) {
 					return;
@@ -107,7 +111,10 @@ export default ruleCreator.createRule(typescriptLanguage, {
 			node: ts.Node,
 			identifierName: string,
 		): ts.Node | undefined {
-			if (ts.isSpreadElement(node) || ts.isSpreadAssignment(node)) {
+			if (
+				typescript.isSpreadElement(node) ||
+				typescript.isSpreadAssignment(node)
+			) {
 				const spreadName = getIdentifierName(node.expression);
 				if (spreadName === identifierName) {
 					return node;
@@ -115,7 +122,7 @@ export default ruleCreator.createRule(typescriptLanguage, {
 			}
 
 			let result: ts.Node | undefined = undefined;
-			ts.forEachChild(node, (child) => {
+			typescript.forEachChild(node, (child) => {
 				result ??= findSpreadElement(child, identifierName);
 			});
 

--- a/packages/plugin-flint/src/rules/getStartSourceFile.ts
+++ b/packages/plugin-flint/src/rules/getStartSourceFile.ts
@@ -1,9 +1,8 @@
-import { SyntaxKind } from "typescript";
-
 import {
 	getTSNodeRange,
 	typescriptLanguage,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { isTypeFromTS } from "../utils/isTypeFromTS.ts";
 import { ruleCreator } from "./ruleCreator.ts";

--- a/packages/plugin-flint/src/rules/invalidCodeLines.ts
+++ b/packages/plugin-flint/src/rules/invalidCodeLines.ts
@@ -1,11 +1,10 @@
-import { SyntaxKind } from "typescript";
-
 import type { FileChange } from "@flint.fyi/core";
 import {
 	getTSNodeRange,
 	typescriptLanguage,
 	type AST,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { getRuleTesterDescribedCases } from "../utils/getRuleTesterDescribedCases.ts";
 import type {

--- a/packages/plugin-flint/src/rules/missingPlaceholders.ts
+++ b/packages/plugin-flint/src/rules/missingPlaceholders.ts
@@ -1,10 +1,9 @@
-import { SyntaxKind } from "typescript";
-
 import {
 	getTSNodeRange,
 	typescriptLanguage,
 	type AST,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { findProperty } from "../utils/findProperty.ts";
 import {

--- a/packages/plugin-flint/src/rules/nodePropertyInChecks.ts
+++ b/packages/plugin-flint/src/rules/nodePropertyInChecks.ts
@@ -1,9 +1,8 @@
-import { SyntaxKind } from "typescript";
-
 import {
 	getTSNodeRange,
 	typescriptLanguage,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { isTypeFromTS } from "../utils/isTypeFromTS.ts";
 import { ruleCreator } from "./ruleCreator.ts";

--- a/packages/plugin-flint/src/rules/pluginRuleOrdering.ts
+++ b/packages/plugin-flint/src/rules/pluginRuleOrdering.ts
@@ -1,10 +1,13 @@
-import ts, { SyntaxKind } from "typescript";
+import type ts from "typescript";
 
 import {
 	getTSNodeRange,
 	typescriptLanguage,
 	type AST,
 } from "@flint.fyi/typescript-language";
+import typescript, {
+	SyntaxKind,
+} from "@flint.fyi/typescript-language/typescript";
 
 import { findProperty } from "../utils/findProperty.ts";
 import { ruleCreator } from "./ruleCreator.ts";
@@ -51,7 +54,7 @@ function isCreatePluginCall(
 	}
 
 	const resolvedSymbol =
-		symbol.flags & ts.SymbolFlags.Alias
+		symbol.flags & typescript.SymbolFlags.Alias
 			? typeChecker.getAliasedSymbol(symbol)
 			: symbol;
 

--- a/packages/plugin-flint/src/rules/testCaseNonStaticCode.ts
+++ b/packages/plugin-flint/src/rules/testCaseNonStaticCode.ts
@@ -1,10 +1,9 @@
-import { SyntaxKind } from "typescript";
-
 import {
 	getTSNodeRange,
 	typescriptLanguage,
 	type AST,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { getRuleTesterCaseArrays } from "../utils/getRuleTesterCaseArrays.ts";
 import { ruleCreator } from "./ruleCreator.ts";

--- a/packages/plugin-flint/src/rules/testCaseOnlyFlags.ts
+++ b/packages/plugin-flint/src/rules/testCaseOnlyFlags.ts
@@ -1,10 +1,9 @@
-import { SyntaxKind } from "typescript";
-
 import {
 	getTSNodeRange,
 	typescriptLanguage,
 	type AST,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { findProperty } from "../utils/findProperty.ts";
 import { getRuleTesterCaseArrays } from "../utils/getRuleTesterCaseArrays.ts";

--- a/packages/plugin-flint/src/rules/testShorthands.ts
+++ b/packages/plugin-flint/src/rules/testShorthands.ts
@@ -1,10 +1,9 @@
-import { SyntaxKind } from "typescript";
-
 import type { FileChange } from "@flint.fyi/core";
 import {
 	getTSNodeRange,
 	typescriptLanguage,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { getRuleTesterDescribedCases } from "../utils/getRuleTesterDescribedCases.ts";
 import { ruleCreator } from "./ruleCreator.ts";

--- a/packages/plugin-flint/src/rules/unusedMessageIds.ts
+++ b/packages/plugin-flint/src/rules/unusedMessageIds.ts
@@ -1,5 +1,3 @@
-import { SyntaxKind } from "typescript";
-
 import type { CharacterReportRange } from "@flint.fyi/core";
 import {
 	getTSNodeRange,
@@ -7,6 +5,7 @@ import {
 	type AST,
 	type Checker,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { findProperty } from "../utils/findProperty.ts";
 import {

--- a/packages/plugin-flint/src/utils/findProperty.ts
+++ b/packages/plugin-flint/src/utils/findProperty.ts
@@ -1,7 +1,7 @@
 import type ts from "typescript";
-import { SyntaxKind } from "typescript";
 
 import type { AST } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 export function findProperty<Node extends AST.Expression>(
 	properties: ts.NodeArray<AST.ObjectLiteralElementLike>,

--- a/packages/plugin-flint/src/utils/getRuleTesterCaseArrays.ts
+++ b/packages/plugin-flint/src/utils/getRuleTesterCaseArrays.ts
@@ -1,6 +1,5 @@
-import { SyntaxKind } from "typescript";
-
 import type { AST } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { findProperty } from "./findProperty.ts";
 

--- a/packages/plugin-flint/src/utils/importHelpers.test.ts
+++ b/packages/plugin-flint/src/utils/importHelpers.test.ts
@@ -1,5 +1,7 @@
-import ts from "typescript";
+import type ts from "typescript";
 import { describe, expect, it } from "vitest";
+
+import typescript from "@flint.fyi/typescript-language/typescript";
 
 import {
 	isImportedBindingFromModule,
@@ -10,10 +12,10 @@ function parseAndFind<T extends ts.Node>(
 	code: string,
 	isMatch: (node: ts.Node) => node is T,
 ): T {
-	const sourceFile = ts.createSourceFile(
+	const sourceFile = typescript.createSourceFile(
 		"test.ts",
 		code,
-		ts.ScriptTarget.Latest,
+		typescript.ScriptTarget.Latest,
 		true,
 	);
 
@@ -29,7 +31,7 @@ function parseAndFind<T extends ts.Node>(
 			return;
 		}
 
-		ts.forEachChild(node, visit);
+		typescript.forEachChild(node, visit);
 	}
 
 	visit(sourceFile);
@@ -45,7 +47,7 @@ describe("isImportedBindingFromModule", () => {
 	it("returns true for an ImportSpecifier from the matching module", () => {
 		const specifier = parseAndFind<ts.ImportSpecifier>(
 			`import { foo } from "my-module";`,
-			ts.isImportSpecifier,
+			typescript.isImportSpecifier,
 		);
 
 		expect(isImportedBindingFromModule(specifier, "my-module")).toBe(true);
@@ -54,7 +56,7 @@ describe("isImportedBindingFromModule", () => {
 	it("returns true for a NamespaceImport from the matching module", () => {
 		const nsImport = parseAndFind<ts.NamespaceImport>(
 			`import * as ns from "my-module";`,
-			ts.isNamespaceImport,
+			typescript.isNamespaceImport,
 		);
 
 		expect(isImportedBindingFromModule(nsImport, "my-module")).toBe(true);
@@ -63,7 +65,7 @@ describe("isImportedBindingFromModule", () => {
 	it("returns false for an ImportSpecifier from a different module", () => {
 		const specifier = parseAndFind<ts.ImportSpecifier>(
 			`import { foo } from "other-module";`,
-			ts.isImportSpecifier,
+			typescript.isImportSpecifier,
 		);
 
 		expect(isImportedBindingFromModule(specifier, "my-module")).toBe(false);
@@ -72,7 +74,7 @@ describe("isImportedBindingFromModule", () => {
 	it("returns false for a NamespaceImport from a different module", () => {
 		const nsImport = parseAndFind<ts.NamespaceImport>(
 			`import * as ns from "other-module";`,
-			ts.isNamespaceImport,
+			typescript.isNamespaceImport,
 		);
 
 		expect(isImportedBindingFromModule(nsImport, "my-module")).toBe(false);
@@ -81,7 +83,7 @@ describe("isImportedBindingFromModule", () => {
 	it("returns false for a non-import node", () => {
 		const identifier = parseAndFind<ts.Identifier>(
 			`const x = 1;`,
-			ts.isIdentifier,
+			typescript.isIdentifier,
 		);
 
 		expect(isImportedBindingFromModule(identifier, "my-module")).toBe(false);
@@ -92,7 +94,7 @@ describe("isImportedSpecifierFromModule", () => {
 	it("returns true for a matching named import", () => {
 		const specifier = parseAndFind<ts.ImportSpecifier>(
 			`import { reportSourceCode } from "@flint.fyi/volar-language";`,
-			ts.isImportSpecifier,
+			typescript.isImportSpecifier,
 		);
 
 		expect(
@@ -107,7 +109,7 @@ describe("isImportedSpecifierFromModule", () => {
 	it("returns true for a renamed import matching the original name", () => {
 		const specifier = parseAndFind<ts.ImportSpecifier>(
 			`import { reportSourceCode as report } from "@flint.fyi/volar-language";`,
-			ts.isImportSpecifier,
+			typescript.isImportSpecifier,
 		);
 
 		expect(
@@ -122,7 +124,7 @@ describe("isImportedSpecifierFromModule", () => {
 	it("returns false when the imported name does not match", () => {
 		const specifier = parseAndFind<ts.ImportSpecifier>(
 			`import { otherFunction } from "@flint.fyi/volar-language";`,
-			ts.isImportSpecifier,
+			typescript.isImportSpecifier,
 		);
 
 		expect(
@@ -137,7 +139,7 @@ describe("isImportedSpecifierFromModule", () => {
 	it("returns false when the module does not match", () => {
 		const specifier = parseAndFind<ts.ImportSpecifier>(
 			`import { reportSourceCode } from "other-module";`,
-			ts.isImportSpecifier,
+			typescript.isImportSpecifier,
 		);
 
 		expect(
@@ -152,7 +154,7 @@ describe("isImportedSpecifierFromModule", () => {
 	it("returns false for a NamespaceImport", () => {
 		const nsImport = parseAndFind<ts.NamespaceImport>(
 			`import * as ns from "@flint.fyi/volar-language";`,
-			ts.isNamespaceImport,
+			typescript.isNamespaceImport,
 		);
 
 		expect(

--- a/packages/plugin-flint/src/utils/importHelpers.ts
+++ b/packages/plugin-flint/src/utils/importHelpers.ts
@@ -1,6 +1,7 @@
-import { SyntaxKind, type Node } from "typescript";
+import type { Node } from "typescript";
 
 import type { AST } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 export function isImportedBindingFromModule(
 	declaration: Node,

--- a/packages/plugin-flint/src/utils/messageHelpers.ts
+++ b/packages/plugin-flint/src/utils/messageHelpers.ts
@@ -1,6 +1,5 @@
-import { SyntaxKind } from "typescript";
-
 import type { AST } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 interface MessageStringVisitorContext {
 	isInArray: boolean;

--- a/packages/plugin-flint/src/utils/parseTestCases.ts
+++ b/packages/plugin-flint/src/utils/parseTestCases.ts
@@ -1,5 +1,3 @@
-import { SyntaxKind } from "typescript";
-
 import {
 	isStaticString,
 	isStringRawNoSubstitution,
@@ -7,6 +5,7 @@ import {
 	type StaticString,
 	type StringRawNoSubstitution,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { findProperty } from "./findProperty.ts";
 import { tsAstToLiteral } from "./tsAstToLiteral.ts";

--- a/packages/plugin-flint/src/utils/ruleCreatorHelpers.ts
+++ b/packages/plugin-flint/src/utils/ruleCreatorHelpers.ts
@@ -1,6 +1,5 @@
-import { SyntaxKind } from "typescript";
-
 import type { AST, Checker } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 export function isLanguageCreateRule(
 	node: AST.CallExpression,

--- a/packages/plugin-flint/src/utils/tsAstToLiteral.ts
+++ b/packages/plugin-flint/src/utils/tsAstToLiteral.ts
@@ -4,9 +4,12 @@
 // Changing from the switch to manual ifs is due to:
 // https://github.com/Microsoft/TypeScript/issues/56275
 
-import ts, { SyntaxKind } from "typescript";
+import type ts from "typescript";
 
 import type { AST } from "@flint.fyi/typescript-language";
+import typescript, {
+	SyntaxKind,
+} from "@flint.fyi/typescript-language/typescript";
 
 export function tsAstToLiteral(node: AST.ArrayLiteralExpression): unknown[];
 export function tsAstToLiteral(node: AST.ObjectLiteralExpression): object;
@@ -21,24 +24,24 @@ export function tsAstToLiteral(node: ts.Node): unknown {
 			return true;
 	}
 
-	if (ts.isArrayLiteralExpression(node)) {
+	if (typescript.isArrayLiteralExpression(node)) {
 		return node.elements
 			.filter((element) => element.kind !== SyntaxKind.SpreadElement)
 			.map((element) => tsAstToLiteral(element));
 	}
 
-	if (ts.isNumericLiteral(node)) {
+	if (typescript.isNumericLiteral(node)) {
 		return parseFloat(node.text);
 	}
 
-	if (ts.isObjectLiteralExpression(node)) {
+	if (typescript.isObjectLiteralExpression(node)) {
 		return Object.fromEntries(
 			node.properties
 				.filter(
 					(
 						property,
 					): property is ts.PropertyAssignment & { name: ts.Identifier } =>
-						ts.isPropertyAssignment(property) &&
+						typescript.isPropertyAssignment(property) &&
 						(property.name.kind === SyntaxKind.Identifier ||
 							property.name.kind === SyntaxKind.StringLiteral),
 				)
@@ -49,7 +52,7 @@ export function tsAstToLiteral(node: ts.Node): unknown {
 		);
 	}
 
-	if (ts.isStringLiteral(node)) {
+	if (typescript.isStringLiteral(node)) {
 		return node.text;
 	}
 

--- a/packages/ts-patch/src/install-patch-hooks.ts
+++ b/packages/ts-patch/src/install-patch-hooks.ts
@@ -8,17 +8,19 @@ registerHooks({
 	load(url, context, nextLoad) {
 		const next = nextLoad(url, context);
 
-		if (
-			url !== typescriptUrl ||
-			next.source == null ||
-			!(next.source instanceof Buffer)
-		) {
+		if (url !== typescriptUrl || next.source == null) {
 			return next;
 		}
 
+		// Node hands ESM loads a Buffer and `require()` loads a string.
+		const source =
+			typeof next.source === "string"
+				? next.source
+				: new TextDecoder().decode(next.source);
+
 		return {
 			...next,
-			source: transformTscContent(next.source.toString()),
+			source: transformTscContent(source),
 		};
 	},
 });

--- a/packages/ts/src/rules/accessorPairTypes.ts
+++ b/packages/ts/src/rules/accessorPairTypes.ts
@@ -1,10 +1,11 @@
-import { SyntaxKind, type NodeArray } from "typescript";
+import type { NodeArray } from "typescript";
 
 import {
 	typescriptLanguage,
 	type AST,
 	type TypeScriptFileServices,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/ts/src/rules/accessorThisRecursion.ts
+++ b/packages/ts/src/rules/accessorThisRecursion.ts
@@ -1,11 +1,14 @@
-import * as tsutils from "ts-api-utils";
-import ts, { SyntaxKind } from "typescript";
+import type ts from "typescript";
 
 import {
 	typescriptLanguage,
 	type AST,
 	type TypeScriptFileServices,
 } from "@flint.fyi/typescript-language";
+import tsutils from "@flint.fyi/typescript-language/ts-api-utils";
+import typescript, {
+	SyntaxKind,
+} from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 
@@ -71,11 +74,11 @@ export default ruleCreator.createRule(typescriptLanguage, {
 					return;
 				}
 
-				if (ts.isPropertyAccessExpression(node)) {
+				if (typescript.isPropertyAccessExpression(node)) {
 					checkPropertyAccessExpression(node);
 				}
 
-				ts.forEachChild(node, checkNode);
+				typescript.forEachChild(node, checkNode);
 			}
 
 			function checkPropertyAccessExpression(
@@ -97,7 +100,7 @@ export default ruleCreator.createRule(typescriptLanguage, {
 						},
 					});
 				} else if (
-					ts.isBinaryExpression(node.parent) &&
+					typescript.isBinaryExpression(node.parent) &&
 					node.parent.left === node &&
 					node.parent.operatorToken.kind === SyntaxKind.EqualsToken
 				) {
@@ -113,7 +116,7 @@ export default ruleCreator.createRule(typescriptLanguage, {
 
 			// TODO: This will be more clean when there is a scope manager
 			// https://github.com/flint-fyi/flint/issues/400
-			ts.forEachChild(accessor.body, checkNode);
+			typescript.forEachChild(accessor.body, checkNode);
 		}
 
 		return {

--- a/packages/ts/src/rules/anyArguments.ts
+++ b/packages/ts/src/rules/anyArguments.ts
@@ -1,5 +1,4 @@
-import * as tsutils from "ts-api-utils";
-import ts, { SyntaxKind } from "typescript";
+import type ts from "typescript";
 
 import {
 	typescriptLanguage,
@@ -7,6 +6,10 @@ import {
 	type Checker,
 	type TypeScriptFileServices,
 } from "@flint.fyi/typescript-language";
+import tsutils from "@flint.fyi/typescript-language/ts-api-utils";
+import typescript, {
+	SyntaxKind,
+} from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 import { AnyType, discriminateAnyType } from "./utils/discriminateAnyType.ts";
@@ -90,7 +93,7 @@ export default ruleCreator.createRule(typescriptLanguage, {
 							if (
 								tsutils.isTypeFlagSet(
 									restType,
-									ts.TypeFlags.Any | ts.TypeFlags.Unknown,
+									typescript.TypeFlags.Any | typescript.TypeFlags.Unknown,
 								)
 							) {
 								continue;
@@ -101,7 +104,7 @@ export default ruleCreator.createRule(typescriptLanguage, {
 									elementType &&
 									tsutils.isTypeFlagSet(
 										elementType,
-										ts.TypeFlags.Any | ts.TypeFlags.Unknown,
+										typescript.TypeFlags.Any | typescript.TypeFlags.Unknown,
 									)
 								) {
 									continue;
@@ -205,7 +208,7 @@ export default ruleCreator.createRule(typescriptLanguage, {
 				if (
 					tsutils.isTypeFlagSet(
 						parameterInfo.type,
-						ts.TypeFlags.Any | ts.TypeFlags.Unknown,
+						typescript.TypeFlags.Any | typescript.TypeFlags.Unknown,
 					)
 				) {
 					parameterIndex++;
@@ -302,7 +305,7 @@ export default ruleCreator.createRule(typescriptLanguage, {
 						if (
 							tsutils.isTypeFlagSet(
 								parameterType,
-								ts.TypeFlags.Any | ts.TypeFlags.Unknown,
+								typescript.TypeFlags.Any | typescript.TypeFlags.Unknown,
 							)
 						) {
 							continue;
@@ -342,7 +345,7 @@ export default ruleCreator.createRule(typescriptLanguage, {
 
 			if (
 				lastParamDeclaration &&
-				ts.isParameter(lastParamDeclaration) &&
+				typescript.isParameter(lastParamDeclaration) &&
 				lastParamDeclaration.dotDotDotToken
 			) {
 				if (index < parameters.length - 1) {
@@ -416,7 +419,7 @@ export default ruleCreator.createRule(typescriptLanguage, {
 				if (
 					tsutils.isTypeFlagSet(
 						parameterType,
-						ts.TypeFlags.Any | ts.TypeFlags.Unknown,
+						typescript.TypeFlags.Any | typescript.TypeFlags.Unknown,
 					)
 				) {
 					continue;

--- a/packages/ts/src/rules/anyAssignments.ts
+++ b/packages/ts/src/rules/anyAssignments.ts
@@ -1,11 +1,14 @@
-import * as tsutils from "ts-api-utils";
-import ts, { SyntaxKind } from "typescript";
+import type ts from "typescript";
 
 import {
 	typescriptLanguage,
 	type AST,
 	type Checker,
 } from "@flint.fyi/typescript-language";
+import tsutils from "@flint.fyi/typescript-language/ts-api-utils";
+import typescript, {
+	SyntaxKind,
+} from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 import { AnyType, discriminateAnyType } from "./utils/discriminateAnyType.ts";
@@ -14,7 +17,7 @@ import { isUnsafeAssignment } from "./utils/isUnsafeAssignment.ts";
 
 function isTypeAny(type: ts.Type): boolean {
 	return (
-		tsutils.isTypeFlagSet(type, ts.TypeFlags.Any) &&
+		tsutils.isTypeFlagSet(type, typescript.TypeFlags.Any) &&
 		!tsutils.isIntrinsicErrorType(type)
 	);
 }
@@ -29,7 +32,10 @@ function isTypeAnyArray(type: ts.Type, checker: Checker): boolean {
 }
 
 function isTypeAnyOrUnknown(type: ts.Type): boolean {
-	return tsutils.isTypeFlagSet(type, ts.TypeFlags.Any | ts.TypeFlags.Unknown);
+	return tsutils.isTypeFlagSet(
+		type,
+		typescript.TypeFlags.Any | typescript.TypeFlags.Unknown,
+	);
 }
 
 export default ruleCreator.createRule(typescriptLanguage, {
@@ -132,7 +138,7 @@ export default ruleCreator.createRule(typescriptLanguage, {
 
 			for (let i = 0; i < pattern.elements.length; i++) {
 				const element = pattern.elements[i];
-				if (!element || ts.isOmittedExpression(element)) {
+				if (!element || typescript.isOmittedExpression(element)) {
 					continue;
 				}
 
@@ -157,7 +163,7 @@ export default ruleCreator.createRule(typescriptLanguage, {
 						},
 					});
 					didReport = true;
-				} else if (ts.isArrayBindingPattern(name)) {
+				} else if (typescript.isArrayBindingPattern(name)) {
 					didReport =
 						checkArrayDestructureWorker(
 							name,
@@ -165,7 +171,7 @@ export default ruleCreator.createRule(typescriptLanguage, {
 							sourceFile,
 							typeChecker,
 						) || didReport;
-				} else if (ts.isObjectBindingPattern(name)) {
+				} else if (typescript.isObjectBindingPattern(name)) {
 					didReport =
 						checkObjectDestructureWorker(
 							name,
@@ -196,16 +202,16 @@ export default ruleCreator.createRule(typescriptLanguage, {
 				const propertyName = element.propertyName ?? element.name;
 
 				if (
-					ts.isIdentifier(propertyName) ||
-					ts.isStringLiteral(propertyName) ||
-					ts.isNumericLiteral(propertyName)
+					typescript.isIdentifier(propertyName) ||
+					typescript.isStringLiteral(propertyName) ||
+					typescript.isNumericLiteral(propertyName)
 				) {
 					key = propertyName.text;
-				} else if (ts.isComputedPropertyName(propertyName)) {
+				} else if (typescript.isComputedPropertyName(propertyName)) {
 					const expression = propertyName.expression;
 					if (
-						ts.isStringLiteral(expression) ||
-						ts.isNoSubstitutionTemplateLiteral(expression)
+						typescript.isStringLiteral(expression) ||
+						typescript.isNoSubstitutionTemplateLiteral(expression)
 					) {
 						key = expression.text;
 					}
@@ -237,7 +243,7 @@ export default ruleCreator.createRule(typescriptLanguage, {
 						},
 					});
 					didReport = true;
-				} else if (ts.isArrayBindingPattern(name)) {
+				} else if (typescript.isArrayBindingPattern(name)) {
 					didReport =
 						checkArrayDestructureWorker(
 							name,
@@ -245,7 +251,7 @@ export default ruleCreator.createRule(typescriptLanguage, {
 							sourceFile,
 							typeChecker,
 						) || didReport;
-				} else if (ts.isObjectBindingPattern(name)) {
+				} else if (typescript.isObjectBindingPattern(name)) {
 					didReport =
 						checkObjectDestructureWorker(
 							name,

--- a/packages/ts/src/rules/anyCalls.ts
+++ b/packages/ts/src/rules/anyCalls.ts
@@ -1,12 +1,14 @@
-import * as tsutils from "ts-api-utils";
-import { SyntaxKind, TypeFlags } from "typescript";
-
 import {
 	getTSNodeRange,
 	typescriptLanguage,
 	type AST,
 	type TypeScriptFileServices,
 } from "@flint.fyi/typescript-language";
+import tsutils from "@flint.fyi/typescript-language/ts-api-utils";
+import {
+	SyntaxKind,
+	TypeFlags,
+} from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 import { getConstrainedTypeAtLocation } from "./utils/getConstrainedType.ts";

--- a/packages/ts/src/rules/anyMemberAccess.ts
+++ b/packages/ts/src/rules/anyMemberAccess.ts
@@ -1,12 +1,14 @@
-import * as tsutils from "ts-api-utils";
-import { SyntaxKind, TypeFlags } from "typescript";
-
 import {
 	getTSNodeRange,
 	typescriptLanguage,
 	type AST,
 	type Checker,
 } from "@flint.fyi/typescript-language";
+import tsutils from "@flint.fyi/typescript-language/ts-api-utils";
+import {
+	SyntaxKind,
+	TypeFlags,
+} from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 import { getConstrainedTypeAtLocation } from "./utils/getConstrainedType.ts";

--- a/packages/ts/src/rules/anyReturns.ts
+++ b/packages/ts/src/rules/anyReturns.ts
@@ -1,5 +1,4 @@
-import * as tsutils from "ts-api-utils";
-import ts, { SyntaxKind } from "typescript";
+import type ts from "typescript";
 
 import {
 	getTSNodeRange,
@@ -7,6 +6,10 @@ import {
 	type AST,
 	type TypeScriptFileServices,
 } from "@flint.fyi/typescript-language";
+import tsutils from "@flint.fyi/typescript-language/ts-api-utils";
+import typescript, {
+	SyntaxKind,
+} from "@flint.fyi/typescript-language/typescript";
 import { nullThrows } from "@flint.fyi/utils";
 
 import { ruleCreator } from "./ruleCreator.ts";
@@ -64,7 +67,7 @@ export default ruleCreator.createRule(typescriptLanguage, {
 			{ program, sourceFile, typeChecker }: TypeScriptFileServices,
 		): void {
 			const type = typeChecker.getTypeAtLocation(returnNode);
-			const functionNode = ts.findAncestor(
+			const functionNode = typescript.findAncestor(
 				returnNode,
 				// TODO: I believe isFunctionLikeDeclaration was incorrectly marked
 				// as deprecated in https://github.com/JoshuaKGoldberg/ts-api-utils/pull/124
@@ -111,7 +114,7 @@ export default ruleCreator.createRule(typescriptLanguage, {
 						returnNodeType === signatureReturnType ||
 						tsutils.isTypeFlagSet(
 							signatureReturnType,
-							ts.TypeFlags.Any | ts.TypeFlags.Unknown,
+							typescript.TypeFlags.Any | typescript.TypeFlags.Unknown,
 						)
 					) {
 						return;
@@ -132,7 +135,7 @@ export default ruleCreator.createRule(typescriptLanguage, {
 							(awaitedSignatureReturnType &&
 								tsutils.isTypeFlagSet(
 									awaitedSignatureReturnType,
-									ts.TypeFlags.Any | ts.TypeFlags.Unknown,
+									typescript.TypeFlags.Any | typescript.TypeFlags.Unknown,
 								))
 						) {
 							return;
@@ -148,7 +151,10 @@ export default ruleCreator.createRule(typescriptLanguage, {
 					const functionReturnType = signature.getReturnType();
 					if (
 						(anyType === AnyType.Any || anyType === AnyType.Error) &&
-						tsutils.isTypeFlagSet(functionReturnType, ts.TypeFlags.Unknown)
+						tsutils.isTypeFlagSet(
+							functionReturnType,
+							typescript.TypeFlags.Unknown,
+						)
 					) {
 						return;
 					}
@@ -160,7 +166,7 @@ export default ruleCreator.createRule(typescriptLanguage, {
 								typeChecker.getTypeArguments(functionReturnType)[0],
 								"Array type should have at least one type argument",
 							),
-							ts.TypeFlags.Unknown,
+							typescript.TypeFlags.Unknown,
 						)
 					) {
 						return;
@@ -169,7 +175,7 @@ export default ruleCreator.createRule(typescriptLanguage, {
 					if (
 						awaitedType &&
 						anyType === AnyType.PromiseAny &&
-						tsutils.isTypeFlagSet(awaitedType, ts.TypeFlags.Unknown)
+						tsutils.isTypeFlagSet(awaitedType, typescript.TypeFlags.Unknown)
 					) {
 						return;
 					}
@@ -199,7 +205,7 @@ export default ruleCreator.createRule(typescriptLanguage, {
 						thisExpression &&
 						tsutils.isTypeFlagSet(
 							getConstrainedTypeAtLocation(thisExpression, typeChecker),
-							ts.TypeFlags.Any,
+							typescript.TypeFlags.Any,
 						)
 					) {
 						message = "unsafeReturnThis";

--- a/packages/ts/src/rules/arguments.ts
+++ b/packages/ts/src/rules/arguments.ts
@@ -1,23 +1,26 @@
-import ts, { SyntaxKind } from "typescript";
+import type ts from "typescript";
 
 import {
 	getTSNodeRange,
 	typescriptLanguage,
 } from "@flint.fyi/typescript-language";
+import typescript, {
+	SyntaxKind,
+} from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 
 function isNonArrowFunctionBoundary(node: ts.Node): "quit" | boolean {
-	if (ts.isArrowFunction(node)) {
+	if (typescript.isArrowFunction(node)) {
 		return "quit";
 	}
 	return (
-		ts.isFunctionDeclaration(node) ||
-		ts.isFunctionExpression(node) ||
-		ts.isMethodDeclaration(node) ||
-		ts.isGetAccessorDeclaration(node) ||
-		ts.isSetAccessorDeclaration(node) ||
-		ts.isConstructorDeclaration(node)
+		typescript.isFunctionDeclaration(node) ||
+		typescript.isFunctionExpression(node) ||
+		typescript.isMethodDeclaration(node) ||
+		typescript.isGetAccessorDeclaration(node) ||
+		typescript.isSetAccessorDeclaration(node) ||
+		typescript.isConstructorDeclaration(node)
 	);
 }
 
@@ -66,7 +69,7 @@ export default ruleCreator.createRule(typescriptLanguage, {
 
 					// TODO: This might get simpler when we have scope analysis.
 					// https://github.com/JoshuaKGoldberg/flint/issues/400
-					if (!ts.findAncestor(node, isNonArrowFunctionBoundary)) {
+					if (!typescript.findAncestor(node, isNonArrowFunctionBoundary)) {
 						return;
 					}
 
@@ -78,10 +81,10 @@ export default ruleCreator.createRule(typescriptLanguage, {
 							.getDeclarations()
 							?.some(
 								(declaration) =>
-									ts.isParameter(declaration) ||
-									ts.isVariableDeclaration(declaration) ||
-									ts.isPropertyDeclaration(declaration) ||
-									ts.isBindingElement(declaration),
+									typescript.isParameter(declaration) ||
+									typescript.isVariableDeclaration(declaration) ||
+									typescript.isPropertyDeclaration(declaration) ||
+									typescript.isBindingElement(declaration),
 							)
 					) {
 						return;

--- a/packages/ts/src/rules/arrayCallbackReturns.ts
+++ b/packages/ts/src/rules/arrayCallbackReturns.ts
@@ -1,11 +1,10 @@
-import * as tsutils from "ts-api-utils";
-import { SyntaxKind } from "typescript";
-
 import {
 	forEachChild,
 	typescriptLanguage,
 	type AST,
 } from "@flint.fyi/typescript-language";
+import tsutils from "@flint.fyi/typescript-language/ts-api-utils";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/ts/src/rules/arrayConstructors.ts
+++ b/packages/ts/src/rules/arrayConstructors.ts
@@ -1,5 +1,3 @@
-import { SyntaxKind } from "typescript";
-
 import {
 	getTSNodeRange,
 	isGlobalDeclarationOfName,
@@ -7,6 +5,7 @@ import {
 	type AST,
 	type TypeScriptFileServices,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/ts/src/rules/arrayDeleteUnnecessaryCounts.ts
+++ b/packages/ts/src/rules/arrayDeleteUnnecessaryCounts.ts
@@ -1,5 +1,3 @@
-import { SyntaxKind } from "typescript";
-
 import {
 	getTSNodeRange,
 	hasSameTokens,
@@ -7,6 +5,7 @@ import {
 	unwrapParenthesizedNode,
 	type AST,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 import { getConstrainedTypeAtLocation } from "./utils/getConstrainedType.ts";

--- a/packages/ts/src/rules/arrayElementDeletions.ts
+++ b/packages/ts/src/rules/arrayElementDeletions.ts
@@ -1,10 +1,9 @@
-import { SyntaxKind } from "typescript";
-
 import {
 	getTSNodeRange,
 	typescriptLanguage,
 	type AST,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 import { isArrayOrTupleTypeAtLocation } from "./utils/isArrayOrTupleTypeAtLocation.ts";

--- a/packages/ts/src/rules/arrayEmptyCallbackSlots.ts
+++ b/packages/ts/src/rules/arrayEmptyCallbackSlots.ts
@@ -1,5 +1,3 @@
-import { SyntaxKind } from "typescript";
-
 import {
 	getStaticNumberValue,
 	getTSNodeRange,
@@ -7,6 +5,7 @@ import {
 	typescriptLanguage,
 	type AST,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/ts/src/rules/arrayExistenceChecksConsistency.ts
+++ b/packages/ts/src/rules/arrayExistenceChecksConsistency.ts
@@ -1,10 +1,9 @@
-import { SyntaxKind } from "typescript";
-
 import {
 	getTSNodeRange,
 	typescriptLanguage,
 	type AST,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/ts/src/rules/arrayFilteredFinds.ts
+++ b/packages/ts/src/rules/arrayFilteredFinds.ts
@@ -1,5 +1,3 @@
-import { SyntaxKind } from "typescript";
-
 import {
 	getStaticNumberValue,
 	getTSNodeRange,
@@ -7,6 +5,7 @@ import {
 	type AST,
 	type Checker,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 import { isArrayOrTupleTypeAtLocation } from "./utils/isArrayOrTupleTypeAtLocation.ts";

--- a/packages/ts/src/rules/arrayFinds.ts
+++ b/packages/ts/src/rules/arrayFinds.ts
@@ -1,11 +1,10 @@
-import { SyntaxKind } from "typescript";
-
 import {
 	getTSNodeRange,
 	typescriptLanguage,
 	type AST,
 	type Checker,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/ts/src/rules/arrayFlatMapMethods.ts
+++ b/packages/ts/src/rules/arrayFlatMapMethods.ts
@@ -1,5 +1,3 @@
-import { SyntaxKind } from "typescript";
-
 import {
 	getStaticNumberValue,
 	getTSNodeRange,
@@ -7,6 +5,7 @@ import {
 	type AST,
 	type Checker,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 import { isArrayOrTupleTypeAtLocation } from "./utils/isArrayOrTupleTypeAtLocation.ts";

--- a/packages/ts/src/rules/arrayFlatMethods.ts
+++ b/packages/ts/src/rules/arrayFlatMethods.ts
@@ -1,11 +1,10 @@
-import { SyntaxKind } from "typescript";
-
 import {
 	getTSNodeRange,
 	typescriptLanguage,
 	type AST,
 	type Checker,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 import { isArrayOrTupleTypeAtLocation } from "./utils/isArrayOrTupleTypeAtLocation.ts";

--- a/packages/ts/src/rules/arrayFlatUnnecessaryDepths.ts
+++ b/packages/ts/src/rules/arrayFlatUnnecessaryDepths.ts
@@ -1,10 +1,9 @@
-import { SyntaxKind } from "typescript";
-
 import {
 	getStaticNumberValue,
 	getTSNodeRange,
 	typescriptLanguage,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 import { isArrayOrTupleTypeAtLocation } from "./utils/isArrayOrTupleTypeAtLocation.ts";

--- a/packages/ts/src/rules/arrayIncludes.ts
+++ b/packages/ts/src/rules/arrayIncludes.ts
@@ -1,5 +1,3 @@
-import { SyntaxKind } from "typescript";
-
 import {
 	getStaticNumberValue,
 	getTSNodeRange,
@@ -7,6 +5,7 @@ import {
 	type AST,
 	type Checker,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 import { getConstrainedTypeAtLocation } from "./utils/getConstrainedType.ts";

--- a/packages/ts/src/rules/arrayIncludesMethods.ts
+++ b/packages/ts/src/rules/arrayIncludesMethods.ts
@@ -1,11 +1,10 @@
-import { SyntaxKind } from "typescript";
-
 import {
 	getTSNodeRange,
 	typescriptLanguage,
 	type AST,
 	type Checker,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 import { isArrayOrTupleTypeAtLocation } from "./utils/isArrayOrTupleTypeAtLocation.ts";

--- a/packages/ts/src/rules/arrayIndexOfMethods.ts
+++ b/packages/ts/src/rules/arrayIndexOfMethods.ts
@@ -1,11 +1,10 @@
-import { SyntaxKind } from "typescript";
-
 import {
 	getTSNodeRange,
 	typescriptLanguage,
 	type AST,
 	type Checker,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 import { isArrayOrTupleTypeAtLocation } from "./utils/isArrayOrTupleTypeAtLocation.ts";

--- a/packages/ts/src/rules/arrayLoops.ts
+++ b/packages/ts/src/rules/arrayLoops.ts
@@ -1,10 +1,9 @@
-import { SyntaxKind } from "typescript";
-
 import {
 	getTSNodeRange,
 	typescriptLanguage,
 	type AST,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 import { isArrayOrTupleTypeAtLocation } from "./utils/isArrayOrTupleTypeAtLocation.ts";

--- a/packages/ts/src/rules/arrayMapIdentities.ts
+++ b/packages/ts/src/rules/arrayMapIdentities.ts
@@ -1,6 +1,7 @@
-import { SyntaxKind, type NodeArray } from "typescript";
+import type { NodeArray } from "typescript";
 
 import { typescriptLanguage, type AST } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/ts/src/rules/arrayMutableSorts.ts
+++ b/packages/ts/src/rules/arrayMutableSorts.ts
@@ -1,11 +1,10 @@
-import { SyntaxKind } from "typescript";
-
 import {
 	getTSNodeRange,
 	isBuiltinArrayMethod,
 	typescriptLanguage,
 	type AST,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/ts/src/rules/arrayReduceTypeArguments.ts
+++ b/packages/ts/src/rules/arrayReduceTypeArguments.ts
@@ -1,10 +1,9 @@
-import { SyntaxKind } from "typescript";
-
 import {
 	getTSNodeRange,
 	typescriptLanguage,
 	type AST,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 import { isArrayOrTupleTypeAtLocation } from "./utils/isArrayOrTupleTypeAtLocation.ts";

--- a/packages/ts/src/rules/arraySliceUnnecessaryEnd.ts
+++ b/packages/ts/src/rules/arraySliceUnnecessaryEnd.ts
@@ -1,11 +1,10 @@
-import { SyntaxKind } from "typescript";
-
 import {
 	getTSNodeRange,
 	hasSameTokens,
 	typescriptLanguage,
 	type AST,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/ts/src/rules/arraySomeMethods.ts
+++ b/packages/ts/src/rules/arraySomeMethods.ts
@@ -1,10 +1,11 @@
-import { SyntaxKind, type TypeChecker } from "typescript";
+import type { TypeChecker } from "typescript";
 
 import {
 	getTSNodeRange,
 	typescriptLanguage,
 	type AST,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/ts/src/rules/arrayTernarySpreadingConsistency.ts
+++ b/packages/ts/src/rules/arrayTernarySpreadingConsistency.ts
@@ -1,6 +1,5 @@
-import { SyntaxKind } from "typescript";
-
 import { typescriptLanguage, type AST } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/ts/src/rules/arrayTypes.ts
+++ b/packages/ts/src/rules/arrayTypes.ts
@@ -1,4 +1,3 @@
-import { SyntaxKind } from "typescript";
 import { z } from "zod/v4";
 
 import {
@@ -7,6 +6,7 @@ import {
 	typescriptLanguage,
 	type AST,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/ts/src/rules/arrayUnnecessaryLengthChecks.ts
+++ b/packages/ts/src/rules/arrayUnnecessaryLengthChecks.ts
@@ -1,10 +1,9 @@
-import { SyntaxKind } from "typescript";
-
 import {
 	getTSNodeRange,
 	typescriptLanguage,
 	type AST,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/ts/src/rules/asConstAssertions.ts
+++ b/packages/ts/src/rules/asConstAssertions.ts
@@ -1,10 +1,9 @@
-import { SyntaxKind } from "typescript";
-
 import {
 	getTSNodeRange,
 	typescriptLanguage,
 	type AST,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/ts/src/rules/assignmentOperatorShorthands.ts
+++ b/packages/ts/src/rules/assignmentOperatorShorthands.ts
@@ -1,10 +1,9 @@
-import { SyntaxKind } from "typescript";
-
 import {
 	getTSNodeRange,
 	hasSameTokens,
 	typescriptLanguage,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/ts/src/rules/asyncFunctionAwaits.ts
+++ b/packages/ts/src/rules/asyncFunctionAwaits.ts
@@ -1,5 +1,4 @@
-import * as tsutils from "ts-api-utils";
-import { SyntaxKind, type TypeChecker } from "typescript";
+import type { TypeChecker } from "typescript";
 
 import {
 	forEachChild,
@@ -8,6 +7,8 @@ import {
 	type AST,
 	type TypeScriptFileServices,
 } from "@flint.fyi/typescript-language";
+import tsutils from "@flint.fyi/typescript-language/ts-api-utils";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/ts/src/rules/asyncPromiseExecutors.ts
+++ b/packages/ts/src/rules/asyncPromiseExecutors.ts
@@ -1,9 +1,8 @@
-import { SyntaxKind } from "typescript";
-
 import {
 	isGlobalDeclaration,
 	typescriptLanguage,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 import { nullThrows } from "@flint.fyi/utils";
 
 import { ruleCreator } from "./ruleCreator.ts";

--- a/packages/ts/src/rules/asyncUnnecessaryPromiseWrappers.ts
+++ b/packages/ts/src/rules/asyncUnnecessaryPromiseWrappers.ts
@@ -1,6 +1,5 @@
-import { SyntaxKind } from "typescript";
-
 import { typescriptLanguage, type AST } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/ts/src/rules/atAccesses.ts
+++ b/packages/ts/src/rules/atAccesses.ts
@@ -1,6 +1,3 @@
-import * as tsutils from "ts-api-utils";
-import { SyntaxKind } from "typescript";
-
 import {
 	getTSNodeRange,
 	hasSameTokens,
@@ -8,6 +5,8 @@ import {
 	unwrapParenthesizedNode,
 	type AST,
 } from "@flint.fyi/typescript-language";
+import tsutils from "@flint.fyi/typescript-language/ts-api-utils";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/ts/src/rules/builtinCoercions.ts
+++ b/packages/ts/src/rules/builtinCoercions.ts
@@ -1,11 +1,10 @@
-import { SyntaxKind } from "typescript";
-
 import {
 	getTSNodeRange,
 	typescriptLanguage,
 	type AST,
 	type TypeScriptFileServices,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/ts/src/rules/builtinConstructorNews.ts
+++ b/packages/ts/src/rules/builtinConstructorNews.ts
@@ -1,11 +1,10 @@
-import { SyntaxKind } from "typescript";
-
 import {
 	isGlobalDeclarationOfName,
 	typescriptLanguage,
 	type AST,
 	type TypeScriptFileServices,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/ts/src/rules/caseDeclarations.ts
+++ b/packages/ts/src/rules/caseDeclarations.ts
@@ -1,5 +1,4 @@
-import * as tsutils from "ts-api-utils";
-import ts, { SyntaxKind } from "typescript";
+import type ts from "typescript";
 
 import {
 	getTSNodeRange,
@@ -7,6 +6,10 @@ import {
 	type AST,
 	type TypeScriptFileServices,
 } from "@flint.fyi/typescript-language";
+import tsutils from "@flint.fyi/typescript-language/ts-api-utils";
+import typescript, {
+	SyntaxKind,
+} from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 
@@ -40,7 +43,7 @@ export default ruleCreator.createRule(typescriptLanguage, {
 					statement.kind === SyntaxKind.VariableStatement &&
 					tsutils.isNodeFlagSet(
 						statement.declarationList,
-						ts.NodeFlags.Let | ts.NodeFlags.Const,
+						typescript.NodeFlags.Let | typescript.NodeFlags.Const,
 					)
 				) {
 					return statement.declarationList.getChildAt(0, sourceFile);

--- a/packages/ts/src/rules/caseDuplicates.ts
+++ b/packages/ts/src/rules/caseDuplicates.ts
@@ -1,10 +1,9 @@
-import { SyntaxKind } from "typescript";
-
 import {
 	hasSameTokens,
 	typescriptLanguage,
 	type AST,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/ts/src/rules/caseFallthroughs.ts
+++ b/packages/ts/src/rules/caseFallthroughs.ts
@@ -1,11 +1,11 @@
+import type { NodeArray } from "typescript";
+
+import { typescriptLanguage, type AST } from "@flint.fyi/typescript-language";
 import {
 	getLeadingCommentRanges,
 	getTrailingCommentRanges,
 	SyntaxKind,
-	type NodeArray,
-} from "typescript";
-
-import { typescriptLanguage, type AST } from "@flint.fyi/typescript-language";
+} from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/ts/src/rules/catchCallbackTypes.ts
+++ b/packages/ts/src/rules/catchCallbackTypes.ts
@@ -1,13 +1,4 @@
-import * as tsutils from "ts-api-utils";
-import {
-	isFunctionLike,
-	isInterfaceDeclaration,
-	isPropertyAccessExpression,
-	TypeFlags,
-	type Program,
-	type Type,
-	type TypeChecker,
-} from "typescript";
+import type { Program, Type, TypeChecker } from "typescript";
 
 import {
 	declarationIncludesGlobal,
@@ -15,6 +6,13 @@ import {
 	type AST,
 	type Checker,
 } from "@flint.fyi/typescript-language";
+import tsutils from "@flint.fyi/typescript-language/ts-api-utils";
+import {
+	isFunctionLike,
+	isInterfaceDeclaration,
+	isPropertyAccessExpression,
+	TypeFlags,
+} from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 import { getConstrainedTypeAtLocation } from "./utils/getConstrainedType.ts";

--- a/packages/ts/src/rules/caughtVariableNames.ts
+++ b/packages/ts/src/rules/caughtVariableNames.ts
@@ -1,6 +1,5 @@
-import { SyntaxKind } from "typescript";
-
 import { typescriptLanguage } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/ts/src/rules/chainedAssignments.ts
+++ b/packages/ts/src/rules/chainedAssignments.ts
@@ -1,12 +1,11 @@
-import * as tsutils from "ts-api-utils";
-import { SyntaxKind } from "typescript";
-
 import {
 	getTSNodeRange,
 	typescriptLanguage,
 	unwrapParenthesizedNode,
 	unwrapParentParenthesizedExpressions,
 } from "@flint.fyi/typescript-language";
+import tsutils from "@flint.fyi/typescript-language/ts-api-utils";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/ts/src/rules/charAtComparisons.ts
+++ b/packages/ts/src/rules/charAtComparisons.ts
@@ -1,4 +1,4 @@
-import { SyntaxKind, TypeFlags, type Type } from "typescript";
+import type { Type } from "typescript";
 
 import {
 	getStaticStringValue,
@@ -6,6 +6,10 @@ import {
 	type AST,
 	type Checker,
 } from "@flint.fyi/typescript-language";
+import {
+	SyntaxKind,
+	TypeFlags,
+} from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/ts/src/rules/classFieldDeclarations.ts
+++ b/packages/ts/src/rules/classFieldDeclarations.ts
@@ -1,10 +1,11 @@
-import ts, { SyntaxKind } from "typescript";
-
 import {
 	getTSNodeRange,
 	typescriptLanguage,
 	type AST,
 } from "@flint.fyi/typescript-language";
+import typescript, {
+	SyntaxKind,
+} from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 
@@ -17,7 +18,7 @@ function isLiteralValue(node: AST.AnyNode) {
 		node.kind === SyntaxKind.TrueKeyword ||
 		node.kind === SyntaxKind.FalseKeyword ||
 		node.kind === SyntaxKind.NullKeyword ||
-		ts.isLiteralExpression(node)
+		typescript.isLiteralExpression(node)
 	);
 }
 

--- a/packages/ts/src/rules/classLiteralProperties.ts
+++ b/packages/ts/src/rules/classLiteralProperties.ts
@@ -1,10 +1,9 @@
-import { SyntaxKind } from "typescript";
-
 import {
 	getTSNodeRange,
 	typescriptLanguage,
 	type AST,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/ts/src/rules/classMemberDuplicates.ts
+++ b/packages/ts/src/rules/classMemberDuplicates.ts
@@ -1,10 +1,11 @@
-import { SyntaxKind, type Node } from "typescript";
+import type { Node } from "typescript";
 
 import {
 	getTSNodeRange,
 	typescriptLanguage,
 	type AST,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/ts/src/rules/classMethodsThis.ts
+++ b/packages/ts/src/rules/classMethodsThis.ts
@@ -1,7 +1,10 @@
-import ts, { SyntaxKind } from "typescript";
+import type ts from "typescript";
 import { z } from "zod/v4";
 
 import { typescriptLanguage, type AST } from "@flint.fyi/typescript-language";
+import typescript, {
+	SyntaxKind,
+} from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 
@@ -33,8 +36,8 @@ function containsThis(node: ts.Node): boolean {
 			const classNode = node as ts.ClassDeclaration | ts.ClassExpression;
 			for (const member of classNode.members) {
 				if (
-					ts.isPropertyDeclaration(member) &&
-					ts.isComputedPropertyName(member.name) &&
+					typescript.isPropertyDeclaration(member) &&
+					typescript.isComputedPropertyName(member.name) &&
 					containsThis(member.name.expression)
 				) {
 					return true;
@@ -53,7 +56,7 @@ function containsThis(node: ts.Node): boolean {
 			return true;
 
 		default:
-			return ts.forEachChild(node, containsThis) ?? false;
+			return typescript.forEachChild(node, containsThis) ?? false;
 	}
 }
 

--- a/packages/ts/src/rules/combinedPushes.ts
+++ b/packages/ts/src/rules/combinedPushes.ts
@@ -1,11 +1,10 @@
-import { SyntaxKind } from "typescript";
-
 import {
 	typescriptLanguage,
 	type AST,
 	type Checker,
 	type TypeScriptFileServices,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/ts/src/rules/consecutiveNonNullAssertions.ts
+++ b/packages/ts/src/rules/consecutiveNonNullAssertions.ts
@@ -1,6 +1,5 @@
-import { SyntaxKind } from "typescript";
-
 import { typescriptLanguage } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/ts/src/rules/consoleCalls.ts
+++ b/packages/ts/src/rules/consoleCalls.ts
@@ -1,10 +1,9 @@
-import { SyntaxKind } from "typescript";
-
 import {
 	getTSNodeRange,
 	isGlobalVariable,
 	typescriptLanguage,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/ts/src/rules/constantAssignments.ts
+++ b/packages/ts/src/rules/constantAssignments.ts
@@ -1,11 +1,12 @@
-import ts, { SyntaxKind } from "typescript";
-
 import {
 	getModifyingReferences,
 	getTSNodeRange,
 	typescriptLanguage,
 	type AST,
 } from "@flint.fyi/typescript-language";
+import typescript, {
+	SyntaxKind,
+} from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 
@@ -49,7 +50,10 @@ export default ruleCreator.createRule(typescriptLanguage, {
 		return {
 			visitors: {
 				VariableDeclarationList: (node, { sourceFile }) => {
-					if (!(node.flags & ts.NodeFlags.Const) || !node.declarations.length) {
+					if (
+						!(node.flags & typescript.NodeFlags.Const) ||
+						!node.declarations.length
+					) {
 						return;
 					}
 

--- a/packages/ts/src/rules/constructorGenericCalls.ts
+++ b/packages/ts/src/rules/constructorGenericCalls.ts
@@ -1,4 +1,4 @@
-import ts, { SyntaxKind } from "typescript";
+import type ts from "typescript";
 import { z } from "zod/v4";
 
 import {
@@ -6,6 +6,9 @@ import {
 	type AST,
 	type TypeScriptFileServices,
 } from "@flint.fyi/typescript-language";
+import typescript, {
+	SyntaxKind,
+} from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 
@@ -153,7 +156,7 @@ export default ruleCreator.createRule(typescriptLanguage, {
 			}
 
 			if (
-				!ts.isTypeReferenceNode(typeAnnotation) ||
+				!typescript.isTypeReferenceNode(typeAnnotation) ||
 				typeAnnotation.typeName.kind !== SyntaxKind.Identifier ||
 				typeAnnotation.typeName.text !== constructorName ||
 				isBuiltInTypedArray(typeAnnotation.typeName.text) ||

--- a/packages/ts/src/rules/constructorReturns.ts
+++ b/packages/ts/src/rules/constructorReturns.ts
@@ -1,11 +1,10 @@
-import * as tsutils from "ts-api-utils";
-import { SyntaxKind } from "typescript";
-
 import {
 	forEachChild,
 	typescriptLanguage,
 	type AST,
 } from "@flint.fyi/typescript-language";
+import tsutils from "@flint.fyi/typescript-language/ts-api-utils";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/ts/src/rules/constructorSupers.ts
+++ b/packages/ts/src/rules/constructorSupers.ts
@@ -1,11 +1,10 @@
-import * as tsutils from "ts-api-utils";
-import { SyntaxKind } from "typescript";
-
 import {
 	forEachChild,
 	typescriptLanguage,
 	type AST,
 } from "@flint.fyi/typescript-language";
+import tsutils from "@flint.fyi/typescript-language/ts-api-utils";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/ts/src/rules/dateConstructorClones.ts
+++ b/packages/ts/src/rules/dateConstructorClones.ts
@@ -1,11 +1,10 @@
-import { SyntaxKind } from "typescript";
-
 import {
 	isGlobalDeclarationOfName,
 	typescriptLanguage,
 	type AST,
 	type Checker,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/ts/src/rules/dateNowTimestamps.ts
+++ b/packages/ts/src/rules/dateNowTimestamps.ts
@@ -1,4 +1,4 @@
-import { SyntaxKind, type Program } from "typescript";
+import type { Program } from "typescript";
 
 import {
 	getTSNodeRange,
@@ -7,6 +7,7 @@ import {
 	type AST,
 	type Checker,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/ts/src/rules/defaultCaseLast.ts
+++ b/packages/ts/src/rules/defaultCaseLast.ts
@@ -1,6 +1,5 @@
-import { SyntaxKind } from "typescript";
-
 import { typescriptLanguage } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 import { nullThrows } from "@flint.fyi/utils";
 
 import { ruleCreator } from "./ruleCreator.ts";

--- a/packages/ts/src/rules/deprecated.ts
+++ b/packages/ts/src/rules/deprecated.ts
@@ -1,10 +1,13 @@
-import ts, { SyntaxKind } from "typescript";
+import type ts from "typescript";
 
 import {
 	getTSNodeRange,
 	typescriptLanguage,
 	type AST,
 } from "@flint.fyi/typescript-language";
+import typescript, {
+	SyntaxKind,
+} from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 
@@ -45,7 +48,7 @@ export default ruleCreator.createRule(typescriptLanguage, {
 
 		function isDeprecatedFromDeclarations(symbol: ts.Symbol | undefined) {
 			return symbol?.getDeclarations()?.some((declaration) => {
-				const tags = ts.getJSDocTags(declaration);
+				const tags = typescript.getJSDocTags(declaration);
 				return tags.some(
 					(tag) =>
 						tag.tagName.text === "deprecated" ||
@@ -63,7 +66,7 @@ export default ruleCreator.createRule(typescriptLanguage, {
 				return false;
 			}
 
-			if (!(symbol.flags & ts.SymbolFlags.Alias)) {
+			if (!(symbol.flags & typescript.SymbolFlags.Alias)) {
 				return !!(
 					checkAliasedSymbol &&
 					(getJsDocDeprecation(symbol, typeChecker) ||
@@ -74,7 +77,7 @@ export default ruleCreator.createRule(typescriptLanguage, {
 			const targetSymbol = typeChecker.getAliasedSymbol(symbol);
 			let current: ts.Symbol | undefined = symbol;
 
-			while (current.flags & ts.SymbolFlags.Alias) {
+			while (current.flags & typescript.SymbolFlags.Alias) {
 				if (
 					getJsDocDeprecation(current, typeChecker) ||
 					isDeprecatedFromDeclarations(current)
@@ -196,7 +199,7 @@ export default ruleCreator.createRule(typescriptLanguage, {
 			const symbol = typeChecker.getSymbolAtLocation(node);
 
 			const aliasedSymbol =
-				symbol && symbol.flags & ts.SymbolFlags.Alias
+				symbol && symbol.flags & typescript.SymbolFlags.Alias
 					? typeChecker.getAliasedSymbol(symbol)
 					: symbol;
 
@@ -482,11 +485,14 @@ function isInsideHeritageClause(node: AST.AnyNode) {
 	let current: ts.Node | undefined = node.parent;
 
 	while (current) {
-		if (ts.isHeritageClause(current)) {
+		if (typescript.isHeritageClause(current)) {
 			return true;
 		}
 
-		if (ts.isSourceFile(current) || ts.isClassDeclaration(current)) {
+		if (
+			typescript.isSourceFile(current) ||
+			typescript.isClassDeclaration(current)
+		) {
 			break;
 		}
 		// eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion -- removing causes type error on the `while` loop. TSESLint bug?
@@ -505,18 +511,18 @@ function isInsideImport(node: AST.AnyNode) {
 	let current: ts.Node | undefined = node.parent;
 
 	while (current) {
-		if (ts.isImportDeclaration(current)) {
+		if (typescript.isImportDeclaration(current)) {
 			return true;
 		}
 
 		if (
-			ts.isSourceFile(current) ||
-			ts.isFunctionDeclaration(current) ||
-			ts.isFunctionExpression(current) ||
-			ts.isArrowFunction(current) ||
-			ts.isClassDeclaration(current) ||
-			ts.isClassExpression(current) ||
-			ts.isBlock(current)
+			typescript.isSourceFile(current) ||
+			typescript.isFunctionDeclaration(current) ||
+			typescript.isFunctionExpression(current) ||
+			typescript.isArrowFunction(current) ||
+			typescript.isClassDeclaration(current) ||
+			typescript.isClassExpression(current) ||
+			typescript.isBlock(current)
 		) {
 			return false;
 		}

--- a/packages/ts/src/rules/destructuringConsistency.ts
+++ b/packages/ts/src/rules/destructuringConsistency.ts
@@ -1,5 +1,3 @@
-import ts, { SyntaxKind } from "typescript";
-
 import {
 	getScopeManager,
 	getTSNodeRange,
@@ -7,6 +5,9 @@ import {
 	type AST,
 	type Scope,
 } from "@flint.fyi/typescript-language";
+import typescript, {
+	SyntaxKind,
+} from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 
@@ -129,7 +130,7 @@ export default ruleCreator.createRule(typescriptLanguage, {
 						destructured.destructuredProperties.get(propertyName);
 
 					if (
-						(ts.isCallExpression(node.parent) &&
+						(typescript.isCallExpression(node.parent) &&
 							node.parent.expression === node) ||
 						isLeftHandSide(node)
 					) {
@@ -163,7 +164,10 @@ export default ruleCreator.createRule(typescriptLanguage, {
 					destructuredObjects.length = 0;
 				},
 				VariableDeclaration: (node, { sourceFile }) => {
-					if (!node.initializer || !ts.isObjectBindingPattern(node.name)) {
+					if (
+						!node.initializer ||
+						!typescript.isObjectBindingPattern(node.name)
+					) {
 						return;
 					}
 
@@ -174,22 +178,22 @@ export default ruleCreator.createRule(typescriptLanguage, {
 
 					const properties = new Map<string, null | string>();
 					for (const element of node.name.elements) {
-						if (!ts.isBindingElement(element)) {
+						if (!typescript.isBindingElement(element)) {
 							continue;
 						}
 
 						if (element.propertyName) {
-							if (ts.isIdentifier(element.propertyName)) {
+							if (typescript.isIdentifier(element.propertyName)) {
 								if (
-									ts.isObjectBindingPattern(element.name) ||
-									ts.isArrayBindingPattern(element.name)
+									typescript.isObjectBindingPattern(element.name) ||
+									typescript.isArrayBindingPattern(element.name)
 								) {
 									properties.set(element.propertyName.text, null);
-								} else if (ts.isIdentifier(element.name)) {
+								} else if (typescript.isIdentifier(element.name)) {
 									properties.set(element.propertyName.text, element.name.text);
 								}
 							}
-						} else if (ts.isIdentifier(element.name)) {
+						} else if (typescript.isIdentifier(element.name)) {
 							properties.set(element.name.text, element.name.text);
 						}
 					}

--- a/packages/ts/src/rules/duplicateArguments.ts
+++ b/packages/ts/src/rules/duplicateArguments.ts
@@ -1,11 +1,10 @@
-import { SyntaxKind } from "typescript";
-
 import {
 	getTSNodeRange,
 	typescriptLanguage,
 	type AST,
 	type TypeScriptFileServices,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/ts/src/rules/dynamicDeletes.ts
+++ b/packages/ts/src/rules/dynamicDeletes.ts
@@ -1,13 +1,13 @@
+import type { Expression } from "typescript";
+
+import { typescriptLanguage } from "@flint.fyi/typescript-language";
 import {
 	isElementAccessExpression,
 	isNumericLiteral,
 	isPrefixUnaryExpression,
 	isStringLiteral,
 	SyntaxKind,
-	type Expression,
-} from "typescript";
-
-import { typescriptLanguage } from "@flint.fyi/typescript-language";
+} from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/ts/src/rules/elseIfDuplicates.ts
+++ b/packages/ts/src/rules/elseIfDuplicates.ts
@@ -1,11 +1,10 @@
-import { SyntaxKind } from "typescript";
-
 import {
 	getTSNodeRange,
 	hasSameTokens,
 	typescriptLanguage,
 	type AST,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/ts/src/rules/elseReturns.ts
+++ b/packages/ts/src/rules/elseReturns.ts
@@ -1,10 +1,9 @@
-import { SyntaxKind } from "typescript";
-
 import {
 	getTSNodeRange,
 	typescriptLanguage,
 	type AST,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/ts/src/rules/emptyBlocks.ts
+++ b/packages/ts/src/rules/emptyBlocks.ts
@@ -1,10 +1,9 @@
-import { SyntaxKind } from "typescript";
-
 import {
 	getTSNodeRange,
 	typescriptLanguage,
 	type AST,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/ts/src/rules/emptyExports.ts
+++ b/packages/ts/src/rules/emptyExports.ts
@@ -1,10 +1,11 @@
-import ts, { SyntaxKind } from "typescript";
-
 import {
 	getTSNodeRange,
 	typescriptLanguage,
 	type AST,
 } from "@flint.fyi/typescript-language";
+import typescript, {
+	SyntaxKind,
+} from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 
@@ -17,8 +18,8 @@ const moduleIndicatorKinds = new Set([
 
 function hasExportModifier(node: AST.Statement) {
 	return !!(
-		ts.canHaveModifiers(node) &&
-		ts
+		typescript.canHaveModifiers(node) &&
+		typescript
 			.getModifiers(node)
 			?.some((modifier) => modifier.kind === SyntaxKind.ExportKeyword)
 	);

--- a/packages/ts/src/rules/emptyFiles.ts
+++ b/packages/ts/src/rules/emptyFiles.ts
@@ -1,6 +1,5 @@
-import { SyntaxKind } from "typescript";
-
 import { typescriptLanguage, type AST } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/ts/src/rules/emptyFunctions.ts
+++ b/packages/ts/src/rules/emptyFunctions.ts
@@ -1,10 +1,11 @@
-import { SyntaxKind, type Node } from "typescript";
+import type { Node } from "typescript";
 
 import {
 	getTSNodeRange,
 	typescriptLanguage,
 	type AST,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/ts/src/rules/emptyObjectTypes.ts
+++ b/packages/ts/src/rules/emptyObjectTypes.ts
@@ -1,9 +1,8 @@
-import { SyntaxKind } from "typescript";
-
 import {
 	getTSNodeRange,
 	typescriptLanguage,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/ts/src/rules/enumInitializers.ts
+++ b/packages/ts/src/rules/enumInitializers.ts
@@ -1,9 +1,8 @@
-import { SyntaxKind } from "typescript";
-
 import {
 	getTSNodeRange,
 	typescriptLanguage,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/ts/src/rules/enumMemberLiterals.ts
+++ b/packages/ts/src/rules/enumMemberLiterals.ts
@@ -1,10 +1,9 @@
-import { SyntaxKind } from "typescript";
-
 import {
 	getTSNodeRange,
 	typescriptLanguage,
 	type AST,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/ts/src/rules/enumValueConsistency.ts
+++ b/packages/ts/src/rules/enumValueConsistency.ts
@@ -1,11 +1,10 @@
-import ts from "typescript";
-
 import {
 	getTSNodeRange,
 	typescriptLanguage,
 	type AST,
 	type Checker,
 } from "@flint.fyi/typescript-language";
+import typescript from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 
@@ -19,12 +18,12 @@ function getEnumMemberKind(member: AST.EnumMember, typeChecker: Checker) {
 	const type = typeChecker.getTypeAtLocation(member);
 
 	if (type.isNumberLiteral()) {
-		if ((type.flags & ts.TypeFlags.NumberLike) !== 0) {
+		if ((type.flags & typescript.TypeFlags.NumberLike) !== 0) {
 			return enumMemberKinds.Number;
 		}
 	} else if (
 		type.isStringLiteral() &&
-		(type.flags & ts.TypeFlags.StringLike) !== 0
+		(type.flags & typescript.TypeFlags.StringLike) !== 0
 	) {
 		return enumMemberKinds.String;
 	}

--- a/packages/ts/src/rules/enumValueDuplicates.ts
+++ b/packages/ts/src/rules/enumValueDuplicates.ts
@@ -1,10 +1,9 @@
-import { SyntaxKind } from "typescript";
-
 import {
 	getStaticValue,
 	getTSNodeRange,
 	typescriptLanguage,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/ts/src/rules/equalityOperatorNegations.ts
+++ b/packages/ts/src/rules/equalityOperatorNegations.ts
@@ -1,9 +1,8 @@
-import { SyntaxKind } from "typescript";
-
 import {
 	typescriptLanguage,
 	unwrapParenthesizedNode,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/ts/src/rules/errorMessages.ts
+++ b/packages/ts/src/rules/errorMessages.ts
@@ -1,4 +1,4 @@
-import { SyntaxKind, type NodeArray, type Program } from "typescript";
+import type { NodeArray, Program } from "typescript";
 
 import {
 	getStaticStringValue,
@@ -9,6 +9,7 @@ import {
 	type Checker,
 	type TypeScriptFileServices,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/ts/src/rules/errorSubclassProperties.ts
+++ b/packages/ts/src/rules/errorSubclassProperties.ts
@@ -1,10 +1,9 @@
-import { SyntaxKind } from "typescript";
-
 import {
 	getTSNodeRange,
 	typescriptLanguage,
 	type AST,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 import { isErrorSubclass } from "./utils/isErrorSubclass.ts";

--- a/packages/ts/src/rules/errorUnnecessaryCaptureStackTraces.ts
+++ b/packages/ts/src/rules/errorUnnecessaryCaptureStackTraces.ts
@@ -1,28 +1,31 @@
-import ts, { SyntaxKind } from "typescript";
+import type ts from "typescript";
 
 import {
 	getTSNodeRange,
 	typescriptLanguage,
 } from "@flint.fyi/typescript-language";
+import typescript, {
+	SyntaxKind,
+} from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 import { isErrorSubclass } from "./utils/isErrorSubclass.ts";
 
 function isCaptureStackTraceCall(node: ts.Node): boolean {
-	if (!ts.isCallExpression(node) && !ts.isOptionalChain(node)) {
+	if (!typescript.isCallExpression(node) && !typescript.isOptionalChain(node)) {
 		return false;
 	}
 
-	const callExpression = ts.isCallExpression(node) ? node : undefined;
+	const callExpression = typescript.isCallExpression(node) ? node : undefined;
 	if (!callExpression) {
-		return ts.isCallExpression(node) && isCaptureStackTraceCall(node);
+		return typescript.isCallExpression(node) && isCaptureStackTraceCall(node);
 	}
 
 	return (
-		ts.isPropertyAccessExpression(callExpression.expression) &&
-		ts.isIdentifier(callExpression.expression.expression) &&
+		typescript.isPropertyAccessExpression(callExpression.expression) &&
+		typescript.isIdentifier(callExpression.expression.expression) &&
 		callExpression.expression.expression.text === "Error" &&
-		ts.isIdentifier(callExpression.expression.name) &&
+		typescript.isIdentifier(callExpression.expression.name) &&
 		callExpression.expression.name.text === "captureStackTrace"
 	);
 }
@@ -31,23 +34,23 @@ function isValidSecondArgument(
 	node: ts.Expression,
 	className: string | undefined,
 ): boolean {
-	if (ts.isIdentifier(node)) {
+	if (typescript.isIdentifier(node)) {
 		return node.text === className;
 	}
 
 	if (
-		ts.isPropertyAccessExpression(node) &&
+		typescript.isPropertyAccessExpression(node) &&
 		node.expression.kind === SyntaxKind.ThisKeyword &&
-		ts.isIdentifier(node.name) &&
+		typescript.isIdentifier(node.name) &&
 		node.name.text === "constructor"
 	) {
 		return true;
 	}
 
 	if (
-		ts.isMetaProperty(node) &&
+		typescript.isMetaProperty(node) &&
 		node.keywordToken === SyntaxKind.NewKeyword &&
-		ts.isIdentifier(node.name) &&
+		typescript.isIdentifier(node.name) &&
 		node.name.text === "target"
 	) {
 		return true;
@@ -83,7 +86,7 @@ export default ruleCreator.createRule(typescriptLanguage, {
 					}
 
 					for (const member of node.members) {
-						if (!ts.isConstructorDeclaration(member) || !member.body) {
+						if (!typescript.isConstructorDeclaration(member) || !member.body) {
 							continue;
 						}
 
@@ -92,7 +95,7 @@ export default ruleCreator.createRule(typescriptLanguage, {
 								statement.kind !== SyntaxKind.ExpressionStatement ||
 								!(
 									statement.expression.kind === SyntaxKind.CallExpression ||
-									ts.isCallChain(statement.expression)
+									typescript.isCallChain(statement.expression)
 								) ||
 								!isCaptureStackTraceCall(statement.expression)
 							) {

--- a/packages/ts/src/rules/evolvingVariableTypes.ts
+++ b/packages/ts/src/rules/evolvingVariableTypes.ts
@@ -1,6 +1,7 @@
-import ts, { SyntaxKind } from "typescript";
-
 import { typescriptLanguage } from "@flint.fyi/typescript-language";
+import typescript, {
+	SyntaxKind,
+} from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 
@@ -35,7 +36,7 @@ export default ruleCreator.createRule(typescriptLanguage, {
 						node.type !== undefined ||
 						node.name.kind !== SyntaxKind.Identifier ||
 						node.parent.kind === SyntaxKind.CatchClause ||
-						node.parent.flags & ts.NodeFlags.Const ||
+						node.parent.flags & typescript.NodeFlags.Const ||
 						node.parent.parent.kind === SyntaxKind.ForInStatement ||
 						node.parent.parent.kind === SyntaxKind.ForOfStatement
 					) {

--- a/packages/ts/src/rules/exceptionAssignments.ts
+++ b/packages/ts/src/rules/exceptionAssignments.ts
@@ -1,11 +1,10 @@
-import { SyntaxKind } from "typescript";
-
 import {
 	getModifyingReferences,
 	getTSNodeRange,
 	typescriptLanguage,
 	type AST,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/ts/src/rules/explicitAnys.ts
+++ b/packages/ts/src/rules/explicitAnys.ts
@@ -1,10 +1,9 @@
-import { SyntaxKind } from "typescript";
-
 import {
 	getTSNodeRange,
 	typescriptLanguage,
 	type AST,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/ts/src/rules/exponentiationOperators.ts
+++ b/packages/ts/src/rules/exponentiationOperators.ts
@@ -1,10 +1,9 @@
-import { SyntaxKind } from "typescript";
-
 import {
 	getTSNodeRange,
 	isGlobalDeclarationOfName,
 	typescriptLanguage,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/ts/src/rules/exportFromImports.ts
+++ b/packages/ts/src/rules/exportFromImports.ts
@@ -1,4 +1,4 @@
-import ts, { SyntaxKind } from "typescript";
+import type ts from "typescript";
 
 import {
 	getStaticStringValue,
@@ -6,6 +6,9 @@ import {
 	typescriptLanguage,
 	type AST,
 } from "@flint.fyi/typescript-language";
+import typescript, {
+	SyntaxKind,
+} from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 
@@ -42,9 +45,9 @@ function getImportInfo(
 	}
 
 	if (clause.namedBindings) {
-		if (ts.isNamespaceImport(clause.namedBindings)) {
+		if (typescript.isNamespaceImport(clause.namedBindings)) {
 			info.namespaceImport = clause.namedBindings.name.text;
-		} else if (ts.isNamedImports(clause.namedBindings)) {
+		} else if (typescript.isNamedImports(clause.namedBindings)) {
 			for (const element of clause.namedBindings.elements) {
 				const importedName = element.propertyName
 					? element.propertyName.text
@@ -137,7 +140,7 @@ export default ruleCreator.createRule(typescriptLanguage, {
 					for (const exportDeclaration of namedExports) {
 						if (
 							!exportDeclaration.exportClause ||
-							!ts.isNamedExports(exportDeclaration.exportClause)
+							!typescript.isNamedExports(exportDeclaration.exportClause)
 						) {
 							continue;
 						}
@@ -185,7 +188,7 @@ export default ruleCreator.createRule(typescriptLanguage, {
 					}
 
 					for (const exportAssignment of exportAssignments) {
-						if (!ts.isIdentifier(exportAssignment.expression)) {
+						if (!typescript.isIdentifier(exportAssignment.expression)) {
 							continue;
 						}
 

--- a/packages/ts/src/rules/exportMutables.ts
+++ b/packages/ts/src/rules/exportMutables.ts
@@ -1,17 +1,18 @@
-import ts, { SyntaxKind } from "typescript";
-
 import {
 	getTSNodeRange,
 	typescriptLanguage,
 	type AST,
 } from "@flint.fyi/typescript-language";
+import typescript, {
+	SyntaxKind,
+} from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 
 function isMutableDeclaration(node: AST.VariableDeclarationList): boolean {
 	return (
-		(node.flags & ts.NodeFlags.Let) !== 0 ||
-		(node.flags & ts.NodeFlags.Const) === 0
+		(node.flags & typescript.NodeFlags.Let) !== 0 ||
+		(node.flags & typescript.NodeFlags.Const) === 0
 	);
 }
 

--- a/packages/ts/src/rules/exportUniqueNames.ts
+++ b/packages/ts/src/rules/exportUniqueNames.ts
@@ -1,11 +1,11 @@
 import type ts from "typescript";
-import { SyntaxKind } from "typescript";
 
 import {
 	getTSNodeRange,
 	typescriptLanguage,
 	type AST,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/ts/src/rules/extraneousClasses.ts
+++ b/packages/ts/src/rules/extraneousClasses.ts
@@ -1,4 +1,4 @@
-import { SyntaxKind, type NodeArray } from "typescript";
+import type { NodeArray } from "typescript";
 import { z } from "zod/v4";
 
 import {
@@ -6,6 +6,7 @@ import {
 	type AST,
 	type TypeScriptFileServices,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/ts/src/rules/fetchMethodBodies.ts
+++ b/packages/ts/src/rules/fetchMethodBodies.ts
@@ -1,10 +1,9 @@
-import { SyntaxKind } from "typescript";
-
 import {
 	getTSNodeRange,
 	typescriptLanguage,
 	type AST,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/ts/src/rules/finallyStatementSafety.ts
+++ b/packages/ts/src/rules/finallyStatementSafety.ts
@@ -1,6 +1,5 @@
-import { SyntaxKind } from "typescript";
-
 import { typescriptLanguage, type AST } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/ts/src/rules/forDirections.ts
+++ b/packages/ts/src/rules/forDirections.ts
@@ -1,10 +1,9 @@
-import { SyntaxKind } from "typescript";
-
 import {
 	getTSNodeRange,
 	typescriptLanguage,
 	type AST,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/ts/src/rules/forInArrays.ts
+++ b/packages/ts/src/rules/forInArrays.ts
@@ -1,10 +1,11 @@
-import * as tsutils from "ts-api-utils";
-import ts from "typescript";
+import type ts from "typescript";
 
 import {
 	typescriptLanguage,
 	type Checker,
 } from "@flint.fyi/typescript-language";
+import tsutils from "@flint.fyi/typescript-language/ts-api-utils";
+import typescript from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 import { getConstrainedTypeAtLocation } from "./utils/getConstrainedType.ts";
@@ -40,7 +41,7 @@ export default ruleCreator.createRule(typescriptLanguage, {
 
 			return tsutils.isTypeFlagSet(
 				typeChecker.getTypeOfSymbol(lengthProperty),
-				ts.TypeFlags.NumberLike,
+				typescript.TypeFlags.NumberLike,
 			);
 		}
 

--- a/packages/ts/src/rules/forInGuards.ts
+++ b/packages/ts/src/rules/forInGuards.ts
@@ -1,6 +1,5 @@
-import { SyntaxKind } from "typescript";
-
 import { typescriptLanguage, type AST } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/ts/src/rules/functionApplySpreads.ts
+++ b/packages/ts/src/rules/functionApplySpreads.ts
@@ -1,5 +1,3 @@
-import { SyntaxKind } from "typescript";
-
 import {
 	getTSNodeRange,
 	hasSameTokens,
@@ -7,6 +5,7 @@ import {
 	typescriptLanguage,
 	type AST,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/ts/src/rules/functionCurryingRedundancy.ts
+++ b/packages/ts/src/rules/functionCurryingRedundancy.ts
@@ -1,10 +1,9 @@
-import { SyntaxKind } from "typescript";
-
 import {
 	isFunction,
 	typescriptLanguage,
 	type AST,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 import { nullThrows } from "@flint.fyi/utils";
 
 import { ruleCreator } from "./ruleCreator.ts";

--- a/packages/ts/src/rules/functionDeclarationStyles.ts
+++ b/packages/ts/src/rules/functionDeclarationStyles.ts
@@ -1,4 +1,3 @@
-import { SyntaxKind } from "typescript";
 import { z } from "zod/v4";
 
 import {
@@ -6,6 +5,7 @@ import {
 	typescriptLanguage,
 	type AST,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/ts/src/rules/functionNameMatches.ts
+++ b/packages/ts/src/rules/functionNameMatches.ts
@@ -1,10 +1,9 @@
-import { SyntaxKind } from "typescript";
-
 import {
 	getTSNodeRange,
 	typescriptLanguage,
 	type AST,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/ts/src/rules/functionNewCalls.ts
+++ b/packages/ts/src/rules/functionNewCalls.ts
@@ -1,4 +1,4 @@
-import { SyntaxKind, type Program } from "typescript";
+import type { Program } from "typescript";
 
 import {
 	getTSNodeRange,
@@ -9,6 +9,7 @@ import {
 	type Checker,
 	type TypeScriptFileServices,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/ts/src/rules/generatorFunctionYields.ts
+++ b/packages/ts/src/rules/generatorFunctionYields.ts
@@ -1,11 +1,14 @@
-import * as tsutils from "ts-api-utils";
-import ts, { SyntaxKind } from "typescript";
+import type ts from "typescript";
 
 import {
 	typescriptLanguage,
 	type AST,
 	type TypeScriptFileServices,
 } from "@flint.fyi/typescript-language";
+import tsutils from "@flint.fyi/typescript-language/ts-api-utils";
+import typescript, {
+	SyntaxKind,
+} from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 
@@ -71,8 +74,8 @@ function blockContainsYield(block: AST.Block) {
 			return false;
 		}
 
-		return ts.forEachChild(node, checkForYield);
+		return typescript.forEachChild(node, checkForYield);
 	}
 
-	return ts.forEachChild(block, checkForYield);
+	return typescript.forEachChild(block, checkForYield);
 }

--- a/packages/ts/src/rules/getterReturns.ts
+++ b/packages/ts/src/rules/getterReturns.ts
@@ -1,6 +1,5 @@
-import { SyntaxKind } from "typescript";
-
 import { typescriptLanguage, type AST } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/ts/src/rules/globalAssignments.ts
+++ b/packages/ts/src/rules/globalAssignments.ts
@@ -1,11 +1,10 @@
-import * as tsutils from "ts-api-utils";
-import { SyntaxKind } from "typescript";
-
 import {
 	getTSNodeRange,
 	isGlobalVariable,
 	typescriptLanguage,
 } from "@flint.fyi/typescript-language";
+import tsutils from "@flint.fyi/typescript-language/ts-api-utils";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/ts/src/rules/globalObjectCalls.ts
+++ b/packages/ts/src/rules/globalObjectCalls.ts
@@ -1,11 +1,10 @@
-import { SyntaxKind } from "typescript";
-
 import {
 	getTSNodeRange,
 	typescriptLanguage,
 	type AST,
 	type TypeScriptFileServices,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/ts/src/rules/globalThisAliases.ts
+++ b/packages/ts/src/rules/globalThisAliases.ts
@@ -1,4 +1,4 @@
-import { SyntaxKind, type Program } from "typescript";
+import type { Program } from "typescript";
 
 import {
 	declarationIncludesGlobal,
@@ -7,6 +7,7 @@ import {
 	type AST,
 	type Checker,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/ts/src/rules/impliedEvals.ts
+++ b/packages/ts/src/rules/impliedEvals.ts
@@ -1,12 +1,4 @@
-import * as tsutils from "ts-api-utils";
-import {
-	SignatureKind,
-	SymbolFlags,
-	SyntaxKind,
-	TypeFlags,
-	type Program,
-	type Type,
-} from "typescript";
+import type { Program, Type } from "typescript";
 
 import {
 	getTSNodeRange,
@@ -15,6 +7,13 @@ import {
 	type Checker,
 	type TypeScriptFileServices,
 } from "@flint.fyi/typescript-language";
+import tsutils from "@flint.fyi/typescript-language/ts-api-utils";
+import {
+	SignatureKind,
+	SymbolFlags,
+	SyntaxKind,
+	TypeFlags,
+} from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 import { isBuiltinSymbolLike } from "./utils/isBuiltinSymbolLike.ts";

--- a/packages/ts/src/rules/importEmptyBlocks.ts
+++ b/packages/ts/src/rules/importEmptyBlocks.ts
@@ -1,9 +1,8 @@
-import { SyntaxKind } from "typescript";
-
 import {
 	getTSNodeRange,
 	typescriptLanguage,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/ts/src/rules/importTypeSideEffects.ts
+++ b/packages/ts/src/rules/importTypeSideEffects.ts
@@ -1,9 +1,8 @@
-import { SyntaxKind } from "typescript";
-
 import {
 	getTSNodeRange,
 	typescriptLanguage,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/ts/src/rules/indexedObjectTypes.ts
+++ b/packages/ts/src/rules/indexedObjectTypes.ts
@@ -1,4 +1,4 @@
-import { SyntaxKind, type NodeArray } from "typescript";
+import type { NodeArray } from "typescript";
 import { z } from "zod/v4";
 
 import {
@@ -7,6 +7,7 @@ import {
 	typescriptLanguage,
 	type AST,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/ts/src/rules/instanceOfArrays.ts
+++ b/packages/ts/src/rules/instanceOfArrays.ts
@@ -1,11 +1,10 @@
-import { SyntaxKind } from "typescript";
-
 import {
 	getTSNodeRange,
 	isGlobalDeclarationOfName,
 	typescriptLanguage,
 	unwrapParenthesizedNode,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/ts/src/rules/irregularWhitespaces.ts
+++ b/packages/ts/src/rules/irregularWhitespaces.ts
@@ -1,8 +1,3 @@
-import {
-	getLeadingCommentRanges,
-	getTrailingCommentRanges,
-	SyntaxKind,
-} from "typescript";
 import { z } from "zod/v4";
 
 import {
@@ -10,6 +5,11 @@ import {
 	typescriptLanguage,
 	type AST,
 } from "@flint.fyi/typescript-language";
+import {
+	getLeadingCommentRanges,
+	getTrailingCommentRanges,
+	SyntaxKind,
+} from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/ts/src/rules/isNaNComparisons.ts
+++ b/packages/ts/src/rules/isNaNComparisons.ts
@@ -1,4 +1,4 @@
-import { SyntaxKind, type Program } from "typescript";
+import type { Program } from "typescript";
 
 import {
 	getTSNodeRange,
@@ -8,6 +8,7 @@ import {
 	type AST,
 	type Checker,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/ts/src/rules/literalConstructorWrappers.ts
+++ b/packages/ts/src/rules/literalConstructorWrappers.ts
@@ -1,18 +1,17 @@
 import {
+	isGlobalDeclarationOfName,
+	typescriptLanguage,
+	type AST,
+	type TypeScriptFileServices,
+} from "@flint.fyi/typescript-language";
+import {
 	isBigIntLiteral,
 	isIdentifier,
 	isLiteralExpression,
 	isNumericLiteral,
 	isStringLiteral,
 	SyntaxKind,
-} from "typescript";
-
-import {
-	isGlobalDeclarationOfName,
-	typescriptLanguage,
-	type AST,
-	type TypeScriptFileServices,
-} from "@flint.fyi/typescript-language";
+} from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/ts/src/rules/mathMethods.ts
+++ b/packages/ts/src/rules/mathMethods.ts
@@ -1,4 +1,4 @@
-import { SyntaxKind, type Program } from "typescript";
+import type { Program } from "typescript";
 
 import {
 	getTSNodeRange,
@@ -8,6 +8,7 @@ import {
 	type AST,
 	type Checker,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 import { skipParentheses } from "./utils/skipParentheses.ts";

--- a/packages/ts/src/rules/meaninglessVoidOperators.ts
+++ b/packages/ts/src/rules/meaninglessVoidOperators.ts
@@ -1,7 +1,8 @@
-import * as tsutils from "ts-api-utils";
-import ts from "typescript";
+import type ts from "typescript";
 
 import { typescriptLanguage } from "@flint.fyi/typescript-language";
+import tsutils from "@flint.fyi/typescript-language/ts-api-utils";
+import typescript from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 import { getConstrainedTypeAtLocation } from "./utils/getConstrainedType.ts";
@@ -9,7 +10,7 @@ import { getConstrainedTypeAtLocation } from "./utils/getConstrainedType.ts";
 function isVoidOrUndefinedType(type: ts.Type) {
 	return tsutils.isTypeFlagSet(
 		type,
-		ts.TypeFlags.Void | ts.TypeFlags.Undefined,
+		typescript.TypeFlags.Void | typescript.TypeFlags.Undefined,
 	);
 }
 

--- a/packages/ts/src/rules/misleadingVoidExpressions.ts
+++ b/packages/ts/src/rules/misleadingVoidExpressions.ts
@@ -1,5 +1,4 @@
-import * as tsutils from "ts-api-utils";
-import { SyntaxKind, TypeFlags, type Type } from "typescript";
+import type { Type } from "typescript";
 
 import {
 	getTSNodeRange,
@@ -7,6 +6,11 @@ import {
 	type AST,
 	type TypeScriptFileServices,
 } from "@flint.fyi/typescript-language";
+import tsutils from "@flint.fyi/typescript-language/ts-api-utils";
+import {
+	SyntaxKind,
+	TypeFlags,
+} from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 import { getConstrainedTypeAtLocation } from "./utils/getConstrainedType.ts";

--- a/packages/ts/src/rules/moduleSpecifierLists.ts
+++ b/packages/ts/src/rules/moduleSpecifierLists.ts
@@ -1,10 +1,9 @@
-import { SyntaxKind } from "typescript";
-
 import {
 	getTSNodeRange,
 	typescriptLanguage,
 	type AST,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/ts/src/rules/multilineAmbiguities.ts
+++ b/packages/ts/src/rules/multilineAmbiguities.ts
@@ -1,6 +1,5 @@
-import { SyntaxKind } from "typescript";
-
 import { typescriptLanguage, type AST } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/ts/src/rules/namedDefaultExports.ts
+++ b/packages/ts/src/rules/namedDefaultExports.ts
@@ -1,10 +1,11 @@
-import { SyntaxKind, type NodeArray } from "typescript";
+import type { NodeArray } from "typescript";
 
 import {
 	getTSNodeRange,
 	typescriptLanguage,
 	type AST,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/ts/src/rules/namespaceDeclarations.ts
+++ b/packages/ts/src/rules/namespaceDeclarations.ts
@@ -1,11 +1,12 @@
-import * as tsutils from "ts-api-utils";
-import { SyntaxKind, type ModifierLike, type NodeArray } from "typescript";
+import type { ModifierLike, NodeArray } from "typescript";
 import { z } from "zod/v4";
 
 import {
 	getTSNodeRange,
 	typescriptLanguage,
 } from "@flint.fyi/typescript-language";
+import tsutils from "@flint.fyi/typescript-language/ts-api-utils";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/ts/src/rules/namespaceImplicitAmbientImports.ts
+++ b/packages/ts/src/rules/namespaceImplicitAmbientImports.ts
@@ -1,17 +1,18 @@
-import ts, { SyntaxKind } from "typescript";
-
 import {
 	getTSNodeRange,
 	typescriptLanguage,
 	type AST,
 } from "@flint.fyi/typescript-language";
+import typescript, {
+	SyntaxKind,
+} from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 
 function hasExportModifier(node: AST.Statement) {
 	return !!(
-		ts.canHaveModifiers(node) &&
-		ts
+		typescript.canHaveModifiers(node) &&
+		typescript
 			.getModifiers(node)
 			?.some((modifier) => modifier.kind === SyntaxKind.ExportKeyword)
 	);

--- a/packages/ts/src/rules/nativeObjectExtensions.ts
+++ b/packages/ts/src/rules/nativeObjectExtensions.ts
@@ -1,5 +1,3 @@
-import { SyntaxKind } from "typescript";
-
 import {
 	getTSNodeRange,
 	isGlobalDeclarationOfName,
@@ -7,6 +5,7 @@ import {
 	type AST,
 	type TypeScriptFileServices,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/ts/src/rules/negativeIndexLengthMethods.ts
+++ b/packages/ts/src/rules/negativeIndexLengthMethods.ts
@@ -1,5 +1,3 @@
-import ts, { SyntaxKind } from "typescript";
-
 import {
 	getTSNodeRange,
 	hasSameTokens,
@@ -8,6 +6,9 @@ import {
 	type AST,
 	type Checker,
 } from "@flint.fyi/typescript-language";
+import typescript, {
+	SyntaxKind,
+} from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 import { getConstrainedTypeAtLocation } from "./utils/getConstrainedType.ts";
@@ -130,7 +131,7 @@ function isSupportedType(
 	const type = getConstrainedTypeAtLocation(node, typeChecker);
 
 	return isTypeRecursive(type, (constituent) => {
-		if ((constituent.flags & ts.TypeFlags.Any) !== 0) {
+		if ((constituent.flags & typescript.TypeFlags.Any) !== 0) {
 			return true;
 		}
 
@@ -148,7 +149,7 @@ function isSupportedType(
 
 		if (
 			constituent.isStringLiteral() ||
-			(constituent.flags & ts.TypeFlags.String) !== 0
+			(constituent.flags & typescript.TypeFlags.String) !== 0
 		) {
 			return supportedTypes.has("String");
 		}

--- a/packages/ts/src/rules/negativeZeroComparisons.ts
+++ b/packages/ts/src/rules/negativeZeroComparisons.ts
@@ -1,6 +1,5 @@
-import { SyntaxKind } from "typescript";
-
 import { typescriptLanguage, type AST } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 import {

--- a/packages/ts/src/rules/nestedStandaloneIfs.ts
+++ b/packages/ts/src/rules/nestedStandaloneIfs.ts
@@ -1,10 +1,9 @@
-import { SyntaxKind } from "typescript";
-
 import {
 	getTSNodeRange,
 	typescriptLanguage,
 	type AST,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/ts/src/rules/newDefinitions.ts
+++ b/packages/ts/src/rules/newDefinitions.ts
@@ -1,10 +1,9 @@
-import { SyntaxKind } from "typescript";
-
 import {
 	getTSNodeRange,
 	typescriptLanguage,
 	type AST,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/ts/src/rules/newExpressions.ts
+++ b/packages/ts/src/rules/newExpressions.ts
@@ -1,10 +1,9 @@
-import { SyntaxKind } from "typescript";
-
 import {
 	getTSNodeRange,
 	typescriptLanguage,
 	type AST,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/ts/src/rules/newNativeNonConstructors.ts
+++ b/packages/ts/src/rules/newNativeNonConstructors.ts
@@ -1,10 +1,9 @@
-import { SyntaxKind } from "typescript";
-
 import {
 	getTSNodeRange,
 	isGlobalDeclaration,
 	typescriptLanguage,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/ts/src/rules/nonNullAssertedNullishCoalesces.ts
+++ b/packages/ts/src/rules/nonNullAssertedNullishCoalesces.ts
@@ -1,5 +1,4 @@
-import * as tsutils from "ts-api-utils";
-import ts, { SyntaxKind } from "typescript";
+import type ts from "typescript";
 
 import {
 	getTSNodeRange,
@@ -7,6 +6,10 @@ import {
 	type AST,
 	type Checker,
 } from "@flint.fyi/typescript-language";
+import tsutils from "@flint.fyi/typescript-language/ts-api-utils";
+import typescript, {
+	SyntaxKind,
+} from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 
@@ -33,11 +36,11 @@ function hasNoAssignmentBeforeNode(
 			continue;
 		}
 
-		if (ts.isVariableDeclaration(declaration)) {
+		if (typescript.isVariableDeclaration(declaration)) {
 			if (declaration.exclamationToken || declaration.initializer) {
 				return false;
 			}
-		} else if (ts.isParameter(declaration) && declaration.initializer) {
+		} else if (typescript.isParameter(declaration) && declaration.initializer) {
 			return false;
 		}
 	}
@@ -48,13 +51,13 @@ function hasNoAssignmentBeforeNode(
 	}
 
 	function findModifyingReference(current: ts.Node): boolean {
-		if (ts.isIdentifier(current)) {
+		if (typescript.isIdentifier(current)) {
 			const currentSymbol = typeChecker.getSymbolAtLocation(current);
 			if (currentSymbol?.valueDeclaration === valueDeclaration) {
 				const parent = current.parent;
 
 				if (
-					ts.isBinaryExpression(parent) &&
+					typescript.isBinaryExpression(parent) &&
 					tsutils.isAssignmentKind(parent.operatorToken.kind) &&
 					parent.left === current &&
 					parent.getEnd() < nodeEnd
@@ -63,8 +66,8 @@ function hasNoAssignmentBeforeNode(
 				}
 
 				if (
-					(ts.isPostfixUnaryExpression(parent) ||
-						ts.isPrefixUnaryExpression(parent)) &&
+					(typescript.isPostfixUnaryExpression(parent) ||
+						typescript.isPrefixUnaryExpression(parent)) &&
 					parent.operand === current &&
 					parent.getEnd() < nodeEnd
 				) {
@@ -73,7 +76,7 @@ function hasNoAssignmentBeforeNode(
 			}
 		}
 
-		return ts.forEachChild(current, findModifyingReference) ?? false;
+		return typescript.forEachChild(current, findModifyingReference) ?? false;
 	}
 
 	return !findModifyingReference(sourceFile);

--- a/packages/ts/src/rules/nonNullAssertedOptionalChains.ts
+++ b/packages/ts/src/rules/nonNullAssertedOptionalChains.ts
@@ -1,10 +1,9 @@
-import { SyntaxKind } from "typescript";
-
 import {
 	getTSNodeRange,
 	typescriptLanguage,
 	type AST,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/ts/src/rules/nonNullAssertionPlacement.ts
+++ b/packages/ts/src/rules/nonNullAssertionPlacement.ts
@@ -1,6 +1,7 @@
-import { SyntaxKind, type Expression, type SourceFile } from "typescript";
+import type { Expression, SourceFile } from "typescript";
 
 import { typescriptLanguage } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/ts/src/rules/nonNullableTypeAssertions.ts
+++ b/packages/ts/src/rules/nonNullableTypeAssertions.ts
@@ -1,5 +1,4 @@
-import * as tsutils from "ts-api-utils";
-import ts, { SyntaxKind } from "typescript";
+import type ts from "typescript";
 
 import {
 	getTSNodeRange,
@@ -8,11 +7,15 @@ import {
 	type Checker,
 	type TypeScriptFileServices,
 } from "@flint.fyi/typescript-language";
+import tsutils from "@flint.fyi/typescript-language/ts-api-utils";
+import typescript, {
+	SyntaxKind,
+} from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 
 function couldBeNullish(type: ts.Type): boolean {
-	if (type.flags & ts.TypeFlags.TypeParameter) {
+	if (type.flags & typescript.TypeFlags.TypeParameter) {
 		const constraint = type.getConstraint();
 		return constraint === undefined || couldBeNullish(constraint);
 	}
@@ -21,7 +24,11 @@ function couldBeNullish(type: ts.Type): boolean {
 		return type.types.some(couldBeNullish);
 	}
 
-	return (type.flags & (ts.TypeFlags.Null | ts.TypeFlags.Undefined)) !== 0;
+	return (
+		(type.flags &
+			(typescript.TypeFlags.Null | typescript.TypeFlags.Undefined)) !==
+		0
+	);
 }
 
 function getTypesIfNotLoose(
@@ -29,7 +36,12 @@ function getTypesIfNotLoose(
 	typeChecker: Checker,
 ) {
 	const type = typeChecker.getTypeAtLocation(node);
-	if (tsutils.isTypeFlagSet(type, ts.TypeFlags.Any | ts.TypeFlags.Unknown)) {
+	if (
+		tsutils.isTypeFlagSet(
+			type,
+			typescript.TypeFlags.Any | typescript.TypeFlags.Unknown,
+		)
+	) {
 		return undefined;
 	}
 
@@ -66,7 +78,10 @@ function sameTypeWithoutNullish(
 	originalTypes: ts.Type[],
 ) {
 	const nonNullishOriginalTypes = originalTypes.filter(
-		(type) => (type.flags & (ts.TypeFlags.Null | ts.TypeFlags.Undefined)) === 0,
+		(type) =>
+			(type.flags &
+				(typescript.TypeFlags.Null | typescript.TypeFlags.Undefined)) ===
+			0,
 	);
 
 	if (nonNullishOriginalTypes.length === originalTypes.length) {

--- a/packages/ts/src/rules/nullishCheckStyle.ts
+++ b/packages/ts/src/rules/nullishCheckStyle.ts
@@ -1,10 +1,10 @@
-import { isNullKeyword } from "ts-api-utils";
 import { z } from "zod/v4";
 
 import {
 	getTSNodeRange,
 	typescriptLanguage,
 } from "@flint.fyi/typescript-language";
+import tsutils from "@flint.fyi/typescript-language/ts-api-utils";
 
 import { ruleCreator } from "./ruleCreator.ts";
 import {
@@ -190,8 +190,8 @@ export default ruleCreator.createRule(typescriptLanguage, {
 						} else if (
 							options.looseNullishComparisonStyle === "prefer-undefined"
 						) {
-							const leftIsNull = isNullKeyword(node.left);
-							const rightIsNull = isNullKeyword(node.right);
+							const leftIsNull = tsutils.isNullKeyword(node.left);
+							const rightIsNull = tsutils.isNullKeyword(node.right);
 
 							if (leftIsNull || rightIsNull) {
 								context.report({

--- a/packages/ts/src/rules/nullishCoalescingOperators.ts
+++ b/packages/ts/src/rules/nullishCoalescingOperators.ts
@@ -1,5 +1,4 @@
-import * as tsutils from "ts-api-utils";
-import ts, { SyntaxKind } from "typescript";
+import type ts from "typescript";
 import { z } from "zod/v4";
 
 import type { CharacterReportRange } from "@flint.fyi/core";
@@ -10,6 +9,10 @@ import {
 	type AST,
 	type Checker,
 } from "@flint.fyi/typescript-language";
+import tsutils from "@flint.fyi/typescript-language/ts-api-utils";
+import typescript, {
+	SyntaxKind,
+} from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 
@@ -327,14 +330,14 @@ function isFalsyLiteralType(part: ts.Type) {
 
 	const flags = part.getFlags();
 
-	if (flags & ts.TypeFlags.BooleanLiteral) {
+	if (flags & typescript.TypeFlags.BooleanLiteral) {
 		const literal = part as unknown as { intrinsicName?: string };
 		if (literal.intrinsicName === "false") {
 			return true;
 		}
 	}
 
-	if (flags & ts.TypeFlags.BigIntLiteral) {
+	if (flags & typescript.TypeFlags.BigIntLiteral) {
 		const value = (part as ts.BigIntLiteralType).value;
 		if (!value.negative && value.base10Value === "0") {
 			return true;
@@ -375,7 +378,7 @@ function isMixedLogicalExpression(node: AST.BinaryExpression) {
 function isNullishType(type: ts.Type) {
 	return tsutils.isTypeFlagSet(
 		type,
-		ts.TypeFlags.Null | ts.TypeFlags.Undefined,
+		typescript.TypeFlags.Null | typescript.TypeFlags.Undefined,
 	);
 }
 
@@ -408,7 +411,10 @@ function isTypeEligibleForPreferNullish(
 ) {
 	if (
 		!typeCanBeNullish(type) ||
-		tsutils.isTypeFlagSet(type, ts.TypeFlags.Any | ts.TypeFlags.Unknown) ||
+		tsutils.isTypeFlagSet(
+			type,
+			typescript.TypeFlags.Any | typescript.TypeFlags.Unknown,
+		) ||
 		!ignorePrimitives
 	) {
 		return true;
@@ -417,16 +423,16 @@ function isTypeEligibleForPreferNullish(
 	const ignorableFlags = [
 		(ignorePrimitives === true ||
 			(typeof ignorePrimitives === "object" && ignorePrimitives.bigint)) &&
-			ts.TypeFlags.BigIntLike,
+			typescript.TypeFlags.BigIntLike,
 		(ignorePrimitives === true ||
 			(typeof ignorePrimitives === "object" && ignorePrimitives.boolean)) &&
-			ts.TypeFlags.BooleanLike,
+			typescript.TypeFlags.BooleanLike,
 		(ignorePrimitives === true ||
 			(typeof ignorePrimitives === "object" && ignorePrimitives.number)) &&
-			ts.TypeFlags.NumberLike,
+			typescript.TypeFlags.NumberLike,
 		(ignorePrimitives === true ||
 			(typeof ignorePrimitives === "object" && ignorePrimitives.string)) &&
-			ts.TypeFlags.StringLike,
+			typescript.TypeFlags.StringLike,
 	]
 		.filter((flag) => typeof flag === "number")
 		.reduce((previous, flag) => previous | flag, 0);
@@ -441,7 +447,10 @@ function shouldIgnoreNode(
 ) {
 	const type = typeChecker.getTypeAtLocation(node);
 	return (
-		tsutils.isTypeFlagSet(type, ts.TypeFlags.Any | ts.TypeFlags.Unknown) ||
+		tsutils.isTypeFlagSet(
+			type,
+			typescript.TypeFlags.Any | typescript.TypeFlags.Unknown,
+		) ||
 		!typeCanBeNullish(type) ||
 		typeHasNonNullishFalsyValues(type) ||
 		!isTypeEligibleForPreferNullish(type, ignorePrimitives)
@@ -459,10 +468,10 @@ function typeHasNonNullishFalsyValues(type: ts.Type) {
 			(constituent) =>
 				isFalsyLiteralType(constituent) ||
 				constituent.getFlags() &
-					(ts.TypeFlags.String |
-						ts.TypeFlags.Number |
-						ts.TypeFlags.BigInt |
-						ts.TypeFlags.Boolean),
+					(typescript.TypeFlags.String |
+						typescript.TypeFlags.Number |
+						typescript.TypeFlags.BigInt |
+						typescript.TypeFlags.Boolean),
 		);
 }
 

--- a/packages/ts/src/rules/numberMethodRanges.ts
+++ b/packages/ts/src/rules/numberMethodRanges.ts
@@ -1,10 +1,9 @@
-import { SyntaxKind } from "typescript";
-
 import {
 	getTSNodeRange,
 	typescriptLanguage,
 	type AST,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/ts/src/rules/numberStaticMethods.ts
+++ b/packages/ts/src/rules/numberStaticMethods.ts
@@ -1,4 +1,4 @@
-import ts, { SyntaxKind } from "typescript";
+import type ts from "typescript";
 
 import {
 	getTSNodeRange,
@@ -6,6 +6,9 @@ import {
 	typescriptLanguage,
 	type AST,
 } from "@flint.fyi/typescript-language";
+import typescript, {
+	SyntaxKind,
+} from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 
@@ -16,9 +19,11 @@ const globalReplacements = new Map([
 
 function isDeclarationName(node: ts.Identifier) {
 	return (
-		(ts.isFunctionDeclaration(node.parent) && node.parent.name === node) ||
-		(ts.isVariableDeclaration(node.parent) && node.parent.name === node) ||
-		(ts.isParameter(node.parent) && node.parent.name === node)
+		(typescript.isFunctionDeclaration(node.parent) &&
+			node.parent.name === node) ||
+		(typescript.isVariableDeclaration(node.parent) &&
+			node.parent.name === node) ||
+		(typescript.isParameter(node.parent) && node.parent.name === node)
 	);
 }
 
@@ -33,13 +38,15 @@ function isLeftHandSide(node: AST.Identifier) {
 
 function isPropertyAccessOfNode(node: ts.Identifier) {
 	return (
-		ts.isPropertyAccessExpression(node.parent) && node.parent.name === node
+		typescript.isPropertyAccessExpression(node.parent) &&
+		node.parent.name === node
 	);
 }
 
 function isPropertyShorthandOfNode(node: ts.Identifier) {
 	return (
-		ts.isShorthandPropertyAssignment(node.parent) && node.parent.name === node
+		typescript.isShorthandPropertyAssignment(node.parent) &&
+		node.parent.name === node
 	);
 }
 

--- a/packages/ts/src/rules/numericErasingOperations.ts
+++ b/packages/ts/src/rules/numericErasingOperations.ts
@@ -1,11 +1,10 @@
-import { SyntaxKind } from "typescript";
-
 import {
 	getStaticNumberValue,
 	getTSNodeRange,
 	typescriptLanguage,
 	type AST,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/ts/src/rules/numericLiteralParsing.ts
+++ b/packages/ts/src/rules/numericLiteralParsing.ts
@@ -1,5 +1,3 @@
-import { SyntaxKind } from "typescript";
-
 import {
 	getStaticNumberValue,
 	getStaticStringValue,
@@ -8,6 +6,7 @@ import {
 	typescriptLanguage,
 	type AST,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 import { nullThrows } from "@flint.fyi/utils";
 
 import { ruleCreator } from "./ruleCreator.ts";

--- a/packages/ts/src/rules/objectAssignSpreads.ts
+++ b/packages/ts/src/rules/objectAssignSpreads.ts
@@ -1,4 +1,4 @@
-import { SyntaxKind, type Program } from "typescript";
+import type { Program } from "typescript";
 
 import {
 	getTSNodeRange,
@@ -7,6 +7,7 @@ import {
 	type AST,
 	type Checker,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/ts/src/rules/objectCalls.ts
+++ b/packages/ts/src/rules/objectCalls.ts
@@ -1,5 +1,3 @@
-import { SyntaxKind } from "typescript";
-
 import {
 	getTSNodeRange,
 	isGlobalDeclarationOfName,
@@ -7,6 +5,7 @@ import {
 	type AST,
 	type TypeScriptFileServices,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/ts/src/rules/objectEntriesMethods.ts
+++ b/packages/ts/src/rules/objectEntriesMethods.ts
@@ -1,4 +1,4 @@
-import { SyntaxKind, type Program } from "typescript";
+import type { Program } from "typescript";
 
 import {
 	getTSNodeRange,
@@ -7,6 +7,7 @@ import {
 	type AST,
 	type Checker,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 import { isArrayOrTupleTypeAtLocation } from "./utils/isArrayOrTupleTypeAtLocation.ts";

--- a/packages/ts/src/rules/objectHasOwns.ts
+++ b/packages/ts/src/rules/objectHasOwns.ts
@@ -1,4 +1,4 @@
-import { SyntaxKind, type Program } from "typescript";
+import type { Program } from "typescript";
 
 import {
 	getTSNodeRange,
@@ -7,6 +7,7 @@ import {
 	type AST,
 	type Checker,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/ts/src/rules/objectKeyDuplicates.ts
+++ b/packages/ts/src/rules/objectKeyDuplicates.ts
@@ -1,10 +1,11 @@
-import { SyntaxKind, type Node } from "typescript";
+import type { Node } from "typescript";
 
 import {
 	getTSNodeRange,
 	typescriptLanguage,
 	type AST,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/ts/src/rules/objectProto.ts
+++ b/packages/ts/src/rules/objectProto.ts
@@ -1,6 +1,5 @@
-import { SyntaxKind } from "typescript";
-
 import { typescriptLanguage } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/ts/src/rules/objectPrototypeBuiltIns.ts
+++ b/packages/ts/src/rules/objectPrototypeBuiltIns.ts
@@ -1,10 +1,9 @@
-import { SyntaxKind } from "typescript";
-
 import {
 	getTSNodeRange,
 	typescriptLanguage,
 	type AST,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 import { nullThrows } from "@flint.fyi/utils";
 
 import { ruleCreator } from "./ruleCreator.ts";

--- a/packages/ts/src/rules/objectShorthand.ts
+++ b/packages/ts/src/rules/objectShorthand.ts
@@ -1,5 +1,3 @@
-import { SyntaxKind } from "typescript";
-
 import {
 	forEachChild,
 	getTSNodeRange,
@@ -7,6 +5,7 @@ import {
 	unwrapParenthesizedNode,
 	type AST,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/ts/src/rules/objectSpreadUnnecessaryFallbacks.ts
+++ b/packages/ts/src/rules/objectSpreadUnnecessaryFallbacks.ts
@@ -1,10 +1,9 @@
-import { SyntaxKind } from "typescript";
-
 import {
 	getTSNodeRange,
 	typescriptLanguage,
 	type AST,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/ts/src/rules/objectTypeDefinitions.ts
+++ b/packages/ts/src/rules/objectTypeDefinitions.ts
@@ -1,9 +1,8 @@
-import { SyntaxKind } from "typescript";
-
 import {
 	getTSNodeRange,
 	typescriptLanguage,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/ts/src/rules/operatorAssignmentShorthand.ts
+++ b/packages/ts/src/rules/operatorAssignmentShorthand.ts
@@ -1,11 +1,10 @@
-import { SyntaxKind } from "typescript";
-
 import {
 	getTSNodeRange,
 	hasSameTokens,
 	typescriptLanguage,
 	type AST,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/ts/src/rules/overloadSignaturesAdjacent.ts
+++ b/packages/ts/src/rules/overloadSignaturesAdjacent.ts
@@ -1,4 +1,4 @@
-import ts, { SyntaxKind } from "typescript";
+import type ts from "typescript";
 
 import {
 	getTSNodeRange,
@@ -6,6 +6,9 @@ import {
 	type AST,
 	type TypeScriptFileServices,
 } from "@flint.fyi/typescript-language";
+import typescript, {
+	SyntaxKind,
+} from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 
@@ -121,7 +124,7 @@ function getNameFromPropertyName(
 ): undefined | { name: string; type: "computed" | "normal" | "quoted" } {
 	switch (name.kind) {
 		case SyntaxKind.ComputedPropertyName:
-			if (ts.isStringLiteral(name.expression)) {
+			if (typescript.isStringLiteral(name.expression)) {
 				return { name: name.expression.text, type: "quoted" };
 			}
 			return undefined;
@@ -151,7 +154,7 @@ function isSameMethod(method1: Method, method2: Method | undefined) {
 
 function isStatic(node: ts.Node) {
 	return (
-		ts.canHaveModifiers(node) &&
+		typescript.canHaveModifiers(node) &&
 		!!node.modifiers?.some((mod) => mod.kind === SyntaxKind.StaticKeyword)
 	);
 }

--- a/packages/ts/src/rules/parseIntRadixes.ts
+++ b/packages/ts/src/rules/parseIntRadixes.ts
@@ -1,4 +1,4 @@
-import { SyntaxKind, type Program } from "typescript";
+import type { Program } from "typescript";
 
 import {
 	getStaticNumberValue,
@@ -9,6 +9,7 @@ import {
 	type Checker,
 	type TypeScriptFileServices,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/ts/src/rules/propertyAccessNotation.ts
+++ b/packages/ts/src/rules/propertyAccessNotation.ts
@@ -1,4 +1,4 @@
-import ts, { SyntaxKind } from "typescript";
+import type ts from "typescript";
 import { z } from "zod/v4";
 
 import {
@@ -7,6 +7,9 @@ import {
 	type AST,
 	type Checker,
 } from "@flint.fyi/typescript-language";
+import typescript, {
+	SyntaxKind,
+} from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 
@@ -60,7 +63,9 @@ const javascriptReservedWords = new Set([
 ]);
 
 function getModifiers(node: null | ts.Node | undefined) {
-	return node && ts.canHaveModifiers(node) ? ts.getModifiers(node) : undefined;
+	return node && typescript.canHaveModifiers(node)
+		? typescript.getModifiers(node)
+		: undefined;
 }
 
 // TODO: Use a util like getStaticValue
@@ -167,7 +172,10 @@ export default ruleCreator.createRule(typescriptLanguage, {
 						if (
 							typeChecker
 								.getIndexInfosOfType(objectType)
-								.some((info) => info.keyType.flags & ts.TypeFlags.StringLike)
+								.some(
+									(info) =>
+										info.keyType.flags & typescript.TypeFlags.StringLike,
+								)
 						) {
 							return;
 						}

--- a/packages/ts/src/rules/recursionOnlyArguments.ts
+++ b/packages/ts/src/rules/recursionOnlyArguments.ts
@@ -1,6 +1,3 @@
-import * as tsutils from "ts-api-utils";
-import { SyntaxKind } from "typescript";
-
 import {
 	getScopeManager,
 	getTSNodeRange,
@@ -9,6 +6,8 @@ import {
 	type ScopeManager,
 	type TypeScriptFileServices,
 } from "@flint.fyi/typescript-language";
+import tsutils from "@flint.fyi/typescript-language/ts-api-utils";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 import { getFunctionName } from "./utils/getFunctionName.ts";

--- a/packages/ts/src/rules/redundantTypeConstituents.ts
+++ b/packages/ts/src/rules/redundantTypeConstituents.ts
@@ -1,42 +1,45 @@
-import * as tsutils from "ts-api-utils";
-import ts, { SyntaxKind } from "typescript";
+import type ts from "typescript";
 
 import {
 	getTSNodeRange,
 	typescriptLanguage,
 	type AST,
 } from "@flint.fyi/typescript-language";
+import tsutils from "@flint.fyi/typescript-language/ts-api-utils";
+import typescript, {
+	SyntaxKind,
+} from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 
 const literalToPrimitiveTypeFlags: Record<number, ts.TypeFlags> = {
-	[ts.TypeFlags.BigIntLiteral]: ts.TypeFlags.BigInt,
-	[ts.TypeFlags.BooleanLiteral]: ts.TypeFlags.Boolean,
-	[ts.TypeFlags.NumberLiteral]: ts.TypeFlags.Number,
-	[ts.TypeFlags.StringLiteral]: ts.TypeFlags.String,
-	[ts.TypeFlags.TemplateLiteral]: ts.TypeFlags.String,
+	[typescript.TypeFlags.BigIntLiteral]: typescript.TypeFlags.BigInt,
+	[typescript.TypeFlags.BooleanLiteral]: typescript.TypeFlags.Boolean,
+	[typescript.TypeFlags.NumberLiteral]: typescript.TypeFlags.Number,
+	[typescript.TypeFlags.StringLiteral]: typescript.TypeFlags.String,
+	[typescript.TypeFlags.TemplateLiteral]: typescript.TypeFlags.String,
 };
 
 const literalTypeFlags = [
-	ts.TypeFlags.BigIntLiteral,
-	ts.TypeFlags.BooleanLiteral,
-	ts.TypeFlags.NumberLiteral,
-	ts.TypeFlags.StringLiteral,
-	ts.TypeFlags.TemplateLiteral,
+	typescript.TypeFlags.BigIntLiteral,
+	typescript.TypeFlags.BooleanLiteral,
+	typescript.TypeFlags.NumberLiteral,
+	typescript.TypeFlags.StringLiteral,
+	typescript.TypeFlags.TemplateLiteral,
 ];
 
 const primitiveTypeFlags = [
-	ts.TypeFlags.BigInt,
-	ts.TypeFlags.Boolean,
-	ts.TypeFlags.Number,
-	ts.TypeFlags.String,
+	typescript.TypeFlags.BigInt,
+	typescript.TypeFlags.Boolean,
+	typescript.TypeFlags.Number,
+	typescript.TypeFlags.String,
 ];
 
 const primitiveTypeFlagNames: Record<number, string> = {
-	[ts.TypeFlags.BigInt]: "bigint",
-	[ts.TypeFlags.Boolean]: "boolean",
-	[ts.TypeFlags.Number]: "number",
-	[ts.TypeFlags.String]: "string",
+	[typescript.TypeFlags.BigInt]: "bigint",
+	[typescript.TypeFlags.Boolean]: "boolean",
+	[typescript.TypeFlags.Number]: "number",
+	[typescript.TypeFlags.String]: "string",
 };
 
 function describeLiteralType(type: ts.Type): string {
@@ -57,15 +60,15 @@ function describeLiteralType(type: ts.Type): string {
 		return String(type.aliasSymbol.escapedName);
 	}
 
-	if (type.flags & ts.TypeFlags.Any) {
+	if (type.flags & typescript.TypeFlags.Any) {
 		return "any";
 	}
 
-	if (type.flags & ts.TypeFlags.Never) {
+	if (type.flags & typescript.TypeFlags.Never) {
 		return "never";
 	}
 
-	if (type.flags & ts.TypeFlags.Unknown) {
+	if (type.flags & typescript.TypeFlags.Unknown) {
 		return "unknown";
 	}
 
@@ -214,7 +217,7 @@ export default ruleCreator.createRule(typescriptLanguage, {
 						for (const typePart of typeParts) {
 							const typeName = describeLiteralType(typePart);
 
-							if (typePart.flags === ts.TypeFlags.Any) {
+							if (typePart.flags === typescript.TypeFlags.Any) {
 								context.report({
 									data: { container: "intersection", typeName },
 									message:
@@ -224,7 +227,7 @@ export default ruleCreator.createRule(typescriptLanguage, {
 								continue;
 							}
 
-							if (typePart.flags === ts.TypeFlags.Never) {
+							if (typePart.flags === typescript.TypeFlags.Never) {
 								context.report({
 									data: { container: "intersection", typeName },
 									message: "overrides",
@@ -233,7 +236,7 @@ export default ruleCreator.createRule(typescriptLanguage, {
 								continue;
 							}
 
-							if (typePart.flags === ts.TypeFlags.Unknown) {
+							if (typePart.flags === typescript.TypeFlags.Unknown) {
 								context.report({
 									data: { container: "intersection", typeName },
 									message: "overridden",
@@ -338,13 +341,14 @@ export default ruleCreator.createRule(typescriptLanguage, {
 							const typeName = describeLiteralType(typePart);
 
 							if (
-								typePart.flags === ts.TypeFlags.Any ||
-								typePart.flags === ts.TypeFlags.Unknown
+								typePart.flags === typescript.TypeFlags.Any ||
+								typePart.flags === typescript.TypeFlags.Unknown
 							) {
 								context.report({
 									data: { container: "union", typeName },
 									message:
-										typePart.flags === ts.TypeFlags.Any && typeName !== "any"
+										typePart.flags === typescript.TypeFlags.Any &&
+										typeName !== "any"
 											? "errorTypeOverrides"
 											: "overrides",
 									range: getTSNodeRange(typeNode, sourceFile),
@@ -353,7 +357,7 @@ export default ruleCreator.createRule(typescriptLanguage, {
 							}
 
 							if (
-								typePart.flags === ts.TypeFlags.Never &&
+								typePart.flags === typescript.TypeFlags.Never &&
 								!isNodeInsideReturnType(node)
 							) {
 								context.report({

--- a/packages/ts/src/rules/regexAllGlobalFlags.ts
+++ b/packages/ts/src/rules/regexAllGlobalFlags.ts
@@ -1,10 +1,12 @@
-import { SyntaxKind, TypeFlags } from "typescript";
-
 import {
 	getTSNodeRange,
 	typescriptLanguage,
 	type AST,
 } from "@flint.fyi/typescript-language";
+import {
+	SyntaxKind,
+	TypeFlags,
+} from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/ts/src/rules/regexAmbiguousInvalidity.ts
+++ b/packages/ts/src/rules/regexAmbiguousInvalidity.ts
@@ -5,7 +5,6 @@ import {
 	type AST as RegExpAST,
 } from "@eslint-community/regexpp";
 import type { CharacterClassElement } from "@eslint-community/regexpp/ast";
-import { SyntaxKind } from "typescript";
 
 import {
 	isGlobalDeclarationOfName,
@@ -13,6 +12,7 @@ import {
 	type AST,
 	type TypeScriptFileServices,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/ts/src/rules/regexControlCharacters.ts
+++ b/packages/ts/src/rules/regexControlCharacters.ts
@@ -1,10 +1,9 @@
-import { SyntaxKind } from "typescript";
-
 import {
 	typescriptLanguage,
 	type AST,
 	type TypeScriptFileServices,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 import { getRegExpLiteralDetails } from "./utils/getRegExpLiteralDetails.ts";

--- a/packages/ts/src/rules/regexDollarEscapes.ts
+++ b/packages/ts/src/rules/regexDollarEscapes.ts
@@ -1,10 +1,12 @@
-import { SyntaxKind, TypeFlags } from "typescript";
-
 import {
 	typescriptLanguage,
 	type AST,
 	type Checker,
 } from "@flint.fyi/typescript-language";
+import {
+	SyntaxKind,
+	TypeFlags,
+} from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/ts/src/rules/regexExecutors.ts
+++ b/packages/ts/src/rules/regexExecutors.ts
@@ -1,11 +1,13 @@
-import { SyntaxKind, TypeFlags } from "typescript";
-
 import {
 	getStaticStringValue,
 	getTSNodeRange,
 	typescriptLanguage,
 	type AST,
 } from "@flint.fyi/typescript-language";
+import {
+	SyntaxKind,
+	TypeFlags,
+} from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 import { getConstrainedTypeAtLocation } from "./utils/getConstrainedType.ts";

--- a/packages/ts/src/rules/regexLookaroundAssertions.ts
+++ b/packages/ts/src/rules/regexLookaroundAssertions.ts
@@ -2,13 +2,16 @@ import {
 	visitRegExpAST,
 	type AST as RegExpAST,
 } from "@eslint-community/regexpp";
-import { SyntaxKind, TypeFlags } from "typescript";
 
 import {
 	getTSNodeRange,
 	typescriptLanguage,
 	type AST,
 } from "@flint.fyi/typescript-language";
+import {
+	SyntaxKind,
+	TypeFlags,
+} from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 import { getConstrainedTypeAtLocation } from "./utils/getConstrainedType.ts";

--- a/packages/ts/src/rules/regexMatchNotation.ts
+++ b/packages/ts/src/rules/regexMatchNotation.ts
@@ -2,9 +2,9 @@ import {
 	visitRegExpAST,
 	type AST as RegExpAST,
 } from "@eslint-community/regexpp";
-import { SyntaxKind } from "typescript";
 
 import { typescriptLanguage, type AST } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 import { parseRegexpAst } from "./utils/parseRegexpAst.ts";

--- a/packages/ts/src/rules/regexNamedReplacements.ts
+++ b/packages/ts/src/rules/regexNamedReplacements.ts
@@ -2,13 +2,16 @@ import {
 	visitRegExpAST,
 	type AST as RegExpAST,
 } from "@eslint-community/regexpp";
-import { SyntaxKind, TypeFlags } from "typescript";
 
 import {
 	getTSNodeRange,
 	typescriptLanguage,
 	type AST,
 } from "@flint.fyi/typescript-language";
+import {
+	SyntaxKind,
+	TypeFlags,
+} from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 import { getConstrainedTypeAtLocation } from "./utils/getConstrainedType.ts";

--- a/packages/ts/src/rules/regexNonStandardFlags.ts
+++ b/packages/ts/src/rules/regexNonStandardFlags.ts
@@ -1,10 +1,9 @@
-import { SyntaxKind } from "typescript";
-
 import {
 	typescriptLanguage,
 	type AST,
 	type TypeScriptFileServices,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 import { getRegExpConstruction } from "./utils/getRegExpConstruction.ts";

--- a/packages/ts/src/rules/regexResultArrayGroups.ts
+++ b/packages/ts/src/rules/regexResultArrayGroups.ts
@@ -3,7 +3,7 @@ import type {
 	CapturingGroup,
 	RegExpLiteral,
 } from "@eslint-community/regexpp/ast";
-import ts, { SyntaxKind } from "typescript";
+import type ts from "typescript";
 
 import {
 	getTSNodeRange,
@@ -12,6 +12,9 @@ import {
 	type Checker,
 	type TypeScriptFileServices,
 } from "@flint.fyi/typescript-language";
+import typescript, {
+	SyntaxKind,
+} from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 import { getRegExpConstruction } from "./utils/getRegExpConstruction.ts";
@@ -50,16 +53,16 @@ function findAssignmentsToSymbol(
 
 	function visit(node: ts.Node) {
 		if (
-			ts.isBinaryExpression(node) &&
+			typescript.isBinaryExpression(node) &&
 			node.operatorToken.kind === SyntaxKind.EqualsToken &&
-			ts.isIdentifier(node.left)
+			typescript.isIdentifier(node.left)
 		) {
 			const leftSymbol = typeChecker.getSymbolAtLocation(node.left);
 			if (leftSymbol === symbol) {
 				assignments.push(node);
 			}
 		}
-		ts.forEachChild(node, visit);
+		typescript.forEachChild(node, visit);
 	}
 
 	visit(sourceFile);
@@ -102,7 +105,7 @@ function getNamedGroupsFromExpression(
 		const symbol = typeChecker.getSymbolAtLocation(unwrapped);
 		if (symbol) {
 			const resolvedSymbol =
-				symbol.flags & ts.SymbolFlags.Alias
+				symbol.flags & typescript.SymbolFlags.Alias
 					? typeChecker.getAliasedSymbol(symbol)
 					: symbol;
 			return getRegexInfoFromSymbol(resolvedSymbol, typeChecker, sourceFile);
@@ -180,7 +183,7 @@ function getRegexFromMatchAllCall(
 	}
 
 	const objectType = typeChecker.getTypeAtLocation(node.expression.expression);
-	if (!(objectType.flags & ts.TypeFlags.StringLike)) {
+	if (!(objectType.flags & typescript.TypeFlags.StringLike)) {
 		return undefined;
 	}
 
@@ -204,7 +207,7 @@ function getRegexFromMatchCall(
 	}
 
 	const objectType = typeChecker.getTypeAtLocation(node.expression.expression);
-	if (!(objectType.flags & ts.TypeFlags.StringLike)) {
+	if (!(objectType.flags & typescript.TypeFlags.StringLike)) {
 		return undefined;
 	}
 
@@ -253,7 +256,7 @@ function getRegexInfoFromExpression(
 			if (declarations) {
 				for (const declaration of declarations) {
 					if (
-						ts.isVariableDeclaration(declaration) &&
+						typescript.isVariableDeclaration(declaration) &&
 						declaration.initializer
 					) {
 						return getRegexInfoFromExpression(
@@ -279,7 +282,10 @@ function getRegexInfoFromSymbol(
 
 	if (declarations) {
 		for (const declaration of declarations) {
-			if (ts.isVariableDeclaration(declaration) && declaration.initializer) {
+			if (
+				typescript.isVariableDeclaration(declaration) &&
+				declaration.initializer
+			) {
 				const callExpression = extractCallExpression(
 					declaration.initializer as AST.Expression,
 				);
@@ -301,7 +307,7 @@ function getRegexInfoFromSymbol(
 				}
 			}
 
-			if (ts.isParameter(declaration)) {
+			if (typescript.isParameter(declaration)) {
 				continue;
 			}
 		}
@@ -334,7 +340,7 @@ function getRegexInfoFromSymbol(
 }
 
 function isAnyType(type: ts.Type): boolean {
-	return (type.flags & ts.TypeFlags.Any) !== 0;
+	return (type.flags & typescript.TypeFlags.Any) !== 0;
 }
 
 function isRegExpExecArrayOrRegExpMatchArray(
@@ -353,8 +359,8 @@ function isRegExpExecArrayOrRegExpMatchArray(
 		return type.types.every(
 			(constituent) =>
 				isRegExpExecArrayOrRegExpMatchArray(constituent, typeChecker) ||
-				(constituent.flags & ts.TypeFlags.Null) !== 0 ||
-				(constituent.flags & ts.TypeFlags.Undefined) !== 0,
+				(constituent.flags & typescript.TypeFlags.Null) !== 0 ||
+				(constituent.flags & typescript.TypeFlags.Undefined) !== 0,
 		);
 	}
 

--- a/packages/ts/src/rules/regexTestMethods.ts
+++ b/packages/ts/src/rules/regexTestMethods.ts
@@ -1,10 +1,11 @@
-import ts, { SyntaxKind } from "typescript";
-
 import {
 	getTSNodeRange,
 	typescriptLanguage,
 	type AST,
 } from "@flint.fyi/typescript-language";
+import typescript, {
+	SyntaxKind,
+} from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 import { getConstrainedTypeAtLocation } from "./utils/getConstrainedType.ts";
@@ -133,7 +134,7 @@ export default ruleCreator.createRule(typescriptLanguage, {
 						node.expression.expression,
 						typeChecker,
 					);
-					if (!(objectType.flags & ts.TypeFlags.StringLike)) {
+					if (!(objectType.flags & typescript.TypeFlags.StringLike)) {
 						return;
 					}
 

--- a/packages/ts/src/rules/regexUnicodeFlag.ts
+++ b/packages/ts/src/rules/regexUnicodeFlag.ts
@@ -1,11 +1,10 @@
-import { SyntaxKind } from "typescript";
-
 import type { Fix } from "@flint.fyi/core";
 import {
 	typescriptLanguage,
 	type AST,
 	type TypeScriptFileServices,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 import { getRegExpConstruction } from "./utils/getRegExpConstruction.ts";

--- a/packages/ts/src/rules/regexUnnecessaryDollarReplacements.ts
+++ b/packages/ts/src/rules/regexUnnecessaryDollarReplacements.ts
@@ -2,13 +2,16 @@ import {
 	visitRegExpAST,
 	type AST as RegExpAST,
 } from "@eslint-community/regexpp";
-import { SyntaxKind, TypeFlags } from "typescript";
 
 import {
 	getTSNodeRange,
 	typescriptLanguage,
 	type AST,
 } from "@flint.fyi/typescript-language";
+import {
+	SyntaxKind,
+	TypeFlags,
+} from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 import { getConstrainedTypeAtLocation } from "./utils/getConstrainedType.ts";

--- a/packages/ts/src/rules/regexUnusedFlags.ts
+++ b/packages/ts/src/rules/regexUnusedFlags.ts
@@ -2,13 +2,13 @@ import {
 	visitRegExpAST,
 	type AST as RegExpAST,
 } from "@eslint-community/regexpp";
-import { SyntaxKind } from "typescript";
 
 import {
 	typescriptLanguage,
 	type AST,
 	type TypeScriptFileServices,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 import { getRegExpConstruction } from "./utils/getRegExpConstruction.ts";

--- a/packages/ts/src/rules/regexValidity.ts
+++ b/packages/ts/src/rules/regexValidity.ts
@@ -1,10 +1,9 @@
-import { SyntaxKind } from "typescript";
-
 import {
 	typescriptLanguage,
 	type AST,
 	type TypeScriptFileServices,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 import { getRegExpConstruction } from "./utils/getRegExpConstruction.ts";

--- a/packages/ts/src/rules/requireImports.ts
+++ b/packages/ts/src/rules/requireImports.ts
@@ -1,10 +1,11 @@
-import { SyntaxKind, type TypeChecker } from "typescript";
+import type { TypeChecker } from "typescript";
 
 import {
 	getTSNodeRange,
 	typescriptLanguage,
 	type AST,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/ts/src/rules/responseJsonMethods.ts
+++ b/packages/ts/src/rules/responseJsonMethods.ts
@@ -1,10 +1,9 @@
-import { SyntaxKind } from "typescript";
-
 import {
 	getTSNodeRange,
 	typescriptLanguage,
 	type AST,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/ts/src/rules/restrictedIdentifiers.ts
+++ b/packages/ts/src/rules/restrictedIdentifiers.ts
@@ -1,4 +1,3 @@
-import { SyntaxKind } from "typescript";
 import z from "zod/v4";
 
 import {
@@ -7,6 +6,7 @@ import {
 	type AST,
 	type TypeScriptFileServices,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/ts/src/rules/restrictedImports.ts
+++ b/packages/ts/src/rules/restrictedImports.ts
@@ -1,4 +1,4 @@
-import ts, { SyntaxKind } from "typescript";
+import type ts from "typescript";
 import { z } from "zod/v4";
 
 import type { CharacterReportRange } from "@flint.fyi/core";
@@ -6,6 +6,9 @@ import {
 	getTSNodeRange,
 	typescriptLanguage,
 } from "@flint.fyi/typescript-language";
+import typescript, {
+	SyntaxKind,
+} from "@flint.fyi/typescript-language/typescript";
 
 import { getSpecifierNames } from "../type-utils/getSpecifierNames.ts";
 import { matchesSpecifier } from "../type-utils/matchesSpecifier.ts";
@@ -45,7 +48,7 @@ function resolveSymbolDeclarations(
 		return undefined;
 	}
 
-	if (symbol.flags & ts.SymbolFlags.Alias) {
+	if (symbol.flags & typescript.SymbolFlags.Alias) {
 		symbol = typeChecker.getAliasedSymbol(symbol);
 	}
 

--- a/packages/ts/src/rules/returnAssignments.ts
+++ b/packages/ts/src/rules/returnAssignments.ts
@@ -1,12 +1,11 @@
-import * as tsutils from "ts-api-utils";
-import { SyntaxKind } from "typescript";
-
 import {
 	getTSNodeRange,
 	typescriptLanguage,
 	unwrapParenthesizedNode,
 	type AST,
 } from "@flint.fyi/typescript-language";
+import tsutils from "@flint.fyi/typescript-language/ts-api-utils";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/ts/src/rules/returnThisTypes.ts
+++ b/packages/ts/src/rules/returnThisTypes.ts
@@ -1,5 +1,4 @@
-import * as tsutils from "ts-api-utils";
-import { SyntaxKind, type InterfaceType, type TypeChecker } from "typescript";
+import type { InterfaceType, TypeChecker } from "typescript";
 
 import {
 	getTSNodeRange,
@@ -7,6 +6,8 @@ import {
 	type AST,
 	type TypeScriptFileServices,
 } from "@flint.fyi/typescript-language";
+import tsutils from "@flint.fyi/typescript-language/ts-api-utils";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 import { forEachReturnStatement } from "./utils/forEachReturnStatement.ts";

--- a/packages/ts/src/rules/selfAssignments.ts
+++ b/packages/ts/src/rules/selfAssignments.ts
@@ -1,10 +1,9 @@
-import { SyntaxKind } from "typescript";
-
 import {
 	getTSNodeRange,
 	hasSameTokens,
 	typescriptLanguage,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/ts/src/rules/sequences.ts
+++ b/packages/ts/src/rules/sequences.ts
@@ -1,9 +1,8 @@
-import { SyntaxKind } from "typescript";
-
 import {
 	getTSNodeRange,
 	typescriptLanguage,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/ts/src/rules/setSizeLengthChecks.ts
+++ b/packages/ts/src/rules/setSizeLengthChecks.ts
@@ -1,3 +1,12 @@
+import type { Program } from "typescript";
+
+import {
+	getTSNodeRange,
+	isGlobalDeclarationOfName,
+	typescriptLanguage,
+	type AST,
+	type Checker,
+} from "@flint.fyi/typescript-language";
 import {
 	isArrayLiteralExpression,
 	isIdentifier,
@@ -7,16 +16,7 @@ import {
 	isVariableDeclaration,
 	NodeFlags,
 	SyntaxKind,
-	type Program,
-} from "typescript";
-
-import {
-	getTSNodeRange,
-	isGlobalDeclarationOfName,
-	typescriptLanguage,
-	type AST,
-	type Checker,
-} from "@flint.fyi/typescript-language";
+} from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/ts/src/rules/setterReturns.ts
+++ b/packages/ts/src/rules/setterReturns.ts
@@ -1,11 +1,10 @@
-import * as tsutils from "ts-api-utils";
-import { SyntaxKind } from "typescript";
-
 import {
 	forEachChild,
 	typescriptLanguage,
 	type AST,
 } from "@flint.fyi/typescript-language";
+import tsutils from "@flint.fyi/typescript-language/ts-api-utils";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/ts/src/rules/shadowedRestrictedNames.ts
+++ b/packages/ts/src/rules/shadowedRestrictedNames.ts
@@ -1,10 +1,11 @@
-import { SyntaxKind, type NodeArray } from "typescript";
+import type { NodeArray } from "typescript";
 
 import {
 	getTSNodeRange,
 	typescriptLanguage,
 	type AST,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/ts/src/rules/singleVariableDeclarations.ts
+++ b/packages/ts/src/rules/singleVariableDeclarations.ts
@@ -1,9 +1,8 @@
-import { SyntaxKind } from "typescript";
-
 import {
 	getTSNodeRange,
 	typescriptLanguage,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/ts/src/rules/sizeComparisonOperators.ts
+++ b/packages/ts/src/rules/sizeComparisonOperators.ts
@@ -1,4 +1,3 @@
-import { SyntaxKind } from "typescript";
 import { z } from "zod/v4";
 
 import {
@@ -7,6 +6,7 @@ import {
 	typescriptLanguage,
 	type AST,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/ts/src/rules/sparseArrays.ts
+++ b/packages/ts/src/rules/sparseArrays.ts
@@ -1,6 +1,5 @@
-import { SyntaxKind } from "typescript";
-
 import { typescriptLanguage } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 import { nullThrows } from "@flint.fyi/utils";
 
 import { ruleCreator } from "./ruleCreator.ts";

--- a/packages/ts/src/rules/staticMemberOnlyClasses.ts
+++ b/packages/ts/src/rules/staticMemberOnlyClasses.ts
@@ -1,4 +1,4 @@
-import ts, { SyntaxKind } from "typescript";
+import type ts from "typescript";
 
 import {
 	getTSNodeRange,
@@ -6,11 +6,14 @@ import {
 	type AST,
 	type TypeScriptFileServices,
 } from "@flint.fyi/typescript-language";
+import typescript, {
+	SyntaxKind,
+} from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 
 function hasDecorators(node: AST.ClassDeclaration | AST.ClassExpression) {
-	return node.modifiers?.some(ts.isDecorator) ?? false;
+	return node.modifiers?.some(typescript.isDecorator) ?? false;
 }
 
 function hasExtendsClause(node: AST.ClassDeclaration | AST.ClassExpression) {

--- a/packages/ts/src/rules/stringCaseMismatches.ts
+++ b/packages/ts/src/rules/stringCaseMismatches.ts
@@ -1,9 +1,8 @@
-import { SyntaxKind } from "typescript";
-
 import {
 	getStaticStringValue,
 	typescriptLanguage,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/ts/src/rules/stringCodePoints.ts
+++ b/packages/ts/src/rules/stringCodePoints.ts
@@ -1,10 +1,12 @@
-import * as tsutils from "ts-api-utils";
-import { SyntaxKind, TypeFlags } from "typescript";
-
 import {
 	isGlobalDeclarationOfName,
 	typescriptLanguage,
 } from "@flint.fyi/typescript-language";
+import tsutils from "@flint.fyi/typescript-language/ts-api-utils";
+import {
+	SyntaxKind,
+	TypeFlags,
+} from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/ts/src/rules/stringSliceMethods.ts
+++ b/packages/ts/src/rules/stringSliceMethods.ts
@@ -1,10 +1,12 @@
-import * as tsutils from "ts-api-utils";
-import { SyntaxKind, TypeFlags } from "typescript";
-
 import {
 	getTSNodeRange,
 	typescriptLanguage,
 } from "@flint.fyi/typescript-language";
+import tsutils from "@flint.fyi/typescript-language/ts-api-utils";
+import {
+	SyntaxKind,
+	TypeFlags,
+} from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 import { getConstrainedTypeAtLocation } from "./utils/getConstrainedType.ts";

--- a/packages/ts/src/rules/stringStartsEndsWith.ts
+++ b/packages/ts/src/rules/stringStartsEndsWith.ts
@@ -1,9 +1,8 @@
-import { SyntaxKind } from "typescript";
-
 import {
 	getTSNodeRange,
 	typescriptLanguage,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/ts/src/rules/structuredCloneMethods.ts
+++ b/packages/ts/src/rules/structuredCloneMethods.ts
@@ -1,4 +1,4 @@
-import { SyntaxKind, type Program } from "typescript";
+import type { Program } from "typescript";
 
 import {
 	isGlobalDeclarationOfName,
@@ -6,6 +6,7 @@ import {
 	type AST,
 	type Checker,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/ts/src/rules/symbolDescriptions.ts
+++ b/packages/ts/src/rules/symbolDescriptions.ts
@@ -1,6 +1,5 @@
-import { SyntaxKind } from "typescript";
-
 import { typescriptLanguage } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/ts/src/rules/thisAliases.ts
+++ b/packages/ts/src/rules/thisAliases.ts
@@ -1,6 +1,5 @@
-import { SyntaxKind } from "typescript";
-
 import { typescriptLanguage, type AST } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/ts/src/rules/thisBeforeSuper.ts
+++ b/packages/ts/src/rules/thisBeforeSuper.ts
@@ -1,10 +1,9 @@
-import { SyntaxKind } from "typescript";
-
 import {
 	forEachChild,
 	typescriptLanguage,
 	type AST,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/ts/src/rules/throwErrors.ts
+++ b/packages/ts/src/rules/throwErrors.ts
@@ -1,5 +1,4 @@
-import * as tsutils from "ts-api-utils";
-import { TypeFlags, type Program, type Type } from "typescript";
+import type { Program, Type } from "typescript";
 
 import {
 	declarationIncludesGlobal,
@@ -8,6 +7,8 @@ import {
 	type AST,
 	type TypeScriptFileServices,
 } from "@flint.fyi/typescript-language";
+import tsutils from "@flint.fyi/typescript-language/ts-api-utils";
+import { TypeFlags } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 import { getConstrainedTypeAtLocation } from "./utils/getConstrainedType.ts";

--- a/packages/ts/src/rules/topLevelAwaits.ts
+++ b/packages/ts/src/rules/topLevelAwaits.ts
@@ -1,13 +1,16 @@
-import ts, { SyntaxKind } from "typescript";
+import type ts from "typescript";
 
 import { typescriptLanguage, type AST } from "@flint.fyi/typescript-language";
+import typescript, {
+	SyntaxKind,
+} from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 
 function hasExportModifier(node: AST.Statement) {
 	return !!(
-		ts.canHaveModifiers(node) &&
-		ts
+		typescript.canHaveModifiers(node) &&
+		typescript
 			.getModifiers(node)
 			?.some((modifier) => modifier.kind === SyntaxKind.ExportKeyword)
 	);
@@ -18,13 +21,13 @@ function isInsideFunction(node: ts.Node): boolean {
 
 	while (current) {
 		if (
-			ts.isFunctionDeclaration(current) ||
-			ts.isFunctionExpression(current) ||
-			ts.isArrowFunction(current) ||
-			ts.isMethodDeclaration(current) ||
-			ts.isConstructorDeclaration(current) ||
-			ts.isGetAccessorDeclaration(current) ||
-			ts.isSetAccessorDeclaration(current)
+			typescript.isFunctionDeclaration(current) ||
+			typescript.isFunctionExpression(current) ||
+			typescript.isArrowFunction(current) ||
+			typescript.isMethodDeclaration(current) ||
+			typescript.isConstructorDeclaration(current) ||
+			typescript.isGetAccessorDeclaration(current) ||
+			typescript.isSetAccessorDeclaration(current)
 		) {
 			return true;
 		} // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion -- removing causes type error on the `while` loop. TSESLint bug?

--- a/packages/ts/src/rules/tsComments.ts
+++ b/packages/ts/src/rules/tsComments.ts
@@ -1,4 +1,4 @@
-import * as tsutils from "ts-api-utils";
+import type { Comment } from "ts-api-utils";
 import { z } from "zod/v4";
 
 import type {
@@ -6,6 +6,7 @@ import type {
 	ReportInterpolationData,
 } from "@flint.fyi/core";
 import { typescriptLanguage } from "@flint.fyi/typescript-language";
+import tsutils from "@flint.fyi/typescript-language/ts-api-utils";
 
 import { ruleCreator } from "./ruleCreator.ts";
 
@@ -125,7 +126,7 @@ export default ruleCreator.createRule(typescriptLanguage, {
 			visitors: {
 				SourceFile(node, { options }) {
 					function reportCommentDirective(
-						comment: tsutils.Comment,
+						comment: Comment,
 						directive: string,
 						data: ReportInterpolationData,
 						messageDefault: MessageForContext<typeof context>,
@@ -197,7 +198,7 @@ export default ruleCreator.createRule(typescriptLanguage, {
 					}
 
 					function checkComment(
-						comment: tsutils.Comment,
+						comment: Comment,
 						directive: SuppressionDirective,
 						description: string,
 					) {

--- a/packages/ts/src/rules/tslintComments.ts
+++ b/packages/ts/src/rules/tslintComments.ts
@@ -1,6 +1,5 @@
-import * as tsutils from "ts-api-utils";
-
 import { typescriptLanguage } from "@flint.fyi/typescript-language";
+import tsutils from "@flint.fyi/typescript-language/ts-api-utils";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/ts/src/rules/typeAssertionStyles.ts
+++ b/packages/ts/src/rules/typeAssertionStyles.ts
@@ -1,10 +1,9 @@
-import { SyntaxKind } from "typescript";
-
 import {
 	getTSNodeRange,
 	typescriptLanguage,
 	type AST,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/ts/src/rules/typeImports.ts
+++ b/packages/ts/src/rules/typeImports.ts
@@ -1,12 +1,4 @@
-import {
-	isExpressionWithTypeArguments,
-	isShorthandPropertyAssignment,
-	isTypeNode,
-	isTypeParameterDeclaration,
-	SymbolFlags,
-	SyntaxKind,
-	type Symbol,
-} from "typescript";
+import type { Symbol } from "typescript";
 import { z } from "zod/v4";
 
 import {
@@ -16,6 +8,14 @@ import {
 	type AST,
 	type Checker,
 } from "@flint.fyi/typescript-language";
+import {
+	isExpressionWithTypeArguments,
+	isShorthandPropertyAssignment,
+	isTypeNode,
+	isTypeParameterDeclaration,
+	SymbolFlags,
+	SyntaxKind,
+} from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/ts/src/rules/typeofComparisons.ts
+++ b/packages/ts/src/rules/typeofComparisons.ts
@@ -1,11 +1,10 @@
-import { SyntaxKind } from "typescript";
-
 import {
 	getStaticStringValue,
 	getTSNodeRange,
 	typescriptLanguage,
 	type AST,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/ts/src/rules/unassignedVariables.ts
+++ b/packages/ts/src/rules/unassignedVariables.ts
@@ -1,9 +1,10 @@
-import ts, { SyntaxKind } from "typescript";
-
 import {
 	getModifyingReferences,
 	typescriptLanguage,
 } from "@flint.fyi/typescript-language";
+import typescript, {
+	SyntaxKind,
+} from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 
@@ -37,7 +38,7 @@ export default ruleCreator.createRule(typescriptLanguage, {
 
 					if (
 						node.parent.kind === SyntaxKind.VariableDeclarationList &&
-						!!(node.parent.flags & ts.NodeFlags.Const)
+						!!(node.parent.flags & typescript.NodeFlags.Const)
 					) {
 						return;
 					}

--- a/packages/ts/src/rules/undefinedTypeofChecks.ts
+++ b/packages/ts/src/rules/undefinedTypeofChecks.ts
@@ -1,10 +1,9 @@
-import { SyntaxKind } from "typescript";
-
 import {
 	getTSNodeRange,
 	typescriptLanguage,
 	type AST,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/ts/src/rules/undefinedVariables.ts
+++ b/packages/ts/src/rules/undefinedVariables.ts
@@ -1,6 +1,5 @@
-import { SyntaxKind } from "typescript";
-
 import { typescriptLanguage } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/ts/src/rules/unnecessaryBinds.ts
+++ b/packages/ts/src/rules/unnecessaryBinds.ts
@@ -1,9 +1,12 @@
-import ts, { SyntaxKind } from "typescript";
+import type ts from "typescript";
 
 import {
 	getTSNodeRange,
 	typescriptLanguage,
 } from "@flint.fyi/typescript-language";
+import typescript, {
+	SyntaxKind,
+} from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 
@@ -15,9 +18,9 @@ function containsThis(node: ts.Node): boolean {
 	}
 
 	if (
-		ts.isFunctionExpression(node) ||
-		ts.isFunctionDeclaration(node) ||
-		ts.isArrowFunction(node)
+		typescript.isFunctionExpression(node) ||
+		typescript.isFunctionDeclaration(node) ||
+		typescript.isArrowFunction(node)
 	) {
 		return false;
 	}
@@ -34,23 +37,23 @@ function containsThis(node: ts.Node): boolean {
 // TODO: Use a util like getStaticValue
 // https://github.com/flint-fyi/flint/issues/1298
 function isStaticValue(node: ts.Expression): boolean {
-	if (ts.isParenthesizedExpression(node)) {
+	if (typescript.isParenthesizedExpression(node)) {
 		return isStaticValue(node.expression);
 	}
 
-	if (ts.isPrefixUnaryExpression(node)) {
+	if (typescript.isPrefixUnaryExpression(node)) {
 		return isStaticValue(node.operand);
 	}
 
-	if (ts.isIdentifier(node)) {
+	if (typescript.isIdentifier(node)) {
 		return true;
 	}
 
-	if (ts.isPropertyAccessExpression(node)) {
+	if (typescript.isPropertyAccessExpression(node)) {
 		return isStaticValue(node.expression);
 	}
 
-	if (ts.isElementAccessExpression(node)) {
+	if (typescript.isElementAccessExpression(node)) {
 		return (
 			isStaticValue(node.expression) && isStaticValue(node.argumentExpression)
 		);
@@ -62,16 +65,16 @@ function isStaticValue(node: ts.Expression): boolean {
 		node.kind === SyntaxKind.TrueKeyword ||
 		node.kind === SyntaxKind.FalseKeyword ||
 		node.kind === SyntaxKind.NullKeyword ||
-		ts.isBigIntLiteral(node) ||
-		ts.isNumericLiteral(node) ||
-		ts.isStringLiteral(node) ||
-		ts.isNoSubstitutionTemplateLiteral(node) ||
+		typescript.isBigIntLiteral(node) ||
+		typescript.isNumericLiteral(node) ||
+		typescript.isStringLiteral(node) ||
+		typescript.isNoSubstitutionTemplateLiteral(node) ||
 		node.kind === SyntaxKind.RegularExpressionLiteral
 	);
 }
 
 function unwrapParentheses(node: ts.Expression): ts.Expression {
-	while (ts.isParenthesizedExpression(node)) {
+	while (typescript.isParenthesizedExpression(node)) {
 		node = node.expression;
 	}
 	return node;
@@ -133,7 +136,7 @@ export default ruleCreator.createRule(typescriptLanguage, {
 							}
 						: undefined;
 
-					if (ts.isArrowFunction(boundFunction)) {
+					if (typescript.isArrowFunction(boundFunction)) {
 						context.report({
 							fix,
 							message: "arrowBind",
@@ -146,7 +149,7 @@ export default ruleCreator.createRule(typescriptLanguage, {
 					}
 
 					if (
-						ts.isFunctionExpression(boundFunction) &&
+						typescript.isFunctionExpression(boundFunction) &&
 						!containsThis(boundFunction.body)
 					) {
 						context.report({

--- a/packages/ts/src/rules/unnecessaryBlocks.ts
+++ b/packages/ts/src/rules/unnecessaryBlocks.ts
@@ -1,14 +1,15 @@
-import { isNodeFlagSet } from "ts-api-utils";
-import ts, { SyntaxKind } from "typescript";
-
 import { typescriptLanguage, type AST } from "@flint.fyi/typescript-language";
+import tsutils from "@flint.fyi/typescript-language/ts-api-utils";
+import typescript, {
+	SyntaxKind,
+} from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 
 function isUsingVariableStatement(node: AST.AnyNode) {
 	return (
 		node.kind === SyntaxKind.VariableStatement &&
-		isNodeFlagSet(node.declarationList, ts.NodeFlags.Using)
+		tsutils.isNodeFlagSet(node.declarationList, typescript.NodeFlags.Using)
 	);
 }
 

--- a/packages/ts/src/rules/unnecessaryBooleanCasts.ts
+++ b/packages/ts/src/rules/unnecessaryBooleanCasts.ts
@@ -1,10 +1,9 @@
-import { SyntaxKind } from "typescript";
-
 import {
 	getTSNodeRange,
 	typescriptLanguage,
 	type AST,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 import { isInBooleanContext } from "./utils/isInBooleanContext.ts";

--- a/packages/ts/src/rules/unnecessaryCatches.ts
+++ b/packages/ts/src/rules/unnecessaryCatches.ts
@@ -1,6 +1,5 @@
-import { SyntaxKind } from "typescript";
-
 import { typescriptLanguage } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/ts/src/rules/unnecessaryComparisons.ts
+++ b/packages/ts/src/rules/unnecessaryComparisons.ts
@@ -1,5 +1,3 @@
-import { SyntaxKind } from "typescript";
-
 import {
 	getStaticNumberValue,
 	getTSNodeRange,
@@ -8,6 +6,7 @@ import {
 	unwrapParenthesizedNode,
 	type AST,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 import { isComparisonOperator } from "./utils/operators.ts";

--- a/packages/ts/src/rules/unnecessaryConcatenation.ts
+++ b/packages/ts/src/rules/unnecessaryConcatenation.ts
@@ -1,9 +1,8 @@
-import { SyntaxKind } from "typescript";
-
 import {
 	getTSNodeRange,
 	typescriptLanguage,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/ts/src/rules/unnecessaryEscapes.ts
+++ b/packages/ts/src/rules/unnecessaryEscapes.ts
@@ -1,10 +1,9 @@
-import { SyntaxKind } from "typescript";
-
 import {
 	typescriptLanguage,
 	type AST,
 	type TypeScriptFileServices,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/ts/src/rules/unnecessaryMathClamps.ts
+++ b/packages/ts/src/rules/unnecessaryMathClamps.ts
@@ -1,4 +1,4 @@
-import { SyntaxKind, type Program } from "typescript";
+import type { Program } from "typescript";
 
 import {
 	getStaticNumberValue,
@@ -9,6 +9,7 @@ import {
 	type AST,
 	type Checker,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/ts/src/rules/unnecessaryRenames.ts
+++ b/packages/ts/src/rules/unnecessaryRenames.ts
@@ -1,5 +1,3 @@
-import { SyntaxKind } from "typescript";
-
 import type { CharacterReportRange } from "@flint.fyi/core";
 import {
 	getTSNodeRange,
@@ -7,6 +5,7 @@ import {
 	unwrapParenthesizedNode,
 	type AST,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 import { countCommentsInRange } from "./utils/countCommentsInRange.ts";

--- a/packages/ts/src/rules/unnecessaryTernaries.ts
+++ b/packages/ts/src/rules/unnecessaryTernaries.ts
@@ -1,11 +1,10 @@
-import { SyntaxKind } from "typescript";
-
 import {
 	getTSNodeRange,
 	hasSameTokens,
 	typescriptLanguage,
 	type AST,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/ts/src/rules/unnecessaryUseStricts.ts
+++ b/packages/ts/src/rules/unnecessaryUseStricts.ts
@@ -1,9 +1,10 @@
-import ts, { SyntaxKind } from "typescript";
-
 import {
 	getTSNodeRange,
 	typescriptLanguage,
 } from "@flint.fyi/typescript-language";
+import typescript, {
+	SyntaxKind,
+} from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 
@@ -29,7 +30,7 @@ export default ruleCreator.createRule(typescriptLanguage, {
 		return {
 			visitors: {
 				SourceFile(node, { sourceFile }) {
-					if (!ts.isExternalModule(sourceFile)) {
+					if (!typescript.isExternalModule(sourceFile)) {
 						return;
 					}
 

--- a/packages/ts/src/rules/unsafeNegations.ts
+++ b/packages/ts/src/rules/unsafeNegations.ts
@@ -1,9 +1,8 @@
-import { SyntaxKind } from "typescript";
-
 import {
 	typescriptLanguage,
 	unwrapParenthesizedNode,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/ts/src/rules/utils/collectAccessorPairs.ts
+++ b/packages/ts/src/rules/utils/collectAccessorPairs.ts
@@ -1,7 +1,7 @@
 import type ts from "typescript";
-import { SyntaxKind } from "typescript";
 
 import type { AST } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 export interface AccessorInfo {
 	index: number;

--- a/packages/ts/src/rules/utils/countCommentsInRange.ts
+++ b/packages/ts/src/rules/utils/countCommentsInRange.ts
@@ -1,15 +1,16 @@
-import ts, { SyntaxKind } from "typescript";
-
 import type { CharacterReportRange } from "@flint.fyi/core";
+import typescript, {
+	SyntaxKind,
+} from "@flint.fyi/typescript-language/typescript";
 
 export function countCommentsInRange(
 	sourceText: string,
 	{ begin, end }: CharacterReportRange,
 ): number {
-	const scanner = ts.createScanner(
-		ts.ScriptTarget.Latest,
+	const scanner = typescript.createScanner(
+		typescript.ScriptTarget.Latest,
 		false,
-		ts.LanguageVariant.Standard,
+		typescript.LanguageVariant.Standard,
 		sourceText.slice(begin, end),
 	);
 	let count = 0;

--- a/packages/ts/src/rules/utils/discriminateAnyType.ts
+++ b/packages/ts/src/rules/utils/discriminateAnyType.ts
@@ -1,7 +1,8 @@
-import * as tsutils from "ts-api-utils";
-import ts from "typescript";
+import type ts from "typescript";
 
 import type { Checker } from "@flint.fyi/typescript-language";
+import tsutils from "@flint.fyi/typescript-language/ts-api-utils";
+import typescript from "@flint.fyi/typescript-language/typescript";
 import { nullThrows } from "@flint.fyi/utils";
 
 export const AnyType = {
@@ -35,7 +36,7 @@ function discriminateAnyTypeWorker(
 		return AnyType.Safe;
 	}
 	visited.add(type);
-	if (tsutils.isTypeFlagSet(type, ts.TypeFlags.Any)) {
+	if (tsutils.isTypeFlagSet(type, typescript.TypeFlags.Any)) {
 		return tsutils.isIntrinsicErrorType(type) ? AnyType.Error : AnyType.Any;
 	}
 	if (checker.isArrayType(type)) {
@@ -44,7 +45,7 @@ function discriminateAnyTypeWorker(
 			"Array type should have at least one type argument",
 		);
 		if (
-			tsutils.isTypeFlagSet(elementType, ts.TypeFlags.Any) &&
+			tsutils.isTypeFlagSet(elementType, typescript.TypeFlags.Any) &&
 			!tsutils.isIntrinsicErrorType(elementType)
 		) {
 			return AnyType.AnyArray;

--- a/packages/ts/src/rules/utils/equalityOperators.ts
+++ b/packages/ts/src/rules/utils/equalityOperators.ts
@@ -1,9 +1,8 @@
-import { SyntaxKind } from "typescript";
-
 import {
 	unwrapParenthesizedNode,
 	type AST,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 export type EqualityOperator = "!=" | "!==" | "==" | "===";
 

--- a/packages/ts/src/rules/utils/forEachReturnStatement.ts
+++ b/packages/ts/src/rules/utils/forEachReturnStatement.ts
@@ -1,4 +1,8 @@
-import ts, { SyntaxKind } from "typescript";
+import type ts from "typescript";
+
+import typescript, {
+	SyntaxKind,
+} from "@flint.fyi/typescript-language/typescript";
 
 // Copied from typescript https://github.com/microsoft/TypeScript/blob/42b0e3c4630c129ca39ce0df9fff5f0d1b4dd348/src/compiler/utilities.ts#L1335
 // Warning: This has the same semantics as the forEach family of functions,
@@ -26,7 +30,7 @@ export function forEachReturnStatement<T>(
 			case SyntaxKind.TryStatement:
 			case SyntaxKind.WhileStatement:
 			case SyntaxKind.WithStatement:
-				return ts.forEachChild(node, traverse);
+				return typescript.forEachChild(node, traverse);
 
 			case SyntaxKind.ReturnStatement:
 				return visitor(node as ts.ReturnStatement);

--- a/packages/ts/src/rules/utils/formatReportedType.ts
+++ b/packages/ts/src/rules/utils/formatReportedType.ts
@@ -1,7 +1,7 @@
-import * as tsutils from "ts-api-utils";
 import type ts from "typescript";
 
 import type { Checker } from "@flint.fyi/typescript-language";
+import tsutils from "@flint.fyi/typescript-language/ts-api-utils";
 
 export function formatReportedType(
 	type: ts.Type,

--- a/packages/ts/src/rules/utils/getFunctionName.test.ts
+++ b/packages/ts/src/rules/utils/getFunctionName.test.ts
@@ -1,14 +1,14 @@
+import type { Node } from "typescript";
+import { describe, expect, it } from "vitest";
+
+import type { AST } from "@flint.fyi/typescript-language";
 import {
 	createSourceFile,
 	forEachChild,
 	ScriptKind,
 	ScriptTarget,
 	SyntaxKind,
-	type Node,
-} from "typescript";
-import { describe, expect, it } from "vitest";
-
-import type { AST } from "@flint.fyi/typescript-language";
+} from "@flint.fyi/typescript-language/typescript";
 
 import { getFunctionName } from "./getFunctionName.ts";
 

--- a/packages/ts/src/rules/utils/getFunctionName.ts
+++ b/packages/ts/src/rules/utils/getFunctionName.ts
@@ -1,6 +1,5 @@
-import { SyntaxKind } from "typescript";
-
 import type { AST } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 export function getFunctionName(
 	node:

--- a/packages/ts/src/rules/utils/getRegExpConstruction.ts
+++ b/packages/ts/src/rules/utils/getRegExpConstruction.ts
@@ -1,4 +1,4 @@
-import { SyntaxKind, type NodeArray } from "typescript";
+import type { NodeArray } from "typescript";
 
 import {
 	getStaticStringValue,
@@ -6,6 +6,7 @@ import {
 	type AST,
 	type TypeScriptFileServices,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 export interface RegExpConstruction {
 	args: NodeArray<AST.Expression>;

--- a/packages/ts/src/rules/utils/getThisExpression.ts
+++ b/packages/ts/src/rules/utils/getThisExpression.ts
@@ -1,6 +1,5 @@
-import { SyntaxKind } from "typescript";
-
 import type { AST } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { skipParentheses } from "./skipParentheses.ts";
 

--- a/packages/ts/src/rules/utils/isBuiltinSymbolLike.ts
+++ b/packages/ts/src/rules/utils/isBuiltinSymbolLike.ts
@@ -1,5 +1,7 @@
-import * as tsutils from "ts-api-utils";
-import ts from "typescript";
+import type ts from "typescript";
+
+import tsutils from "@flint.fyi/typescript-language/ts-api-utils";
+import typescript from "@flint.fyi/typescript-language/typescript";
 
 export function isBuiltinSymbolLike(
 	program: ts.Program,
@@ -24,7 +26,7 @@ export function isBuiltinSymbolLike(
 		if (
 			actualSymbolName === "Function" &&
 			tsutils.isObjectType(subType) &&
-			tsutils.isObjectFlagSet(subType, ts.ObjectFlags.Anonymous)
+			tsutils.isObjectFlagSet(subType, typescript.ObjectFlags.Anonymous)
 		) {
 			return false;
 		}

--- a/packages/ts/src/rules/utils/isDirectEqualityCheck.ts
+++ b/packages/ts/src/rules/utils/isDirectEqualityCheck.ts
@@ -1,6 +1,5 @@
-import { SyntaxKind } from "typescript";
-
 import type { AST } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 export function isDirectEqualityCheck(
 	node: AST.ArrowFunction | AST.FunctionExpression,

--- a/packages/ts/src/rules/utils/isErrorSubclass.ts
+++ b/packages/ts/src/rules/utils/isErrorSubclass.ts
@@ -1,10 +1,14 @@
-import { isIdentifier, SyntaxKind, type Program } from "typescript";
+import type { Program } from "typescript";
 
 import {
 	isGlobalDeclaration,
 	type AST,
 	type Checker,
 } from "@flint.fyi/typescript-language";
+import {
+	isIdentifier,
+	SyntaxKind,
+} from "@flint.fyi/typescript-language/typescript";
 
 const builtinErrorNames = new Set([
 	"Error",

--- a/packages/ts/src/rules/utils/isInBooleanContext.ts
+++ b/packages/ts/src/rules/utils/isInBooleanContext.ts
@@ -1,6 +1,5 @@
-import { SyntaxKind } from "typescript";
-
 import type { AST } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 export function isInBooleanContext(node: AST.AnyNode): boolean {
 	switch (node.parent.kind) {

--- a/packages/ts/src/rules/utils/isUnsafeAssignment.ts
+++ b/packages/ts/src/rules/utils/isUnsafeAssignment.ts
@@ -1,7 +1,10 @@
-import * as tsutils from "ts-api-utils";
-import ts, { SyntaxKind } from "typescript";
+import type ts from "typescript";
 
 import type { AST } from "@flint.fyi/typescript-language";
+import tsutils from "@flint.fyi/typescript-language/ts-api-utils";
+import typescript, {
+	SyntaxKind,
+} from "@flint.fyi/typescript-language/typescript";
 import { nullThrows } from "@flint.fyi/utils";
 
 /**
@@ -26,13 +29,13 @@ function isUnsafeAssignmentWorker(
 	senderNode: AST.Expression,
 	visited: Map<ts.Type, Set<ts.Type>>,
 ): false | { receiver: ts.Type; sender: ts.Type } {
-	if (tsutils.isTypeFlagSet(type, ts.TypeFlags.Any)) {
+	if (tsutils.isTypeFlagSet(type, typescript.TypeFlags.Any)) {
 		// Allow assignment of any ==> unknown.
-		if (tsutils.isTypeFlagSet(receiver, ts.TypeFlags.Unknown)) {
+		if (tsutils.isTypeFlagSet(receiver, typescript.TypeFlags.Unknown)) {
 			return false;
 		}
 
-		if (!tsutils.isTypeFlagSet(receiver, ts.TypeFlags.Any)) {
+		if (!tsutils.isTypeFlagSet(receiver, typescript.TypeFlags.Any)) {
 			return { receiver, sender: type };
 		}
 	}

--- a/packages/ts/src/rules/utils/operators.ts
+++ b/packages/ts/src/rules/utils/operators.ts
@@ -1,6 +1,5 @@
-import { SyntaxKind } from "typescript";
-
 import type { AST } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 export function isComparisonOperator(token: AST.BinaryOperatorToken): boolean {
 	switch (token.kind) {

--- a/packages/ts/src/rules/utils/skipParentheses.ts
+++ b/packages/ts/src/rules/utils/skipParentheses.ts
@@ -1,6 +1,5 @@
-import { SyntaxKind } from "typescript";
-
 import type { AST } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 export function skipParentheses(node: AST.Expression): AST.Expression {
 	while (node.kind === SyntaxKind.ParenthesizedExpression) {

--- a/packages/ts/src/rules/variableDeletions.ts
+++ b/packages/ts/src/rules/variableDeletions.ts
@@ -1,6 +1,5 @@
-import { SyntaxKind } from "typescript";
-
 import { typescriptLanguage } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/ts/src/rules/wrapperObjects.ts
+++ b/packages/ts/src/rules/wrapperObjects.ts
@@ -1,10 +1,9 @@
-import { SyntaxKind } from "typescript";
-
 import {
 	getTSNodeRange,
 	isGlobalDeclarationOfName,
 	typescriptLanguage,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "./ruleCreator.ts";
 

--- a/packages/ts/src/type-utils/isDeclaredInModuleBlock.ts
+++ b/packages/ts/src/type-utils/isDeclaredInModuleBlock.ts
@@ -1,4 +1,6 @@
-import ts from "typescript";
+import type ts from "typescript";
+
+import typescript from "@flint.fyi/typescript-language/typescript";
 
 // TODO (#400): Switch to scope analysis
 export function isDeclaredInModuleBlock(
@@ -6,11 +8,11 @@ export function isDeclaredInModuleBlock(
 	packageName: string,
 ): boolean {
 	let current: ts.Node = declaration;
-	while (!ts.isSourceFile(current)) {
+	while (!typescript.isSourceFile(current)) {
 		if (
-			ts.isModuleDeclaration(current) &&
-			!(current.flags & ts.NodeFlags.Namespace) &&
-			ts.isStringLiteral(current.name) &&
+			typescript.isModuleDeclaration(current) &&
+			!(current.flags & typescript.NodeFlags.Namespace) &&
+			typescript.isStringLiteral(current.name) &&
 			current.name.text === packageName
 		) {
 			return true;

--- a/packages/ts/src/type-utils/isFromFile.ts
+++ b/packages/ts/src/type-utils/isFromFile.ts
@@ -1,7 +1,8 @@
 import path from "node:path";
 
-import ts from "typescript";
+import type ts from "typescript";
 
+import typescript from "@flint.fyi/typescript-language/typescript";
 import { pathKey } from "@flint.fyi/utils";
 
 export function isFromFile(
@@ -16,7 +17,7 @@ export function isFromFile(
 		);
 	}
 
-	const caseSensitive = ts.sys.useCaseSensitiveFileNames;
+	const caseSensitive = typescript.sys.useCaseSensitiveFileNames;
 	return (
 		pathKey(sourceFile.fileName, caseSensitive) ===
 		pathKey(

--- a/packages/typescript-language/package.json
+++ b/packages/typescript-language/package.json
@@ -16,7 +16,9 @@
 	"sideEffects": true,
 	"type": "module",
 	"exports": {
-		".": "./src/index.ts"
+		".": "./src/index.ts",
+		"./ts-api-utils": "./src/ts-api-utils.ts",
+		"./typescript": "./src/typescript.ts"
 	},
 	"files": [
 		"dist/"
@@ -45,7 +47,9 @@
 	"publishConfig": {
 		"access": "public",
 		"exports": {
-			".": "./dist/index.mjs"
+			".": "./dist/index.mjs",
+			"./ts-api-utils": "./dist/ts-api-utils.mjs",
+			"./typescript": "./dist/typescript.mjs"
 		}
 	}
 }

--- a/packages/typescript-language/src/collectReferencedFilePaths.ts
+++ b/packages/typescript-language/src/collectReferencedFilePaths.ts
@@ -1,11 +1,12 @@
 import * as path from "node:path";
 
-import * as tsutils from "ts-api-utils";
-import ts from "typescript";
+import type ts from "typescript";
 
 import { nullThrows } from "@flint.fyi/utils";
 
+import tsutils from "./ts-api-utils.ts";
 import type * as AST from "./types/ast.ts";
+import typescript from "./typescript.ts";
 
 export function collectReferencedFilePaths(
 	program: ts.Program,
@@ -14,13 +15,13 @@ export function collectReferencedFilePaths(
 	const modulePaths = new Set<string>();
 
 	function resolveModulePath(moduleSpecifier: string): string | undefined {
-		const resolved = ts.resolveModuleName(
+		const resolved = typescript.resolveModuleName(
 			moduleSpecifier,
 			sourceFile.fileName,
 			program.getCompilerOptions(),
 			// TODO: Eventually, the file system should be abstracted
 			// https://github.com/flint-fyi/flint/issues/73
-			ts.sys,
+			typescript.sys,
 		);
 
 		if (resolved.resolvedModule?.isExternalLibraryImport === false) {
@@ -54,7 +55,7 @@ export function collectReferencedFilePaths(
 			modulePaths.add(resolvedPath);
 		}
 
-		ts.forEachChild(node, visit);
+		typescript.forEachChild(node, visit);
 	}
 
 	visit(sourceFile);
@@ -65,17 +66,17 @@ export function collectReferencedFilePaths(
 function isAwaitImportCall(node: ts.Node): node is AST.AwaitExpression & {
 	expression: ts.CallExpression & { arguments: [ts.StringLiteral] };
 } {
-	return ts.isAwaitExpression(node) && isImportCall(node.expression);
+	return typescript.isAwaitExpression(node) && isImportCall(node.expression);
 }
 
 function isImportCall(
 	node: ts.Node,
 ): node is ts.CallExpression & { arguments: [ts.StringLiteral] } {
 	return (
-		ts.isCallExpression(node) &&
+		typescript.isCallExpression(node) &&
 		tsutils.isImportExpression(node.expression) &&
 		!!node.arguments.length &&
-		ts.isStringLiteral(
+		typescript.isStringLiteral(
 			nullThrows(
 				node.arguments[0],
 				"First argument is expected to be present by prior length check",
@@ -88,7 +89,8 @@ function isImportDeclaration(
 	node: ts.Node,
 ): node is AST.ImportDeclaration & { moduleSpecifier: AST.StringLiteral } {
 	return (
-		ts.isImportDeclaration(node) && ts.isStringLiteral(node.moduleSpecifier)
+		typescript.isImportDeclaration(node) &&
+		typescript.isStringLiteral(node.moduleSpecifier)
 	);
 }
 
@@ -96,8 +98,8 @@ function isImportTypeNode(node: ts.Node): node is ts.ImportTypeNode & {
 	argument: ts.LiteralTypeNode & { literal: ts.StringLiteral };
 } {
 	return (
-		ts.isImportTypeNode(node) &&
-		ts.isLiteralTypeNode(node.argument) &&
-		ts.isStringLiteral(node.argument.literal)
+		typescript.isImportTypeNode(node) &&
+		typescript.isLiteralTypeNode(node.argument) &&
+		typescript.isStringLiteral(node.argument.literal)
 	);
 }

--- a/packages/typescript-language/src/convertTypeScriptDiagnosticToLanguageReport.ts
+++ b/packages/typescript-language/src/convertTypeScriptDiagnosticToLanguageReport.ts
@@ -4,7 +4,7 @@
 
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 
-import ts from "typescript";
+import type ts from "typescript";
 
 import {
 	getColumnAndLineOfPosition,
@@ -12,6 +12,8 @@ import {
 	type LanguageReport,
 	type SourceFileWithLineMapAndFileName,
 } from "@flint.fyi/core";
+
+import typescript from "./typescript.ts";
 
 export interface TSDiagnostic extends TSDiagnosticRelatedInformation {
 	relatedInformation?: TSDiagnosticRelatedInformation[];
@@ -54,7 +56,10 @@ function formatReport(diagnostic: TSDiagnostic) {
 	}
 	output += color(`TS${diagnostic.code}`, COLOR.Grey);
 	output += ": ";
-	output += ts.flattenDiagnosticMessageText(diagnostic.messageText, "\n");
+	output += typescript.flattenDiagnosticMessageText(
+		diagnostic.messageText,
+		"\n",
+	);
 	if (diagnostic.file !== undefined) {
 		output += "\n";
 		output += formatCodeSpan(
@@ -80,7 +85,8 @@ function formatReport(diagnostic: TSDiagnostic) {
 				output += formatCodeSpan(file, start!, length!, indent, COLOR.Cyan);
 			}
 			output += "\n";
-			output += indent + ts.flattenDiagnosticMessageText(messageText, "\n");
+			output +=
+				indent + typescript.flattenDiagnosticMessageText(messageText, "\n");
 		}
 	}
 

--- a/packages/typescript-language/src/createTypeScriptServerHost.ts
+++ b/packages/typescript-language/src/createTypeScriptServerHost.ts
@@ -2,10 +2,12 @@ import fs from "node:fs";
 import timers from "node:timers";
 
 import { resolve } from "pathe";
-import ts from "typescript";
+import type ts from "typescript";
 
 import { commonlyIgnoredPaths, type LinterHost } from "@flint.fyi/core";
 import { assert, FlintAssertionError } from "@flint.fyi/utils";
+
+import typescript from "./typescript.ts";
 
 function serverHostMethodNotImplemented(methodName: string): never {
 	throw new FlintAssertionError(
@@ -30,7 +32,7 @@ export function createTypeScriptServerHost(
 	host: LinterHost,
 ): ts.server.ServerHost {
 	return {
-		...ts.sys,
+		...typescript.sys,
 		args: [],
 		clearImmediate: timers.clearImmediate,
 		clearTimeout: timers.clearTimeout,
@@ -90,7 +92,7 @@ export function createTypeScriptServerHost(
 			};
 			fs.readdirSync = patchedReaddirSync;
 			try {
-				return ts.sys.readDirectory(
+				return typescript.sys.readDirectory(
 					directoryPath,
 					extensions,
 					exclude,
@@ -128,13 +130,13 @@ export function createTypeScriptServerHost(
 					let eventKind: ts.FileWatcherEventKind;
 					switch (event) {
 						case "changed":
-							eventKind = ts.FileWatcherEventKind.Changed;
+							eventKind = typescript.FileWatcherEventKind.Changed;
 							break;
 						case "created":
-							eventKind = ts.FileWatcherEventKind.Created;
+							eventKind = typescript.FileWatcherEventKind.Created;
 							break;
 						case "deleted":
-							eventKind = ts.FileWatcherEventKind.Deleted;
+							eventKind = typescript.FileWatcherEventKind.Deleted;
 							break;
 					}
 					callback(filePath, eventKind);

--- a/packages/typescript-language/src/directives/parseDirectivesFromTypeScriptFile.test.ts
+++ b/packages/typescript-language/src/directives/parseDirectivesFromTypeScriptFile.test.ts
@@ -1,7 +1,7 @@
-import ts from "typescript";
 import { describe, expect, it } from "vitest";
 
 import type * as AST from "../types/ast.ts";
+import typescript from "../typescript.ts";
 import {
 	extractDirectivesFromTypeScriptFile,
 	parseDirectivesFromTypeScriptFile,
@@ -9,10 +9,10 @@ import {
 
 describe(parseDirectivesFromTypeScriptFile, () => {
 	it("returns empty arrays when there are no directives", () => {
-		const sourceFile = ts.createSourceFile(
+		const sourceFile = typescript.createSourceFile(
 			"test.ts",
 			"// unrelated",
-			ts.ScriptTarget.ESNext,
+			typescript.ScriptTarget.ESNext,
 			true,
 		) as AST.SourceFile;
 
@@ -25,14 +25,14 @@ describe(parseDirectivesFromTypeScriptFile, () => {
 	});
 
 	it("returns parsed directives when there are comment directives", () => {
-		const sourceFile = ts.createSourceFile(
+		const sourceFile = typescript.createSourceFile(
 			"test.ts",
 			`
                 // flint-disable-file a
                 // flint-disable-next-line b
                 // flint-invalid
             `,
-			ts.ScriptTarget.ESNext,
+			typescript.ScriptTarget.ESNext,
 			true,
 		) as AST.SourceFile;
 
@@ -112,10 +112,10 @@ describe(parseDirectivesFromTypeScriptFile, () => {
 });
 
 function createSourceFile(content: string) {
-	return ts.createSourceFile(
+	return typescript.createSourceFile(
 		"test.ts",
 		content,
-		ts.ScriptTarget.ESNext,
+		typescript.ScriptTarget.ESNext,
 		true,
 	) as AST.SourceFile;
 }

--- a/packages/typescript-language/src/directives/parseDirectivesFromTypeScriptFile.ts
+++ b/packages/typescript-language/src/directives/parseDirectivesFromTypeScriptFile.ts
@@ -1,6 +1,3 @@
-import * as tsutils from "ts-api-utils";
-import ts, { SyntaxKind } from "typescript";
-
 import {
 	DirectivesCollector,
 	type DirectiveCollection,
@@ -9,7 +6,9 @@ import {
 import { nullThrows } from "@flint.fyi/utils";
 
 import { normalizeRange } from "../normalizeRange.ts";
+import tsutils from "../ts-api-utils.ts";
 import type * as AST from "../types/ast.ts";
+import typescript, { SyntaxKind } from "../typescript.ts";
 
 export interface ExtractedDirective {
 	range: NormalizedReportRangeObject;
@@ -80,7 +79,7 @@ function computeNextCodeLine(
 	}
 
 	// Skip comments and whitespace to find the first token on the next line
-	const scanner = ts.createScanner(
+	const scanner = typescript.createScanner(
 		sourceFile.languageVersion,
 		true,
 		sourceFile.languageVariant,

--- a/packages/typescript-language/src/language.ts
+++ b/packages/typescript-language/src/language.ts
@@ -2,12 +2,7 @@ import path from "node:path";
 
 import { createProjectService } from "@typescript-eslint/project-service";
 import { debugForFile } from "debug-for-file";
-import {
-	getPreEmitDiagnostics,
-	SyntaxKind,
-	type Node,
-	type Program,
-} from "typescript";
+import type { Node, Program } from "typescript";
 
 import {
 	createLanguage,
@@ -32,6 +27,7 @@ import type { TypeScriptNodesByName, TypeScriptNodeVisitors } from "./nodes.ts";
 import { orderTypeScriptFilePaths } from "./orderTypeScriptFilePaths.ts";
 import type * as AST from "./types/ast.ts";
 import type { Checker } from "./types/checker.ts";
+import { getPreEmitDiagnostics, SyntaxKind } from "./typescript.ts";
 
 export interface TypeScriptFileServices {
 	program: Program;

--- a/packages/typescript-language/src/orderTypeScriptFilePaths.ts
+++ b/packages/typescript-language/src/orderTypeScriptFilePaths.ts
@@ -1,10 +1,11 @@
 import { dirname, resolve } from "pathe";
-import ts from "typescript";
+import type ts from "typescript";
 
 import type { LinterHost } from "@flint.fyi/core";
 import { normalizePath, pathKey, type PathKey } from "@flint.fyi/utils";
 
 import { createTypeScriptServerHost } from "./createTypeScriptServerHost.ts";
+import typescript from "./typescript.ts";
 
 interface FilePathInfo {
 	absolute: string;
@@ -54,7 +55,7 @@ export function orderTypeScriptFilePaths(
 			return configByDirectory.get(directoryKey);
 		}
 
-		const configPath = ts.findConfigFile(
+		const configPath = typescript.findConfigFile(
 			directoryPathNormalized,
 			(path) => parseHost.fileExists(path),
 			tsConfigFileName,
@@ -72,7 +73,7 @@ export function orderTypeScriptFilePaths(
 			return parsedConfigByPath.get(configKey);
 		}
 
-		const parsed = ts.getParsedCommandLineOfConfigFile(
+		const parsed = typescript.getParsedCommandLineOfConfigFile(
 			configPath,
 			{},
 			parseHost,
@@ -86,7 +87,7 @@ export function orderTypeScriptFilePaths(
 						),
 						references: (parsed.projectReferences ?? [])
 							.map((reference) =>
-								resolve(cwd, ts.resolveProjectReferencePath(reference)),
+								resolve(cwd, typescript.resolveProjectReferencePath(reference)),
 							)
 							.sort(comparePaths),
 					};

--- a/packages/typescript-language/src/scope/identifierReferences.ts
+++ b/packages/typescript-language/src/scope/identifierReferences.ts
@@ -1,7 +1,6 @@
-import * as tsutils from "ts-api-utils";
-import { SyntaxKind } from "typescript";
-
+import tsutils from "../ts-api-utils.ts";
 import type * as AST from "../types/ast.ts";
+import { SyntaxKind } from "../typescript.ts";
 
 export function isNonReferenceIdentifier(identifier: AST.Identifier): boolean {
 	if (

--- a/packages/typescript-language/src/scope/scopeManager.test.ts
+++ b/packages/typescript-language/src/scope/scopeManager.test.ts
@@ -1,15 +1,18 @@
-import ts, { SyntaxKind } from "typescript";
 import { describe, expect, it } from "vitest";
 
 import type * as AST from "../types/ast.ts";
+import typescript, { SyntaxKind } from "../typescript.ts";
 import { forEachChild } from "../utils/forEachChild.ts";
 import { getScopeManager } from "./scopeManager.ts";
 
-function createSourceFile(sourceText: string, scriptKind = ts.ScriptKind.TS) {
-	return ts.createSourceFile(
+function createSourceFile(
+	sourceText: string,
+	scriptKind = typescript.ScriptKind.TS,
+) {
+	return typescript.createSourceFile(
 		"test.ts",
 		sourceText,
-		ts.ScriptTarget.ESNext,
+		typescript.ScriptTarget.ESNext,
 		true,
 		scriptKind,
 	) as AST.SourceFile;
@@ -209,7 +212,7 @@ describe(getScopeManager, () => {
 				return <input name="value" />;
 			}
 		`,
-			ts.ScriptKind.TSX,
+			typescript.ScriptKind.TSX,
 		);
 
 		const scopeManager = getScopeManager(sourceFile);

--- a/packages/typescript-language/src/scope/scopeManager.ts
+++ b/packages/typescript-language/src/scope/scopeManager.ts
@@ -1,7 +1,7 @@
 import { WeakCachedFactory } from "cached-factory";
-import { SyntaxKind } from "typescript";
 
 import type * as AST from "../types/ast.ts";
+import { SyntaxKind } from "../typescript.ts";
 import { forEachChild } from "../utils/forEachChild.ts";
 import {
 	isNonReferenceIdentifier,

--- a/packages/typescript-language/src/scope/scopes.ts
+++ b/packages/typescript-language/src/scope/scopes.ts
@@ -1,6 +1,5 @@
-import ts, { SyntaxKind } from "typescript";
-
 import type * as AST from "../types/ast.ts";
+import typescript, { SyntaxKind } from "../typescript.ts";
 import type {
 	FunctionWithParameters,
 	ScopeInternal,
@@ -53,7 +52,7 @@ export function getVariableDeclarationScope(
 ): ScopeInternal {
 	if (
 		node.parent.kind === SyntaxKind.VariableDeclarationList &&
-		!(node.parent.flags & ts.NodeFlags.BlockScoped)
+		!(node.parent.flags & typescript.NodeFlags.BlockScoped)
 	) {
 		return findContainingVariableScope(scope);
 	}

--- a/packages/typescript-language/src/ts-api-utils.ts
+++ b/packages/typescript-language/src/ts-api-utils.ts
@@ -1,0 +1,12 @@
+import { createRequire } from "node:module";
+
+import type * as tsutils from "ts-api-utils";
+
+// ts-api-utils' ESM build imports `typescript`, which makes Node run
+// cjs-module-lexer over all ~9MB of it. Its CJS build `require`s TypeScript
+// instead, reusing the instance already in the require cache.
+const require = createRequire(import.meta.url);
+
+const tsApiUtils = require("ts-api-utils") as typeof tsutils;
+
+export default tsApiUtils;

--- a/packages/typescript-language/src/typescript.ts
+++ b/packages/typescript-language/src/typescript.ts
@@ -1,0 +1,79 @@
+import { createRequire } from "node:module";
+import type * as ts from "typescript";
+
+// Importing `typescript` from ESM makes Node run cjs-module-lexer over all ~9MB
+// of it to enumerate named exports, work `enableCompileCache()` does not cover.
+// `require` skips it, so all internal value access goes through this module.
+const require = createRequire(import.meta.url);
+
+const typescript = require("typescript") as typeof ts;
+
+export default typescript;
+
+export type NodeFlags = ts.NodeFlags;
+export type ScriptKind = ts.ScriptKind;
+export type ScriptTarget = ts.ScriptTarget;
+export type SignatureKind = ts.SignatureKind;
+export type SymbolFlags = ts.SymbolFlags;
+export type SyntaxKind = ts.SyntaxKind;
+export type TypeFlags = ts.TypeFlags;
+
+export const NodeFlags: typeof ts.NodeFlags = typescript.NodeFlags;
+export const ScriptKind: typeof ts.ScriptKind = typescript.ScriptKind;
+export const ScriptTarget: typeof ts.ScriptTarget = typescript.ScriptTarget;
+export const SignatureKind: typeof ts.SignatureKind = typescript.SignatureKind;
+export const SymbolFlags: typeof ts.SymbolFlags = typescript.SymbolFlags;
+export const SyntaxKind: typeof ts.SyntaxKind = typescript.SyntaxKind;
+export const TypeFlags: typeof ts.TypeFlags = typescript.TypeFlags;
+
+export const createSourceFile: typeof ts.createSourceFile =
+	typescript.createSourceFile;
+export const forEachChild: typeof ts.forEachChild = typescript.forEachChild;
+export const getLeadingCommentRanges: typeof ts.getLeadingCommentRanges =
+	typescript.getLeadingCommentRanges;
+export const getPreEmitDiagnostics: typeof ts.getPreEmitDiagnostics =
+	typescript.getPreEmitDiagnostics;
+export const getTrailingCommentRanges: typeof ts.getTrailingCommentRanges =
+	typescript.getTrailingCommentRanges;
+export const isArrayLiteralExpression: typeof ts.isArrayLiteralExpression =
+	typescript.isArrayLiteralExpression;
+export const isBigIntLiteral: typeof ts.isBigIntLiteral =
+	typescript.isBigIntLiteral;
+export const isClassDeclaration: typeof ts.isClassDeclaration =
+	typescript.isClassDeclaration;
+export const isElementAccessExpression: typeof ts.isElementAccessExpression =
+	typescript.isElementAccessExpression;
+export const isExpressionWithTypeArguments: typeof ts.isExpressionWithTypeArguments =
+	typescript.isExpressionWithTypeArguments;
+export const isFunctionDeclaration: typeof ts.isFunctionDeclaration =
+	typescript.isFunctionDeclaration;
+export const isFunctionLike: typeof ts.isFunctionLike =
+	typescript.isFunctionLike;
+export const isIdentifier: typeof ts.isIdentifier = typescript.isIdentifier;
+export const isInterfaceDeclaration: typeof ts.isInterfaceDeclaration =
+	typescript.isInterfaceDeclaration;
+export const isLiteralExpression: typeof ts.isLiteralExpression =
+	typescript.isLiteralExpression;
+export const isNewExpression: typeof ts.isNewExpression =
+	typescript.isNewExpression;
+export const isNumericLiteral: typeof ts.isNumericLiteral =
+	typescript.isNumericLiteral;
+export const isParenthesizedExpression: typeof ts.isParenthesizedExpression =
+	typescript.isParenthesizedExpression;
+export const isPrefixUnaryExpression: typeof ts.isPrefixUnaryExpression =
+	typescript.isPrefixUnaryExpression;
+export const isPropertyAccessExpression: typeof ts.isPropertyAccessExpression =
+	typescript.isPropertyAccessExpression;
+export const isPropertySignature: typeof ts.isPropertySignature =
+	typescript.isPropertySignature;
+export const isShorthandPropertyAssignment: typeof ts.isShorthandPropertyAssignment =
+	typescript.isShorthandPropertyAssignment;
+export const isSpreadElement: typeof ts.isSpreadElement =
+	typescript.isSpreadElement;
+export const isStringLiteral: typeof ts.isStringLiteral =
+	typescript.isStringLiteral;
+export const isTypeNode: typeof ts.isTypeNode = typescript.isTypeNode;
+export const isTypeParameterDeclaration: typeof ts.isTypeParameterDeclaration =
+	typescript.isTypeParameterDeclaration;
+export const isVariableDeclaration: typeof ts.isVariableDeclaration =
+	typescript.isVariableDeclaration;

--- a/packages/typescript-language/src/utils/containsGlobalDeclarations.test.ts
+++ b/packages/typescript-language/src/utils/containsGlobalDeclarations.test.ts
@@ -1,6 +1,6 @@
-import ts from "typescript";
 import { describe, expect, it } from "vitest";
 
+import typescript from "../typescript.ts";
 import { containsGlobalDeclarations } from "./containsGlobalDeclarations.ts";
 
 describe(containsGlobalDeclarations, () => {
@@ -67,10 +67,10 @@ describe(containsGlobalDeclarations, () => {
 });
 
 function getSourceFile(rawFileContent: string) {
-	return ts.createSourceFile(
+	return typescript.createSourceFile(
 		"mayContainGlobals.ts",
 		rawFileContent,
-		ts.ScriptTarget.ESNext,
+		typescript.ScriptTarget.ESNext,
 		true,
 	);
 }

--- a/packages/typescript-language/src/utils/containsGlobalDeclarations.ts
+++ b/packages/typescript-language/src/utils/containsGlobalDeclarations.ts
@@ -1,4 +1,6 @@
-import ts, { SyntaxKind } from "typescript";
+import type ts from "typescript";
+
+import typescript, { SyntaxKind } from "../typescript.ts";
 
 /**
  * Inspects top-level statements of a TS source file to determine
@@ -7,11 +9,14 @@ import ts, { SyntaxKind } from "typescript";
 export function containsGlobalDeclarations(
 	sourceFileNode: ts.SourceFile,
 ): boolean {
-	const isModule = ts.isExternalModule(sourceFileNode);
+	const isModule = typescript.isExternalModule(sourceFileNode);
 
 	return sourceFileNode.statements.some((statement) => {
 		// Checks for 'declare global {}'
-		if (ts.isModuleDeclaration(statement) && statement.name.text === "global") {
+		if (
+			typescript.isModuleDeclaration(statement) &&
+			statement.name.text === "global"
+		) {
 			return true;
 		}
 
@@ -21,12 +26,12 @@ export function containsGlobalDeclarations(
 		}
 
 		// In a script file, top-level `declare` statements affect the global scope
-		const canHaveModifiers = ts.canHaveModifiers(statement);
+		const canHaveModifiers = typescript.canHaveModifiers(statement);
 		if (!canHaveModifiers) {
 			return false;
 		}
 
-		const modifiers = ts.getModifiers(statement);
+		const modifiers = typescript.getModifiers(statement);
 		return modifiers?.some((mod) => mod.kind === SyntaxKind.DeclareKeyword);
 	});
 }

--- a/packages/typescript-language/src/utils/forEachChild.ts
+++ b/packages/typescript-language/src/utils/forEachChild.ts
@@ -1,9 +1,10 @@
-import ts from "typescript";
+import type ts from "typescript";
 
 import type * as AST from "../types/ast.ts";
+import typescript from "../typescript.ts";
 
 // TODO (#2772): Fill out remaining TypeScript APIs
-export const forEachChild = ts.forEachChild as unknown as <T>(
+export const forEachChild = typescript.forEachChild as unknown as <T>(
 	node: AST.AnyNode,
 	cbNode: (node: AST.AnyNode) => T | undefined,
 	cbNodes?: (nodes: ts.NodeArray<AST.AnyNode>) => T | undefined,

--- a/packages/typescript-language/src/utils/getStaticValue.test.ts
+++ b/packages/typescript-language/src/utils/getStaticValue.test.ts
@@ -1,7 +1,8 @@
-import ts, { SyntaxKind } from "typescript";
+import type ts from "typescript";
 import { describe, expect, it } from "vitest";
 
 import type * as AST from "../types/ast.ts";
+import typescript, { SyntaxKind } from "../typescript.ts";
 import {
 	getStaticNumberValue,
 	getStaticStringValue,
@@ -81,12 +82,12 @@ describe(getStaticStringValue, () => {
 });
 
 function parseExpression(source: string): AST.Expression {
-	const sourceFile = ts.createSourceFile(
+	const sourceFile = typescript.createSourceFile(
 		"getStaticValue.test.ts",
 		`const value = ${source};`,
-		ts.ScriptTarget.ESNext,
+		typescript.ScriptTarget.ESNext,
 		true,
-		ts.ScriptKind.TS,
+		typescript.ScriptKind.TS,
 	);
 	const statement = sourceFile.statements[0];
 	if (statement?.kind !== SyntaxKind.VariableStatement) {

--- a/packages/typescript-language/src/utils/getStaticValue.ts
+++ b/packages/typescript-language/src/utils/getStaticValue.ts
@@ -1,6 +1,5 @@
-import { SyntaxKind } from "typescript";
-
 import type * as AST from "../types/ast.ts";
+import { SyntaxKind } from "../typescript.ts";
 import { unwrapParenthesizedNode } from "./unwrapParenthesizedNode.ts";
 
 export interface StaticValue {

--- a/packages/typescript-language/src/utils/hasSameTokens.ts
+++ b/packages/typescript-language/src/utils/hasSameTokens.ts
@@ -1,6 +1,7 @@
-import ts, { SyntaxKind } from "typescript";
+import type ts from "typescript";
 
 import type * as AST from "../types/ast.ts";
+import typescript, { SyntaxKind } from "../typescript.ts";
 import { unwrapParenthesizedNode } from "./unwrapParenthesizedNode.ts";
 
 export function hasSameTokens(
@@ -23,7 +24,7 @@ export function hasSameTokens(
 			return false;
 		}
 
-		if (ts.isTokenKind(currentA.kind)) {
+		if (typescript.isTokenKind(currentA.kind)) {
 			if (!areSameToken(currentA, currentB, sourceFile)) {
 				return false;
 			}
@@ -50,12 +51,12 @@ function areSameToken(
 	sourceFile: AST.SourceFile,
 ): boolean {
 	if (
-		ts.isIdentifier(nodeA) ||
-		ts.isPrivateIdentifier(nodeA) ||
-		ts.isNumericLiteral(nodeA) ||
-		ts.isBigIntLiteral(nodeA) ||
-		ts.isStringLiteral(nodeA) ||
-		ts.isNoSubstitutionTemplateLiteral(nodeA)
+		typescript.isIdentifier(nodeA) ||
+		typescript.isPrivateIdentifier(nodeA) ||
+		typescript.isNumericLiteral(nodeA) ||
+		typescript.isBigIntLiteral(nodeA) ||
+		typescript.isStringLiteral(nodeA) ||
+		typescript.isNoSubstitutionTemplateLiteral(nodeA)
 	) {
 		return nodeA.text === (nodeB as typeof nodeA).text;
 	}

--- a/packages/typescript-language/src/utils/isBuiltinArrayMethod.ts
+++ b/packages/typescript-language/src/utils/isBuiltinArrayMethod.ts
@@ -1,7 +1,8 @@
 import type ts from "typescript";
-import { SyntaxKind } from "typescript";
 
 import type { AST, Checker } from "@flint.fyi/typescript-language";
+
+import { SyntaxKind } from "../typescript.ts";
 
 export type BuiltInArrayMethodNode = AST.CallExpression & {
 	expression: AST.PropertyAccessExpression & {

--- a/packages/typescript-language/src/utils/isGlobalDeclarationOfName.ts
+++ b/packages/typescript-language/src/utils/isGlobalDeclarationOfName.ts
@@ -1,3 +1,7 @@
+import type { Declaration, Node, Program } from "typescript";
+
+import type { Checker } from "@flint.fyi/typescript-language";
+
 import {
 	isClassDeclaration,
 	isFunctionDeclaration,
@@ -5,13 +9,7 @@ import {
 	isInterfaceDeclaration,
 	isPropertySignature,
 	isVariableDeclaration,
-	type Declaration,
-	type Node,
-	type Program,
-} from "typescript";
-
-import type { Checker } from "@flint.fyi/typescript-language";
-
+} from "../typescript.ts";
 import { declarationIncludesGlobal } from "./declarationIncludesGlobal.ts";
 
 /**

--- a/packages/typescript-language/src/utils/isInlineArrayCreation.ts
+++ b/packages/typescript-language/src/utils/isInlineArrayCreation.ts
@@ -1,4 +1,6 @@
-import ts from "typescript";
+import type ts from "typescript";
+
+import typescript from "../typescript.ts";
 
 const methodsReturningNewArray = new Set([
 	"concat",
@@ -23,20 +25,20 @@ const objectStaticMethods = new Set(["entries", "keys", "values"]);
  * so mutating methods like .sort() or .reverse() are safe to use.
  */
 export function isInlineArrayCreation(node: ts.Expression): boolean {
-	if (ts.isArrayLiteralExpression(node)) {
+	if (typescript.isArrayLiteralExpression(node)) {
 		return true;
 	}
 
-	if (ts.isParenthesizedExpression(node)) {
+	if (typescript.isParenthesizedExpression(node)) {
 		return isInlineArrayCreation(node.expression);
 	}
 
-	if (ts.isCallExpression(node)) {
-		if (ts.isPropertyAccessExpression(node.expression)) {
+	if (typescript.isCallExpression(node)) {
+		if (typescript.isPropertyAccessExpression(node.expression)) {
 			const methodName = node.expression.name.text;
 
 			if (
-				ts.isIdentifier(node.expression.expression) &&
+				typescript.isIdentifier(node.expression.expression) &&
 				node.expression.expression.text === "Object" &&
 				objectStaticMethods.has(methodName)
 			) {
@@ -44,7 +46,7 @@ export function isInlineArrayCreation(node: ts.Expression): boolean {
 			}
 
 			if (
-				ts.isIdentifier(node.expression.expression) &&
+				typescript.isIdentifier(node.expression.expression) &&
 				node.expression.expression.text === "Array" &&
 				(methodName === "from" || methodName === "of")
 			) {
@@ -57,17 +59,17 @@ export function isInlineArrayCreation(node: ts.Expression): boolean {
 		}
 
 		if (
-			ts.isIdentifier(node.expression) &&
+			typescript.isIdentifier(node.expression) &&
 			node.expression.text === "Array" &&
-			ts.isNewExpression(node.parent)
+			typescript.isNewExpression(node.parent)
 		) {
 			return true;
 		}
 	}
 
 	if (
-		ts.isNewExpression(node) &&
-		ts.isIdentifier(node.expression) &&
+		typescript.isNewExpression(node) &&
+		typescript.isIdentifier(node.expression) &&
 		node.expression.text === "Array"
 	) {
 		return true;

--- a/packages/typescript-language/src/utils/isStaticString.ts
+++ b/packages/typescript-language/src/utils/isStaticString.ts
@@ -1,6 +1,6 @@
-import { SyntaxKind } from "typescript";
-
 import type { AST } from "@flint.fyi/typescript-language";
+
+import { SyntaxKind } from "../typescript.ts";
 
 export type StaticString =
 	| AST.NoSubstitutionTemplateLiteral

--- a/packages/typescript-language/src/utils/isStringRawNoSubstitution.ts
+++ b/packages/typescript-language/src/utils/isStringRawNoSubstitution.ts
@@ -1,6 +1,6 @@
-import { SyntaxKind } from "typescript";
-
 import type { AST } from "@flint.fyi/typescript-language";
+
+import { SyntaxKind } from "../typescript.ts";
 
 export interface StringRawNoSubstitution extends AST.TaggedTemplateExpression {
 	template: AST.NoSubstitutionTemplateLiteral;

--- a/packages/typescript-language/src/utils/unwrapParentParenthesizedExpressions.ts
+++ b/packages/typescript-language/src/utils/unwrapParentParenthesizedExpressions.ts
@@ -1,6 +1,5 @@
-import { SyntaxKind } from "typescript";
-
 import type * as AST from "../types/ast.ts";
+import { SyntaxKind } from "../typescript.ts";
 
 export function unwrapParentParenthesizedExpressions(
 	node: AST.BinaryExpression | AST.ParenthesizedExpression,

--- a/packages/typescript-language/src/utils/unwrapParenthesizedNode.ts
+++ b/packages/typescript-language/src/utils/unwrapParenthesizedNode.ts
@@ -1,6 +1,5 @@
-import { SyntaxKind } from "typescript";
-
 import type * as AST from "../types/ast.ts";
+import { SyntaxKind } from "../typescript.ts";
 
 export function unwrapParenthesizedNode(node: AST.AnyNode): AST.AnyNode {
 	return node.kind === SyntaxKind.ParenthesizedExpression

--- a/packages/typescript-language/tsdown.config.ts
+++ b/packages/typescript-language/tsdown.config.ts
@@ -4,6 +4,7 @@ import { base } from "@flint.fyi/build/tsdown";
 
 const config: UserConfig = defineConfig({
 	...base,
+	entry: ["src/index.ts", "src/ts-api-utils.ts", "src/typescript.ts"],
 });
 
 export default config;

--- a/packages/vitest/src/createStatementPaddingRule.ts
+++ b/packages/vitest/src/createStatementPaddingRule.ts
@@ -1,5 +1,3 @@
-import ts, { SyntaxKind } from "typescript";
-
 import type { Rule } from "@flint.fyi/core";
 import {
 	getTSNodeRange,
@@ -7,6 +5,9 @@ import {
 	type AST,
 	type TypeScriptFileServices,
 } from "@flint.fyi/typescript-language";
+import typescript, {
+	SyntaxKind,
+} from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator, type VitestRuleAbout } from "./ruleCreator.ts";
 
@@ -49,7 +50,7 @@ export function createStatementPaddingRule(
 				node: AST.AnyNode,
 				sourceFile: AST.SourceFile,
 			) {
-				const leadingComments = ts.getLeadingCommentRanges(
+				const leadingComments = typescript.getLeadingCommentRanges(
 					sourceFile.text,
 					node.getFullStart(),
 				);
@@ -75,7 +76,7 @@ export function createStatementPaddingRule(
 				node: AST.AnyNode,
 				sourceFile: AST.SourceFile,
 			) {
-				const trailingComments = ts.getTrailingCommentRanges(
+				const trailingComments = typescript.getTrailingCommentRanges(
 					sourceFile.text,
 					node.getEnd(),
 				);

--- a/packages/vitest/src/rules/nodeTestImports.ts
+++ b/packages/vitest/src/rules/nodeTestImports.ts
@@ -1,9 +1,8 @@
-import { SyntaxKind } from "typescript";
-
 import {
 	getTSNodeRange,
 	typescriptLanguage,
 } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 import { ruleCreator } from "../ruleCreator.ts";
 

--- a/packages/vitest/src/utils/parseVitestFunctionCall.ts
+++ b/packages/vitest/src/utils/parseVitestFunctionCall.ts
@@ -1,6 +1,5 @@
-import { SyntaxKind } from "typescript";
-
 import type { AST } from "@flint.fyi/typescript-language";
+import { SyntaxKind } from "@flint.fyi/typescript-language/typescript";
 
 const knownVitestFunctionNames = [
 	"afterAll",

--- a/packages/volar-language/src/language.ts
+++ b/packages/volar-language/src/language.ts
@@ -6,13 +6,8 @@ import type {
 } from "@volar/language-core";
 import type { TypeScriptServiceScript as VolarTypeScriptServiceScript } from "@volar/typescript";
 import { proxyCreateProgram } from "@volar/typescript/lib/node/proxyCreateProgram.js";
-import {
-	getPreEmitDiagnostics,
-	type CreateProgramOptions,
-	type Node,
-	type Program,
-} from "typescript";
 import type ts from "typescript";
+import type { CreateProgramOptions, Node, Program } from "typescript";
 
 import {
 	createLanguage,
@@ -44,6 +39,7 @@ import {
 	type TypeScriptFileServices,
 	type TypeScriptNodesByName,
 } from "@flint.fyi/typescript-language";
+import { getPreEmitDiagnostics } from "@flint.fyi/typescript-language/typescript";
 import { assert, FlintAssertionError, nullThrows } from "@flint.fyi/utils";
 
 import packageJson from "../package.json" with { type: "json" };

--- a/packages/vue/src/rules/vForKeys.ts
+++ b/packages/vue/src/rules/vForKeys.ts
@@ -1,7 +1,8 @@
 import * as vue from "@vue/compiler-dom";
-import ts from "typescript";
+import type ts from "typescript";
 
 import type { CharacterReportRange } from "@flint.fyi/core";
+import typescript from "@flint.fyi/typescript-language/typescript";
 import { nullThrows } from "@flint.fyi/utils";
 import { reportSourceCode } from "@flint.fyi/volar-language";
 import { vueLanguage } from "@flint.fyi/vue-language";
@@ -195,7 +196,7 @@ export default ruleCreator.createRule(vueLanguage, {
 							if (
 								currentBegin >= valueRange.begin &&
 								currentEnd <= valueRange.end &&
-								ts.isIdentifier(current)
+								typescript.isIdentifier(current)
 							) {
 								const symbol =
 									services.typeChecker.getSymbolAtLocation(current);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1124,9 +1124,6 @@ importers:
       '@flint.fyi/typescript-language':
         specifier: workspace:^
         version: link:../typescript-language
-      ts-api-utils:
-        specifier: ^2.4.0
-        version: 2.5.0(typescript@6.0.3)
       typescript:
         specifier: ^6.0.0
         version: 6.0.3


### PR DESCRIPTION
SASSAFRAS

## PR Checklist

- [x] Addresses an existing open issue: fixes #3250
- [ ] That issue was marked as [`status: accepting prs`](https://github.com/flint-fyi/flint/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/flint-fyi/flint/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

`typescript` is CommonJS, so importing it from ESM makes Node run cjs-module-lexer across all ~9 MB of `typescript.js` to enumerate the named exports for an ESM namespace — work `enableCompileCache()` does not cover. `packages/ts-patch/src/install-patch.ts` already loads TypeScript with `require`, so the same library was being loaded through both a CJS and an ESM path in one process.

This adds two tiny shims to `@flint.fyi/typescript-language` and points internal value imports at them:

- `@flint.fyi/typescript-language/typescript` — `createRequire(import.meta.url)("typescript")`, re-exported as a default plus the enums and helpers used across the repo.
- `@flint.fyi/typescript-language/ts-api-utils` — `createRequire(import.meta.url)("ts-api-utils")`, which picks up that package's CJS build.

The second shim is what makes the first one pay off. `ts-api-utils`'s ESM build does `import ts from "typescript"`, so as long as anything in the graph reaches it, the lexer pass happens anyway; its CJS build `require`s TypeScript and reuses the instance already in the require cache. With both in place, `cjs-module-lexer` drops from ~68 ms to ~3 ms of a two-file run's CPU profile, and `typescript.js` is loaded exactly once, by `install-patch`.

The convention after this change is: **types come from `"typescript"` directly** (`import type` is erased, so it costs nothing), **values come from the shim**. In the 70 files that used `import ts from "typescript"` for both, `ts` now names the type-only namespace and `typescript` names the runtime module.

Two supporting changes:

- `packages/ts-patch/src/install-patch-hooks.ts` only patched TypeScript's source when `load` handed it a `Buffer`. `registerHooks` also intercepts `require()`, where Node hands it a string — so under Vitest the patched build was silently skipped once TypeScript came in through `require`. It now handles both, which is what keeps `.astro`/`.vue` extension support (`_flintGetExtraSupportedExtensions`) working.
- `ts-api-utils` is no longer referenced from `packages/performance`, so its dependency entry is removed (with the matching `pnpm-lock.yaml` importer entry). **This is the one change I could not verify with an install** — my local `pnpm` is v10 and this repo needs v11, so the lockfile edit is by hand: the three-line importer entry for `packages/performance` is dropped and nothing else. Worth a `pnpm install --lockfile-only` before merging.

## Measurements

`node packages/flint/bin/index.js --cache-ignore --skip-formatting --skip-language-reports`, hyperfine, 3 warmups × 10 runs, alternating branches within a single session (the machine drifts by 10–20% over tens of minutes, so back-to-back single runs are not comparable):

| files | rules | main | this branch | delta |
| --- | --- | --- | --- | --- |
| 2 | 1 | 826 ms ± 28 ms | 656 ms ± 33 ms | **−170 ms (−21%)** |
| 2 | many | 841 ms ± 30 ms | 673 ms ± 34 ms | **−168 ms (−20%)** |
| 256 | many | 1.368 s ± 62 ms | 1.194 s ± 166 ms | **−174 ms (−13%)** |
| 1024 | many | 3.043 s ± 70 ms | 2.819 s ± 113 ms | **−224 ms (−7%)** |

Startup only, no linting — loading `install-patch` plus the `@flint.fyi/ts` plugin graph and exiting:

| | main | this branch | delta |
| --- | --- | --- | --- |
| module graph load | 435 ms ± 37 ms / 449 ms ± 21 ms | 280 ms ± 22 ms / 284 ms ± 19 ms | **−158 ms (−36%)** |

The `--version` benchmark from the issue investigation is flat, and deliberately reported as such:

```
hyperfine -N --warmup 3 'node packages/flint/bin/index.js --version'
main:        139–140 ms
this branch: 143–145 ms
```

`--version` short-circuits before any plugin is imported, so it never reaches a value import of `typescript` — it measures `install-patch` and the CLI shell only. It is not a useful isolation for this change; the module-graph row above is.

## Not covered

- **Bundled plugin output (the other half of #3250) is deferred.** Worth noting that the published packages already get most of that win: `@flint.fyi/ts`'s `publishConfig` points at `dist/index.mjs`, a single ~918 KB bundle, so an installed Flint does not load 301 separate rule modules. The 425 ms → 224 ms gap in the issue is specific to running from source, which is what `packages/flint/bin/index.js` does and what these benchmarks measure. Closing it would mean making the CLI prefer `dist` over `src`, i.e. making a fresh clone require a build before `flint` runs — a build-system change rather than a perf change, so I left it alone.
- **`typescript/lib/tsserverlibrary` is a non-issue on TypeScript 6.** `@typescript-eslint/project-service` still requires it, but in 6.0.3 that file is 1 KB and its whole body is `module.exports = require("./typescript.js")`, so it costs nothing and does not produce a second copy of TypeScript.
- The four `e2e` test failures on this branch (`cspell`, `directives`, `no-reports`, `typescript`) reproduce identically on `main` at 116a836e and are unrelated. The `packages/site` lint errors (missing `astro:content` types) likewise reproduce on `main`.
