### PR TITLE
feat: add Biome performance comparison

### DIFF
--- a/.changeset/native-linter-comparisons.md
+++ b/.changeset/native-linter-comparisons.md
@@ -1,0 +1,5 @@
+---
+"@flint.fyi/rule-data": patch
+---
+
+Update Biome rule mappings for Biome 2.5.

--- a/packages/performance-testing/README.md
+++ b/packages/performance-testing/README.md
@@ -1,7 +1,7 @@
 <h1 align="center"><code>@flint.fyi/performance-testing</code></h1>
 
 <p align="center">
-	Runs performance measurements for Flint and other linters.
+	Runs performance measurements for Flint against Biome and ESLint.
 	❤️‍🔥
 </p>
 

--- a/packages/performance-testing/README.md
+++ b/packages/performance-testing/README.md
@@ -1,7 +1,7 @@
 <h1 align="center"><code>@flint.fyi/performance-testing</code></h1>
 
 <p align="center">
-	Runs performance measurements for Flint against Biome and ESLint.
+	Runs performance measurements for Flint and other linters.
 	❤️‍🔥
 </p>
 

--- a/packages/performance-testing/package.json
+++ b/packages/performance-testing/package.json
@@ -22,6 +22,7 @@
 		"test": "vitest --project performance-testing"
 	},
 	"dependencies": {
+		"@biomejs/biome": "catalog:comparisons",
 		"@flint.fyi/rule-data": "workspace:^",
 		"console-table-without-index": "catalog:dev",
 		"debug-for-file": "catalog:dev",

--- a/packages/performance-testing/src/creators/createCaseFiles.test.ts
+++ b/packages/performance-testing/src/creators/createCaseFiles.test.ts
@@ -18,6 +18,7 @@ describe(createCaseFiles, () => {
 		const actual = createCaseFiles({ files: 2, rules: 1 });
 
 		expect(Object.keys(actual)).toEqual([
+			"biome.json",
 			"eslint.config.js",
 			"flint.config.ts",
 			"src",

--- a/packages/performance-testing/src/creators/createCaseFiles.ts
+++ b/packages/performance-testing/src/creators/createCaseFiles.ts
@@ -1,5 +1,6 @@
 import type { TestCase } from "../testCases.ts";
 import type { Structure } from "../writing/writeStructure.ts";
+import { createBiomeConfigFile } from "./files/createBiomeConfigFile.ts";
 import { createESLintConfigFile } from "./files/createESLintConfigFile.ts";
 import { createFlintConfigFile } from "./files/createFlintConfigFile.ts";
 import { createStandardTSConfigFile } from "./files/createStandardTSConfigFile.ts";
@@ -11,6 +12,7 @@ export function countCaseFiles(testCase: TestCase): number {
 
 export function createCaseFiles(testCase: TestCase): Structure {
 	return {
+		"biome.json": [createBiomeConfigFile(testCase.rules), "json"],
 		"eslint.config.js": [createESLintConfigFile(testCase.rules), "typescript"],
 		"flint.config.ts": [createFlintConfigFile(testCase.rules), "typescript"],
 		src: createSourceFiles(testCase),

--- a/packages/performance-testing/src/creators/files/createBiomeConfigFile.test.ts
+++ b/packages/performance-testing/src/creators/files/createBiomeConfigFile.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+
+import { createBiomeConfigFile } from "./createBiomeConfigFile.ts";
+import { comparedRules } from "./rules.ts";
+
+describe(createBiomeConfigFile, () => {
+	it("enables only the single rule when given the 1 rules count", () => {
+		expect(createBiomeConfigFile(1)).toEqual({
+			linter: {
+				includes: ["src/**/*.ts"],
+				rules: {
+					preset: "none",
+					suspicious: {
+						noForIn: "error",
+					},
+				},
+			},
+		});
+	});
+
+	it("enables every compared rule when given the many rules preset", () => {
+		const actual = JSON.stringify(createBiomeConfigFile("many"));
+
+		expect(
+			comparedRules.many
+				.flatMap(({ biome }) => biome)
+				.every((name) => actual.includes(`"${name}":"error"`)),
+		).toBe(true);
+	});
+});

--- a/packages/performance-testing/src/creators/files/createBiomeConfigFile.ts
+++ b/packages/performance-testing/src/creators/files/createBiomeConfigFile.ts
@@ -1,0 +1,56 @@
+import schema from "@biomejs/biome/configuration_schema.json" with { type: "json" };
+
+import type { TestCaseRules } from "../../testCases.ts";
+import { comparedRules } from "./rules.ts";
+
+const biomeRuleGroups = [
+	"a11y",
+	"complexity",
+	"correctness",
+	"nursery",
+	"performance",
+	"security",
+	"style",
+	"suspicious",
+] as const;
+
+export function createBiomeConfigFile(rules: TestCaseRules): object {
+	const enabled = new Map<string, Record<string, "error">>();
+
+	for (const name of comparedRules[rules].flatMap(({ biome }) => biome)) {
+		const group = findBiomeRuleGroup(name);
+		const groupRules = enabled.get(group) ?? {};
+		groupRules[name] = "error";
+		enabled.set(group, groupRules);
+	}
+
+	const configuredRules = Object.fromEntries(
+		[...enabled, ["preset", "none"]].sort(([a], [b]) => a.localeCompare(b)),
+	) as Record<string, "none" | Record<string, "error">>;
+
+	return {
+		linter: {
+			includes: ["src/**/*.ts"],
+			rules: configuredRules,
+		},
+	};
+}
+
+function findBiomeRuleGroup(name: string): string {
+	const group = biomeRuleGroups.find((candidate) =>
+		Object.hasOwn(
+			schema.$defs[
+				`${candidate.charAt(0).toUpperCase()}${candidate.slice(1)}` as Capitalize<
+					typeof candidate
+				>
+			].properties,
+			name,
+		),
+	);
+
+	if (!group) {
+		throw new Error(`No Biome group is known for ${name}.`);
+	}
+
+	return group;
+}

--- a/packages/performance-testing/src/creators/files/rules.test.ts
+++ b/packages/performance-testing/src/creators/files/rules.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+
+import { comparedRules, ruleCounts } from "./rules.ts";
+
+describe("comparedRules", () => {
+	it("contains the same linter intersection for common and many", () => {
+		expect(ruleCounts).toEqual({
+			1: 1,
+			common: 52,
+			many: 133,
+		});
+
+		for (const compared of comparedRules.many) {
+			expect(compared.biome.length).toBeGreaterThan(0);
+			expect(compared.eslint).not.toHaveLength(0);
+			expect(compared.flint).not.toHaveLength(0);
+		}
+	});
+});

--- a/packages/performance-testing/src/creators/files/rules.ts
+++ b/packages/performance-testing/src/creators/files/rules.ts
@@ -3,6 +3,7 @@ import { ruleData, type LinterRuleReference } from "@flint.fyi/rule-data";
 import type { TestCaseRules } from "../../testCases.ts";
 
 export interface ComparedRule {
+	biome: string[];
 	eslint: string;
 	flint: string;
 	preset: string | undefined;
@@ -13,11 +14,11 @@ const measuredPresets = new Set(["javascript", "logical", "stylistic"]);
 
 const singleRuleName = "forInArrays";
 
-function compareESLintRules(a: string, b: string) {
+function compareESLintRules(a: string, b: string): number {
 	return rankESLintRule(a) - rankESLintRule(b) || a.localeCompare(b);
 }
 
-function rankESLintRule(name: string) {
+function rankESLintRule(name: string): number {
 	if (name.startsWith("@typescript-eslint/")) {
 		return 0;
 	}
@@ -28,7 +29,7 @@ function rankESLintRule(name: string) {
 // Flint rules are often mapped to several overlapping ESLint rules, such as a
 // core rule and its typescript-eslint extension. Enabling all of them would
 // make ESLint repeat work that Flint only does once.
-function selectESLintRule(references: LinterRuleReference[]) {
+function selectESLintRule(references: LinterRuleReference[]): string {
 	return references
 		.map((reference) => reference.name)
 		.reduce((selected, name) =>
@@ -43,6 +44,7 @@ const comparableRules: ComparedRule[] = ruleData
 		if (
 			flint.plugin !== "ts" ||
 			flint.status !== "implemented" ||
+			!details.biome?.length ||
 			!details.eslint?.length
 		) {
 			return [];
@@ -50,6 +52,7 @@ const comparableRules: ComparedRule[] = ruleData
 
 		return [
 			{
+				biome: details.biome.map((reference) => reference.name),
 				eslint: selectESLintRule(details.eslint),
 				flint: flint.name,
 				preset: flint.preset,
@@ -70,7 +73,7 @@ const commonRules = manyRules.filter(
 const singleRule = manyRules.find((rule) => rule.flint === singleRuleName);
 
 if (!singleRule) {
-	throw new Error(`No ESLint comparison is known for ts/${singleRuleName}.`);
+	throw new Error(`No Biome comparison is known for ts/${singleRuleName}.`);
 }
 
 export const comparedRules: Record<TestCaseRules, ComparedRule[]> = {

--- a/packages/performance-testing/src/creators/files/rules.ts
+++ b/packages/performance-testing/src/creators/files/rules.ts
@@ -14,11 +14,11 @@ const measuredPresets = new Set(["javascript", "logical", "stylistic"]);
 
 const singleRuleName = "forInArrays";
 
-function compareESLintRules(a: string, b: string): number {
+function compareESLintRules(a: string, b: string) {
 	return rankESLintRule(a) - rankESLintRule(b) || a.localeCompare(b);
 }
 
-function rankESLintRule(name: string): number {
+function rankESLintRule(name: string) {
 	if (name.startsWith("@typescript-eslint/")) {
 		return 0;
 	}
@@ -29,7 +29,7 @@ function rankESLintRule(name: string): number {
 // Flint rules are often mapped to several overlapping ESLint rules, such as a
 // core rule and its typescript-eslint extension. Enabling all of them would
 // make ESLint repeat work that Flint only does once.
-function selectESLintRule(references: LinterRuleReference[]): string {
+function selectESLintRule(references: LinterRuleReference[]) {
 	return references
 		.map((reference) => reference.name)
 		.reduce((selected, name) =>
@@ -71,9 +71,20 @@ const commonRules = manyRules.filter(
 );
 
 const singleRule = manyRules.find((rule) => rule.flint === singleRuleName);
+const singleRuleDetails = ruleData.find(
+	(details) =>
+		details.flint.name === singleRuleName && details.flint.plugin === "ts",
+);
 
 if (!singleRule) {
-	throw new Error(`No Biome comparison is known for ts/${singleRuleName}.`);
+	const missingLinters = [
+		...(singleRuleDetails?.biome?.length ? [] : ["Biome"]),
+		...(singleRuleDetails?.eslint?.length ? [] : ["ESLint"]),
+	];
+
+	throw new Error(
+		`No ${missingLinters.join(" or ")} comparison is known for ts/${singleRuleName}.`,
+	);
 }
 
 export const comparedRules: Record<TestCaseRules, ComparedRule[]> = {

--- a/packages/performance-testing/src/measure.ts
+++ b/packages/performance-testing/src/measure.ts
@@ -12,6 +12,13 @@ import { testCaseEntries, testCasesPath } from "./testCases.ts";
 
 const results: unknown[] = [];
 
+const biomeCommand = `node ${path.resolve(
+	path.dirname(
+		fileURLToPath(import.meta.resolve("@biomejs/biome/package.json")),
+	),
+	"bin/biome",
+)} lint src`;
+
 const eslintCommand = `node ${path.resolve(
 	path.dirname(fileURLToPath(import.meta.resolve("eslint"))),
 	"../bin/eslint.js",
@@ -26,6 +33,8 @@ for (const files of testCaseEntries[0].values) {
 		const testCase = { files, rules };
 		const testCaseSlug = createTestCaseSlug(testCase);
 		// flint-disable-next-line performance/loopAwaits
+		const biome = await runInHyperfine(biomeCommand, "Biome", testCaseSlug);
+		// flint-disable-next-line performance/loopAwaits
 		const eslint = await runInHyperfine(eslintCommand, "ESLint", testCaseSlug);
 		// flint-disable-next-line performance/loopAwaits
 		const flint = await runInHyperfine(flintCommand, "Flint", testCaseSlug);
@@ -36,9 +45,11 @@ for (const files of testCaseEntries[0].values) {
 		results.push({
 			files: countCaseFiles(testCase),
 			rules: ruleCounts[rules],
+			biome,
 			eslint,
 			flint,
-			delta: calculateDelta(eslint, flint),
+			vsBiome: calculateDelta(biome, flint),
+			vsESLint: calculateDelta(eslint, flint),
 		});
 		/* eslint-enable perfectionist/sort-objects */
 	}

--- a/packages/performance-testing/src/measure.ts
+++ b/packages/performance-testing/src/measure.ts
@@ -28,15 +28,13 @@ const eslintCommand = `node ${path.resolve(
 // cache against ESLint runs that have none.
 const flintCommand = `node ${path.resolve(testCasesPath, "node_modules/flint/bin/index.js")} --cache-ignore --skip-formatting --skip-language-reports`;
 
+// flint-disable-lines-begin performance/loopAwaits
 for (const files of testCaseEntries[0].values) {
 	for (const rules of testCaseEntries[1].values) {
 		const testCase = { files, rules };
 		const testCaseSlug = createTestCaseSlug(testCase);
-		// flint-disable-next-line performance/loopAwaits
 		const biome = await runInHyperfine(biomeCommand, "Biome", testCaseSlug);
-		// flint-disable-next-line performance/loopAwaits
 		const eslint = await runInHyperfine(eslintCommand, "ESLint", testCaseSlug);
-		// flint-disable-next-line performance/loopAwaits
 		const flint = await runInHyperfine(flintCommand, "Flint", testCaseSlug);
 
 		// Measurements run one at a time: linters sharing the machine would
@@ -54,5 +52,6 @@ for (const files of testCaseEntries[0].values) {
 		/* eslint-enable perfectionist/sort-objects */
 	}
 }
+// flint-disable-lines-end performance/loopAwaits
 
 console.table(table(results));

--- a/packages/rule-data/src/data.json
+++ b/packages/rule-data/src/data.json
@@ -16084,8 +16084,8 @@
 	{
 		"biome": [
 			{
-				"name": "useFind",
-				"url": "https://biomejs.dev/linter/rules/use-find"
+				"name": "useArrayFind",
+				"url": "https://biomejs.dev/linter/rules/use-array-find"
 			}
 		],
 		"eslint": [
@@ -19893,8 +19893,8 @@
 	{
 		"biome": [
 			{
-				"name": "useSpread",
-				"url": "https://biomejs.dev/linter/rules/use-spread"
+				"name": "useSpreadOverApply",
+				"url": "https://biomejs.dev/linter/rules/use-spread-over-apply"
 			}
 		],
 		"eslint": [
@@ -23442,12 +23442,6 @@
 		]
 	},
 	{
-		"biome": [
-			{
-				"name": "noFloatingClasses",
-				"url": "https://biomejs.dev/linter/rules/no-floating-classes"
-			}
-		],
 		"eslint": [
 			{
 				"name": "no-new",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1440,6 +1440,9 @@ importers:
 
   packages/performance-testing:
     dependencies:
+      '@biomejs/biome':
+        specifier: catalog:comparisons
+        version: 2.5.12
       '@flint.fyi/rule-data':
         specifier: workspace:^
         version: link:../rule-data


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #3440
- [x] That issue was marked as [`status: accepting prs`](https://github.com/flint-fyi/flint/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/flint-fyi/flint/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Adds Biome to the performance-testing harness alongside ESLint and Flint.

Generated cases now include a Biome configuration whose rule groups are discovered from Biome's installed schema.
The common and many rule sets are restricted to conceptual rules supported by Flint, ESLint, and Biome, and measurement output reports Flint's percentage delta against both competitors.

Also corrects stale Biome rule mappings discovered while building the shared rule set.

❤️‍🔥 