### PR TITLE
ci: file issues for missing rule-data coverage on Renovate PRs

### DIFF
--- a/.github/workflows/rule-data-renovate.yaml
+++ b/.github/workflows/rule-data-renovate.yaml
@@ -1,0 +1,32 @@
+name: Rule Data Renovate
+
+on:
+  pull_request:
+    paths:
+      - packages/rule-data/package.json
+      - pnpm-workspace.yaml
+
+concurrency:
+  group: rule-data-renovate-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  file_missing_rules_issues:
+    name: File Missing Rules Issues
+    if: >-
+      github.event.pull_request.user.login == 'renovate[bot]' &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - uses: $/.github/actions/setup
+      - run: pnpm run --filter=rule-data file-missing-rules-issues
+        env:
+          GH_REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/packages/rule-data/package.json
+++ b/packages/rule-data/package.json
@@ -22,6 +22,8 @@
 		"dist/"
 	],
 	"scripts": {
+		"file-missing-rules-issues": "node scripts/file-missing-rules-issues.ts",
+		"report-missing-rules": "node scripts/report-missing-rules.ts",
 		"sort-data": "node scripts/sort-data.ts",
 		"test": "vitest --project rule-data"
 	},

--- a/packages/rule-data/scripts/file-missing-rules-issues.ts
+++ b/packages/rule-data/scripts/file-missing-rules-issues.ts
@@ -1,0 +1,119 @@
+import { execFileSync } from "node:child_process";
+import fs from "node:fs/promises";
+import process from "node:process";
+
+import {
+	formatRuleCoverage,
+	hasRuleCoverageGaps,
+	ruleCoverageSources,
+	type RuleCoverage,
+} from "../src/test-utils/coverage.ts";
+
+interface ExistingIssue {
+	number: number;
+	title: string;
+}
+
+const labels = [
+	"area: documentation",
+	"package: comparisons",
+	"status: accepting prs",
+];
+
+const pullRequestNumber = requireEnvironmentVariable("PULL_REQUEST_NUMBER");
+const runUrl = requireEnvironmentVariable("RUN_URL");
+
+const existingIssues = JSON.parse(
+	gh([
+		"issue",
+		"list",
+		"--json",
+		"number,title",
+		"--limit",
+		"1000",
+		"--state",
+		"open",
+	]),
+) as ExistingIssue[];
+
+for (const { collect, linter } of ruleCoverageSources) {
+	const coverage = await collect();
+
+	if (!hasRuleCoverageGaps(coverage)) {
+		continue;
+	}
+
+	const title = `📝 Documentation: Add missing ${linter} rules to rule-data`;
+	const body = createIssueBody(linter, coverage);
+	const existingIssue = existingIssues.find((issue) => issue.title === title);
+
+	if (existingIssue) {
+		gh(
+			["issue", "edit", String(existingIssue.number), "--body-file", "-"],
+			body,
+		);
+		console.log(`Updated #${existingIssue.number}: ${title}`);
+	} else {
+		const url = gh(
+			[
+				"issue",
+				"create",
+				"--title",
+				title,
+				"--body-file",
+				"-",
+				...labels.flatMap((label) => ["--label", label]),
+			],
+			body,
+		).trim();
+		console.log(`Created ${url}: ${title}`);
+	}
+
+	if (process.env.GITHUB_STEP_SUMMARY) {
+		await fs.appendFile(
+			process.env.GITHUB_STEP_SUMMARY,
+			`## ${linter}\n\n${formatRuleCoverage(linter, coverage)}\n\n`,
+		);
+	}
+}
+
+function createIssueBody(linter: string, coverage: RuleCoverage): string {
+	return [
+		"### Documentation Report Checklist",
+		"",
+		"- [x] I have checked the latest `main` branch of the repository.",
+		"- [x] I have [searched for related issues](https://github.com/flint-fyi/flint/issues?q=is%3Aissue) and found none that matched my issue.",
+		"",
+		"### Overview",
+		"",
+		`Renovate PR #${pullRequestNumber} updates a dependency whose ${linter} rules no longer match \`packages/rule-data/src/data.json\`.`,
+		"`packages/rule-data/src/data.test.ts` fails on that PR until the data is synced.",
+		"",
+		formatRuleCoverage(linter, coverage),
+		"",
+		"### Additional Info",
+		"",
+		`Filed by the [Rule Data Renovate workflow](${runUrl}).`,
+		`This issue is updated in place while Renovate PRs keep reporting ${linter} gaps, so the lists above reflect the latest failing run.`,
+		"",
+		"To resolve:",
+		"",
+		"1. Add each missing rule to `packages/rule-data/src/data.json`, and remove stale or duplicate references.",
+		"2. Run `pnpm --filter=rule-data sort-data`.",
+		"3. Push to the Renovate branch, or open a PR that bumps the dependency and closes this issue.",
+	].join("\n");
+}
+
+function gh(args: string[], input?: string): string {
+	return execFileSync("gh", args, { encoding: "utf8", input });
+}
+
+function requireEnvironmentVariable(name: string): string {
+	const value = process.env[name];
+
+	if (!value) {
+		throw new Error(`Missing required environment variable: ${name}`);
+	}
+
+	return value;
+}

--- a/packages/rule-data/scripts/file-missing-rules-issues.ts
+++ b/packages/rule-data/scripts/file-missing-rules-issues.ts
@@ -3,9 +3,9 @@ import fs from "node:fs/promises";
 import process from "node:process";
 
 import {
+	collectRuleCoverageReports,
 	formatRuleCoverage,
 	hasRuleCoverageGaps,
-	ruleCoverageSources,
 	type RuleCoverage,
 } from "../src/test-utils/coverage.ts";
 
@@ -36,9 +36,9 @@ const existingIssues = JSON.parse(
 	]),
 ) as ExistingIssue[];
 
-for (const { collect, linter } of ruleCoverageSources) {
-	const coverage = await collect();
+const summarySections: string[] = [];
 
+for (const { coverage, linter } of await collectRuleCoverageReports()) {
 	if (!hasRuleCoverageGaps(coverage)) {
 		continue;
 	}
@@ -69,12 +69,15 @@ for (const { collect, linter } of ruleCoverageSources) {
 		console.log(`Created ${url}: ${title}`);
 	}
 
-	if (process.env.GITHUB_STEP_SUMMARY) {
-		await fs.appendFile(
-			process.env.GITHUB_STEP_SUMMARY,
-			`## ${linter}\n\n${formatRuleCoverage(linter, coverage)}\n\n`,
-		);
-	}
+	summarySections.push(
+		`## ${linter}\n\n${formatRuleCoverage(linter, coverage)}`,
+	);
+}
+
+const summaryPath = process.env.GITHUB_STEP_SUMMARY;
+
+if (summaryPath && summarySections.length) {
+	await fs.appendFile(summaryPath, `${summarySections.join("\n\n")}\n`);
 }
 
 function createIssueBody(linter: string, coverage: RuleCoverage): string {

--- a/packages/rule-data/scripts/file-missing-rules-issues.ts
+++ b/packages/rule-data/scripts/file-missing-rules-issues.ts
@@ -16,7 +16,7 @@ interface ExistingIssue {
 
 const labels = [
 	"area: documentation",
-	"package: comparisons",
+	"package: rule-data",
 	"status: accepting prs",
 ];
 
@@ -101,9 +101,10 @@ function createIssueBody(linter: string, coverage: RuleCoverage): string {
 		"",
 		"To resolve:",
 		"",
-		"1. Add each missing rule to `packages/rule-data/src/data.json`, and remove stale or duplicate references.",
-		"2. Run `pnpm --filter=rule-data sort-data`.",
-		"3. Push to the Renovate branch, or open a PR that bumps the dependency and closes this issue.",
+		"1. Add each missing rule to `packages/rule-data/src/data.json`, and remove stale references.",
+		"2. For rules that shouldn't be skipped, file a [new rule issue](https://github.com/flint-fyi/flint/issues/new?template=03-new-rule.yaml) to track the Flint equivalent.",
+		"3. Run `pnpm --filter=rule-data sort-data`.",
+		"4. Push to the Renovate branch, or open a PR that bumps the dependency and closes this issue.",
 	].join("\n");
 }
 

--- a/packages/rule-data/scripts/report-missing-rules.ts
+++ b/packages/rule-data/scripts/report-missing-rules.ts
@@ -1,0 +1,26 @@
+import process from "node:process";
+
+import {
+	formatRuleCoverage,
+	hasRuleCoverageGaps,
+	ruleCoverageSources,
+} from "../src/test-utils/coverage.ts";
+
+let reportedGaps = false;
+
+for (const { collect, linter } of ruleCoverageSources) {
+	const coverage = await collect();
+
+	if (!hasRuleCoverageGaps(coverage)) {
+		continue;
+	}
+
+	reportedGaps = true;
+	console.log(`## ${linter}\n\n${formatRuleCoverage(linter, coverage)}\n`);
+}
+
+if (reportedGaps) {
+	process.exitCode = 1;
+} else {
+	console.log("data.json covers all rules from every compared linter.");
+}

--- a/packages/rule-data/scripts/report-missing-rules.ts
+++ b/packages/rule-data/scripts/report-missing-rules.ts
@@ -1,16 +1,14 @@
 import process from "node:process";
 
 import {
+	collectRuleCoverageReports,
 	formatRuleCoverage,
 	hasRuleCoverageGaps,
-	ruleCoverageSources,
 } from "../src/test-utils/coverage.ts";
 
 let reportedGaps = false;
 
-for (const { collect, linter } of ruleCoverageSources) {
-	const coverage = await collect();
-
+for (const { coverage, linter } of await collectRuleCoverageReports()) {
 	if (!hasRuleCoverageGaps(coverage)) {
 		continue;
 	}

--- a/packages/rule-data/src/data.test.ts
+++ b/packages/rule-data/src/data.test.ts
@@ -1,47 +1,7 @@
-import { builtinRules } from "eslint/use-at-your-own-risk";
 import { describe, expect, it } from "vitest";
 
 import { getFlintRuleId, ruleData } from "./index.ts";
-import {
-	findBiomeRulesInFlint,
-	getBiomeLintRules,
-} from "./test-utils/biome.ts";
-import {
-	findESLintRulesInCore,
-	findESLintRulesInPlugin,
-	pluginsRulesByName,
-} from "./test-utils/eslint.ts";
-import {
-	findMarkdownlintRules,
-	findMarkdownlintRulesInFlint,
-} from "./test-utils/markdownlint.ts";
-import {
-	findOxlintRulesInFlint,
-	getOxlintLintRules,
-	getOxlintRuleConfigName,
-} from "./test-utils/oxlint.ts";
-
-const excludedESLintRulesByPluginName = new Map([
-	// These rules are exported in the React plugin but not mentioned on react.dev.
-	// We're treating them as an internal implementation detail for now.
-	[
-		"react-hooks",
-		new Set([
-			"capitalized-calls",
-			"exhaustive-effect-dependencies",
-			"fbt",
-			"hooks",
-			"invariant",
-			"memo-dependencies",
-			"memoized-effect-dependencies",
-			"no-deriving-state-in-effects",
-			"rule-suppression",
-			"syntax",
-			"todo",
-			"void-use-memo",
-		]),
-	],
-]);
+import { ruleCoverageSources } from "./test-utils/coverage.ts";
 
 describe("data.json", () => {
 	it("should not include any duplicate Flint rules", () => {
@@ -64,82 +24,14 @@ describe("data.json", () => {
 		}
 	});
 
-	describe("Comparison with ESLint", () => {
-		it("includes all builtin rules", () => {
-			const builtinESLintRuleNames = new Set<string>(
-				// builtinRules is marked as deprecated since it's in "use-at-your-own-risk", not actually deprecated
-				// flint-disable-lines-begin ts/deprecated
-				// eslint-disable-next-line @typescript-eslint/no-deprecated
-				[...builtinRules]
-					// flint-disable-lines-end ts/deprecated
-					.flatMap(([ruleName, module]) =>
-						!module.meta?.deprecated ? [ruleName] : [],
-					)
-					.sort(),
-			);
-
-			const builtinESLintRuleNamesCoveredByFlint = new Set(
-				findESLintRulesInCore().map((rule) => rule.name),
-			);
-
-			expect(builtinESLintRuleNamesCoveredByFlint).toEqual(
-				builtinESLintRuleNames,
-			);
-		});
-
-		it.each(Array.from(pluginsRulesByName.entries()))(
-			"includes all %s rules",
-			(pluginName, rules) => {
-				const pluginRuleNames = new Set(
-					Object.keys(rules)
-						.filter(
-							(ruleName) =>
-								!excludedESLintRulesByPluginName.get(pluginName)?.has(ruleName),
-						)
-						.map((ruleName) => `${pluginName}/${ruleName}`)
-						.sort(),
-				);
-
-				const pluginESLintRuleNamesCoveredByFlint = new Set(
-					findESLintRulesInPlugin(pluginName)
-						.map((rule) => rule.name)
-						.sort(),
-				);
-
-				expect(pluginESLintRuleNamesCoveredByFlint).toEqual(pluginRuleNames);
-			},
-		);
-	});
-
-	it("includes all Biome rules", () => {
-		const biomeRuleNames = getBiomeLintRules();
-
-		const biomeRulesCoveredByFlint = Array.from(
-			new Set(findBiomeRulesInFlint().map((comparison) => comparison.name)),
-		).sort();
-
-		expect(biomeRuleNames).toEqual(biomeRulesCoveredByFlint);
-	});
-
-	it("includes all Markdownlint rules", async () => {
-		const markdownlintRuleNames = (await findMarkdownlintRules())
-			.map((rule) => rule.names.at(-1))
-			.sort();
-
-		const markdownlintRulesCoveredByFlint = findMarkdownlintRulesInFlint()
-			.map((comparison) => comparison.name)
-			.sort();
-
-		expect(markdownlintRuleNames).toEqual(markdownlintRulesCoveredByFlint);
-	});
-
-	it("includes all Oxlint rules", async () => {
-		const oxlintRuleNames = await getOxlintLintRules();
-
-		const oxlintRulesCoveredByFlint = findOxlintRulesInFlint()
-			.map((comparison) => getOxlintRuleConfigName(comparison.name))
-			.sort();
-
-		expect(oxlintRuleNames).toEqual(oxlintRulesCoveredByFlint);
-	});
+	it.each(ruleCoverageSources)(
+		"includes all $linter rules",
+		async ({ collect }) => {
+			expect(await collect()).toEqual({
+				duplicates: [],
+				missing: [],
+				stale: [],
+			});
+		},
+	);
 });

--- a/packages/rule-data/src/data.test.ts
+++ b/packages/rule-data/src/data.test.ts
@@ -27,11 +27,7 @@ describe("data.json", () => {
 	it.each(ruleCoverageSources)(
 		"includes all $linter rules",
 		async ({ collect }) => {
-			expect(await collect()).toEqual({
-				duplicates: [],
-				missing: [],
-				stale: [],
-			});
+			expect(await collect()).toEqual({ missing: [], stale: [] });
 		},
 	);
 });

--- a/packages/rule-data/src/test-utils/coverage.test.ts
+++ b/packages/rule-data/src/test-utils/coverage.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from "vitest";
+
+import { compareRuleCoverage, formatRuleCoverage } from "./coverage.ts";
+
+describe(compareRuleCoverage, () => {
+	it("reports nothing when the covered names match the available rules", () => {
+		expect(
+			compareRuleCoverage(
+				[
+					{ name: "a", url: undefined },
+					{ name: "b", url: "https://example.com/b" },
+				],
+				["b", "a"],
+			),
+		).toEqual({ duplicates: [], missing: [], stale: [] });
+	});
+
+	it("reports duplicate covered names", () => {
+		expect(
+			compareRuleCoverage([{ name: "a", url: undefined }], ["a", "a"]),
+		).toEqual({ duplicates: ["a"], missing: [], stale: [] });
+	});
+
+	it("allows duplicate covered names when mappings are many-to-one", () => {
+		expect(
+			compareRuleCoverage([{ name: "a", url: undefined }], ["a", "a"], {
+				allowDuplicates: true,
+			}),
+		).toEqual({ duplicates: [], missing: [], stale: [] });
+	});
+
+	it("reports available rules that are not covered, sorted by name", () => {
+		expect(
+			compareRuleCoverage(
+				[
+					{ name: "c", url: "https://example.com/c" },
+					{ name: "a", url: undefined },
+					{ name: "b", url: undefined },
+				],
+				["b"],
+			),
+		).toEqual({
+			duplicates: [],
+			missing: [
+				{ name: "a", url: undefined },
+				{ name: "c", url: "https://example.com/c" },
+			],
+			stale: [],
+		});
+	});
+
+	it("reports covered names that are no longer available, sorted", () => {
+		expect(
+			compareRuleCoverage([{ name: "a", url: undefined }], ["z", "a", "y"]),
+		).toEqual({ duplicates: [], missing: [], stale: ["y", "z"] });
+	});
+});
+
+describe(formatRuleCoverage, () => {
+	it("renders missing rules as a checklist with optional urls", () => {
+		expect(
+			formatRuleCoverage("unicorn", {
+				duplicates: [],
+				missing: [
+					{ name: "unicorn/a", url: "https://example.com/a" },
+					{ name: "unicorn/b", url: undefined },
+				],
+				stale: [],
+			}),
+		).toBe(
+			[
+				"**Missing from data.json (2):**",
+				"",
+				"- [ ] [`unicorn/a`](https://example.com/a)",
+				"- [ ] `unicorn/b`",
+			].join("\n"),
+		);
+	});
+
+	it("renders stale rules after missing rules", () => {
+		expect(
+			formatRuleCoverage("unicorn", {
+				duplicates: [],
+				missing: [{ name: "unicorn/a", url: undefined }],
+				stale: ["unicorn/z"],
+			}),
+		).toBe(
+			[
+				"**Missing from data.json (1):**",
+				"",
+				"- [ ] `unicorn/a`",
+				"",
+				"**In data.json but no longer provided by unicorn (1):**",
+				"",
+				"- `unicorn/z`",
+			].join("\n"),
+		);
+	});
+
+	it("renders duplicate rules after stale rules", () => {
+		expect(
+			formatRuleCoverage("Oxlint", {
+				duplicates: ["typescript/no-explicit-any"],
+				missing: [],
+				stale: ["typescript/no-var-requires"],
+			}),
+		).toBe(
+			[
+				"**In data.json but no longer provided by Oxlint (1):**",
+				"",
+				"- `typescript/no-var-requires`",
+				"",
+				"**Duplicated in data.json (1):**",
+				"",
+				"- `typescript/no-explicit-any`",
+			].join("\n"),
+		);
+	});
+});

--- a/packages/rule-data/src/test-utils/coverage.test.ts
+++ b/packages/rule-data/src/test-utils/coverage.test.ts
@@ -1,6 +1,22 @@
 import { describe, expect, it } from "vitest";
 
-import { compareRuleCoverage, formatRuleCoverage } from "./coverage.ts";
+import {
+	collectRuleCoverageReports,
+	compareRuleCoverage,
+	formatRuleCoverage,
+	hasRuleCoverageGaps,
+	ruleCoverageSources,
+} from "./coverage.ts";
+
+describe(collectRuleCoverageReports, () => {
+	it("collects one report per source, preserving source order", async () => {
+		const reports = await collectRuleCoverageReports();
+
+		expect(reports.map(({ linter }) => linter)).toEqual(
+			ruleCoverageSources.map(({ linter }) => linter),
+		);
+	});
+});
 
 describe(compareRuleCoverage, () => {
 	it("reports nothing when the covered names match the available rules", () => {
@@ -78,5 +94,39 @@ describe(formatRuleCoverage, () => {
 				"- [ ] `unicorn/z`",
 			].join("\n"),
 		);
+	});
+
+	it("renders only stale rules when no rules are missing", () => {
+		expect(
+			formatRuleCoverage("unicorn", {
+				missing: [],
+				stale: ["unicorn/z"],
+			}),
+		).toBe(
+			[
+				"**In data.json but no longer provided by unicorn (1):**",
+				"",
+				"- [ ] `unicorn/z`",
+			].join("\n"),
+		);
+	});
+});
+
+describe(hasRuleCoverageGaps, () => {
+	it("returns false when no rules are missing or stale", () => {
+		expect(hasRuleCoverageGaps({ missing: [], stale: [] })).toBe(false);
+	});
+
+	it("returns true when rules are missing", () => {
+		expect(
+			hasRuleCoverageGaps({
+				missing: [{ name: "a", url: undefined }],
+				stale: [],
+			}),
+		).toBe(true);
+	});
+
+	it("returns true when rules are stale", () => {
+		expect(hasRuleCoverageGaps({ missing: [], stale: ["a"] })).toBe(true);
 	});
 });

--- a/packages/rule-data/src/test-utils/coverage.test.ts
+++ b/packages/rule-data/src/test-utils/coverage.test.ts
@@ -10,23 +10,9 @@ describe(compareRuleCoverage, () => {
 					{ name: "a", url: undefined },
 					{ name: "b", url: "https://example.com/b" },
 				],
-				["b", "a"],
+				["b", "a", "a"],
 			),
-		).toEqual({ duplicates: [], missing: [], stale: [] });
-	});
-
-	it("reports duplicate covered names", () => {
-		expect(
-			compareRuleCoverage([{ name: "a", url: undefined }], ["a", "a"]),
-		).toEqual({ duplicates: ["a"], missing: [], stale: [] });
-	});
-
-	it("allows duplicate covered names when mappings are many-to-one", () => {
-		expect(
-			compareRuleCoverage([{ name: "a", url: undefined }], ["a", "a"], {
-				allowDuplicates: true,
-			}),
-		).toEqual({ duplicates: [], missing: [], stale: [] });
+		).toEqual({ missing: [], stale: [] });
 	});
 
 	it("reports available rules that are not covered, sorted by name", () => {
@@ -40,7 +26,6 @@ describe(compareRuleCoverage, () => {
 				["b"],
 			),
 		).toEqual({
-			duplicates: [],
 			missing: [
 				{ name: "a", url: undefined },
 				{ name: "c", url: "https://example.com/c" },
@@ -52,7 +37,7 @@ describe(compareRuleCoverage, () => {
 	it("reports covered names that are no longer available, sorted", () => {
 		expect(
 			compareRuleCoverage([{ name: "a", url: undefined }], ["z", "a", "y"]),
-		).toEqual({ duplicates: [], missing: [], stale: ["y", "z"] });
+		).toEqual({ missing: [], stale: ["y", "z"] });
 	});
 });
 
@@ -60,7 +45,6 @@ describe(formatRuleCoverage, () => {
 	it("renders missing rules as a checklist with optional urls", () => {
 		expect(
 			formatRuleCoverage("unicorn", {
-				duplicates: [],
 				missing: [
 					{ name: "unicorn/a", url: "https://example.com/a" },
 					{ name: "unicorn/b", url: undefined },
@@ -77,10 +61,9 @@ describe(formatRuleCoverage, () => {
 		);
 	});
 
-	it("renders stale rules after missing rules", () => {
+	it("renders stale rules as a checklist after missing rules", () => {
 		expect(
 			formatRuleCoverage("unicorn", {
-				duplicates: [],
 				missing: [{ name: "unicorn/a", url: undefined }],
 				stale: ["unicorn/z"],
 			}),
@@ -92,27 +75,7 @@ describe(formatRuleCoverage, () => {
 				"",
 				"**In data.json but no longer provided by unicorn (1):**",
 				"",
-				"- `unicorn/z`",
-			].join("\n"),
-		);
-	});
-
-	it("renders duplicate rules after stale rules", () => {
-		expect(
-			formatRuleCoverage("Oxlint", {
-				duplicates: ["typescript/no-explicit-any"],
-				missing: [],
-				stale: ["typescript/no-var-requires"],
-			}),
-		).toBe(
-			[
-				"**In data.json but no longer provided by Oxlint (1):**",
-				"",
-				"- `typescript/no-var-requires`",
-				"",
-				"**Duplicated in data.json (1):**",
-				"",
-				"- `typescript/no-explicit-any`",
+				"- [ ] `unicorn/z`",
 			].join("\n"),
 		);
 	});

--- a/packages/rule-data/src/test-utils/coverage.ts
+++ b/packages/rule-data/src/test-utils/coverage.ts
@@ -1,0 +1,195 @@
+import type { Rule } from "eslint";
+import { builtinRules } from "eslint/use-at-your-own-risk";
+
+import { findBiomeRulesInFlint, getBiomeLintRules } from "./biome.ts";
+import {
+	findESLintRulesInCore,
+	findESLintRulesInPlugin,
+	pluginsRulesByName,
+} from "./eslint.ts";
+import {
+	findMarkdownlintRules,
+	findMarkdownlintRulesInFlint,
+} from "./markdownlint.ts";
+import {
+	findOxlintRulesInFlint,
+	getOxlintLintRules,
+	getOxlintRuleConfigName,
+} from "./oxlint.ts";
+
+export interface LinterRule {
+	name: string;
+	url: string | undefined;
+}
+
+export interface RuleCoverage {
+	duplicates: string[];
+	missing: LinterRule[];
+	stale: string[];
+}
+
+export interface RuleCoverageSource {
+	collect: () => Promise<RuleCoverage> | RuleCoverage;
+	linter: string;
+}
+
+const excludedESLintRulesByPluginName = new Map([
+	// These rules are exported in the React plugin but not mentioned on react.dev.
+	// We're treating them as an internal implementation detail for now.
+	[
+		"react-hooks",
+		new Set([
+			"capitalized-calls",
+			"exhaustive-effect-dependencies",
+			"fbt",
+			"hooks",
+			"invariant",
+			"memo-dependencies",
+			"memoized-effect-dependencies",
+			"no-deriving-state-in-effects",
+			"rule-suppression",
+			"syntax",
+			"todo",
+			"void-use-memo",
+		]),
+	],
+]);
+
+export function compareRuleCoverage(
+	available: LinterRule[],
+	covered: Iterable<string>,
+	{ allowDuplicates = false }: { allowDuplicates?: boolean } = {},
+): RuleCoverage {
+	const availableNames = new Set(available.map((rule) => rule.name));
+	const coveredNames = new Set<string>();
+	const duplicates = new Set<string>();
+
+	for (const name of covered) {
+		if (coveredNames.has(name) && !allowDuplicates) {
+			duplicates.add(name);
+		}
+
+		coveredNames.add(name);
+	}
+
+	return {
+		duplicates: Array.from(duplicates).sort(),
+		missing: available
+			.filter((rule) => !coveredNames.has(rule.name))
+			.sort((a, b) => a.name.localeCompare(b.name)),
+		stale: Array.from(coveredNames)
+			.filter((name) => !availableNames.has(name))
+			.sort(),
+	};
+}
+
+export function formatRuleCoverage(
+	linter: string,
+	{ duplicates, missing, stale }: RuleCoverage,
+): string {
+	const sections: string[] = [];
+
+	if (missing.length) {
+		sections.push(
+			`**Missing from data.json (${missing.length}):**`,
+			missing
+				.map(({ name, url }) =>
+					url ? `- [ ] [\`${name}\`](${url})` : `- [ ] \`${name}\``,
+				)
+				.join("\n"),
+		);
+	}
+
+	if (stale.length) {
+		sections.push(
+			`**In data.json but no longer provided by ${linter} (${stale.length}):**`,
+			stale.map((name) => `- \`${name}\``).join("\n"),
+		);
+	}
+
+	if (duplicates.length) {
+		sections.push(
+			`**Duplicated in data.json (${duplicates.length}):**`,
+			duplicates.map((name) => `- \`${name}\``).join("\n"),
+		);
+	}
+
+	return sections.join("\n\n");
+}
+
+export function hasRuleCoverageGaps({
+	duplicates,
+	missing,
+	stale,
+}: RuleCoverage): boolean {
+	return Boolean(duplicates.length || missing.length || stale.length);
+}
+
+function collectBiomeCoverage(): RuleCoverage {
+	return compareRuleCoverage(
+		getBiomeLintRules().map((name) => ({ name, url: undefined })),
+		findBiomeRulesInFlint().map((rule) => rule.name),
+		{ allowDuplicates: true },
+	);
+}
+
+function collectESLintCoreCoverage(): RuleCoverage {
+	return compareRuleCoverage(
+		// builtinRules is marked as deprecated since it's in "use-at-your-own-risk", not actually deprecated
+		// flint-disable-lines-begin ts/deprecated
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
+		[...builtinRules]
+			// flint-disable-lines-end ts/deprecated
+			.flatMap(([name, rule]) =>
+				rule.meta?.deprecated ? [] : [{ name, url: rule.meta?.docs?.url }],
+			),
+		findESLintRulesInCore().map((rule) => rule.name),
+		{ allowDuplicates: true },
+	);
+}
+
+function collectESLintPluginCoverage(
+	pluginName: string,
+	rules: object,
+): RuleCoverage {
+	const excludedRuleNames = excludedESLintRulesByPluginName.get(pluginName);
+
+	return compareRuleCoverage(
+		Object.entries(rules as Record<string, Rule.RuleModule>)
+			.filter(([name]) => !excludedRuleNames?.has(name))
+			.map(([name, rule]) => ({
+				name: `${pluginName}/${name}`,
+				url: rule.meta?.docs?.url,
+			})),
+		findESLintRulesInPlugin(pluginName).map((rule) => rule.name),
+		{ allowDuplicates: true },
+	);
+}
+
+async function collectMarkdownlintCoverage(): Promise<RuleCoverage> {
+	return compareRuleCoverage(
+		(await findMarkdownlintRules()).flatMap((rule) => {
+			const name = rule.names.at(-1);
+			return name ? [{ name, url: undefined }] : [];
+		}),
+		findMarkdownlintRulesInFlint().map((rule) => rule.name),
+	);
+}
+
+async function collectOxlintCoverage(): Promise<RuleCoverage> {
+	return compareRuleCoverage(
+		(await getOxlintLintRules()).map((name) => ({ name, url: undefined })),
+		findOxlintRulesInFlint().map((rule) => getOxlintRuleConfigName(rule.name)),
+	);
+}
+
+export const ruleCoverageSources: RuleCoverageSource[] = [
+	{ collect: collectESLintCoreCoverage, linter: "ESLint" },
+	...Array.from(pluginsRulesByName, ([pluginName, rules]) => ({
+		collect: () => collectESLintPluginCoverage(pluginName, rules),
+		linter: pluginName,
+	})),
+	{ collect: collectBiomeCoverage, linter: "Biome" },
+	{ collect: collectMarkdownlintCoverage, linter: "Markdownlint" },
+	{ collect: collectOxlintCoverage, linter: "Oxlint" },
+].sort((a, b) => a.linter.localeCompare(b.linter));

--- a/packages/rule-data/src/test-utils/coverage.ts
+++ b/packages/rule-data/src/test-utils/coverage.ts
@@ -28,6 +28,11 @@ export interface RuleCoverage {
 	stale: string[];
 }
 
+export interface RuleCoverageReport {
+	coverage: RuleCoverage;
+	linter: string;
+}
+
 export interface RuleCoverageSource {
 	collect: () => Promise<RuleCoverage> | RuleCoverage;
 	linter: string;
@@ -54,6 +59,17 @@ const excludedESLintRulesByPluginName = new Map([
 		]),
 	],
 ]);
+
+export async function collectRuleCoverageReports(): Promise<
+	RuleCoverageReport[]
+> {
+	return Promise.all(
+		ruleCoverageSources.map(async ({ collect, linter }) => ({
+			coverage: await collect(),
+			linter,
+		})),
+	);
+}
 
 export function compareRuleCoverage(
 	available: LinterRule[],

--- a/packages/rule-data/src/test-utils/coverage.ts
+++ b/packages/rule-data/src/test-utils/coverage.ts
@@ -158,10 +158,9 @@ function collectESLintPluginCoverage(
 
 async function collectMarkdownlintCoverage(): Promise<RuleCoverage> {
 	return compareRuleCoverage(
-		(await findMarkdownlintRules()).flatMap((rule) => {
-			const name = rule.names.at(-1);
-			return name ? [{ name, url: undefined }] : [];
-		}),
+		(await findMarkdownlintRules()).flatMap((rule) =>
+			rule.names.slice(-1).map((name) => ({ name, url: undefined })),
+		),
 		findMarkdownlintRulesInFlint().map((rule) => rule.name),
 	);
 }

--- a/packages/rule-data/src/test-utils/coverage.ts
+++ b/packages/rule-data/src/test-utils/coverage.ts
@@ -23,7 +23,6 @@ export interface LinterRule {
 }
 
 export interface RuleCoverage {
-	duplicates: string[];
 	missing: LinterRule[];
 	stale: string[];
 }
@@ -74,22 +73,11 @@ export async function collectRuleCoverageReports(): Promise<
 export function compareRuleCoverage(
 	available: LinterRule[],
 	covered: Iterable<string>,
-	{ allowDuplicates = false }: { allowDuplicates?: boolean } = {},
 ): RuleCoverage {
 	const availableNames = new Set(available.map((rule) => rule.name));
-	const coveredNames = new Set<string>();
-	const duplicates = new Set<string>();
-
-	for (const name of covered) {
-		if (coveredNames.has(name) && !allowDuplicates) {
-			duplicates.add(name);
-		}
-
-		coveredNames.add(name);
-	}
+	const coveredNames = new Set(covered);
 
 	return {
-		duplicates: Array.from(duplicates).sort(),
 		missing: available
 			.filter((rule) => !coveredNames.has(rule.name))
 			.sort((a, b) => a.name.localeCompare(b.name)),
@@ -101,7 +89,7 @@ export function compareRuleCoverage(
 
 export function formatRuleCoverage(
 	linter: string,
-	{ duplicates, missing, stale }: RuleCoverage,
+	{ missing, stale }: RuleCoverage,
 ): string {
 	const sections: string[] = [];
 
@@ -119,33 +107,21 @@ export function formatRuleCoverage(
 	if (stale.length) {
 		sections.push(
 			`**In data.json but no longer provided by ${linter} (${stale.length}):**`,
-			stale.map((name) => `- \`${name}\``).join("\n"),
-		);
-	}
-
-	if (duplicates.length) {
-		sections.push(
-			`**Duplicated in data.json (${duplicates.length}):**`,
-			duplicates.map((name) => `- \`${name}\``).join("\n"),
+			stale.map((name) => `- [ ] \`${name}\``).join("\n"),
 		);
 	}
 
 	return sections.join("\n\n");
 }
 
-export function hasRuleCoverageGaps({
-	duplicates,
-	missing,
-	stale,
-}: RuleCoverage): boolean {
-	return Boolean(duplicates.length || missing.length || stale.length);
+export function hasRuleCoverageGaps({ missing, stale }: RuleCoverage): boolean {
+	return Boolean(missing.length || stale.length);
 }
 
 function collectBiomeCoverage(): RuleCoverage {
 	return compareRuleCoverage(
 		getBiomeLintRules().map((name) => ({ name, url: undefined })),
 		findBiomeRulesInFlint().map((rule) => rule.name),
-		{ allowDuplicates: true },
 	);
 }
 
@@ -160,7 +136,6 @@ function collectESLintCoreCoverage(): RuleCoverage {
 				rule.meta?.deprecated ? [] : [{ name, url: rule.meta?.docs?.url }],
 			),
 		findESLintRulesInCore().map((rule) => rule.name),
-		{ allowDuplicates: true },
 	);
 }
 
@@ -178,7 +153,6 @@ function collectESLintPluginCoverage(
 				url: rule.meta?.docs?.url,
 			})),
 		findESLintRulesInPlugin(pluginName).map((rule) => rule.name),
-		{ allowDuplicates: true },
 	);
 }
 

--- a/packages/rule-data/src/test-utils/oxlint.ts
+++ b/packages/rule-data/src/test-utils/oxlint.ts
@@ -14,12 +14,13 @@ export function findOxlintRulesInFlint(): LinterRuleReference[] {
 }
 
 export async function getOxlintLintRules(): Promise<string[]> {
-	const schema = (await import(
+	const { default: schema } = (await import(
 		new URL(
 			"configuration_schema.json",
 			import.meta.resolve("oxlint/package.json"),
-		).toString()
-	)) as OxlintSchema;
+		).toString(),
+		{ with: { type: "json" } }
+	)) as { default: OxlintSchema };
 	const properties = schema.definitions?.DummyRuleMap?.properties;
 
 	if (!properties) {


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #2968
- [x] That issue was marked as [`status: accepting prs`](https://github.com/flint-fyi/flint/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/flint-fyi/flint/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Makes missing rule-data coverage actionable instead of an opaque `Set` diff:

- `src/test-utils/coverage.ts` computes per-linter gaps: `missing` (with doc URLs from `meta.docs.url` when available), `stale`, and `duplicates`. `data.test.ts` now asserts on that shape, so a failing test prints the exact rule list.
- `pnpm --filter=rule-data report-missing-rules` prints the same report locally and exits 1 when out of sync.
- `.github/workflows/rule-data-renovate.yaml` runs on same-repo Renovate PRs that touch rule-data dependencies, and files or updates one issue per linter (stable title as the idempotency key), labeled `area: documentation` + `package: comparisons` + `status: accepting prs`, with a copy in the job summary. The job doesn't gate the PR; the existing tests stay the gate.
- Fixes the Oxlint test util's dynamic JSON import (`with { type: "json" }`) so the scripts also run under plain Node.

Verified end to end in a fork sandbox running exactly this code: [run 1](https://github.com/kovsu/flint/actions/runs/32767242283) created kovsu/flint#4 listing all 198 unicorn rules missing between v64 and v73, and [run 2](https://github.com/kovsu/flint/actions/runs/32767357155) updated that same issue in place on a second push.
This PR itself triggers the workflow too, and the job should show as skipped since the author is not `renovate[bot]`.

One tradeoff to flag: the job that imports the just-bumped packages also holds the `issues: write` token. If you'd rather isolate that (an unprivileged collect job handing a report artifact to a `workflow_run` job that only runs default-branch code), I'm happy to do it as a follow-up.

After merging, ticking the rebase checkboxes on the Dependency Dashboard for the currently stuck linter PRs should backfill their issues.

❤️‍🔥
