### PR TITLE
perf(typescript-language): reuse one program per project instead of per file

### DIFF
--- a/packages/typescript-language/src/language.test.ts
+++ b/packages/typescript-language/src/language.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+
+import { createVFSLinterHost, type VFSLinterHost } from "@flint.fyi/core";
+
+import { typescriptLanguage } from "./language.ts";
+
+describe("typescriptLanguage", () => {
+	it("reuses one program when files share a project", () => {
+		const host = createVFSLinterHost({ caseSensitive: true, cwd: "/repo" });
+		upsertJson(host, "/repo/tsconfig.json", {
+			compilerOptions: { strict: true },
+			files: ["src/first.ts", "src/nested/second.ts"],
+		});
+		host.vfsUpsertFile("/repo/src/first.ts", "export const first = 1;\n");
+		host.vfsUpsertFile(
+			"/repo/src/nested/second.ts",
+			"export const second = 2;\n",
+		);
+
+		const factory = typescriptLanguage.createFileFactory(host);
+		using first = factory.createFile(fileAboutData(host, "/repo/src/first.ts"));
+		using second = factory.createFile(
+			fileAboutData(host, "/repo/src/nested/second.ts"),
+		);
+
+		expect(second.services.program).toBe(first.services.program);
+	});
+
+	it("uses each file's own project when projects overlap", () => {
+		const host = createVFSLinterHost({ caseSensitive: true, cwd: "/repo" });
+		upsertJson(host, "/repo/tsconfig.json", {
+			compilerOptions: { strict: false },
+			files: ["packages/outer.ts", "packages/inner/src/inner.ts"],
+		});
+		upsertJson(host, "/repo/packages/inner/tsconfig.json", {
+			compilerOptions: { strict: true },
+			files: ["src/inner.ts"],
+		});
+		host.vfsUpsertFile("/repo/packages/outer.ts", "export const outer = 1;\n");
+		host.vfsUpsertFile(
+			"/repo/packages/inner/src/inner.ts",
+			"export const inner = 2;\n",
+		);
+
+		const factory = typescriptLanguage.createFileFactory(host);
+		using outer = factory.createFile(
+			fileAboutData(host, "/repo/packages/outer.ts"),
+		);
+		using inner = factory.createFile(
+			fileAboutData(host, "/repo/packages/inner/src/inner.ts"),
+		);
+
+		expect({
+			inner: inner.services.program.getCompilerOptions().strict,
+			outer: outer.services.program.getCompilerOptions().strict,
+		}).toEqual({ inner: true, outer: false });
+	});
+});
+
+function fileAboutData(host: VFSLinterHost, filePathAbsolute: string) {
+	return {
+		filePath: filePathAbsolute,
+		filePathAbsolute,
+		sourceText: host.readFileSync(filePathAbsolute) ?? "",
+	};
+}
+
+function upsertJson(host: VFSLinterHost, filePath: string, contents: object) {
+	host.vfsUpsertFile(filePath, JSON.stringify(contents));
+}

--- a/packages/typescript-language/src/language.ts
+++ b/packages/typescript-language/src/language.ts
@@ -2,11 +2,13 @@ import path from "node:path";
 
 import { createProjectService } from "@typescript-eslint/project-service";
 import { debugForFile } from "debug-for-file";
+import { dirname, join } from "pathe";
 import {
 	getPreEmitDiagnostics,
 	SyntaxKind,
 	type Node,
 	type Program,
+	type server,
 } from "typescript";
 
 import {
@@ -20,7 +22,7 @@ import {
 	type LanguageReports,
 	type RuleRuntime,
 } from "@flint.fyi/core";
-import { assert, nullThrows } from "@flint.fyi/utils";
+import { assert, nullThrows, pathKey, type PathKey } from "@flint.fyi/utils";
 
 import packageJson from "../package.json" with { type: "json" };
 import { convertTypeScriptDiagnosticToLanguageReport } from "./convertTypeScriptDiagnosticToLanguageReport.ts";
@@ -98,29 +100,82 @@ export const typescriptLanguage: Language<
 		name: "TypeScript",
 	},
 	createFileFactory: (host) => {
-		const { service } = createProjectService({
-			host: createTypeScriptServerHost(host),
-		});
+		const serverHost = createTypeScriptServerHost(host);
+		const { service } = createProjectService({ host: serverHost });
 
-		function createFile(data: FileAboutData) {
-			log("Opening client file:", data.filePathAbsolute);
-			service.openClientFile(data.filePathAbsolute);
+		const caseSensitiveFS = host.isCaseSensitiveFS();
+		const configPathsByDirectory = new Map<PathKey, string | undefined>();
+		const openedFilePaths = new Set<string>();
+		const projectsByConfigPath = new Map<PathKey, server.Project>();
 
-			log("Retrieving client services:", data.filePathAbsolute);
+		function findConfigPath(directory: string): string | undefined {
+			const directoryKey = pathKey(directory, caseSensitiveFS);
+			if (configPathsByDirectory.has(directoryKey)) {
+				return configPathsByDirectory.get(directoryKey);
+			}
+
+			const configPath = join(directory, "tsconfig.json");
+			const parentDirectory = dirname(directory);
+			const found = serverHost.fileExists(configPath)
+				? configPath
+				: parentDirectory === directory
+					? undefined
+					: findConfigPath(parentDirectory);
+
+			configPathsByDirectory.set(directoryKey, found);
+			return found;
+		}
+
+		function getProgram(filePathAbsolute: string) {
+			const configPath = findConfigPath(dirname(filePathAbsolute));
+			const configPathKey =
+				configPath == null ? undefined : pathKey(configPath, caseSensitiveFS);
+
+			// Files are only reused into an already-open project when they'd resolve
+			// to it anyway: the project owns their closest tsconfig.json and its
+			// program already contains them. Re-opening a file that was opened
+			// before lets the service pick up any change to its text.
+			if (configPathKey && !openedFilePaths.has(filePathAbsolute)) {
+				const program = projectsByConfigPath
+					.get(configPathKey)
+					?.getLanguageService(true)
+					.getProgram();
+				if (program?.getSourceFile(filePathAbsolute)) {
+					return program;
+				}
+			}
+
+			log("Opening client file:", filePathAbsolute);
+			const { configFileName } = service.openClientFile(filePathAbsolute);
+			openedFilePaths.add(filePathAbsolute);
+
+			log("Retrieving client services:", filePathAbsolute);
 			const scriptInfo = nullThrows(
-				service.getScriptInfo(data.filePathAbsolute),
-				`Could not find script info for file: ${data.filePathAbsolute}`,
+				service.getScriptInfo(filePathAbsolute),
+				`Could not find script info for file: ${filePathAbsolute}`,
 			);
 
 			const defaultProject = nullThrows(
 				service.getDefaultProjectForFile(scriptInfo.fileName, true),
-				`Could not find default project for file: ${data.filePathAbsolute}`,
+				`Could not find default project for file: ${filePathAbsolute}`,
 			);
 
-			const program = nullThrows(
+			if (
+				configPathKey &&
+				configFileName &&
+				pathKey(configFileName, caseSensitiveFS) === configPathKey
+			) {
+				projectsByConfigPath.set(configPathKey, defaultProject);
+			}
+
+			return nullThrows(
 				defaultProject.getLanguageService(true).getProgram(),
-				`Could not retrieve program for file: ${data.filePathAbsolute}`,
+				`Could not retrieve program for file: ${filePathAbsolute}`,
 			);
+		}
+
+		function createFile(data: FileAboutData) {
+			const program = getProgram(data.filePathAbsolute);
 
 			const sourceFile = nullThrows(
 				program.getSourceFile(data.filePathAbsolute),
@@ -140,7 +195,7 @@ export const typescriptLanguage: Language<
 						typeChecker: program.getTypeChecker() as unknown as Checker,
 					},
 					[Symbol.dispose]() {
-						service.closeClientFile(data.filePathAbsolute);
+						closeFile(data.filePathAbsolute);
 					},
 				};
 			}
@@ -156,9 +211,15 @@ export const typescriptLanguage: Language<
 					sourceFile as AST.SourceFile,
 				),
 				[Symbol.dispose]() {
-					service.closeClientFile(data.filePathAbsolute);
+					closeFile(data.filePathAbsolute);
 				},
 			};
+		}
+
+		function closeFile(filePathAbsolute: string) {
+			if (openedFilePaths.has(filePathAbsolute)) {
+				service.closeClientFile(filePathAbsolute);
+			}
 		}
 
 		return { createFile };


### PR DESCRIPTION
SASSAFRAS

## PR Checklist

- [x] Addresses an existing open issue: fixes #3252
- [ ] That issue was marked as [`status: accepting prs`](https://github.com/flint-fyi/flint/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/flint-fyi/flint/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

`createFile` asked the `ProjectService` for a project and a program once per file: an `openClientFile`, a `getDefaultProjectForFile`, a forced `getLanguageService(true).getProgram()`, and a matching `closeClientFile` on dispose, 1024 times over for 1024 files that all belong to the same `tsconfig.json`.

The file factory now remembers, per `tsconfig.json`, the project that owns it. A file is served out of an already-open project — with no `openClientFile` at all — when both hold:

1. The closest `tsconfig.json` above the file is the one that project was created for, so `tsserver` would resolve the file to that project anyway (`findConfigPath` walks up from the file's directory, memoized per directory, the same rule as `getConfigFileNameForFile`).
2. That project's program already contains a source file for the path, which is `Project#containsScriptInfo`'s test for the file belonging to the project.

Anything else — a file under a different `tsconfig.json`, a file no `tsconfig.json` covers (the `allowDefaultProject`/inferred-project path), a file the project's program doesn't have, or a path opened earlier whose text may since have changed — falls through to the original open-and-resolve path. The program is always re-fetched through `getLanguageService(true)`, so a reused project still hands out a synchronized program. `Symbol.dispose` closes only the files it opened.

For the 1024-file fixture this is 1 `openClientFile` and 1 `closeClientFile` instead of 1024 of each.

### What the profile actually says

Worth recording, since it differs from the issue's analysis. With `ts.server` instrumented on `main` at 1024 files × 1 rule:

- `ProjectService#openClientFile`: 1024 calls, 876 ms — of which `tryFindDefaultConfiguredProjectAndLoadAncestorsForOpenScriptInfo` is 669 ms, `printProjects` 196 ms, `cleanupProjectsAndScriptInfos` 79 ms — plus 129 ms of `closeClientFile`.
- `Project#getLanguageService(true)` and `LanguageService#getProgram()`: 1024 calls each, **~0 ms total**.
- `ConfiguredProject#updateGraph`: **2 calls total**, not 1024.

So the per-file forced synchronization the issue targets was already free — `updateProjectIfDirty` and `synchronizeHostData` both short-circuit on an unchanged project version. All of the waste was the per-file open/close bookkeeping around it, which is what this removes.

That also answers the issue's open question about superlinearity. The marginal cost per added file at 1 rule climbs on `main` (1.18 ms/file going 2 → 256, 1.29 ms/file going 256 → 1024) and falls on this branch (0.96 ms/file, then 0.81 ms/file). The growth was not repeated graph updates; it was `ScriptInfo` bookkeeping, `realpath` canonicalization, and the per-open project walks getting more expensive as more files were open.

**Overlap with #3256:** ~196 ms of the ~420 ms saved here is `printProjects` logging inside `openClientFile`/`closeClientFile`, which #3256 removes by another route. The two fixes overlap and are **not** additive.

## Measurements

Cold cache (`--cache-ignore --skip-formatting --skip-language-reports`), `hyperfine -r 8`, back to back on the same machine:

| files | rules | main @ 116a836e | this branch | delta |
| --- | --- | --- | --- | --- |
| 2 | 1 | 783 ms ± 27 ms | 779 ms ± 31 ms | −4 ms (−0.5%) |
| 256 | 1 | 1.082 s ± 32 ms | 1.022 s ± 36 ms | −60 ms (−5.5%) |
| 1024 | 1 | 2.072 s ± 74 ms | 1.648 s ± 34 ms | −424 ms (−20.5%) |
| 1024 | many (272) | 3.156 s ± 67 ms | 2.739 s ± 71 ms | −417 ms (−13.2%) |

Warm cache, same runs:

| files | rules | main @ 116a836e | this branch | delta |
| --- | --- | --- | --- | --- |
| 2 | 1 | 808 ms ± 30 ms | 792 ms ± 30 ms | −16 ms (−2.0%) |
| 256 | 1 | 1.070 s ± 68 ms | 1.007 s ± 36 ms | −63 ms (−5.9%) |
| 1024 | 1 | 2.253 s ± 217 ms | 1.648 s ± 40 ms | −605 ms (−26.9%) |
| 1024 | many (272) | 3.194 s ± 68 ms | 2.729 s ± 88 ms | −465 ms (−14.6%) |

Findings are byte-identical to `main` on the 2-file, 256-file, and 1024-file fixtures and on Flint's own source (28 reports, plus the same language reports in the same order).

## Not covered

- Reuse is per closest `tsconfig.json`, so a project reached through project references or a solution-style config — where `tsserver`'s chosen config isn't the closest one — keeps opening every file. That direction fails safe: it only loses the speedup.
- `jsconfig.json` isn't part of the lookup, so a `jsconfig.json`-only project keeps the old per-file path.
- The remaining ~600 ms at 1024 files × 1 rule is the initial program build (`readdir` and `visitDirectory` for the config's file glob, `readFileUtf8`, parse), which is untouched here.
