### PR TITLE
feat: detect duplicate test cases in rule tester

### DIFF
--- a/.changeset/rule-tester-duplicate-test-cases.md
+++ b/.changeset/rule-tester-duplicate-test-cases.md
@@ -1,0 +1,5 @@
+---
+"@flint.fyi/rule-tester": minor
+---
+
+Reject test cases that repeat an earlier test case's code, fileName, files, and options.

--- a/packages/rule-tester/src/RuleTester.test.ts
+++ b/packages/rule-tester/src/RuleTester.test.ts
@@ -10,6 +10,7 @@ import {
 
 import {
 	RuleTester,
+	type TestCases,
 	type TesterSetupDescribe,
 	type TesterSetupIt,
 } from "./RuleTester.ts";
@@ -46,15 +47,66 @@ Another language report.`,
 	it("allows languages without language reports", async () => {
 		await expect(createTestSetup({})()).resolves.toBeUndefined();
 	});
+
+	it("fails a test case that duplicates an earlier test case", async () => {
+		const [first, second] = createTestSetups({
+			testCases: { invalid: [], valid: ["let a;", { code: "let a;" }] },
+		});
+		assert.ok(first);
+		assert.ok(second);
+
+		await expect(first()).resolves.toBeUndefined();
+		expect(second).toThrow(
+			"Expected no duplicate test cases, but an earlier test case has the same code, fileName, files, and options.",
+		);
+	});
+
+	it("allows test cases with the same code and different file names", async () => {
+		const [first, second] = createTestSetups({
+			testCases: {
+				invalid: [],
+				valid: ["let a;", { code: "let a;", fileName: "other.ts" }],
+			},
+		});
+		assert.ok(first);
+		assert.ok(second);
+
+		await expect(first()).resolves.toBeUndefined();
+		await expect(second()).resolves.toBeUndefined();
+	});
+
+	it("allows an invalid test case with the same code as a valid test case", async () => {
+		const [first, second] = createTestSetups({
+			testCases: {
+				invalid: [{ code: "let a;", snapshot: "let a;" }],
+				valid: ["let a;"],
+			},
+		});
+		assert.ok(first);
+		assert.ok(second);
+
+		await expect(first()).resolves.toBeUndefined();
+		await expect(second()).resolves.toBeUndefined();
+	});
 });
 
-function createTestSetup({
-	assertNoLanguageReports,
-	getLanguageReports,
-}: {
+interface TestSetupOptions {
 	assertNoLanguageReports?: boolean;
 	getLanguageReports?: () => LanguageReports;
-}): () => Promise<void> {
+	testCases?: TestCases<undefined>;
+}
+
+function createTestSetup(options: TestSetupOptions): () => Promise<void> {
+	const testSetup = createTestSetups(options)[0];
+	assert.ok(testSetup);
+	return testSetup;
+}
+
+function createTestSetups({
+	assertNoLanguageReports,
+	getLanguageReports,
+	testCases = { invalid: [], valid: [""] },
+}: TestSetupOptions): (() => Promise<void>)[] {
 	const testSetups: (() => Promise<void>)[] = [];
 	const collectTest: TesterSetupIt = (_description, setup): void => {
 		testSetups.push(setup);
@@ -88,9 +140,7 @@ function createTestSetup({
 		it: collectTest,
 		only: collectTest,
 		skip: collectTest,
-	}).describe(rule, { invalid: [], valid: [""] });
+	}).describe(rule, testCases);
 
-	const testSetup = testSetups[0];
-	assert.ok(testSetup);
-	return testSetup;
+	return testSetups;
 }

--- a/packages/rule-tester/src/RuleTester.test.ts
+++ b/packages/rule-tester/src/RuleTester.test.ts
@@ -61,6 +61,31 @@ Another language report.`,
 		);
 	});
 
+	it("fails a duplicate test case whose files use different property order", async () => {
+		const [first, second] = createTestSetups({
+			testCases: {
+				invalid: [],
+				valid: [
+					{ code: "let a;", files: { "a.ts": "a", "b.ts": "b" } },
+					{
+						code: "let a;",
+						files: Object.fromEntries([
+							["b.ts", "b"],
+							["a.ts", "a"],
+						]),
+					},
+				],
+			},
+		});
+		assert.ok(first);
+		assert.ok(second);
+
+		await expect(first()).resolves.toBeUndefined();
+		expect(second).toThrow(
+			"Expected no duplicate test cases, but an earlier test case has the same code, fileName, files, and options.",
+		);
+	});
+
 	it("allows test cases with the same code and different file names", async () => {
 		const [first, second] = createTestSetups({
 			testCases: {

--- a/packages/rule-tester/src/RuleTester.ts
+++ b/packages/rule-tester/src/RuleTester.ts
@@ -137,14 +137,16 @@ export class RuleTester {
 	): void {
 		this.#testerOptions.describe(rule.about.id, () => {
 			this.#testerOptions.describe("invalid", () => {
+				const seenTestCases = new Set<string>();
 				for (const testCase of invalid) {
-					this.#itInvalidCase(rule, testCase);
+					this.#itInvalidCase(rule, testCase, seenTestCases);
 				}
 			});
 
 			this.#testerOptions.describe("valid", () => {
+				const seenTestCases = new Set<string>();
 				for (const testCase of valid) {
-					this.#itValidCase(rule, testCase);
+					this.#itValidCase(rule, testCase, seenTestCases);
 				}
 			});
 		});
@@ -153,13 +155,14 @@ export class RuleTester {
 	#itInvalidCase<OptionsSchema extends AnyOptionalSchema | undefined>(
 		rule: AnyRule<RuleAbout, OptionsSchema>,
 		testCase: InvalidTestCase<InferredInputObject<OptionsSchema>>,
+		seenTestCases: Set<string>,
 	) {
 		const testCaseNormalized = normalizeTestCase(
 			testCase,
 			this.#testerOptions.defaults.fileName,
 		);
 
-		this.#itTestCase(testCaseNormalized, async () => {
+		this.#itTestCase(testCaseNormalized, seenTestCases, async () => {
 			const { languageReports, reports } = await runTestCaseRule(
 				this.#fileFactories,
 				this.#linterHost,
@@ -190,7 +193,11 @@ export class RuleTester {
 		});
 	}
 
-	#itTestCase(testCase: TestCaseNormalized, setup: () => Promise<void>) {
+	#itTestCase(
+		testCase: TestCaseNormalized,
+		seenTestCases: Set<string>,
+		setup: () => Promise<void>,
+	) {
 		let test = testCase.only
 			? this.#testerOptions.only
 			: this.#testerOptions.it;
@@ -213,6 +220,7 @@ export class RuleTester {
 						)
 					: testCase.code),
 			() => {
+				assertNoDuplicateTestCase(testCase, seenTestCases);
 				if (testCase.files != null) {
 					assert.notEqual(
 						Object.keys(testCase.files).length,
@@ -228,6 +236,7 @@ export class RuleTester {
 	#itValidCase<OptionsSchema extends AnyOptionalSchema | undefined>(
 		rule: AnyRule<RuleAbout, OptionsSchema>,
 		testCaseRaw: ValidTestCase<InferredInputObject<OptionsSchema>>,
+		seenTestCases: Set<string>,
 	) {
 		const testCase =
 			typeof testCaseRaw === "string" ? { code: testCaseRaw } : testCaseRaw;
@@ -236,7 +245,7 @@ export class RuleTester {
 			this.#testerOptions.defaults.fileName,
 		);
 
-		this.#itTestCase(testCaseNormalized, async () => {
+		this.#itTestCase(testCaseNormalized, seenTestCases, async () => {
 			const { languageReports, reports } = await runTestCaseRule(
 				this.#fileFactories,
 				this.#linterHost,
@@ -256,6 +265,26 @@ export class RuleTester {
 			}
 		});
 	}
+}
+
+function assertNoDuplicateTestCase(
+	testCase: TestCaseNormalized,
+	seenTestCases: Set<string>,
+): void {
+	const serializedTestCase = JSON.stringify({
+		code: testCase.code,
+		fileName: testCase.fileName,
+		files: testCase.files,
+		options: testCase.options,
+	});
+
+	if (seenTestCases.has(serializedTestCase)) {
+		assert.fail(
+			"Expected no duplicate test cases, but an earlier test case has the same code, fileName, files, and options.",
+		);
+	}
+
+	seenTestCases.add(serializedTestCase);
 }
 
 function assertNoLanguageReports(languageReports: LanguageReports) {

--- a/packages/rule-tester/src/RuleTester.ts
+++ b/packages/rule-tester/src/RuleTester.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import path from "node:path";
+import { isDeepStrictEqual } from "node:util";
 
 import { CachedFactory } from "cached-factory";
 
@@ -57,6 +58,11 @@ export type TesterSetupIt = (
 	description: string,
 	setup: () => Promise<void>,
 ) => void;
+
+type TestCaseDuplicateProperties = Pick<
+	TestCaseNormalized,
+	"code" | "fileName" | "files" | "options"
+>;
 
 export class RuleTester {
 	#fileFactories: CachedFactory<AnyLanguage, AnyLanguageFileFactory>;
@@ -137,14 +143,14 @@ export class RuleTester {
 	): void {
 		this.#testerOptions.describe(rule.about.id, () => {
 			this.#testerOptions.describe("invalid", () => {
-				const seenTestCases = new Set<string>();
+				const seenTestCases: TestCaseDuplicateProperties[] = [];
 				for (const testCase of invalid) {
 					this.#itInvalidCase(rule, testCase, seenTestCases);
 				}
 			});
 
 			this.#testerOptions.describe("valid", () => {
-				const seenTestCases = new Set<string>();
+				const seenTestCases: TestCaseDuplicateProperties[] = [];
 				for (const testCase of valid) {
 					this.#itValidCase(rule, testCase, seenTestCases);
 				}
@@ -155,7 +161,7 @@ export class RuleTester {
 	#itInvalidCase<OptionsSchema extends AnyOptionalSchema | undefined>(
 		rule: AnyRule<RuleAbout, OptionsSchema>,
 		testCase: InvalidTestCase<InferredInputObject<OptionsSchema>>,
-		seenTestCases: Set<string>,
+		seenTestCases: TestCaseDuplicateProperties[],
 	) {
 		const testCaseNormalized = normalizeTestCase(
 			testCase,
@@ -195,7 +201,7 @@ export class RuleTester {
 
 	#itTestCase(
 		testCase: TestCaseNormalized,
-		seenTestCases: Set<string>,
+		seenTestCases: TestCaseDuplicateProperties[],
 		setup: () => Promise<void>,
 	) {
 		let test = testCase.only
@@ -236,7 +242,7 @@ export class RuleTester {
 	#itValidCase<OptionsSchema extends AnyOptionalSchema | undefined>(
 		rule: AnyRule<RuleAbout, OptionsSchema>,
 		testCaseRaw: ValidTestCase<InferredInputObject<OptionsSchema>>,
-		seenTestCases: Set<string>,
+		seenTestCases: TestCaseDuplicateProperties[],
 	) {
 		const testCase =
 			typeof testCaseRaw === "string" ? { code: testCaseRaw } : testCaseRaw;
@@ -269,22 +275,26 @@ export class RuleTester {
 
 function assertNoDuplicateTestCase(
 	testCase: TestCaseNormalized,
-	seenTestCases: Set<string>,
+	seenTestCases: TestCaseDuplicateProperties[],
 ): void {
-	const serializedTestCase = JSON.stringify({
+	const duplicateProperties = {
 		code: testCase.code,
 		fileName: testCase.fileName,
 		files: testCase.files,
 		options: testCase.options,
-	});
+	} satisfies TestCaseDuplicateProperties;
 
-	if (seenTestCases.has(serializedTestCase)) {
+	if (
+		seenTestCases.some((seenTestCase) =>
+			isDeepStrictEqual(seenTestCase, duplicateProperties),
+		)
+	) {
 		assert.fail(
 			"Expected no duplicate test cases, but an earlier test case has the same code, fileName, files, and options.",
 		);
 	}
 
-	seenTestCases.add(serializedTestCase);
+	seenTestCases.push(duplicateProperties);
 }
 
 function assertNoLanguageReports(languageReports: LanguageReports) {

--- a/packages/rule-tester/src/RuleTester.ts
+++ b/packages/rule-tester/src/RuleTester.ts
@@ -59,7 +59,7 @@ export type TesterSetupIt = (
 	setup: () => Promise<void>,
 ) => void;
 
-type TestCaseDuplicateProperties = Pick<
+type TestCaseUniqueProperties = Pick<
 	TestCaseNormalized,
 	"code" | "fileName" | "files" | "options"
 >;
@@ -143,14 +143,14 @@ export class RuleTester {
 	): void {
 		this.#testerOptions.describe(rule.about.id, () => {
 			this.#testerOptions.describe("invalid", () => {
-				const seenTestCases: TestCaseDuplicateProperties[] = [];
+				const seenTestCases: TestCaseUniqueProperties[] = [];
 				for (const testCase of invalid) {
 					this.#itInvalidCase(rule, testCase, seenTestCases);
 				}
 			});
 
 			this.#testerOptions.describe("valid", () => {
-				const seenTestCases: TestCaseDuplicateProperties[] = [];
+				const seenTestCases: TestCaseUniqueProperties[] = [];
 				for (const testCase of valid) {
 					this.#itValidCase(rule, testCase, seenTestCases);
 				}
@@ -161,7 +161,7 @@ export class RuleTester {
 	#itInvalidCase<OptionsSchema extends AnyOptionalSchema | undefined>(
 		rule: AnyRule<RuleAbout, OptionsSchema>,
 		testCase: InvalidTestCase<InferredInputObject<OptionsSchema>>,
-		seenTestCases: TestCaseDuplicateProperties[],
+		seenTestCases: TestCaseUniqueProperties[],
 	) {
 		const testCaseNormalized = normalizeTestCase(
 			testCase,
@@ -201,7 +201,7 @@ export class RuleTester {
 
 	#itTestCase(
 		testCase: TestCaseNormalized,
-		seenTestCases: TestCaseDuplicateProperties[],
+		seenTestCases: TestCaseUniqueProperties[],
 		setup: () => Promise<void>,
 	) {
 		let test = testCase.only
@@ -242,7 +242,7 @@ export class RuleTester {
 	#itValidCase<OptionsSchema extends AnyOptionalSchema | undefined>(
 		rule: AnyRule<RuleAbout, OptionsSchema>,
 		testCaseRaw: ValidTestCase<InferredInputObject<OptionsSchema>>,
-		seenTestCases: TestCaseDuplicateProperties[],
+		seenTestCases: TestCaseUniqueProperties[],
 	) {
 		const testCase =
 			typeof testCaseRaw === "string" ? { code: testCaseRaw } : testCaseRaw;
@@ -275,14 +275,14 @@ export class RuleTester {
 
 function assertNoDuplicateTestCase(
 	testCase: TestCaseNormalized,
-	seenTestCases: TestCaseDuplicateProperties[],
+	seenTestCases: TestCaseUniqueProperties[],
 ): void {
 	const duplicateProperties = {
 		code: testCase.code,
 		fileName: testCase.fileName,
 		files: testCase.files,
 		options: testCase.options,
-	} satisfies TestCaseDuplicateProperties;
+	} satisfies TestCaseUniqueProperties;
 
 	if (
 		seenTestCases.some((seenTestCase) =>

--- a/packages/ts/src/rules/regexOctalEscapes.test.ts
+++ b/packages/ts/src/rules/regexOctalEscapes.test.ts
@@ -65,16 +65,6 @@ new RegExp("()\\1\\2");
                 Octal escape sequence '\2' can be confused with backreferences.
 `,
 		},
-		{
-			code: String.raw`
-new RegExp("\\07");
-`,
-			snapshot: String.raw`
-new RegExp("\\07");
-            ~~~
-            Octal escape sequence '\07' can be confused with backreferences.
-`,
-		},
 	],
 	valid: [
 		String.raw`/\0/;`,


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #342
- [x] That issue was marked as [`status: accepting prs`](https://github.com/flint-fyi/flint/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/flint-fyi/flint/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Compares the same four fields as the plugin-flint testCaseDuplicates rule, ignoring property order, and fixes the existing violation exposed in the tests.
