### PR TITLE
ref: finish migrating to node.kind checks instead of TypeScript node guards

### DIFF
--- a/.agents/skills/implementing-lint-rules/SKILL.md
+++ b/.agents/skills/implementing-lint-rules/SKILL.md
@@ -26,6 +26,7 @@ Example: instead of messages like _"Octal escape sequences should not be used in
 ## AST Node Handling
 
 When you have a TypeScript AST node, such as `AST.Expression` or `AST.*Declaration`, check whether nodes are certain types using a comparison like `node.kind === SyntaxKind.BinaryExpression`.
+Don't use `ts.*` nodes or APIs that work on them if at all possible, since they don't perform type narrowing as well as our `AST` discriminated union.
 
 Always pass source files to `node.getStart(sourceFile)` - don't just call `node.getStart()`.
 Same with other TypeScript APIs that optionally take in a sourceFile.

--- a/.agents/skills/implementing-lint-rules/SKILL.md
+++ b/.agents/skills/implementing-lint-rules/SKILL.md
@@ -45,7 +45,7 @@ Look at other rule tests and try to mirror their layouts and styles as much as p
 Make sure each piece of logic in a rule is unit tested.
 If removing a piece of logic doesn't fail unit tests, that's likely a sign you're missing unit testing some edge case.
 If you can't find an edge case that requires the logic, then remove that logic.
-Example: if removing `ts.isIdentifier(node.parent) &&` from an if statement doesn't fail unit tests, then maybe you're not testing the case of a non-identifier node parent?
+Example: if removing `node.parent.kind === SyntaxKind.Identifier &&` from an if statement doesn't fail unit tests, then maybe you're not testing the case of a non-identifier node parent?
 If that's possible, add those test case(s).
 If that's not possible, remove the logic.
 

--- a/.agents/skills/implementing-lint-rules/SKILL.md
+++ b/.agents/skills/implementing-lint-rules/SKILL.md
@@ -25,9 +25,7 @@ Example: instead of messages like _"Octal escape sequences should not be used in
 
 ## AST Node Handling
 
-When you have an `AST.Expression` or `AST.*Declaration`, check whether nodes are certain types using a comparison like `node.kind === SyntaxKind.BinaryExpression`.
-
-When you have a `ts.Node` type, however, you'll have to use `ts.is*` checks such as `ts.isBinaryExpression`, or failing that, `tsutils` from `ts-api-utils` to get nice type narrowing.
+When you have a TypeScript AST node, such as `AST.Expression` or `AST.*Declaration`, check whether nodes are certain types using a comparison like `node.kind === SyntaxKind.BinaryExpression`.
 
 Always pass source files to `node.getStart(sourceFile)` - don't just call `node.getStart()`.
 Same with other TypeScript APIs that optionally take in a sourceFile.

--- a/.changeset/ast-kind-comparisons.md
+++ b/.changeset/ast-kind-comparisons.md
@@ -1,0 +1,5 @@
+---
+"@flint.fyi/plugin-flint": patch
+---
+
+Suggest comparing `node.kind` to a `SyntaxKind` instead of calling `ts.isXXX()` in `nodePropertyInChecks`.

--- a/packages/browser/src/rules/keyboardEventKeys.ts
+++ b/packages/browser/src/rules/keyboardEventKeys.ts
@@ -1,4 +1,4 @@
-import { isInterfaceDeclaration, SyntaxKind, type Program } from "typescript";
+import { SyntaxKind, type Program } from "typescript";
 
 import {
 	getDeclarationsIfGlobal,
@@ -55,10 +55,10 @@ export default ruleCreator.createRule(typescriptLanguage, {
 			const declaration = nullThrows(
 				declarations[0],
 				"Declaration is expected to be present by the length check",
-			);
+			) as AST.AnyNode;
 
 			return (
-				isInterfaceDeclaration(declaration.parent) &&
+				declaration.parent.kind === SyntaxKind.InterfaceDeclaration &&
 				["KeyboardEvent", "UIEvent"].includes(declaration.parent.name.text)
 			);
 		}

--- a/packages/performance/src/rules/loopFunctions.ts
+++ b/packages/performance/src/rules/loopFunctions.ts
@@ -1,7 +1,8 @@
 import * as tsutils from "ts-api-utils";
-import ts, { SyntaxKind } from "typescript";
+import { SyntaxKind } from "typescript";
 
 import {
+	forEachChild,
 	typescriptLanguage,
 	type AST,
 	type TypeScriptFileServices,
@@ -32,7 +33,7 @@ export default ruleCreator.createRule(typescriptLanguage, {
 		},
 	},
 	setup(context) {
-		const loopVariableNames = new Map<ts.Node, Set<string>>();
+		const loopVariableNames = new Map<AST.AnyNode, Set<string>>();
 
 		function getLoopVariables(
 			loopNode:
@@ -107,28 +108,28 @@ export default ruleCreator.createRule(typescriptLanguage, {
 		}
 
 		function referencesLoopVariable(
-			node: ts.Node,
+			node: AST.AnyNode,
 			loopVariables: Set<string>,
 		): boolean | undefined {
-			if (ts.isIdentifier(node) && loopVariables.has(node.text)) {
+			if (node.kind === SyntaxKind.Identifier && loopVariables.has(node.text)) {
 				return true;
 			}
 
-			return ts.forEachChild(node, (child) => {
+			return forEachChild(node, (child) => {
 				return (
 					!tsutils.isFunctionScopeBoundary(child) &&
-					!ts.isDoStatement(child) &&
-					!ts.isForInStatement(child) &&
-					!ts.isForOfStatement(child) &&
-					!ts.isForStatement(child) &&
-					!ts.isWhileStatement(child) &&
+					child.kind !== SyntaxKind.DoStatement &&
+					child.kind !== SyntaxKind.ForInStatement &&
+					child.kind !== SyntaxKind.ForOfStatement &&
+					child.kind !== SyntaxKind.ForStatement &&
+					child.kind !== SyntaxKind.WhileStatement &&
 					referencesLoopVariable(child, loopVariables)
 				);
 			});
 		}
 
 		function checkFunctionInLoop(
-			node: ts.Node,
+			node: AST.AnyNode,
 			loopNode:
 				| AST.DoStatement
 				| AST.ForInStatement
@@ -143,11 +144,16 @@ export default ruleCreator.createRule(typescriptLanguage, {
 					const start = node.getStart(sourceFile);
 					let keyword = "function";
 
-					if (ts.isFunctionDeclaration(node) || ts.isFunctionExpression(node)) {
+					if (
+						node.kind === SyntaxKind.FunctionDeclaration ||
+						node.kind === SyntaxKind.FunctionExpression
+					) {
 						keyword = "function";
-					} else if (ts.isArrowFunction(node)) {
-						const firstToken = node.getFirstToken(sourceFile);
-						if (firstToken && ts.isIdentifier(firstToken)) {
+					} else if (node.kind === SyntaxKind.ArrowFunction) {
+						const firstToken = node.getFirstToken(sourceFile) as
+							| AST.AnyNode
+							| undefined;
+						if (firstToken?.kind === SyntaxKind.Identifier) {
 							keyword = firstToken.text;
 						} else {
 							keyword = "(";
@@ -166,16 +172,16 @@ export default ruleCreator.createRule(typescriptLanguage, {
 			}
 
 			if (
-				ts.isDoStatement(node) ||
-				ts.isForInStatement(node) ||
-				ts.isForOfStatement(node) ||
-				ts.isForStatement(node) ||
-				ts.isWhileStatement(node)
+				node.kind === SyntaxKind.DoStatement ||
+				node.kind === SyntaxKind.ForInStatement ||
+				node.kind === SyntaxKind.ForOfStatement ||
+				node.kind === SyntaxKind.ForStatement ||
+				node.kind === SyntaxKind.WhileStatement
 			) {
 				return;
 			}
 
-			ts.forEachChild(node, (child) => {
+			forEachChild(node, (child) => {
 				checkFunctionInLoop(child, loopNode, loopVariables, sourceFile);
 			});
 		}

--- a/packages/performance/src/rules/spreadAccumulators.ts
+++ b/packages/performance/src/rules/spreadAccumulators.ts
@@ -1,7 +1,8 @@
 import * as tsutils from "ts-api-utils";
-import ts, { SyntaxKind } from "typescript";
+import { SyntaxKind } from "typescript";
 
 import {
+	forEachChild,
 	typescriptLanguage,
 	type AST,
 	type TypeScriptFileServices,
@@ -31,41 +32,45 @@ export default ruleCreator.createRule(typescriptLanguage, {
 		},
 	},
 	setup(context) {
-		function getIdentifierName(node: ts.Node) {
-			return ts.isIdentifier(node) ? node.text : undefined;
+		function getIdentifierName(node: AST.AnyNode) {
+			return node.kind === SyntaxKind.Identifier ? node.text : undefined;
 		}
 
 		function hasSpreadOfIdentifier(
-			node: ts.Node,
+			node: AST.AnyNode,
 			identifierName: string,
 		): boolean | undefined {
 			if (
-				(ts.isSpreadElement(node) || ts.isSpreadAssignment(node)) &&
+				(node.kind === SyntaxKind.SpreadElement ||
+					node.kind === SyntaxKind.SpreadAssignment) &&
 				identifierName === getIdentifierName(node.expression)
 			) {
 				return true;
 			}
 
-			return ts.forEachChild(node, (child) => {
+			return forEachChild(node, (child) => {
 				return hasSpreadOfIdentifier(child, identifierName);
 			});
 		}
 
-		function checkAssignmentInLoop(node: ts.Node, sourceFile: AST.SourceFile) {
+		function checkAssignmentInLoop(
+			node: AST.AnyNode,
+			sourceFile: AST.SourceFile,
+		) {
 			if (
-				ts.isBinaryExpression(node) &&
+				node.kind === SyntaxKind.BinaryExpression &&
 				node.operatorToken.kind === SyntaxKind.EqualsToken
 			) {
 				checkBinaryEqualsExpression(node, sourceFile);
 			}
 
-			ts.forEachChild(node, (child) => {
+			forEachChild(node, (child) => {
 				if (
-					ts.isDoStatement(child) ||
-					ts.isForInStatement(child) ||
-					ts.isForOfStatement(child) ||
-					ts.isForStatement(child) ||
-					ts.isWhileStatement(child) ||
+					child.kind === SyntaxKind.DoStatement ||
+					child.kind === SyntaxKind.ForInStatement ||
+					child.kind === SyntaxKind.ForOfStatement ||
+					child.kind === SyntaxKind.ForStatement ||
+					child.kind === SyntaxKind.WhileStatement ||
 					tsutils.isFunctionScopeBoundary(child)
 				) {
 					return;
@@ -75,7 +80,7 @@ export default ruleCreator.createRule(typescriptLanguage, {
 		}
 
 		function checkBinaryEqualsExpression(
-			node: ts.BinaryExpression,
+			node: AST.BinaryExpression,
 			sourceFile: AST.SourceFile,
 		) {
 			const leftName = getIdentifierName(node.left);
@@ -104,18 +109,21 @@ export default ruleCreator.createRule(typescriptLanguage, {
 		}
 
 		function findSpreadElement(
-			node: ts.Node,
+			node: AST.AnyNode,
 			identifierName: string,
-		): ts.Node | undefined {
-			if (ts.isSpreadElement(node) || ts.isSpreadAssignment(node)) {
+		): AST.AnyNode | undefined {
+			if (
+				node.kind === SyntaxKind.SpreadElement ||
+				node.kind === SyntaxKind.SpreadAssignment
+			) {
 				const spreadName = getIdentifierName(node.expression);
 				if (spreadName === identifierName) {
 					return node;
 				}
 			}
 
-			let result: ts.Node | undefined = undefined;
-			ts.forEachChild(node, (child) => {
+			let result: AST.AnyNode | undefined = undefined;
+			forEachChild(node, (child) => {
 				result ??= findSpreadElement(child, identifierName);
 			});
 

--- a/packages/plugin-flint/src/rules/nodePropertyInChecks.ts
+++ b/packages/plugin-flint/src/rules/nodePropertyInChecks.ts
@@ -24,7 +24,7 @@ export default ruleCreator.createRule(typescriptLanguage, {
 				"TypeScript AST nodes have complex prototype chains that can lead to unexpected results with `in` checks.",
 			],
 			suggestions: [
-				"Access the property directly or use a type guard function like `ts.isXXX()` instead.",
+				"Access the property directly or compare `node.kind` to the matching `SyntaxKind` instead.",
 			],
 		},
 	},

--- a/packages/plugin-flint/src/utils/importHelpers.test.ts
+++ b/packages/plugin-flint/src/utils/importHelpers.test.ts
@@ -1,4 +1,4 @@
-import ts from "typescript";
+import ts, { SyntaxKind } from "typescript";
 import { describe, expect, it } from "vitest";
 
 import {
@@ -45,7 +45,8 @@ describe("isImportedBindingFromModule", () => {
 	it("returns true for an ImportSpecifier from the matching module", () => {
 		const specifier = parseAndFind<ts.ImportSpecifier>(
 			`import { foo } from "my-module";`,
-			ts.isImportSpecifier,
+			(node): node is ts.ImportSpecifier =>
+				node.kind === SyntaxKind.ImportSpecifier,
 		);
 
 		expect(isImportedBindingFromModule(specifier, "my-module")).toBe(true);
@@ -54,7 +55,8 @@ describe("isImportedBindingFromModule", () => {
 	it("returns true for a NamespaceImport from the matching module", () => {
 		const nsImport = parseAndFind<ts.NamespaceImport>(
 			`import * as ns from "my-module";`,
-			ts.isNamespaceImport,
+			(node): node is ts.NamespaceImport =>
+				node.kind === SyntaxKind.NamespaceImport,
 		);
 
 		expect(isImportedBindingFromModule(nsImport, "my-module")).toBe(true);
@@ -63,7 +65,8 @@ describe("isImportedBindingFromModule", () => {
 	it("returns false for an ImportSpecifier from a different module", () => {
 		const specifier = parseAndFind<ts.ImportSpecifier>(
 			`import { foo } from "other-module";`,
-			ts.isImportSpecifier,
+			(node): node is ts.ImportSpecifier =>
+				node.kind === SyntaxKind.ImportSpecifier,
 		);
 
 		expect(isImportedBindingFromModule(specifier, "my-module")).toBe(false);
@@ -72,7 +75,8 @@ describe("isImportedBindingFromModule", () => {
 	it("returns false for a NamespaceImport from a different module", () => {
 		const nsImport = parseAndFind<ts.NamespaceImport>(
 			`import * as ns from "other-module";`,
-			ts.isNamespaceImport,
+			(node): node is ts.NamespaceImport =>
+				node.kind === SyntaxKind.NamespaceImport,
 		);
 
 		expect(isImportedBindingFromModule(nsImport, "my-module")).toBe(false);
@@ -81,7 +85,7 @@ describe("isImportedBindingFromModule", () => {
 	it("returns false for a non-import node", () => {
 		const identifier = parseAndFind<ts.Identifier>(
 			`const x = 1;`,
-			ts.isIdentifier,
+			(node): node is ts.Identifier => node.kind === SyntaxKind.Identifier,
 		);
 
 		expect(isImportedBindingFromModule(identifier, "my-module")).toBe(false);
@@ -92,7 +96,8 @@ describe("isImportedSpecifierFromModule", () => {
 	it("returns true for a matching named import", () => {
 		const specifier = parseAndFind<ts.ImportSpecifier>(
 			`import { reportSourceCode } from "@flint.fyi/volar-language";`,
-			ts.isImportSpecifier,
+			(node): node is ts.ImportSpecifier =>
+				node.kind === SyntaxKind.ImportSpecifier,
 		);
 
 		expect(
@@ -107,7 +112,8 @@ describe("isImportedSpecifierFromModule", () => {
 	it("returns true for a renamed import matching the original name", () => {
 		const specifier = parseAndFind<ts.ImportSpecifier>(
 			`import { reportSourceCode as report } from "@flint.fyi/volar-language";`,
-			ts.isImportSpecifier,
+			(node): node is ts.ImportSpecifier =>
+				node.kind === SyntaxKind.ImportSpecifier,
 		);
 
 		expect(
@@ -122,7 +128,8 @@ describe("isImportedSpecifierFromModule", () => {
 	it("returns false when the imported name does not match", () => {
 		const specifier = parseAndFind<ts.ImportSpecifier>(
 			`import { otherFunction } from "@flint.fyi/volar-language";`,
-			ts.isImportSpecifier,
+			(node): node is ts.ImportSpecifier =>
+				node.kind === SyntaxKind.ImportSpecifier,
 		);
 
 		expect(
@@ -137,7 +144,8 @@ describe("isImportedSpecifierFromModule", () => {
 	it("returns false when the module does not match", () => {
 		const specifier = parseAndFind<ts.ImportSpecifier>(
 			`import { reportSourceCode } from "other-module";`,
-			ts.isImportSpecifier,
+			(node): node is ts.ImportSpecifier =>
+				node.kind === SyntaxKind.ImportSpecifier,
 		);
 
 		expect(
@@ -152,7 +160,8 @@ describe("isImportedSpecifierFromModule", () => {
 	it("returns false for a NamespaceImport", () => {
 		const nsImport = parseAndFind<ts.NamespaceImport>(
 			`import * as ns from "@flint.fyi/volar-language";`,
-			ts.isNamespaceImport,
+			(node): node is ts.NamespaceImport =>
+				node.kind === SyntaxKind.NamespaceImport,
 		);
 
 		expect(

--- a/packages/plugin-flint/src/utils/tsAstToLiteral.ts
+++ b/packages/plugin-flint/src/utils/tsAstToLiteral.ts
@@ -4,14 +4,14 @@
 // Changing from the switch to manual ifs is due to:
 // https://github.com/Microsoft/TypeScript/issues/56275
 
-import ts, { SyntaxKind } from "typescript";
+import { SyntaxKind } from "typescript";
 
 import type { AST } from "@flint.fyi/typescript-language";
 
 export function tsAstToLiteral(node: AST.ArrayLiteralExpression): unknown[];
 export function tsAstToLiteral(node: AST.ObjectLiteralExpression): object;
-export function tsAstToLiteral(node: ts.Node): unknown;
-export function tsAstToLiteral(node: ts.Node): unknown {
+export function tsAstToLiteral(node: AST.AnyNode): unknown;
+export function tsAstToLiteral(node: AST.AnyNode): unknown {
 	switch (node.kind) {
 		case SyntaxKind.FalseKeyword:
 			return false;
@@ -21,35 +21,37 @@ export function tsAstToLiteral(node: ts.Node): unknown {
 			return true;
 	}
 
-	if (ts.isArrayLiteralExpression(node)) {
+	if (node.kind === SyntaxKind.ArrayLiteralExpression) {
 		return node.elements
 			.filter((element) => element.kind !== SyntaxKind.SpreadElement)
 			.map((element) => tsAstToLiteral(element));
 	}
 
-	if (ts.isNumericLiteral(node)) {
+	if (node.kind === SyntaxKind.NumericLiteral) {
 		return parseFloat(node.text);
 	}
 
-	if (ts.isObjectLiteralExpression(node)) {
+	if (node.kind === SyntaxKind.ObjectLiteralExpression) {
 		return Object.fromEntries(
 			node.properties
 				.filter(
 					(
 						property,
-					): property is ts.PropertyAssignment & { name: ts.Identifier } =>
-						ts.isPropertyAssignment(property) &&
+					): property is AST.PropertyAssignment & {
+						name: AST.Identifier | AST.StringLiteral;
+					} =>
+						property.kind === SyntaxKind.PropertyAssignment &&
 						(property.name.kind === SyntaxKind.Identifier ||
 							property.name.kind === SyntaxKind.StringLiteral),
 				)
 				.map((property) => [
-					property.name.escapedText || property.name.text,
+					property.name.text,
 					tsAstToLiteral(property.initializer),
 				]),
 		);
 	}
 
-	if (ts.isStringLiteral(node)) {
+	if (node.kind === SyntaxKind.StringLiteral) {
 		return node.text;
 	}
 

--- a/packages/site/src/content/docs/rules/flint/nodePropertyInChecks.mdx
+++ b/packages/site/src/content/docs/rules/flint/nodePropertyInChecks.mdx
@@ -26,7 +26,7 @@ if ("CallExpression" in node) {
 <TabItem label="✅ Correct">
 
 ```ts
-if (ts.isCallExpression(node)) {
+if (node.kind === SyntaxKind.CallExpression) {
 }
 ```
 

--- a/packages/ts/src/rules/accessorThisRecursion.ts
+++ b/packages/ts/src/rules/accessorThisRecursion.ts
@@ -1,7 +1,8 @@
 import * as tsutils from "ts-api-utils";
-import ts, { SyntaxKind } from "typescript";
+import { SyntaxKind } from "typescript";
 
 import {
+	forEachChild,
 	typescriptLanguage,
 	type AST,
 	type TypeScriptFileServices,
@@ -66,20 +67,20 @@ export default ruleCreator.createRule(typescriptLanguage, {
 			const propertyName = getPropertyName(accessor, sourceFile);
 			const isGetter = accessor.kind === SyntaxKind.GetAccessor;
 
-			function checkNode(node: ts.Node): void {
+			function checkNode(node: AST.AnyNode): void {
 				if (tsutils.isFunctionScopeBoundary(node)) {
 					return;
 				}
 
-				if (ts.isPropertyAccessExpression(node)) {
+				if (node.kind === SyntaxKind.PropertyAccessExpression) {
 					checkPropertyAccessExpression(node);
 				}
 
-				ts.forEachChild(node, checkNode);
+				forEachChild(node, checkNode);
 			}
 
 			function checkPropertyAccessExpression(
-				node: ts.PropertyAccessExpression,
+				node: AST.JsxTagNamePropertyAccess | AST.PropertyAccessExpression,
 			) {
 				if (
 					node.name.text !== propertyName ||
@@ -97,7 +98,7 @@ export default ruleCreator.createRule(typescriptLanguage, {
 						},
 					});
 				} else if (
-					ts.isBinaryExpression(node.parent) &&
+					node.parent.kind === SyntaxKind.BinaryExpression &&
 					node.parent.left === node &&
 					node.parent.operatorToken.kind === SyntaxKind.EqualsToken
 				) {
@@ -113,7 +114,7 @@ export default ruleCreator.createRule(typescriptLanguage, {
 
 			// TODO: This will be more clean when there is a scope manager
 			// https://github.com/flint-fyi/flint/issues/400
-			ts.forEachChild(accessor.body, checkNode);
+			forEachChild(accessor.body, checkNode);
 		}
 
 		return {

--- a/packages/ts/src/rules/anyArguments.ts
+++ b/packages/ts/src/rules/anyArguments.ts
@@ -338,11 +338,12 @@ export default ruleCreator.createRule(typescriptLanguage, {
 				return undefined;
 			}
 
-			const lastParamDeclaration = lastParam.declarations?.[0];
+			const lastParamDeclaration = lastParam.declarations?.[0] as
+				| AST.AnyNode
+				| undefined;
 
 			if (
-				lastParamDeclaration &&
-				ts.isParameter(lastParamDeclaration) &&
+				lastParamDeclaration?.kind === SyntaxKind.Parameter &&
 				lastParamDeclaration.dotDotDotToken
 			) {
 				if (index < parameters.length - 1) {

--- a/packages/ts/src/rules/anyAssignments.ts
+++ b/packages/ts/src/rules/anyAssignments.ts
@@ -106,7 +106,7 @@ export default ruleCreator.createRule(typescriptLanguage, {
 	},
 	setup(context) {
 		function checkArrayDestructureWorker(
-			pattern: ts.ArrayBindingPattern,
+			pattern: AST.ArrayBindingPattern,
 			senderType: ts.Type,
 			sourceFile: AST.SourceFile,
 			typeChecker: Checker,
@@ -132,7 +132,7 @@ export default ruleCreator.createRule(typescriptLanguage, {
 
 			for (let i = 0; i < pattern.elements.length; i++) {
 				const element = pattern.elements[i];
-				if (!element || ts.isOmittedExpression(element)) {
+				if (!element || element.kind === SyntaxKind.OmittedExpression) {
 					continue;
 				}
 
@@ -157,7 +157,7 @@ export default ruleCreator.createRule(typescriptLanguage, {
 						},
 					});
 					didReport = true;
-				} else if (ts.isArrayBindingPattern(name)) {
+				} else if (name.kind === SyntaxKind.ArrayBindingPattern) {
 					didReport =
 						checkArrayDestructureWorker(
 							name,
@@ -165,7 +165,7 @@ export default ruleCreator.createRule(typescriptLanguage, {
 							sourceFile,
 							typeChecker,
 						) || didReport;
-				} else if (ts.isObjectBindingPattern(name)) {
+				} else if (name.kind === SyntaxKind.ObjectBindingPattern) {
 					didReport =
 						checkObjectDestructureWorker(
 							name,
@@ -180,7 +180,7 @@ export default ruleCreator.createRule(typescriptLanguage, {
 		}
 
 		function checkObjectDestructureWorker(
-			pattern: ts.ObjectBindingPattern,
+			pattern: AST.ObjectBindingPattern,
 			senderType: ts.Type,
 			sourceFile: AST.SourceFile,
 			typeChecker: Checker,
@@ -196,16 +196,16 @@ export default ruleCreator.createRule(typescriptLanguage, {
 				const propertyName = element.propertyName ?? element.name;
 
 				if (
-					ts.isIdentifier(propertyName) ||
-					ts.isStringLiteral(propertyName) ||
-					ts.isNumericLiteral(propertyName)
+					propertyName.kind === SyntaxKind.Identifier ||
+					propertyName.kind === SyntaxKind.StringLiteral ||
+					propertyName.kind === SyntaxKind.NumericLiteral
 				) {
 					key = propertyName.text;
-				} else if (ts.isComputedPropertyName(propertyName)) {
+				} else if (propertyName.kind === SyntaxKind.ComputedPropertyName) {
 					const expression = propertyName.expression;
 					if (
-						ts.isStringLiteral(expression) ||
-						ts.isNoSubstitutionTemplateLiteral(expression)
+						expression.kind === SyntaxKind.StringLiteral ||
+						expression.kind === SyntaxKind.NoSubstitutionTemplateLiteral
 					) {
 						key = expression.text;
 					}
@@ -237,7 +237,7 @@ export default ruleCreator.createRule(typescriptLanguage, {
 						},
 					});
 					didReport = true;
-				} else if (ts.isArrayBindingPattern(name)) {
+				} else if (name.kind === SyntaxKind.ArrayBindingPattern) {
 					didReport =
 						checkArrayDestructureWorker(
 							name,
@@ -245,7 +245,7 @@ export default ruleCreator.createRule(typescriptLanguage, {
 							sourceFile,
 							typeChecker,
 						) || didReport;
-				} else if (ts.isObjectBindingPattern(name)) {
+				} else if (name.kind === SyntaxKind.ObjectBindingPattern) {
 					didReport =
 						checkObjectDestructureWorker(
 							name,
@@ -266,7 +266,7 @@ export default ruleCreator.createRule(typescriptLanguage, {
 			typeChecker: Checker,
 		): boolean {
 			return checkArrayDestructureWorker(
-				pattern as ts.ArrayBindingPattern,
+				pattern,
 				senderType,
 				sourceFile,
 				typeChecker,
@@ -280,7 +280,7 @@ export default ruleCreator.createRule(typescriptLanguage, {
 			typeChecker: Checker,
 		): boolean {
 			return checkObjectDestructureWorker(
-				pattern as ts.ObjectBindingPattern,
+				pattern,
 				senderType,
 				sourceFile,
 				typeChecker,

--- a/packages/ts/src/rules/arguments.ts
+++ b/packages/ts/src/rules/arguments.ts
@@ -8,16 +8,16 @@ import {
 import { ruleCreator } from "./ruleCreator.ts";
 
 function isNonArrowFunctionBoundary(node: ts.Node): "quit" | boolean {
-	if (ts.isArrowFunction(node)) {
+	if (node.kind === SyntaxKind.ArrowFunction) {
 		return "quit";
 	}
 	return (
-		ts.isFunctionDeclaration(node) ||
-		ts.isFunctionExpression(node) ||
-		ts.isMethodDeclaration(node) ||
-		ts.isGetAccessorDeclaration(node) ||
-		ts.isSetAccessorDeclaration(node) ||
-		ts.isConstructorDeclaration(node)
+		node.kind === SyntaxKind.FunctionDeclaration ||
+		node.kind === SyntaxKind.FunctionExpression ||
+		node.kind === SyntaxKind.MethodDeclaration ||
+		node.kind === SyntaxKind.GetAccessor ||
+		node.kind === SyntaxKind.SetAccessor ||
+		node.kind === SyntaxKind.Constructor
 	);
 }
 
@@ -78,10 +78,10 @@ export default ruleCreator.createRule(typescriptLanguage, {
 							.getDeclarations()
 							?.some(
 								(declaration) =>
-									ts.isParameter(declaration) ||
-									ts.isVariableDeclaration(declaration) ||
-									ts.isPropertyDeclaration(declaration) ||
-									ts.isBindingElement(declaration),
+									declaration.kind === SyntaxKind.Parameter ||
+									declaration.kind === SyntaxKind.VariableDeclaration ||
+									declaration.kind === SyntaxKind.PropertyDeclaration ||
+									declaration.kind === SyntaxKind.BindingElement,
 							)
 					) {
 						return;

--- a/packages/ts/src/rules/catchCallbackTypes.ts
+++ b/packages/ts/src/rules/catchCallbackTypes.ts
@@ -1,8 +1,6 @@
 import * as tsutils from "ts-api-utils";
 import {
-	isFunctionLike,
-	isInterfaceDeclaration,
-	isPropertyAccessExpression,
+	SyntaxKind,
 	TypeFlags,
 	type Program,
 	type Type,
@@ -52,12 +50,14 @@ export default ruleCreator.createRule(typescriptLanguage, {
 				return false;
 			}
 
-			return declarations.some(
-				(declaration) =>
-					isInterfaceDeclaration(declaration) &&
-					declaration.name.text === "Promise" &&
-					declarationIncludesGlobal(declaration, program),
-			);
+			return declarations.some((declaration) => {
+				const node = declaration as AST.AnyNode;
+				return (
+					node.kind === SyntaxKind.InterfaceDeclaration &&
+					node.name.text === "Promise" &&
+					declarationIncludesGlobal(declaration, program)
+				);
+			});
 		}
 
 		function isCatchOrThenCallback(
@@ -65,7 +65,7 @@ export default ruleCreator.createRule(typescriptLanguage, {
 			typeChecker: Checker,
 			program: Program,
 		): "catch" | "then" | undefined {
-			if (!isPropertyAccessExpression(node.expression)) {
+			if (node.expression.kind !== SyntaxKind.PropertyAccessExpression) {
 				return undefined;
 			}
 
@@ -91,7 +91,11 @@ export default ruleCreator.createRule(typescriptLanguage, {
 			sourceFile: AST.SourceFile,
 			typeChecker: TypeChecker,
 		) {
-			if (!isFunctionLike(callback) || !callback.parameters.length) {
+			if (
+				(callback.kind !== SyntaxKind.ArrowFunction &&
+					callback.kind !== SyntaxKind.FunctionExpression) ||
+				!callback.parameters.length
+			) {
 				return;
 			}
 

--- a/packages/ts/src/rules/classMethodsThis.ts
+++ b/packages/ts/src/rules/classMethodsThis.ts
@@ -1,7 +1,11 @@
-import ts, { SyntaxKind } from "typescript";
+import { SyntaxKind, type NodeArray } from "typescript";
 import { z } from "zod/v4";
 
-import { typescriptLanguage, type AST } from "@flint.fyi/typescript-language";
+import {
+	forEachChild,
+	typescriptLanguage,
+	type AST,
+} from "@flint.fyi/typescript-language";
 
 import { ruleCreator } from "./ruleCreator.ts";
 
@@ -26,15 +30,14 @@ function classImplementsSomething(
 	);
 }
 
-function containsThis(node: ts.Node): boolean {
+function containsThis(node: AST.AnyNode): boolean {
 	switch (node.kind) {
 		case SyntaxKind.ClassDeclaration:
 		case SyntaxKind.ClassExpression: {
-			const classNode = node as ts.ClassDeclaration | ts.ClassExpression;
-			for (const member of classNode.members) {
+			for (const member of node.members) {
 				if (
-					ts.isPropertyDeclaration(member) &&
-					ts.isComputedPropertyName(member.name) &&
+					member.kind === SyntaxKind.PropertyDeclaration &&
+					member.name.kind === SyntaxKind.ComputedPropertyName &&
 					containsThis(member.name.expression)
 				) {
 					return true;
@@ -53,7 +56,7 @@ function containsThis(node: ts.Node): boolean {
 			return true;
 
 		default:
-			return ts.forEachChild(node, containsThis) ?? false;
+			return forEachChild(node, containsThis) ?? false;
 	}
 }
 
@@ -94,7 +97,7 @@ function getMemberDisplayName(
 }
 
 function hasModifier(
-	modifiers: ts.NodeArray<AST.ModifierLike> | undefined,
+	modifiers: NodeArray<AST.ModifierLike> | undefined,
 	kind: SyntaxKind,
 ): boolean {
 	return modifiers?.some((modifier) => modifier.kind === kind) ?? false;

--- a/packages/ts/src/rules/constructorGenericCalls.ts
+++ b/packages/ts/src/rules/constructorGenericCalls.ts
@@ -1,4 +1,5 @@
-import ts, { SyntaxKind } from "typescript";
+import type ts from "typescript";
+import { SyntaxKind } from "typescript";
 import { z } from "zod/v4";
 
 import {
@@ -153,7 +154,7 @@ export default ruleCreator.createRule(typescriptLanguage, {
 			}
 
 			if (
-				!ts.isTypeReferenceNode(typeAnnotation) ||
+				typeAnnotation.kind !== SyntaxKind.TypeReference ||
 				typeAnnotation.typeName.kind !== SyntaxKind.Identifier ||
 				typeAnnotation.typeName.text !== constructorName ||
 				isBuiltInTypedArray(typeAnnotation.typeName.text) ||

--- a/packages/ts/src/rules/deprecated.ts
+++ b/packages/ts/src/rules/deprecated.ts
@@ -482,11 +482,14 @@ function isInsideHeritageClause(node: AST.AnyNode) {
 	let current: ts.Node | undefined = node.parent;
 
 	while (current) {
-		if (ts.isHeritageClause(current)) {
+		if (current.kind === SyntaxKind.HeritageClause) {
 			return true;
 		}
 
-		if (ts.isSourceFile(current) || ts.isClassDeclaration(current)) {
+		if (
+			current.kind === SyntaxKind.SourceFile ||
+			current.kind === SyntaxKind.ClassDeclaration
+		) {
 			break;
 		}
 		// eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion -- removing causes type error on the `while` loop. TSESLint bug?
@@ -505,18 +508,18 @@ function isInsideImport(node: AST.AnyNode) {
 	let current: ts.Node | undefined = node.parent;
 
 	while (current) {
-		if (ts.isImportDeclaration(current)) {
+		if (current.kind === SyntaxKind.ImportDeclaration) {
 			return true;
 		}
 
 		if (
-			ts.isSourceFile(current) ||
-			ts.isFunctionDeclaration(current) ||
-			ts.isFunctionExpression(current) ||
-			ts.isArrowFunction(current) ||
-			ts.isClassDeclaration(current) ||
-			ts.isClassExpression(current) ||
-			ts.isBlock(current)
+			current.kind === SyntaxKind.SourceFile ||
+			current.kind === SyntaxKind.FunctionDeclaration ||
+			current.kind === SyntaxKind.FunctionExpression ||
+			current.kind === SyntaxKind.ArrowFunction ||
+			current.kind === SyntaxKind.ClassDeclaration ||
+			current.kind === SyntaxKind.ClassExpression ||
+			current.kind === SyntaxKind.Block
 		) {
 			return false;
 		}

--- a/packages/ts/src/rules/destructuringConsistency.ts
+++ b/packages/ts/src/rules/destructuringConsistency.ts
@@ -1,4 +1,4 @@
-import ts, { SyntaxKind } from "typescript";
+import { SyntaxKind } from "typescript";
 
 import {
 	getScopeManager,
@@ -129,7 +129,7 @@ export default ruleCreator.createRule(typescriptLanguage, {
 						destructured.destructuredProperties.get(propertyName);
 
 					if (
-						(ts.isCallExpression(node.parent) &&
+						(node.parent.kind === SyntaxKind.CallExpression &&
 							node.parent.expression === node) ||
 						isLeftHandSide(node)
 					) {
@@ -163,7 +163,10 @@ export default ruleCreator.createRule(typescriptLanguage, {
 					destructuredObjects.length = 0;
 				},
 				VariableDeclaration: (node, { sourceFile }) => {
-					if (!node.initializer || !ts.isObjectBindingPattern(node.name)) {
+					if (
+						!node.initializer ||
+						node.name.kind !== SyntaxKind.ObjectBindingPattern
+					) {
 						return;
 					}
 
@@ -174,22 +177,18 @@ export default ruleCreator.createRule(typescriptLanguage, {
 
 					const properties = new Map<string, null | string>();
 					for (const element of node.name.elements) {
-						if (!ts.isBindingElement(element)) {
-							continue;
-						}
-
 						if (element.propertyName) {
-							if (ts.isIdentifier(element.propertyName)) {
+							if (element.propertyName.kind === SyntaxKind.Identifier) {
 								if (
-									ts.isObjectBindingPattern(element.name) ||
-									ts.isArrayBindingPattern(element.name)
+									element.name.kind === SyntaxKind.ObjectBindingPattern ||
+									element.name.kind === SyntaxKind.ArrayBindingPattern
 								) {
 									properties.set(element.propertyName.text, null);
-								} else if (ts.isIdentifier(element.name)) {
+								} else {
 									properties.set(element.propertyName.text, element.name.text);
 								}
 							}
-						} else if (ts.isIdentifier(element.name)) {
+						} else if (element.name.kind === SyntaxKind.Identifier) {
 							properties.set(element.name.text, element.name.text);
 						}
 					}

--- a/packages/ts/src/rules/dynamicDeletes.ts
+++ b/packages/ts/src/rules/dynamicDeletes.ts
@@ -1,23 +1,16 @@
-import {
-	isElementAccessExpression,
-	isNumericLiteral,
-	isPrefixUnaryExpression,
-	isStringLiteral,
-	SyntaxKind,
-	type Expression,
-} from "typescript";
+import { SyntaxKind } from "typescript";
 
-import { typescriptLanguage } from "@flint.fyi/typescript-language";
+import { typescriptLanguage, type AST } from "@flint.fyi/typescript-language";
 
 import { ruleCreator } from "./ruleCreator.ts";
 
-function isAcceptableIndexExpression(property: Expression): boolean {
+function isAcceptableIndexExpression(property: AST.Expression): boolean {
 	return (
-		isStringLiteral(property) ||
-		isNumericLiteral(property) ||
-		(isPrefixUnaryExpression(property) &&
+		property.kind === SyntaxKind.StringLiteral ||
+		property.kind === SyntaxKind.NumericLiteral ||
+		(property.kind === SyntaxKind.PrefixUnaryExpression &&
 			property.operator === SyntaxKind.MinusToken &&
-			isNumericLiteral(property.operand))
+			property.operand.kind === SyntaxKind.NumericLiteral)
 	);
 }
 
@@ -48,7 +41,7 @@ export default ruleCreator.createRule(typescriptLanguage, {
 					const argument = node.expression;
 
 					if (
-						!isElementAccessExpression(argument) ||
+						argument.kind !== SyntaxKind.ElementAccessExpression ||
 						isAcceptableIndexExpression(argument.argumentExpression)
 					) {
 						return;

--- a/packages/ts/src/rules/errorUnnecessaryCaptureStackTraces.ts
+++ b/packages/ts/src/rules/errorUnnecessaryCaptureStackTraces.ts
@@ -1,53 +1,47 @@
-import ts, { SyntaxKind } from "typescript";
+import { SyntaxKind } from "typescript";
 
 import {
 	getTSNodeRange,
 	typescriptLanguage,
+	type AST,
 } from "@flint.fyi/typescript-language";
 
 import { ruleCreator } from "./ruleCreator.ts";
 import { isErrorSubclass } from "./utils/isErrorSubclass.ts";
 
-function isCaptureStackTraceCall(node: ts.Node): boolean {
-	if (!ts.isCallExpression(node) && !ts.isOptionalChain(node)) {
+function isCaptureStackTraceCall(node: AST.AnyNode): boolean {
+	if (node.kind !== SyntaxKind.CallExpression) {
 		return false;
 	}
 
-	const callExpression = ts.isCallExpression(node) ? node : undefined;
-	if (!callExpression) {
-		return ts.isCallExpression(node) && isCaptureStackTraceCall(node);
-	}
-
 	return (
-		ts.isPropertyAccessExpression(callExpression.expression) &&
-		ts.isIdentifier(callExpression.expression.expression) &&
-		callExpression.expression.expression.text === "Error" &&
-		ts.isIdentifier(callExpression.expression.name) &&
-		callExpression.expression.name.text === "captureStackTrace"
+		node.expression.kind === SyntaxKind.PropertyAccessExpression &&
+		node.expression.expression.kind === SyntaxKind.Identifier &&
+		node.expression.expression.text === "Error" &&
+		node.expression.name.text === "captureStackTrace"
 	);
 }
 
 function isValidSecondArgument(
-	node: ts.Expression,
+	node: AST.Expression,
 	className: string | undefined,
 ): boolean {
-	if (ts.isIdentifier(node)) {
+	if (node.kind === SyntaxKind.Identifier) {
 		return node.text === className;
 	}
 
 	if (
-		ts.isPropertyAccessExpression(node) &&
+		node.kind === SyntaxKind.PropertyAccessExpression &&
 		node.expression.kind === SyntaxKind.ThisKeyword &&
-		ts.isIdentifier(node.name) &&
+		node.name.kind === SyntaxKind.Identifier &&
 		node.name.text === "constructor"
 	) {
 		return true;
 	}
 
 	if (
-		ts.isMetaProperty(node) &&
+		node.kind === SyntaxKind.MetaProperty &&
 		node.keywordToken === SyntaxKind.NewKeyword &&
-		ts.isIdentifier(node.name) &&
 		node.name.text === "target"
 	) {
 		return true;
@@ -83,17 +77,14 @@ export default ruleCreator.createRule(typescriptLanguage, {
 					}
 
 					for (const member of node.members) {
-						if (!ts.isConstructorDeclaration(member) || !member.body) {
+						if (member.kind !== SyntaxKind.Constructor || !member.body) {
 							continue;
 						}
 
 						for (const statement of member.body.statements) {
 							if (
 								statement.kind !== SyntaxKind.ExpressionStatement ||
-								!(
-									statement.expression.kind === SyntaxKind.CallExpression ||
-									ts.isCallChain(statement.expression)
-								) ||
+								statement.expression.kind !== SyntaxKind.CallExpression ||
 								!isCaptureStackTraceCall(statement.expression)
 							) {
 								continue;

--- a/packages/ts/src/rules/exportFromImports.ts
+++ b/packages/ts/src/rules/exportFromImports.ts
@@ -1,4 +1,5 @@
-import ts, { SyntaxKind } from "typescript";
+import type ts from "typescript";
+import { SyntaxKind } from "typescript";
 
 import {
 	getStaticStringValue,
@@ -42,9 +43,9 @@ function getImportInfo(
 	}
 
 	if (clause.namedBindings) {
-		if (ts.isNamespaceImport(clause.namedBindings)) {
+		if (clause.namedBindings.kind === SyntaxKind.NamespaceImport) {
 			info.namespaceImport = clause.namedBindings.name.text;
-		} else if (ts.isNamedImports(clause.namedBindings)) {
+		} else {
 			for (const element of clause.namedBindings.elements) {
 				const importedName = element.propertyName
 					? element.propertyName.text
@@ -136,8 +137,7 @@ export default ruleCreator.createRule(typescriptLanguage, {
 
 					for (const exportDeclaration of namedExports) {
 						if (
-							!exportDeclaration.exportClause ||
-							!ts.isNamedExports(exportDeclaration.exportClause)
+							exportDeclaration.exportClause?.kind !== SyntaxKind.NamedExports
 						) {
 							continue;
 						}
@@ -185,7 +185,7 @@ export default ruleCreator.createRule(typescriptLanguage, {
 					}
 
 					for (const exportAssignment of exportAssignments) {
-						if (!ts.isIdentifier(exportAssignment.expression)) {
+						if (exportAssignment.expression.kind !== SyntaxKind.Identifier) {
 							continue;
 						}
 

--- a/packages/ts/src/rules/literalConstructorWrappers.ts
+++ b/packages/ts/src/rules/literalConstructorWrappers.ts
@@ -1,11 +1,4 @@
-import {
-	isBigIntLiteral,
-	isIdentifier,
-	isLiteralExpression,
-	isNumericLiteral,
-	isStringLiteral,
-	SyntaxKind,
-} from "typescript";
+import { isLiteralExpression, SyntaxKind } from "typescript";
 
 import {
 	isGlobalDeclarationOfName,
@@ -34,13 +27,16 @@ function isLiteralArgument(node: AST.Expression, constructorName: string) {
 			return isLiteralExpression(node) || isBooleanLiteral(node);
 
 		case "Number":
-			return isStringLiteral(node) && isValidNumericString(node.text);
+			return (
+				node.kind === SyntaxKind.StringLiteral &&
+				isValidNumericString(node.text)
+			);
 
 		case "String":
 			return (
-				isNumericLiteral(node) ||
+				node.kind === SyntaxKind.NumericLiteral ||
 				isBooleanLiteral(node) ||
-				isBigIntLiteral(node)
+				node.kind === SyntaxKind.BigIntLiteral
 			);
 
 		default:
@@ -87,7 +83,7 @@ export default ruleCreator.createRule(typescriptLanguage, {
 					node,
 					{ program, sourceFile, typeChecker }: TypeScriptFileServices,
 				) => {
-					if (!isIdentifier(node.expression)) {
+					if (node.expression.kind !== SyntaxKind.Identifier) {
 						return;
 					}
 

--- a/packages/ts/src/rules/nonNullAssertedNullishCoalesces.ts
+++ b/packages/ts/src/rules/nonNullAssertedNullishCoalesces.ts
@@ -1,7 +1,8 @@
 import * as tsutils from "ts-api-utils";
-import ts, { SyntaxKind } from "typescript";
+import { SyntaxKind } from "typescript";
 
 import {
+	forEachChild,
 	getTSNodeRange,
 	typescriptLanguage,
 	type AST,
@@ -21,7 +22,7 @@ function hasNoAssignmentBeforeNode(
 		return false;
 	}
 
-	const declarations = symbol.getDeclarations();
+	const declarations = symbol.getDeclarations() as AST.AnyNode[] | undefined;
 	if (!declarations?.length) {
 		return false;
 	}
@@ -33,11 +34,14 @@ function hasNoAssignmentBeforeNode(
 			continue;
 		}
 
-		if (ts.isVariableDeclaration(declaration)) {
+		if (declaration.kind === SyntaxKind.VariableDeclaration) {
 			if (declaration.exclamationToken || declaration.initializer) {
 				return false;
 			}
-		} else if (ts.isParameter(declaration) && declaration.initializer) {
+		} else if (
+			declaration.kind === SyntaxKind.Parameter &&
+			declaration.initializer
+		) {
 			return false;
 		}
 	}
@@ -47,14 +51,14 @@ function hasNoAssignmentBeforeNode(
 		return true;
 	}
 
-	function findModifyingReference(current: ts.Node): boolean {
-		if (ts.isIdentifier(current)) {
+	function findModifyingReference(current: AST.AnyNode): boolean {
+		if (current.kind === SyntaxKind.Identifier) {
 			const currentSymbol = typeChecker.getSymbolAtLocation(current);
 			if (currentSymbol?.valueDeclaration === valueDeclaration) {
 				const parent = current.parent;
 
 				if (
-					ts.isBinaryExpression(parent) &&
+					parent.kind === SyntaxKind.BinaryExpression &&
 					tsutils.isAssignmentKind(parent.operatorToken.kind) &&
 					parent.left === current &&
 					parent.getEnd() < nodeEnd
@@ -63,8 +67,8 @@ function hasNoAssignmentBeforeNode(
 				}
 
 				if (
-					(ts.isPostfixUnaryExpression(parent) ||
-						ts.isPrefixUnaryExpression(parent)) &&
+					(parent.kind === SyntaxKind.PostfixUnaryExpression ||
+						parent.kind === SyntaxKind.PrefixUnaryExpression) &&
 					parent.operand === current &&
 					parent.getEnd() < nodeEnd
 				) {
@@ -73,7 +77,7 @@ function hasNoAssignmentBeforeNode(
 			}
 		}
 
-		return ts.forEachChild(current, findModifyingReference) ?? false;
+		return forEachChild(current, findModifyingReference) ?? false;
 	}
 
 	return !findModifyingReference(sourceFile);

--- a/packages/ts/src/rules/numberStaticMethods.ts
+++ b/packages/ts/src/rules/numberStaticMethods.ts
@@ -1,4 +1,4 @@
-import ts, { SyntaxKind } from "typescript";
+import { SyntaxKind } from "typescript";
 
 import {
 	getTSNodeRange,
@@ -14,11 +14,13 @@ const globalReplacements = new Map([
 	["isNaN", "Number.isNaN"],
 ]);
 
-function isDeclarationName(node: ts.Identifier) {
+function isDeclarationName(node: AST.Identifier) {
 	return (
-		(ts.isFunctionDeclaration(node.parent) && node.parent.name === node) ||
-		(ts.isVariableDeclaration(node.parent) && node.parent.name === node) ||
-		(ts.isParameter(node.parent) && node.parent.name === node)
+		(node.parent.kind === SyntaxKind.FunctionDeclaration &&
+			node.parent.name === node) ||
+		(node.parent.kind === SyntaxKind.VariableDeclaration &&
+			node.parent.name === node) ||
+		(node.parent.kind === SyntaxKind.Parameter && node.parent.name === node)
 	);
 }
 
@@ -31,15 +33,17 @@ function isLeftHandSide(node: AST.Identifier) {
 	);
 }
 
-function isPropertyAccessOfNode(node: ts.Identifier) {
+function isPropertyAccessOfNode(node: AST.Identifier) {
 	return (
-		ts.isPropertyAccessExpression(node.parent) && node.parent.name === node
+		node.parent.kind === SyntaxKind.PropertyAccessExpression &&
+		node.parent.name === node
 	);
 }
 
-function isPropertyShorthandOfNode(node: ts.Identifier) {
+function isPropertyShorthandOfNode(node: AST.Identifier) {
 	return (
-		ts.isShorthandPropertyAssignment(node.parent) && node.parent.name === node
+		node.parent.kind === SyntaxKind.ShorthandPropertyAssignment &&
+		node.parent.name === node
 	);
 }
 

--- a/packages/ts/src/rules/overloadSignaturesAdjacent.ts
+++ b/packages/ts/src/rules/overloadSignaturesAdjacent.ts
@@ -117,11 +117,11 @@ function getMethodDisplayName(method: Method) {
 // TODO: Use a util like getStaticValue
 // https://github.com/flint-fyi/flint/issues/1298
 function getNameFromPropertyName(
-	name: ts.PropertyName,
+	name: AST.PropertyName,
 ): undefined | { name: string; type: "computed" | "normal" | "quoted" } {
 	switch (name.kind) {
 		case SyntaxKind.ComputedPropertyName:
-			if (ts.isStringLiteral(name.expression)) {
+			if (name.expression.kind === SyntaxKind.StringLiteral) {
 				return { name: name.expression.text, type: "quoted" };
 			}
 			return undefined;

--- a/packages/ts/src/rules/redundantTypeConstituents.ts
+++ b/packages/ts/src/rules/redundantTypeConstituents.ts
@@ -104,9 +104,9 @@ function isDescendantOf(node: AST.AnyNode, potentialAncestor: ts.Node) {
 // TODO: This will be more clean when there is a scope manager
 // https://github.com/flint-fyi/flint/issues/400
 function isNodeInsideReturnType(node: AST.AnyNode) {
-	let current = node.parent as AST.AnyNode | undefined;
+	let current = node.parent;
 
-	while (current) {
+	while (current.kind !== SyntaxKind.SourceFile) {
 		if (
 			current.kind === SyntaxKind.FunctionDeclaration ||
 			current.kind === SyntaxKind.FunctionExpression ||
@@ -121,8 +121,7 @@ function isNodeInsideReturnType(node: AST.AnyNode) {
 			return !!current.type && isDescendantOf(node, current.type);
 		}
 
-		// eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion -- removing causes type error on the `while` loop. TSESLint bug?
-		current = current.parent as AST.AnyNode | undefined;
+		current = current.parent;
 	}
 
 	return false;

--- a/packages/ts/src/rules/regexResultArrayGroups.ts
+++ b/packages/ts/src/rules/regexResultArrayGroups.ts
@@ -6,6 +6,7 @@ import type {
 import ts, { SyntaxKind } from "typescript";
 
 import {
+	forEachChild,
 	getTSNodeRange,
 	typescriptLanguage,
 	type AST,
@@ -46,20 +47,20 @@ function findAssignmentsToSymbol(
 	sourceFile: AST.SourceFile,
 	typeChecker: Checker,
 ) {
-	const assignments: ts.BinaryExpression[] = [];
+	const assignments: AST.BinaryExpression[] = [];
 
-	function visit(node: ts.Node) {
+	function visit(node: AST.AnyNode) {
 		if (
-			ts.isBinaryExpression(node) &&
+			node.kind === SyntaxKind.BinaryExpression &&
 			node.operatorToken.kind === SyntaxKind.EqualsToken &&
-			ts.isIdentifier(node.left)
+			node.left.kind === SyntaxKind.Identifier
 		) {
 			const leftSymbol = typeChecker.getSymbolAtLocation(node.left);
 			if (leftSymbol === symbol) {
 				assignments.push(node);
 			}
 		}
-		ts.forEachChild(node, visit);
+		forEachChild(node, visit);
 	}
 
 	visit(sourceFile);
@@ -249,15 +250,17 @@ function getRegexInfoFromExpression(
 	if (unwrapped.kind === SyntaxKind.Identifier) {
 		const symbol = typeChecker.getSymbolAtLocation(unwrapped);
 		if (symbol) {
-			const declarations = symbol.getDeclarations();
+			const declarations = symbol.getDeclarations() as
+				| AST.AnyNode[]
+				| undefined;
 			if (declarations) {
 				for (const declaration of declarations) {
 					if (
-						ts.isVariableDeclaration(declaration) &&
+						declaration.kind === SyntaxKind.VariableDeclaration &&
 						declaration.initializer
 					) {
 						return getRegexInfoFromExpression(
-							declaration.initializer as AST.Expression,
+							declaration.initializer,
 							typeChecker,
 							sourceFile,
 						);
@@ -275,14 +278,15 @@ function getRegexInfoFromSymbol(
 	typeChecker: Checker,
 	sourceFile: AST.SourceFile,
 ) {
-	const declarations = symbol.getDeclarations();
+	const declarations = symbol.getDeclarations() as AST.AnyNode[] | undefined;
 
 	if (declarations) {
 		for (const declaration of declarations) {
-			if (ts.isVariableDeclaration(declaration) && declaration.initializer) {
-				const callExpression = extractCallExpression(
-					declaration.initializer as AST.Expression,
-				);
+			if (
+				declaration.kind === SyntaxKind.VariableDeclaration &&
+				declaration.initializer
+			) {
+				const callExpression = extractCallExpression(declaration.initializer);
 				if (callExpression) {
 					const regexInfo = getRegexFromCall(
 						callExpression,
@@ -301,7 +305,7 @@ function getRegexInfoFromSymbol(
 				}
 			}
 
-			if (ts.isParameter(declaration)) {
+			if (declaration.kind === SyntaxKind.Parameter) {
 				continue;
 			}
 		}
@@ -309,9 +313,7 @@ function getRegexInfoFromSymbol(
 
 	const assignments = findAssignmentsToSymbol(symbol, sourceFile, typeChecker);
 	for (const assignment of assignments) {
-		const callExpression = extractCallExpression(
-			assignment.right as AST.Expression,
-		);
+		const callExpression = extractCallExpression(assignment.right);
 		if (callExpression) {
 			const regexInfo = getRegexFromCall(
 				callExpression,

--- a/packages/ts/src/rules/setSizeLengthChecks.ts
+++ b/packages/ts/src/rules/setSizeLengthChecks.ts
@@ -1,14 +1,4 @@
-import {
-	isArrayLiteralExpression,
-	isIdentifier,
-	isNewExpression,
-	isParenthesizedExpression,
-	isSpreadElement,
-	isVariableDeclaration,
-	NodeFlags,
-	SyntaxKind,
-	type Program,
-} from "typescript";
+import { NodeFlags, SyntaxKind, type Program } from "typescript";
 
 import {
 	getTSNodeRange,
@@ -26,8 +16,8 @@ function isNewSetExpression(
 	program: Program,
 ) {
 	return (
-		isNewExpression(expression) &&
-		isIdentifier(expression.expression) &&
+		expression.kind === SyntaxKind.NewExpression &&
+		expression.expression.kind === SyntaxKind.Identifier &&
 		expression.expression.text === "Set" &&
 		isGlobalDeclarationOfName(
 			expression.expression,
@@ -49,15 +39,12 @@ function isSetExpression(
 		return true;
 	}
 
-	if (!isIdentifier(unwrapped)) {
+	if (unwrapped.kind !== SyntaxKind.Identifier) {
 		return false;
 	}
 
 	const symbol = typeChecker.getSymbolAtLocation(unwrapped);
-	if (
-		!symbol?.valueDeclaration ||
-		!isVariableDeclaration(symbol.valueDeclaration)
-	) {
+	if (symbol?.valueDeclaration?.kind !== SyntaxKind.VariableDeclaration) {
 		return false;
 	}
 
@@ -79,7 +66,7 @@ function isSetExpression(
 }
 
 function unwrapParentheses(expression: AST.Expression): AST.Expression {
-	while (isParenthesizedExpression(expression)) {
+	while (expression.kind === SyntaxKind.ParenthesizedExpression) {
 		expression = expression.expression;
 	}
 	return expression;
@@ -113,7 +100,7 @@ export default ruleCreator.createRule(typescriptLanguage, {
 					if (
 						node.questionDotToken ||
 						node.name.text !== "length" ||
-						!isArrayLiteralExpression(node.expression) ||
+						node.expression.kind !== SyntaxKind.ArrayLiteralExpression ||
 						node.expression.elements.length !== 1
 					) {
 						return;
@@ -123,7 +110,7 @@ export default ruleCreator.createRule(typescriptLanguage, {
 					const element = node.expression.elements[0]!;
 
 					if (
-						!isSpreadElement(element) ||
+						element.kind !== SyntaxKind.SpreadElement ||
 						!isSetExpression(element.expression, typeChecker, program)
 					) {
 						return;

--- a/packages/ts/src/rules/staticMemberOnlyClasses.ts
+++ b/packages/ts/src/rules/staticMemberOnlyClasses.ts
@@ -1,4 +1,4 @@
-import ts, { SyntaxKind } from "typescript";
+import { SyntaxKind, type NodeArray } from "typescript";
 
 import {
 	getTSNodeRange,
@@ -10,7 +10,11 @@ import {
 import { ruleCreator } from "./ruleCreator.ts";
 
 function hasDecorators(node: AST.ClassDeclaration | AST.ClassExpression) {
-	return node.modifiers?.some(ts.isDecorator) ?? false;
+	return (
+		node.modifiers?.some(
+			(modifier) => modifier.kind === SyntaxKind.Decorator,
+		) ?? false
+	);
 }
 
 function hasExtendsClause(node: AST.ClassDeclaration | AST.ClassExpression) {
@@ -29,9 +33,7 @@ function hasPrivateConstructor(node: AST.ConstructorDeclaration) {
 	);
 }
 
-function hasStaticModifier(
-	modifiers: ts.NodeArray<AST.ModifierLike> | undefined,
-) {
+function hasStaticModifier(modifiers: NodeArray<AST.ModifierLike> | undefined) {
 	return (
 		modifiers?.some((modifier) => modifier.kind === SyntaxKind.StaticKeyword) ??
 		false

--- a/packages/ts/src/rules/topLevelAwaits.ts
+++ b/packages/ts/src/rules/topLevelAwaits.ts
@@ -13,22 +13,23 @@ function hasExportModifier(node: AST.Statement) {
 	);
 }
 
-function isInsideFunction(node: ts.Node): boolean {
-	let current: ts.Node | undefined = node.parent;
+function isInsideFunction(node: AST.AnyNode): boolean {
+	let current = node.parent;
 
-	while (current) {
+	while (current.kind !== SyntaxKind.SourceFile) {
 		if (
-			ts.isFunctionDeclaration(current) ||
-			ts.isFunctionExpression(current) ||
-			ts.isArrowFunction(current) ||
-			ts.isMethodDeclaration(current) ||
-			ts.isConstructorDeclaration(current) ||
-			ts.isGetAccessorDeclaration(current) ||
-			ts.isSetAccessorDeclaration(current)
+			current.kind === SyntaxKind.FunctionDeclaration ||
+			current.kind === SyntaxKind.FunctionExpression ||
+			current.kind === SyntaxKind.ArrowFunction ||
+			current.kind === SyntaxKind.MethodDeclaration ||
+			current.kind === SyntaxKind.Constructor ||
+			current.kind === SyntaxKind.GetAccessor ||
+			current.kind === SyntaxKind.SetAccessor
 		) {
 			return true;
-		} // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion -- removing causes type error on the `while` loop. TSESLint bug?
-		current = current.parent as ts.Node | undefined;
+		}
+
+		current = current.parent;
 	}
 
 	return false;

--- a/packages/ts/src/rules/typeImports.ts
+++ b/packages/ts/src/rules/typeImports.ts
@@ -1,12 +1,4 @@
-import {
-	isExpressionWithTypeArguments,
-	isShorthandPropertyAssignment,
-	isTypeNode,
-	isTypeParameterDeclaration,
-	SymbolFlags,
-	SyntaxKind,
-	type Symbol,
-} from "typescript";
+import { isTypeNode, SymbolFlags, SyntaxKind, type Symbol } from "typescript";
 import { z } from "zod/v4";
 
 import {
@@ -96,7 +88,7 @@ function getReferencedSymbol(typeChecker: Checker, node: AST.Identifier) {
 	let symbol: Symbol | undefined;
 	const parent = node.parent;
 
-	if (isShorthandPropertyAssignment(parent)) {
+	if (parent.kind === SyntaxKind.ShorthandPropertyAssignment) {
 		symbol = typeChecker.getShorthandAssignmentValueSymbol(parent);
 	} else {
 		symbol = typeChecker.getSymbolAtLocation(node);
@@ -198,14 +190,13 @@ function getTypeKeywordRange(node: AST.AnyNode, sourceFile: AST.SourceFile) {
 }
 
 function isInImportDeclaration(node: AST.AnyNode) {
-	let current: AST.AnyNode | undefined = node;
-	while (current) {
+	let current = node;
+	while (current.kind !== SyntaxKind.SourceFile) {
 		if (current.kind === SyntaxKind.ImportDeclaration) {
 			return true;
 		}
 
-		// eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion -- removing causes type error on the `while` loop. TSESLint bug?
-		current = current.parent as AST.AnyNode | undefined;
+		current = current.parent;
 	}
 
 	return false;
@@ -235,12 +226,15 @@ function isOnlyTypeReference(node: AST.Identifier) {
 		if (
 			parent.kind === SyntaxKind.TypeAliasDeclaration ||
 			parent.kind === SyntaxKind.InterfaceDeclaration ||
-			isTypeParameterDeclaration(parent)
+			parent.kind === SyntaxKind.TypeParameter
 		) {
 			return true;
 		}
 
-		if (isTypeNode(parent) && !isExpressionWithTypeArguments(parent)) {
+		if (
+			isTypeNode(parent) &&
+			parent.kind !== SyntaxKind.ExpressionWithTypeArguments
+		) {
 			return true;
 		}
 

--- a/packages/ts/src/rules/unnecessaryBinds.ts
+++ b/packages/ts/src/rules/unnecessaryBinds.ts
@@ -1,29 +1,31 @@
-import ts, { SyntaxKind } from "typescript";
+import { SyntaxKind } from "typescript";
 
 import {
+	forEachChild,
 	getTSNodeRange,
 	typescriptLanguage,
+	type AST,
 } from "@flint.fyi/typescript-language";
 
 import { ruleCreator } from "./ruleCreator.ts";
 
 // TODO: This will be more clean when there is a scope manager
 // https://github.com/flint-fyi/flint/issues/400
-function containsThis(node: ts.Node): boolean {
+function containsThis(node: AST.AnyNode): boolean {
 	if (node.kind === SyntaxKind.ThisKeyword) {
 		return true;
 	}
 
 	if (
-		ts.isFunctionExpression(node) ||
-		ts.isFunctionDeclaration(node) ||
-		ts.isArrowFunction(node)
+		node.kind === SyntaxKind.FunctionExpression ||
+		node.kind === SyntaxKind.FunctionDeclaration ||
+		node.kind === SyntaxKind.ArrowFunction
 	) {
 		return false;
 	}
 
 	let found = false;
-	node.forEachChild((child) => {
+	forEachChild(node, (child) => {
 		if (containsThis(child)) {
 			found = true;
 		}
@@ -33,24 +35,24 @@ function containsThis(node: ts.Node): boolean {
 
 // TODO: Use a util like getStaticValue
 // https://github.com/flint-fyi/flint/issues/1298
-function isStaticValue(node: ts.Expression): boolean {
-	if (ts.isParenthesizedExpression(node)) {
+function isStaticValue(node: AST.Expression): boolean {
+	if (node.kind === SyntaxKind.ParenthesizedExpression) {
 		return isStaticValue(node.expression);
 	}
 
-	if (ts.isPrefixUnaryExpression(node)) {
+	if (node.kind === SyntaxKind.PrefixUnaryExpression) {
 		return isStaticValue(node.operand);
 	}
 
-	if (ts.isIdentifier(node)) {
+	if (node.kind === SyntaxKind.Identifier) {
 		return true;
 	}
 
-	if (ts.isPropertyAccessExpression(node)) {
+	if (node.kind === SyntaxKind.PropertyAccessExpression) {
 		return isStaticValue(node.expression);
 	}
 
-	if (ts.isElementAccessExpression(node)) {
+	if (node.kind === SyntaxKind.ElementAccessExpression) {
 		return (
 			isStaticValue(node.expression) && isStaticValue(node.argumentExpression)
 		);
@@ -62,16 +64,16 @@ function isStaticValue(node: ts.Expression): boolean {
 		node.kind === SyntaxKind.TrueKeyword ||
 		node.kind === SyntaxKind.FalseKeyword ||
 		node.kind === SyntaxKind.NullKeyword ||
-		ts.isBigIntLiteral(node) ||
-		ts.isNumericLiteral(node) ||
-		ts.isStringLiteral(node) ||
-		ts.isNoSubstitutionTemplateLiteral(node) ||
+		node.kind === SyntaxKind.BigIntLiteral ||
+		node.kind === SyntaxKind.NumericLiteral ||
+		node.kind === SyntaxKind.StringLiteral ||
+		node.kind === SyntaxKind.NoSubstitutionTemplateLiteral ||
 		node.kind === SyntaxKind.RegularExpressionLiteral
 	);
 }
 
-function unwrapParentheses(node: ts.Expression): ts.Expression {
-	while (ts.isParenthesizedExpression(node)) {
+function unwrapParentheses(node: AST.Expression): AST.Expression {
+	while (node.kind === SyntaxKind.ParenthesizedExpression) {
 		node = node.expression;
 	}
 	return node;
@@ -133,7 +135,7 @@ export default ruleCreator.createRule(typescriptLanguage, {
 							}
 						: undefined;
 
-					if (ts.isArrowFunction(boundFunction)) {
+					if (boundFunction.kind === SyntaxKind.ArrowFunction) {
 						context.report({
 							fix,
 							message: "arrowBind",
@@ -146,7 +148,7 @@ export default ruleCreator.createRule(typescriptLanguage, {
 					}
 
 					if (
-						ts.isFunctionExpression(boundFunction) &&
+						boundFunction.kind === SyntaxKind.FunctionExpression &&
 						!containsThis(boundFunction.body)
 					) {
 						context.report({

--- a/packages/ts/src/rules/utils/isErrorSubclass.ts
+++ b/packages/ts/src/rules/utils/isErrorSubclass.ts
@@ -1,4 +1,4 @@
-import { isIdentifier, SyntaxKind, type Program } from "typescript";
+import { SyntaxKind, type Program } from "typescript";
 
 import {
 	isGlobalDeclaration,
@@ -33,7 +33,7 @@ export function isErrorSubclass(
 		for (const type of clause.types) {
 			const typeName = type.expression;
 			if (
-				isIdentifier(typeName) &&
+				typeName.kind === SyntaxKind.Identifier &&
 				builtinErrorNames.has(typeName.text) &&
 				isGlobalDeclaration(typeName, typeChecker, program)
 			) {

--- a/packages/ts/src/type-utils/isDeclaredInModuleBlock.ts
+++ b/packages/ts/src/type-utils/isDeclaredInModuleBlock.ts
@@ -1,16 +1,18 @@
-import ts from "typescript";
+import { NodeFlags, SyntaxKind, type Declaration } from "typescript";
+
+import type { AST } from "@flint.fyi/typescript-language";
 
 // TODO (#400): Switch to scope analysis
 export function isDeclaredInModuleBlock(
-	declaration: ts.Declaration,
+	declaration: Declaration,
 	packageName: string,
 ): boolean {
-	let current: ts.Node = declaration;
-	while (!ts.isSourceFile(current)) {
+	let current = declaration as AST.AnyNode;
+	while (current.kind !== SyntaxKind.SourceFile) {
 		if (
-			ts.isModuleDeclaration(current) &&
-			!(current.flags & ts.NodeFlags.Namespace) &&
-			ts.isStringLiteral(current.name) &&
+			current.kind === SyntaxKind.ModuleDeclaration &&
+			!(current.flags & NodeFlags.Namespace) &&
+			current.name.kind === SyntaxKind.StringLiteral &&
 			current.name.text === packageName
 		) {
 			return true;

--- a/packages/typescript-language/src/collectReferencedFilePaths.ts
+++ b/packages/typescript-language/src/collectReferencedFilePaths.ts
@@ -1,11 +1,9 @@
 import * as path from "node:path";
 
-import * as tsutils from "ts-api-utils";
-import ts from "typescript";
-
-import { nullThrows } from "@flint.fyi/utils";
+import ts, { SyntaxKind } from "typescript";
 
 import type * as AST from "./types/ast.ts";
+import { forEachChild } from "./utils/forEachChild.ts";
 
 export function collectReferencedFilePaths(
 	program: ts.Program,
@@ -32,7 +30,7 @@ export function collectReferencedFilePaths(
 		return undefined;
 	}
 
-	function visit(node: ts.Node) {
+	function visit(node: AST.AnyNode) {
 		let path: string | undefined;
 
 		if (isImportDeclaration(node)) {
@@ -57,7 +55,7 @@ export function collectReferencedFilePaths(
 			modulePaths.add(resolvedPath);
 		}
 
-		ts.forEachChild(node, visit);
+		forEachChild(node, visit);
 	}
 
 	visit(sourceFile);
@@ -65,52 +63,48 @@ export function collectReferencedFilePaths(
 	return Array.from(modulePaths);
 }
 
-function isAwaitImportCall(node: ts.Node): node is AST.AwaitExpression & {
-	expression: ts.CallExpression & { arguments: [ts.StringLiteral] };
+function isAwaitImportCall(node: AST.AnyNode): node is AST.AwaitExpression & {
+	expression: AST.CallExpression & { arguments: [AST.StringLiteral] };
 } {
-	return ts.isAwaitExpression(node) && isImportCall(node.expression);
+	return (
+		node.kind === SyntaxKind.AwaitExpression && isImportCall(node.expression)
+	);
 }
 
 function isExportDeclaration(
-	node: ts.Node,
-): node is ts.ExportDeclaration & { moduleSpecifier: ts.StringLiteral } {
+	node: AST.AnyNode,
+): node is AST.ExportDeclaration & { moduleSpecifier: AST.StringLiteral } {
 	return (
-		ts.isExportDeclaration(node) &&
-		node.moduleSpecifier != null &&
-		ts.isStringLiteral(node.moduleSpecifier)
+		node.kind === SyntaxKind.ExportDeclaration &&
+		node.moduleSpecifier?.kind === SyntaxKind.StringLiteral
 	);
 }
 
 function isImportCall(
-	node: ts.Node,
-): node is ts.CallExpression & { arguments: [ts.StringLiteral] } {
+	node: AST.AnyNode,
+): node is AST.CallExpression & { arguments: [AST.StringLiteral] } {
 	return (
-		ts.isCallExpression(node) &&
-		tsutils.isImportExpression(node.expression) &&
-		!!node.arguments.length &&
-		ts.isStringLiteral(
-			nullThrows(
-				node.arguments[0],
-				"First argument is expected to be present by prior length check",
-			),
-		)
+		node.kind === SyntaxKind.CallExpression &&
+		node.expression.kind === SyntaxKind.ImportKeyword &&
+		node.arguments[0]?.kind === SyntaxKind.StringLiteral
 	);
 }
 
 function isImportDeclaration(
-	node: ts.Node,
+	node: AST.AnyNode,
 ): node is AST.ImportDeclaration & { moduleSpecifier: AST.StringLiteral } {
 	return (
-		ts.isImportDeclaration(node) && ts.isStringLiteral(node.moduleSpecifier)
+		node.kind === SyntaxKind.ImportDeclaration &&
+		node.moduleSpecifier.kind === SyntaxKind.StringLiteral
 	);
 }
 
-function isImportTypeNode(node: ts.Node): node is ts.ImportTypeNode & {
-	argument: ts.LiteralTypeNode & { literal: ts.StringLiteral };
+function isImportTypeNode(node: AST.AnyNode): node is AST.ImportTypeNode & {
+	argument: AST.LiteralTypeNode & { literal: AST.StringLiteral };
 } {
 	return (
-		ts.isImportTypeNode(node) &&
-		ts.isLiteralTypeNode(node.argument) &&
-		ts.isStringLiteral(node.argument.literal)
+		node.kind === SyntaxKind.ImportType &&
+		node.argument.kind === SyntaxKind.LiteralType &&
+		node.argument.literal.kind === SyntaxKind.StringLiteral
 	);
 }

--- a/packages/typescript-language/src/utils/containsGlobalDeclarations.test.ts
+++ b/packages/typescript-language/src/utils/containsGlobalDeclarations.test.ts
@@ -1,6 +1,7 @@
 import ts from "typescript";
 import { describe, expect, it } from "vitest";
 
+import type * as AST from "../types/ast.ts";
 import { containsGlobalDeclarations } from "./containsGlobalDeclarations.ts";
 
 describe(containsGlobalDeclarations, () => {
@@ -72,5 +73,5 @@ function getSourceFile(rawFileContent: string) {
 		rawFileContent,
 		ts.ScriptTarget.ESNext,
 		true,
-	);
+	) as unknown as AST.SourceFile;
 }

--- a/packages/typescript-language/src/utils/containsGlobalDeclarations.ts
+++ b/packages/typescript-language/src/utils/containsGlobalDeclarations.ts
@@ -1,17 +1,22 @@
 import ts, { SyntaxKind } from "typescript";
 
+import type * as AST from "../types/ast.ts";
+
 /**
  * Inspects top-level statements of a TS source file to determine
  * if it introduces or modifies entities in the global scope.
  */
 export function containsGlobalDeclarations(
-	sourceFileNode: ts.SourceFile,
+	sourceFileNode: AST.SourceFile,
 ): boolean {
 	const isModule = ts.isExternalModule(sourceFileNode);
 
 	return sourceFileNode.statements.some((statement) => {
 		// Checks for 'declare global {}'
-		if (ts.isModuleDeclaration(statement) && statement.name.text === "global") {
+		if (
+			statement.kind === SyntaxKind.ModuleDeclaration &&
+			statement.name.text === "global"
+		) {
 			return true;
 		}
 

--- a/packages/typescript-language/src/utils/hasSameTokens.ts
+++ b/packages/typescript-language/src/utils/hasSameTokens.ts
@@ -8,8 +8,8 @@ export function hasSameTokens(
 	nodeB: AST.AnyNode,
 	sourceFile: AST.SourceFile,
 ): boolean {
-	const queueA: ts.Node[] = [unwrapParenthesizedNode(nodeA)];
-	const queueB: ts.Node[] = [unwrapParenthesizedNode(nodeB)];
+	const queueA: AST.AnyNode[] = [unwrapParenthesizedNode(nodeA)];
+	const queueB: AST.AnyNode[] = [unwrapParenthesizedNode(nodeB)];
 
 	while (true) {
 		const currentA = queueA.shift();
@@ -30,8 +30,8 @@ export function hasSameTokens(
 			continue;
 		}
 
-		const childrenA = currentA.getChildren(sourceFile);
-		const childrenB = currentB.getChildren(sourceFile);
+		const childrenA = currentA.getChildren(sourceFile) as AST.AnyNode[];
+		const childrenB = currentB.getChildren(sourceFile) as AST.AnyNode[];
 
 		if (childrenA.length !== childrenB.length) {
 			return false;
@@ -45,17 +45,17 @@ export function hasSameTokens(
 }
 
 function areSameToken(
-	nodeA: ts.Node,
-	nodeB: ts.Node,
+	nodeA: AST.AnyNode,
+	nodeB: AST.AnyNode,
 	sourceFile: AST.SourceFile,
 ): boolean {
 	if (
-		ts.isIdentifier(nodeA) ||
-		ts.isPrivateIdentifier(nodeA) ||
-		ts.isNumericLiteral(nodeA) ||
-		ts.isBigIntLiteral(nodeA) ||
-		ts.isStringLiteral(nodeA) ||
-		ts.isNoSubstitutionTemplateLiteral(nodeA)
+		nodeA.kind === SyntaxKind.Identifier ||
+		nodeA.kind === SyntaxKind.PrivateIdentifier ||
+		nodeA.kind === SyntaxKind.NumericLiteral ||
+		nodeA.kind === SyntaxKind.BigIntLiteral ||
+		nodeA.kind === SyntaxKind.StringLiteral ||
+		nodeA.kind === SyntaxKind.NoSubstitutionTemplateLiteral
 	) {
 		return nodeA.text === (nodeB as typeof nodeA).text;
 	}

--- a/packages/typescript-language/src/utils/isGlobalDeclarationOfName.ts
+++ b/packages/typescript-language/src/utils/isGlobalDeclarationOfName.ts
@@ -1,17 +1,8 @@
-import {
-	isClassDeclaration,
-	isFunctionDeclaration,
-	isIdentifier,
-	isInterfaceDeclaration,
-	isPropertySignature,
-	isVariableDeclaration,
-	type Declaration,
-	type Node,
-	type Program,
-} from "typescript";
+import { SyntaxKind, type Node, type Program } from "typescript";
 
 import type { Checker } from "@flint.fyi/typescript-language";
 
+import type * as AST from "../types/ast.ts";
 import { declarationIncludesGlobal } from "./declarationIncludesGlobal.ts";
 
 /**
@@ -28,13 +19,14 @@ export function isGlobalDeclarationOfName(
 		return false;
 	}
 
-	return declarations.every((declaration) => {
+	return declarations.every((tsDeclaration) => {
+		const declaration = tsDeclaration as AST.AnyNode;
+
 		// Special case: a variable set to a known identifier. E.g.:
 		// const CustomFunction = Function;
 		if (
-			isVariableDeclaration(declaration) &&
-			declaration.initializer &&
-			isIdentifier(declaration.initializer)
+			declaration.kind === SyntaxKind.VariableDeclaration &&
+			declaration.initializer?.kind === SyntaxKind.Identifier
 		) {
 			return isGlobalDeclarationOfName(
 				declaration.initializer,
@@ -45,7 +37,7 @@ export function isGlobalDeclarationOfName(
 		}
 
 		// Special case: a property of an interface
-		if (isPropertySignature(declaration)) {
+		if (declaration.kind === SyntaxKind.PropertySignature) {
 			return isGlobalDeclarationOfName(
 				declaration.parent,
 				name,
@@ -56,20 +48,22 @@ export function isGlobalDeclarationOfName(
 
 		return (
 			isDeclarationOfName(declaration, name) &&
-			declarationIncludesGlobal(declaration, program)
+			declarationIncludesGlobal(tsDeclaration, program)
 		);
 	});
 }
 
-function isDeclarationOfName(node: Declaration, name: string) {
-	if (
-		isClassDeclaration(node) ||
-		isFunctionDeclaration(node) ||
-		isInterfaceDeclaration(node) ||
-		isVariableDeclaration(node)
-	) {
-		return node.name && isIdentifier(node.name) && node.name.text === name;
-	}
+function isDeclarationOfName(node: AST.AnyNode, name: string) {
+	switch (node.kind) {
+		case SyntaxKind.ClassDeclaration:
+		case SyntaxKind.FunctionDeclaration:
+		case SyntaxKind.InterfaceDeclaration:
+		case SyntaxKind.VariableDeclaration:
+			return (
+				node.name?.kind === SyntaxKind.Identifier && node.name.text === name
+			);
 
-	return false;
+		default:
+			return false;
+	}
 }

--- a/packages/typescript-language/src/utils/isInlineArrayCreation.ts
+++ b/packages/typescript-language/src/utils/isInlineArrayCreation.ts
@@ -1,4 +1,6 @@
-import ts from "typescript";
+import { SyntaxKind } from "typescript";
+
+import type * as AST from "../types/ast.ts";
 
 const methodsReturningNewArray = new Set([
 	"concat",
@@ -22,21 +24,21 @@ const objectStaticMethods = new Set(["entries", "keys", "values"]);
  * These are cases where a new array is created immediately before the method call,
  * so mutating methods like .sort() or .reverse() are safe to use.
  */
-export function isInlineArrayCreation(node: ts.Expression): boolean {
-	if (ts.isArrayLiteralExpression(node)) {
+export function isInlineArrayCreation(node: AST.Expression): boolean {
+	if (node.kind === SyntaxKind.ArrayLiteralExpression) {
 		return true;
 	}
 
-	if (ts.isParenthesizedExpression(node)) {
+	if (node.kind === SyntaxKind.ParenthesizedExpression) {
 		return isInlineArrayCreation(node.expression);
 	}
 
-	if (ts.isCallExpression(node)) {
-		if (ts.isPropertyAccessExpression(node.expression)) {
+	if (node.kind === SyntaxKind.CallExpression) {
+		if (node.expression.kind === SyntaxKind.PropertyAccessExpression) {
 			const methodName = node.expression.name.text;
 
 			if (
-				ts.isIdentifier(node.expression.expression) &&
+				node.expression.expression.kind === SyntaxKind.Identifier &&
 				node.expression.expression.text === "Object" &&
 				objectStaticMethods.has(methodName)
 			) {
@@ -44,7 +46,7 @@ export function isInlineArrayCreation(node: ts.Expression): boolean {
 			}
 
 			if (
-				ts.isIdentifier(node.expression.expression) &&
+				node.expression.expression.kind === SyntaxKind.Identifier &&
 				node.expression.expression.text === "Array" &&
 				(methodName === "from" || methodName === "of")
 			) {
@@ -57,17 +59,17 @@ export function isInlineArrayCreation(node: ts.Expression): boolean {
 		}
 
 		if (
-			ts.isIdentifier(node.expression) &&
+			node.expression.kind === SyntaxKind.Identifier &&
 			node.expression.text === "Array" &&
-			ts.isNewExpression(node.parent)
+			node.parent.kind === SyntaxKind.NewExpression
 		) {
 			return true;
 		}
 	}
 
 	if (
-		ts.isNewExpression(node) &&
-		ts.isIdentifier(node.expression) &&
+		node.kind === SyntaxKind.NewExpression &&
+		node.expression.kind === SyntaxKind.Identifier &&
 		node.expression.text === "Array"
 	) {
 		return true;

--- a/packages/vitest/src/rules/conditionalExpects.ts
+++ b/packages/vitest/src/rules/conditionalExpects.ts
@@ -1,4 +1,4 @@
-import ts from "typescript";
+import ts, { SyntaxKind } from "typescript";
 import z from "zod/v4";
 
 import {
@@ -179,7 +179,7 @@ function isCatchCall({ expression }: AST.CallExpression): boolean {
 	}
 	if (expression.kind === ts.SyntaxKind.ElementAccessExpression) {
 		return (
-			ts.isStringLiteral(expression.argumentExpression) &&
+			expression.argumentExpression.kind === SyntaxKind.StringLiteral &&
 			expression.argumentExpression.text === "catch"
 		);
 	}

--- a/packages/vue/src/rules/vForKeys.ts
+++ b/packages/vue/src/rules/vForKeys.ts
@@ -1,5 +1,6 @@
 import * as vue from "@vue/compiler-dom";
-import ts from "typescript";
+import type ts from "typescript";
+import { SyntaxKind } from "typescript";
 
 import type { CharacterReportRange } from "@flint.fyi/core";
 import { nullThrows } from "@flint.fyi/utils";
@@ -195,7 +196,7 @@ export default ruleCreator.createRule(vueLanguage, {
 							if (
 								currentBegin >= valueRange.begin &&
 								currentEnd <= valueRange.end &&
-								ts.isIdentifier(current)
+								current.kind === SyntaxKind.Identifier
 							) {
 								const symbol =
 									services.typeChecker.getSymbolAtLocation(current);


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: n/a — split out of #3388 to shrink its diff
- [x] That issue was marked as [`status: accepted`](https://github.com/flint-fyi/flint/blob/main/.github/CONTRIBUTING.md#accepted-issues)
- [x] Steps in [CONTRIBUTING.md](https://github.com/flint-fyi/flint/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Moves AST checks off TypeScript's `isXXX(node)` type guard functions and onto discriminated union comparisons: `node.kind === SyntaxKind.XXX`.

`nodePropertyInChecks`'s suggestion text and docs example now recommend a `kind` comparison rather than `ts.isXXX()`, matching the direction of the codebase.

And, hell yeah, a few checks were flagged as dead code because of the new narrowing.

Deliberately left alone:

- Guards with no single-kind equivalent: `isLiteralExpression`, `isTypeNode`, `isExternalModule`, `isTokenKind`.
- `ts-api-utils` helpers, and type-level APIs such as `ts.TypeFlags` and `ts.Type`.

❤️‍🔥 