### PR TITLE
fix: detect duplicate invalid test cases with `String.raw` snapshots

### DIFF
--- a/.changeset/test-case-duplicates-string-raw-snapshot.md
+++ b/.changeset/test-case-duplicates-string-raw-snapshot.md
@@ -1,0 +1,5 @@
+---
+"@flint.fyi/plugin-flint": patch
+---
+
+Detect duplicate invalid test cases declared with `String.raw` snapshots.

--- a/packages/plugin-flint/src/rules/testCaseDuplicates.test.ts
+++ b/packages/plugin-flint/src/rules/testCaseDuplicates.test.ts
@@ -371,6 +371,40 @@ ruleTester.describe(rule, {
 
 `,
 		},
+		{
+			code: `
+import { RuleTester } from "@flint.fyi/rule-tester";
+import rule from "../ruleCreationMethods";
+
+const ruleTester = new RuleTester();
+
+ruleTester.describe(rule, {
+    valid: [],
+    invalid: [
+        { code: "a", snapshot: String.raw\`a\` },
+        { code: "a", snapshot: String.raw\`a\` },
+    ]
+});
+
+`,
+			snapshot: `
+import { RuleTester } from "@flint.fyi/rule-tester";
+import rule from "../ruleCreationMethods";
+
+const ruleTester = new RuleTester();
+
+ruleTester.describe(rule, {
+    valid: [],
+    invalid: [
+        { code: "a", snapshot: String.raw\`a\` },
+        { code: "a", snapshot: String.raw\`a\` },
+        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        This test code already appeared in a previous test.
+    ]
+});
+
+`,
+		},
 	],
 	valid: [
 		`

--- a/packages/plugin-flint/src/utils/parseTestCases.ts
+++ b/packages/plugin-flint/src/utils/parseTestCases.ts
@@ -92,7 +92,7 @@ export function parseTestCaseInvalid(
 		"options",
 		(node) => node.kind === SyntaxKind.ObjectLiteralExpression,
 	);
-	const snapshot = findProperty(node.properties, "snapshot", isStaticString);
+	const snapshot = findProperty(node.properties, "snapshot", isTestCaseCode);
 	if (!snapshot) {
 		return;
 	}
@@ -112,7 +112,7 @@ export function parseTestCaseInvalid(
 			snapshot,
 		},
 		options: options && tsAstToLiteral(options),
-		snapshot: snapshot.text,
+		snapshot: getTestCaseCode(snapshot),
 	};
 }
 

--- a/packages/plugin-flint/src/utils/types.ts
+++ b/packages/plugin-flint/src/utils/types.ts
@@ -30,7 +30,7 @@ export interface ParsedTestCaseNodes {
 }
 
 export interface ParsedTestCaseNodesInvalid extends ParsedTestCaseNodes {
-	snapshot: ParsedTestCaseStaticStringNode;
+	snapshot: ParsedTestCaseCodeNode;
 }
 export type ParsedTestCaseStaticStringNode =
 	| AST.NoSubstitutionTemplateLiteral

--- a/packages/ts/src/rules/regexOctalEscapes.test.ts
+++ b/packages/ts/src/rules/regexOctalEscapes.test.ts
@@ -65,16 +65,6 @@ new RegExp("()\\1\\2");
                 Octal escape sequence '\2' can be confused with backreferences.
 `,
 		},
-		{
-			code: String.raw`
-new RegExp("\\07");
-`,
-			snapshot: String.raw`
-new RegExp("\\07");
-            ~~~
-            Octal escape sequence '\07' can be confused with backreferences.
-`,
-		},
 	],
 	valid: [
 		String.raw`/\0/;`,


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #3365
- [x] That issue was marked as [`status: accepting prs`](https://github.com/flint-fyi/flint/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/flint-fyi/flint/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

The parser now reads `snapshot` the same way it reads `code`, which also covers the other rules that use it. That exposes one duplicate in the ts regexOctalEscapes tests, the same one #3363 removes.
