### PR TITLE
ci: disable package previews workflow in forks

### DIFF
--- a/.github/workflows/package-previews.yaml
+++ b/.github/workflows/package-previews.yaml
@@ -10,6 +10,7 @@ permissions: {}
 
 jobs:
   publish:
+    if: github.event.repository.fork != true
     name: Publish Package Previews
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [`status: accepting prs`](https://github.com/flint-fyi/flint/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/flint-fyi/flint/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Skips the Package Previews job in fork repositories, where pkg.pr.new is not installed and cannot publish previews.

❤️‍🔥