### PR TITLE
fix(typescript-language): track re-export dependencies

### DIFF
--- a/.changeset/typescript-reexport-dependents.md
+++ b/.changeset/typescript-reexport-dependents.md
@@ -1,0 +1,5 @@
+---
+"@flint.fyi/typescript-language": patch
+---
+
+The TypeScript dependency tracker now respects re-exports.

--- a/packages/typescript-language/src/collectReferencedFilePaths.test.ts
+++ b/packages/typescript-language/src/collectReferencedFilePaths.test.ts
@@ -1,0 +1,70 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import ts from "typescript";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { collectReferencedFilePaths } from "./collectReferencedFilePaths.ts";
+import type * as AST from "./types/ast.ts";
+
+const tempDirectories: string[] = [];
+
+describe(collectReferencedFilePaths, () => {
+	afterEach(async () => {
+		await Promise.all(
+			tempDirectories
+				.splice(0)
+				.map((dir) => rm(dir, { force: true, recursive: true })),
+		);
+	});
+
+	it("includes imports, import types, dynamic imports, and re-exports", async () => {
+		const root = await mkdtemp(path.join(os.tmpdir(), "flint-ts-deps-"));
+		tempDirectories.push(root);
+
+		const indexPath = path.join(root, "index.ts");
+		const dependencyNames = [
+			"imported",
+			"dynamic",
+			"awaited",
+			"typed",
+			"exported",
+			"export-all",
+		];
+
+		await Promise.all([
+			writeFile(
+				indexPath,
+				`
+					import { imported } from "./imported";
+					void import("./dynamic");
+					await import("./awaited");
+					type Typed = import("./typed").Typed;
+					export { exported } from "./exported";
+					export * from "./export-all";
+				`,
+			),
+			...dependencyNames.map((name) =>
+				writeFile(path.join(root, `${name}.ts`), "export const value = 1;"),
+			),
+		]);
+
+		const program = ts.createProgram([indexPath], {
+			allowJs: true,
+			module: ts.ModuleKind.NodeNext,
+			moduleResolution: ts.ModuleResolutionKind.NodeNext,
+			target: ts.ScriptTarget.ESNext,
+		});
+		const sourceFile = program.getSourceFile(indexPath);
+
+		expect(sourceFile).toBeDefined();
+		expect(
+			new Set(
+				collectReferencedFilePaths(program, sourceFile as AST.SourceFile).map(
+					(filePath) => path.basename(filePath, ".ts"),
+				),
+			),
+		).toEqual(new Set(dependencyNames));
+	});
+});

--- a/packages/typescript-language/src/collectReferencedFilePaths.ts
+++ b/packages/typescript-language/src/collectReferencedFilePaths.ts
@@ -25,7 +25,7 @@ export function collectReferencedFilePaths(
 
 		if (resolved.resolvedModule?.isExternalLibraryImport === false) {
 			return path.relative(
-				process.cwd(),
+				program.getCurrentDirectory(),
 				resolved.resolvedModule.resolvedFileName,
 			);
 		}
@@ -37,6 +37,9 @@ export function collectReferencedFilePaths(
 
 		if (isImportDeclaration(node)) {
 			// import { x } from "./foo";
+			path = node.moduleSpecifier.text;
+		} else if (isExportDeclaration(node)) {
+			// export { x } from "./foo"; or export * from "./foo";
 			path = node.moduleSpecifier.text;
 		} else if (isImportCall(node)) {
 			// const x = import("./foo")
@@ -66,6 +69,16 @@ function isAwaitImportCall(node: ts.Node): node is AST.AwaitExpression & {
 	expression: ts.CallExpression & { arguments: [ts.StringLiteral] };
 } {
 	return ts.isAwaitExpression(node) && isImportCall(node.expression);
+}
+
+function isExportDeclaration(
+	node: ts.Node,
+): node is ts.ExportDeclaration & { moduleSpecifier: ts.StringLiteral } {
+	return (
+		ts.isExportDeclaration(node) &&
+		node.moduleSpecifier != null &&
+		ts.isStringLiteral(node.moduleSpecifier)
+	);
 }
 
 function isImportCall(

--- a/packages/typescript-language/src/createTypeScriptServerHost.ts
+++ b/packages/typescript-language/src/createTypeScriptServerHost.ts
@@ -53,6 +53,9 @@ export function createTypeScriptServerHost(
 				"file"
 			);
 		},
+		getCurrentDirectory() {
+			return host.getCurrentDirectory();
+		},
 		readDirectory(directoryPath, extensions, exclude, include, depth) {
 			const originalCwd = process.cwd.bind(process);
 			process.cwd = () => host.getCurrentDirectory();


### PR DESCRIPTION
## PR Checklist

- [ ] Addresses an existing open issue
  - requested in review of #2766
- [ ] That issue was marked as [`status: accepting prs`](https://github.com/flint-fyi/flint/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/flint-fyi/flint/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Track re-exports as TypeScript file dependencies.