### PR TITLE
fix(rule-tester): validate cross-file suggestions individually

### DIFF
--- a/.changeset/rule-tester-cross-file-suggestions.md
+++ b/.changeset/rule-tester-cross-file-suggestions.md
@@ -1,5 +1,5 @@
 ---
-"@flint.fyi/rule-tester": major
+"@flint.fyi/rule-tester": minor
 ---
 
 Reject incomplete or mismatched cross-file suggestion expectations that were previously accepted.

--- a/.changeset/rule-tester-cross-file-suggestions.md
+++ b/.changeset/rule-tester-cross-file-suggestions.md
@@ -1,0 +1,8 @@
+---
+"@flint.fyi/rule-tester": major
+---
+
+Reject incomplete or mismatched cross-file suggestion expectations that were previously accepted.
+Each expected suggestion must match the corresponding reported suggestion in flattened report order, including its own-file or cross-file variant and exact target-path set.
+Update tests to list every reported target path, remove paths that the corresponding suggestion does not target, and keep each suggestion's expectations separate.
+Mixed own-file and cross-file suggestions are now supported in the same test case.

--- a/packages/rule-tester/src/RuleTester.test.ts
+++ b/packages/rule-tester/src/RuleTester.test.ts
@@ -6,6 +6,7 @@ import {
 	createLanguage,
 	RuleCreator,
 	type LanguageReports,
+	type RuleReport,
 } from "@flint.fyi/core";
 
 import {
@@ -113,11 +114,52 @@ Another language report.`,
 		await expect(first()).resolves.toBeUndefined();
 		await expect(second()).resolves.toBeUndefined();
 	});
+
+	it("rejects cross-file suggestion mismatches through the named test callback", async () => {
+		const registerTest = vi.fn<TesterSetupIt>();
+		createTestSetups({
+			it: registerTest,
+			report: {
+				filePath: "file.ts",
+				message: "",
+				range: { begin: 0, end: 1 },
+				suggestions: [{ files: { "unexpected.ts": [] }, id: "suggestion" }],
+			},
+			testCases: {
+				invalid: [
+					{
+						code: "abc",
+						name: "cross-file target mismatch",
+						snapshot: "abc\n~\n",
+						suggestions: [
+							{
+								files: { "expected.ts": [{ original: "abc", updated: "abc" }] },
+								id: "suggestion",
+							},
+						],
+					},
+				],
+				valid: [],
+			},
+		});
+
+		expect(registerTest).toHaveBeenCalledExactlyOnceWith(
+			"cross-file target mismatch",
+			expect.any(Function),
+		);
+		const registeredTest = registerTest.mock.calls[0];
+		assert.ok(registeredTest);
+		await expect(registeredTest[1]()).rejects.toThrow(
+			"Reported suggestion target paths must exactly match expected target paths.",
+		);
+	});
 });
 
 interface TestSetupOptions {
 	assertNoLanguageReports?: boolean;
 	getLanguageReports?: () => LanguageReports;
+	it?: TesterSetupIt;
+	report?: RuleReport<"">;
 	testCases?: TestCases<undefined>;
 }
 
@@ -130,6 +172,8 @@ function createTestSetup(options: TestSetupOptions): () => Promise<void> {
 function createTestSetups({
 	assertNoLanguageReports,
 	getLanguageReports,
+	it: registerTest,
+	report,
 	testCases = { invalid: [], valid: [""] },
 }: TestSetupOptions): (() => Promise<void>)[] {
 	const testSetups: (() => Promise<void>)[] = [];
@@ -154,7 +198,12 @@ function createTestSetups({
 	}).createRule(language, {
 		about: { description: "", id: "languageReports" },
 		messages: { "": { primary: "", secondary: [], suggestions: [] } },
-		setup: () => ({}),
+		setup: (context) => {
+			if (report) {
+				context.report(report);
+			}
+			return {};
+		},
 	});
 
 	new RuleTester({
@@ -162,7 +211,7 @@ function createTestSetups({
 			? {}
 			: { assertNoLanguageReports }),
 		describe: runDescribe,
-		it: collectTest,
+		it: registerTest ?? collectTest,
 		only: collectTest,
 		skip: collectTest,
 	}).describe(rule, testCases);

--- a/packages/rule-tester/src/resolveReportedSuggestions.test.ts
+++ b/packages/rule-tester/src/resolveReportedSuggestions.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import { resolveReportedSuggestions } from "./resolveReportedSuggestions.ts";
+import type { TestSuggestion } from "./types.ts";
 
 const mockReport = {
 	message: { primary: "", secondary: [], suggestions: [] },
@@ -55,15 +56,14 @@ describe("resolveReportedSuggestions", () => {
 		]);
 	});
 
-	it("throws when given a test case with no suggestions", () => {
+	it("throws when an own-file suggestion is expected to target other files", () => {
 		const report = {
 			...mockReport,
 			suggestions: [
 				{
-					files: {
-						"file.ts": [{ range: { begin: 0, end: 3 }, text: "def" }],
-					},
 					id: "suggestion-report",
+					range: { begin: 0, end: 3 },
+					text: "def",
 				},
 			],
 		};
@@ -73,13 +73,15 @@ describe("resolveReportedSuggestions", () => {
 				...mockTestCaseNormalized,
 				suggestions: [
 					{
+						files: {
+							"file.ts": [{ original: "abc", updated: "def" }],
+						},
 						id: "suggestion-result",
-						updated: "...",
 					},
 				],
 			}),
 		).toThrowErrorMatchingInlineSnapshot(
-			`[Error: This test case describes suggestions across files, but the rule is only reporting changes to its own file.]`,
+			`[Error: This test case describes a suggestion across files, but the rule is only reporting changes to its own file.]`,
 		);
 	});
 
@@ -107,9 +109,108 @@ describe("resolveReportedSuggestions", () => {
 				],
 			}),
 		).toThrowErrorMatchingInlineSnapshot(
-			`[Error: This test case describes suggestions across files, but the rule is only reporting changes to its own file.]`,
+			`[Error: This test case describes a suggestion to its own file, but the rule is reporting changes across files.]`,
 		);
 	});
+
+	it.each([["expected.ts", "unexpected.ts"], ["unexpected.ts"], []])(
+		"rejects mismatched target paths: %j",
+		(...filePaths) => {
+			expect(() =>
+				resolveReportedSuggestions(
+					[
+						{
+							...mockReport,
+							suggestions: [
+								{
+									files: Object.fromEntries(
+										filePaths.map((filePath) => [filePath, []]),
+									),
+									id: "suggestion",
+								},
+							],
+						},
+					],
+					{
+						...mockTestCaseNormalized,
+						suggestions: [
+							{
+								files: { "expected.ts": [{ original: "abc", updated: "abc" }] },
+								id: "suggestion",
+							},
+						],
+					},
+				),
+			).toThrow(
+				"Reported suggestion target paths must exactly match expected target paths.",
+			);
+		},
+	);
+
+	it("pairs cross-file suggestions by flattened report order, even with identical ids", () => {
+		const suggestions: TestSuggestion[] = [
+			{
+				files: { "first.ts": [{ original: "abc", updated: "first" }] },
+				id: "suggestion",
+			},
+			{
+				files: { "second.ts": [{ original: "xyz", updated: "second" }] },
+				id: "suggestion",
+			},
+		];
+
+		const result = resolveReportedSuggestions(
+			["first", "second"].map((text) => ({
+				...mockReport,
+				suggestions: [
+					{
+						files: { [`${text}.ts`]: [{ range: { begin: 0, end: 3 }, text }] },
+						id: "suggestion",
+					},
+				],
+			})),
+			{ ...mockTestCaseNormalized, suggestions },
+		);
+
+		expect(result).toEqual(suggestions);
+	});
+
+	it.each([false, true])(
+		"accepts mixed suggestion variants (own-file first: %s)",
+		(ownFileFirst) => {
+			const ownFileReported = {
+				id: "own",
+				range: { begin: 0, end: 3 },
+				text: "own",
+			};
+			const crossFileReported = {
+				files: { "other.ts": [{ range: { begin: 0, end: 3 }, text: "other" }] },
+				id: "cross",
+			};
+			const ownFileExpected = { id: "own", updated: "own" };
+			const crossFileExpected = {
+				files: { "other.ts": [{ original: "abc", updated: "other" }] },
+				id: "cross",
+			};
+			const suggestions = ownFileFirst
+				? [ownFileExpected, crossFileExpected]
+				: [crossFileExpected, ownFileExpected];
+
+			const result = resolveReportedSuggestions(
+				[
+					{
+						...mockReport,
+						suggestions: ownFileFirst
+							? [ownFileReported, crossFileReported]
+							: [crossFileReported, ownFileReported],
+					},
+				],
+				{ ...mockTestCaseNormalized, suggestions },
+			);
+
+			expect(result).toEqual(suggestions);
+		},
+	);
 
 	it("returns id and a files object when given multi-file suggestions with a single file", () => {
 		const report = {

--- a/packages/rule-tester/src/resolveReportedSuggestions.ts
+++ b/packages/rule-tester/src/resolveReportedSuggestions.ts
@@ -80,7 +80,7 @@ function resolveReportedSuggestionForFiles(
 		Object.entries(suggestionExpected.files).map(
 			([filePath, suggestionCasesExpected]) => {
 				const changes = suggestionReported.files[filePath];
-				assert(changes);
+				assert.ok(changes);
 				return [
 					filePath,
 					suggestionCasesExpected.map((suggestionCaseExpected) => ({

--- a/packages/rule-tester/src/resolveReportedSuggestions.ts
+++ b/packages/rule-tester/src/resolveReportedSuggestions.ts
@@ -80,7 +80,10 @@ function resolveReportedSuggestionForFiles(
 		Object.entries(suggestionExpected.files).map(
 			([filePath, suggestionCasesExpected]) => {
 				const changes = suggestionReported.files[filePath];
-				assert.ok(changes);
+				assert.ok(
+					changes,
+					`Expected reported suggestion "${suggestionReported.id}" to provide changes for target "${filePath}".`,
+				);
 				return [
 					filePath,
 					suggestionCasesExpected.map((suggestionCaseExpected) => ({

--- a/packages/rule-tester/src/resolveReportedSuggestions.ts
+++ b/packages/rule-tester/src/resolveReportedSuggestions.ts
@@ -1,3 +1,5 @@
+import assert from "node:assert/strict";
+
 import {
 	applyChangesToText,
 	isSuggestionForFiles,
@@ -26,61 +28,69 @@ export function resolveReportedSuggestions(
 		return;
 	}
 
-	return suggestionsReported.map((suggestionReported) =>
-		isSuggestionForFiles(suggestionReported)
-			? {
-					files: resolveReportedSuggestionForFiles(
-						suggestionReported,
-						testCaseNormalized,
-					),
-					id: suggestionReported.id,
-				}
-			: {
-					id: suggestionReported.id,
-					updated: applyChangesToText(
-						[suggestionReported],
-						testCaseNormalized.code,
-					),
-				},
-	);
+	return suggestionsReported.map((suggestionReported, index) => {
+		const suggestionExpected = testCaseNormalized.suggestions?.[index];
+		if (isSuggestionForFiles(suggestionReported)) {
+			return {
+				files: resolveReportedSuggestionForFiles(
+					suggestionReported,
+					suggestionExpected,
+				),
+				id: suggestionReported.id,
+			};
+		}
+
+		if (suggestionExpected && isTestSuggestionForFiles(suggestionExpected)) {
+			throw new Error(
+				"This test case describes a suggestion across files, but the rule is only reporting changes to its own file.",
+			);
+		}
+
+		return {
+			id: suggestionReported.id,
+			updated: applyChangesToText(
+				[suggestionReported],
+				testCaseNormalized.code,
+			),
+		};
+	});
 }
 
 function resolveReportedSuggestionForFiles(
 	suggestionReported: SuggestionForFiles,
-	testCaseNormalized: InvalidTestCase & TestCaseNormalized,
-) {
-	if (!testCaseNormalized.suggestions) {
+	suggestionExpected: TestSuggestion | undefined,
+): Record<string, TestSuggestionFileCase[]> {
+	if (!suggestionExpected) {
 		return {};
 	}
 
-	if (!testCaseNormalized.suggestions.every(isTestSuggestionForFiles)) {
+	if (!isTestSuggestionForFiles(suggestionExpected)) {
 		throw new Error(
-			"This test case describes suggestions across files, but the rule is only reporting changes to its own file.",
+			"This test case describes a suggestion to its own file, but the rule is reporting changes across files.",
 		);
 	}
 
+	assert.deepStrictEqual(
+		Object.keys(suggestionReported.files).sort(),
+		Object.keys(suggestionExpected.files).sort(),
+		"Reported suggestion target paths must exactly match expected target paths.",
+	);
+
 	return Object.fromEntries(
-		testCaseNormalized.suggestions.flatMap(
-			(suggestionExpected): [string, TestSuggestionFileCase[]][] => {
-				return Object.entries(suggestionExpected.files).map(
-					([filePath, suggestionCasesExpected]) => {
-						return [
-							filePath,
-							suggestionCasesExpected.map((suggestionCaseExpected) => {
-								const changes = suggestionReported.files[filePath];
-								return {
-									original: suggestionCaseExpected.original,
-									updated: changes
-										? applyChangesToText(
-												changes,
-												suggestionCaseExpected.original,
-											)
-										: suggestionCaseExpected.original,
-								};
-							}),
-						];
-					},
-				);
+		Object.entries(suggestionExpected.files).map(
+			([filePath, suggestionCasesExpected]) => {
+				const changes = suggestionReported.files[filePath];
+				assert(changes);
+				return [
+					filePath,
+					suggestionCasesExpected.map((suggestionCaseExpected) => ({
+						original: suggestionCaseExpected.original,
+						updated: applyChangesToText(
+							changes,
+							suggestionCaseExpected.original,
+						),
+					})),
+				];
 			},
 		),
 	);


### PR DESCRIPTION
## PR Checklist

- [ ] Addresses an existing open issue: none
- [ ] That issue was marked as `status: accepting prs`
- [x] Steps in [CONTRIBUTING.md](https://github.com/flint-fyi/flint/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Ensure that tests can't forget about other files, this is useful for #2809 ❤️‍🔥