### PR TITLE
fix(rule-data): point sort-data at src/data.json

### DIFF
--- a/packages/rule-data/scripts/sort-data.ts
+++ b/packages/rule-data/scripts/sort-data.ts
@@ -5,7 +5,7 @@ import { isDeepStrictEqual, parseArgs } from "node:util";
 
 import { ruleData as dataOriginal } from "@flint.fyi/rule-data" with { type: "json" };
 
-const dataFilePath = path.join(import.meta.dirname, "data.json");
+const dataFilePath = path.join(import.meta.dirname, "../src/data.json");
 
 const {
 	values: { check },


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #3259
- [x] That issue was marked as [`status: accepting prs`](https://github.com/flint-fyi/flint/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
  - Not labeled yet, but lishaduck OK'd landing "a separate fix real quick" in the issue thread.
- [x] Steps in [CONTRIBUTING.md](https://github.com/flint-fyi/flint/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

`sort-data.ts` resolved `data.json` relative to its own `scripts/` directory, so write mode would create a stray `scripts/data.json` and never sort the real `src/data.json`. This points the path at `../src/data.json`.

Verified by reversing `src/data.json` and running write mode: the real file gets sorted in place and no stray file appears.

❤️‍🔥
