### PR TITLE
perf(typescript-language): memoize deterministic native checker queries

### DIFF
--- a/packages/typescript-language/src/language.ts
+++ b/packages/typescript-language/src/language.ts
@@ -55,6 +55,17 @@ const log = debugForFile(import.meta.filename);
 // the snapshot is unchanged, which it is for the whole visitor phase.
 const memoizedCheckerCache = new WeakMap<Checker, Checker>();
 
+// Checker queries that are deterministic given a single Type/Symbol argument
+// (for a stable snapshot), so results can be memoized by that argument's identity.
+const firstArgIdentityMethods: ReadonlySet<string> = new Set([
+	"getApparentType",
+	"getBaseConstraintOfType",
+	"getTypeArguments",
+	"getTypeOfSymbol",
+	"isArrayType",
+	"isTupleType",
+]);
+
 function getMemoizedChecker(checker: Checker): Checker {
 	const existing = memoizedCheckerCache.get(checker);
 	if (existing) {
@@ -62,6 +73,7 @@ function getMemoizedChecker(checker: Checker): Checker {
 	}
 	const typeByNode = new WeakMap<object, Type>();
 	const symbolByNode = new WeakMap<object, TSSymbol | undefined>();
+	const singleArgCaches: Record<string, WeakMap<object, unknown>> = {};
 	const rawGetTypeAtLocation = checker.getTypeAtLocation;
 	const rawGetSymbolAtLocation = checker.getSymbolAtLocation;
 	const wrapped = new Proxy(checker, {
@@ -92,6 +104,26 @@ function getMemoizedChecker(checker: Checker): Checker {
 					}
 					const result = rawGetSymbolAtLocation(node as NativeNode);
 					symbolByNode.set(key, result);
+					return result;
+				};
+			}
+			// Other frequently-called checker queries that are deterministic given a
+			// single Type/Symbol argument (per stable snapshot) are memoized by that
+			// argument's identity too, to cut their IPC round-trips.
+			if (firstArgIdentityMethods.has(property as string)) {
+				const cache = (singleArgCaches[property as string] ??= new WeakMap());
+				const raw = Reflect.get(target, property, receiver) as (
+					arg: object,
+				) => unknown;
+				return (arg: object): unknown => {
+					if (arg == null || typeof arg !== "object") {
+						return raw(arg);
+					}
+					if (cache.has(arg)) {
+						return cache.get(arg);
+					}
+					const result = raw(arg);
+					cache.set(arg, result);
 					return result;
 				};
 			}

--- a/packages/typescript-language/src/language.ts
+++ b/packages/typescript-language/src/language.ts
@@ -6,10 +6,13 @@ import {
 	type Node as NativeNode,
 } from "typescript-native/unstable/ast";
 import type {
+	Checker,
 	Diagnostic,
 	Program,
 	Project,
 	Snapshot,
+	Symbol as TSSymbol,
+	Type,
 } from "typescript-native/unstable/sync";
 
 import {
@@ -44,6 +47,60 @@ import type { TypeScriptFileServices } from "./types/services.ts";
 export type { TypeScriptFileServices } from "./types/services.ts";
 
 const log = debugForFile(import.meta.filename);
+
+// The native checker runs out-of-process, so every `getTypeAtLocation` /
+// `getSymbolAtLocation` is an IPC round-trip. Many type-aware rules query the
+// same node, so memoizing per node (per snapshot's checker, keyed by node
+// identity) collapses those repeats to one round-trip. Results are stable while
+// the snapshot is unchanged, which it is for the whole visitor phase.
+const memoizedCheckerCache = new WeakMap<Checker, Checker>();
+
+function getMemoizedChecker(checker: Checker): Checker {
+	const existing = memoizedCheckerCache.get(checker);
+	if (existing) {
+		return existing;
+	}
+	const typeByNode = new WeakMap<object, Type>();
+	const symbolByNode = new WeakMap<object, TSSymbol | undefined>();
+	const rawGetTypeAtLocation = checker.getTypeAtLocation;
+	const rawGetSymbolAtLocation = checker.getSymbolAtLocation;
+	const wrapped = new Proxy(checker, {
+		get(target, property, receiver) {
+			if (property === "getTypeAtLocation") {
+				return (node: NativeNode | readonly NativeNode[]): unknown => {
+					if (Array.isArray(node)) {
+						return rawGetTypeAtLocation(node);
+					}
+					const key = node as object;
+					const cached = typeByNode.get(key);
+					if (cached !== undefined) {
+						return cached;
+					}
+					const result = rawGetTypeAtLocation(node as NativeNode);
+					typeByNode.set(key, result);
+					return result;
+				};
+			}
+			if (property === "getSymbolAtLocation") {
+				return (node: NativeNode | readonly NativeNode[]): unknown => {
+					if (Array.isArray(node)) {
+						return rawGetSymbolAtLocation(node);
+					}
+					const key = node as object;
+					if (symbolByNode.has(key)) {
+						return symbolByNode.get(key);
+					}
+					const result = rawGetSymbolAtLocation(node as NativeNode);
+					symbolByNode.set(key, result);
+					return result;
+				};
+			}
+			return Reflect.get(target, property, receiver) as unknown;
+		},
+	});
+	memoizedCheckerCache.set(checker, wrapped);
+	return wrapped;
+}
 
 type ContentMappedLanguageFileDefinition =
 	LanguageFileDefinition<TypeScriptFileServices> & {
@@ -343,7 +400,7 @@ export const typescriptLanguage: Language<
 					return getSourceFile().spanMap;
 				},
 				get typeChecker() {
-					return getProject().checker;
+					return getMemoizedChecker(getProject().checker);
 				},
 			};
 			const dispose = (): void => {

--- a/packages/typescript-language/src/language.ts
+++ b/packages/typescript-language/src/language.ts
@@ -6,13 +6,10 @@ import {
 	type Node as NativeNode,
 } from "typescript-native/unstable/ast";
 import type {
-	Checker,
 	Diagnostic,
 	Program,
 	Project,
 	Snapshot,
-	Symbol as TSSymbol,
-	Type,
 } from "typescript-native/unstable/sync";
 
 import {
@@ -38,6 +35,7 @@ import {
 import { parseDirectivesFromTypeScriptFile } from "./directives/parseDirectivesFromTypeScriptFile.ts";
 import { getTypeScriptDiagnostics } from "./getTypeScriptDiagnostics.ts";
 import { getTypeScriptFileCacheImpacts } from "./getTypeScriptFileCacheImpacts.ts";
+import { getMemoizedChecker } from "./memoizedChecker.ts";
 import type { TypeScriptNodesByName, TypeScriptNodeVisitors } from "./nodes.ts";
 import { NodeSyntaxKinds } from "./nodeSyntaxKinds.ts";
 import { orderTypeScriptFilePaths } from "./orderTypeScriptFilePaths.ts";
@@ -47,92 +45,6 @@ import type { TypeScriptFileServices } from "./types/services.ts";
 export type { TypeScriptFileServices } from "./types/services.ts";
 
 const log = debugForFile(import.meta.filename);
-
-// The native checker runs out-of-process, so every `getTypeAtLocation` /
-// `getSymbolAtLocation` is an IPC round-trip. Many type-aware rules query the
-// same node, so memoizing per node (per snapshot's checker, keyed by node
-// identity) collapses those repeats to one round-trip. Results are stable while
-// the snapshot is unchanged, which it is for the whole visitor phase.
-const memoizedCheckerCache = new WeakMap<Checker, Checker>();
-
-// Checker queries that are deterministic given a single Type/Symbol argument
-// (for a stable snapshot), so results can be memoized by that argument's identity.
-const firstArgIdentityMethods: ReadonlySet<string> = new Set([
-	"getApparentType",
-	"getBaseConstraintOfType",
-	"getTypeArguments",
-	"getTypeOfSymbol",
-	"isArrayType",
-	"isTupleType",
-]);
-
-function getMemoizedChecker(checker: Checker): Checker {
-	const existing = memoizedCheckerCache.get(checker);
-	if (existing) {
-		return existing;
-	}
-	const typeByNode = new WeakMap<object, Type>();
-	const symbolByNode = new WeakMap<object, TSSymbol | undefined>();
-	const singleArgCaches: Record<string, WeakMap<object, unknown>> = {};
-	const rawGetTypeAtLocation = checker.getTypeAtLocation;
-	const rawGetSymbolAtLocation = checker.getSymbolAtLocation;
-	const wrapped = new Proxy(checker, {
-		get(target, property, receiver) {
-			if (property === "getTypeAtLocation") {
-				return (node: NativeNode | readonly NativeNode[]): unknown => {
-					if (Array.isArray(node)) {
-						return rawGetTypeAtLocation(node);
-					}
-					const key = node as object;
-					const cached = typeByNode.get(key);
-					if (cached !== undefined) {
-						return cached;
-					}
-					const result = rawGetTypeAtLocation(node as NativeNode);
-					typeByNode.set(key, result);
-					return result;
-				};
-			}
-			if (property === "getSymbolAtLocation") {
-				return (node: NativeNode | readonly NativeNode[]): unknown => {
-					if (Array.isArray(node)) {
-						return rawGetSymbolAtLocation(node);
-					}
-					const key = node as object;
-					if (symbolByNode.has(key)) {
-						return symbolByNode.get(key);
-					}
-					const result = rawGetSymbolAtLocation(node as NativeNode);
-					symbolByNode.set(key, result);
-					return result;
-				};
-			}
-			// Other frequently-called checker queries that are deterministic given a
-			// single Type/Symbol argument (per stable snapshot) are memoized by that
-			// argument's identity too, to cut their IPC round-trips.
-			if (firstArgIdentityMethods.has(property as string)) {
-				const cache = (singleArgCaches[property as string] ??= new WeakMap());
-				const raw = Reflect.get(target, property, receiver) as (
-					arg: object,
-				) => unknown;
-				return (arg: object): unknown => {
-					if (arg == null || typeof arg !== "object") {
-						return raw(arg);
-					}
-					if (cache.has(arg)) {
-						return cache.get(arg);
-					}
-					const result = raw(arg);
-					cache.set(arg, result);
-					return result;
-				};
-			}
-			return Reflect.get(target, property, receiver) as unknown;
-		},
-	});
-	memoizedCheckerCache.set(checker, wrapped);
-	return wrapped;
-}
 
 type ContentMappedLanguageFileDefinition =
 	LanguageFileDefinition<TypeScriptFileServices> & {

--- a/packages/typescript-language/src/memoizedChecker.ts
+++ b/packages/typescript-language/src/memoizedChecker.ts
@@ -1,0 +1,123 @@
+import type { Checker } from "typescript-native/unstable/sync";
+
+// The native checker runs out-of-process, so every query (`getTypeAtLocation`,
+// `getSymbolAtLocation`, and friends) is an IPC round-trip. Many type-aware
+// rules query the same node/type/symbol, so memoizing each query by its
+// argument identity collapses those repeats to a single round-trip. Results are
+// stable while the snapshot is unchanged, which it is for the whole visitor
+// phase, so the caches live as long as the checker they wrap.
+const memoizedCheckerCache = new WeakMap<Checker, Checker>();
+
+// Queries that are deterministic given a single object argument (a Node, Type,
+// or Symbol) for a stable snapshot. Memoized by that argument's identity. Only
+// memoized when called with exactly one argument, so overloads that take extra
+// options (e.g. `typeToString(type, enclosingDeclaration, flags)`) fall through
+// to the raw checker rather than returning a wrongly-cached result.
+const SINGLE_ARG_IDENTITY_METHODS: readonly string[] = [
+	"getAliasedSymbol",
+	"getApparentType",
+	"getBaseConstraintOfType",
+	"getContextualType",
+	"getImmediateAliasedSymbol",
+	"getResolvedSignature",
+	"getShorthandAssignmentValueSymbol",
+	"getSymbolAtLocation",
+	"getTypeArguments",
+	"getTypeAtLocation",
+	"getTypeFromTypeNode",
+	"getTypeOfSymbol",
+	"isArrayType",
+	"isTupleType",
+	"typeToString",
+];
+
+// Queries deterministic given two object arguments, memoized by the identity of
+// both (a nested map). Only memoized when called with exactly two arguments.
+const PAIR_IDENTITY_METHODS: readonly string[] = [
+	"getTypeOfSymbolAtLocation",
+	"isTypeAssignableTo",
+];
+
+function buildMemoizedMethods(
+	checker: Checker,
+): Map<string, (...args: unknown[]) => unknown> {
+	const methods = new Map<string, (...args: unknown[]) => unknown>();
+	const source = checker as unknown as Record<string, unknown>;
+
+	for (const name of SINGLE_ARG_IDENTITY_METHODS) {
+		const raw = source[name];
+		if (typeof raw !== "function") {
+			continue;
+		}
+		const rawFn = raw as (...args: unknown[]) => unknown;
+		const cache = new WeakMap<object, unknown>();
+		methods.set(name, function memoizedSingleArg(this: unknown, ...args) {
+			if (args.length !== 1 || !isObject(args[0])) {
+				return rawFn.apply(this, args);
+			}
+			const key = args[0];
+			if (cache.has(key)) {
+				return cache.get(key);
+			}
+			const result = rawFn.apply(this, args);
+			cache.set(key, result);
+			return result;
+		});
+	}
+
+	for (const name of PAIR_IDENTITY_METHODS) {
+		const raw = source[name];
+		if (typeof raw !== "function") {
+			continue;
+		}
+		const rawFn = raw as (...args: unknown[]) => unknown;
+		const outer = new WeakMap<object, WeakMap<object, unknown>>();
+		methods.set(name, function memoizedPair(this: unknown, ...args) {
+			if (args.length !== 2 || !isObject(args[0]) || !isObject(args[1])) {
+				return rawFn.apply(this, args);
+			}
+			let inner = outer.get(args[0]);
+			if (!inner) {
+				inner = new WeakMap();
+				outer.set(args[0], inner);
+			}
+			if (inner.has(args[1])) {
+				return inner.get(args[1]);
+			}
+			const result = rawFn.apply(this, args);
+			inner.set(args[1], result);
+			return result;
+		});
+	}
+
+	return methods;
+}
+
+function isObject(value: unknown): value is object {
+	return value != null && typeof value === "object" && !Array.isArray(value);
+}
+
+/**
+ * Wraps `checker` so its deterministic queries are memoized by argument identity
+ * for the life of the (stable) snapshot. The same wrapper is returned for a
+ * given checker, so caches are shared across every rule that runs on the file.
+ */
+export function getMemoizedChecker(checker: Checker): Checker {
+	const existing = memoizedCheckerCache.get(checker);
+	if (existing) {
+		return existing;
+	}
+
+	const methods = buildMemoizedMethods(checker);
+	const wrapped = new Proxy(checker, {
+		get(target, property, receiver) {
+			const override = methods.get(property as string);
+			if (override) {
+				return override;
+			}
+			return Reflect.get(target, property, receiver) as unknown;
+		},
+	});
+	memoizedCheckerCache.set(checker, wrapped);
+	return wrapped;
+}


### PR DESCRIPTION
Draft — memoization of the out-of-process native checker.

The TS7 native checker runs out-of-process, so every `getTypeAtLocation` /
`getSymbolAtLocation` / etc. is an IPC round-trip. Type-aware rules frequently
query the same node/type/symbol, so wrapping the checker to memoize each
deterministic query by argument identity (for the life of the stable snapshot)
collapses those repeats. Extracted into `memoizedChecker.ts` and extended from
the original 6-method set to every deterministic query rules call:

- single-arg identity: `getTypeAtLocation`, `getSymbolAtLocation`,
  `getApparentType`, `getBaseConstraintOfType`, `getTypeArguments`,
  `getTypeOfSymbol`, `isArrayType`, `isTupleType`, `getAliasedSymbol`,
  `getImmediateAliasedSymbol`, `getContextualType`, `getResolvedSignature`,
  `getShorthandAssignmentValueSymbol`, `getTypeFromTypeNode`, `typeToString`
  (only when called with exactly one argument, so option-bearing overloads
  fall through uncached)
- two-arg identity: `getTypeOfSymbolAtLocation`, `isTypeAssignableTo`

### Measured (hyperfine, `--cache-ignore --skip-formatting --skip-language-reports`)

End-to-end vs no memoization:

| files × rules | no memo | this PR | delta |
| --- | --- | --- | --- |
| 256 × 272  | 961 ms  | 859 ms  | −10.6% |
| 1024 × 119 | 2.498 s | 2.344 s | −6.2%  |
| 1024 × 272 | 3.084 s | 2.723 s | −11.7% |

The extended method set adds ~1% over the original 6-method version — small but
consistent across scales and free (correctness verified: identical report
output). Report parity confirmed against the raw checker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
